### PR TITLE
UI pipelines - jest and lint, plus test and prod

### DIFF
--- a/coops-ui/Jenkinsfile
+++ b/coops-ui/Jenkinsfile
@@ -65,11 +65,10 @@ String getImageTagHash(String imageName, String tag = "") {
   return istag.out.tokenize('@')[1].trim()
 }
 
-node {
-  def run_pipeline = true
+def run_pipeline = true
 
-  // build wasn't triggered by changes so check with user
-  if( !triggerBuild(CONTEXT_DIRECTORY) ) {
+// build wasn't triggered by changes so check with user
+if( !triggerBuild(CONTEXT_DIRECTORY) ) {
     try {
         timeout(time: 1, unit: 'DAYS') {
             input message: "Run pipeline?", id: "1234"//, submitter: 'admin,ljtrent-admin,thorwolpert-admin,rarmitag-admin,kialj876-edit,katiemcgoff-edit,waltermoar-admin'
@@ -78,9 +77,74 @@ node {
         run_pipeline = false;
     }
 
-  }
+}
 
-  if( run_pipeline ) {
+if( run_pipeline ) {
+
+
+    // create NodeJS pod to run verification steps
+    def nodejs_label = "jenkins-nodejs-${UUID.randomUUID().toString()}"
+    podTemplate(label: nodejs_label, name: nodejs_label, serviceAccount: 'jenkins', cloud: 'openshift', containers: [
+        containerTemplate(
+            name: 'jnlp',
+            image: '172.50.0.2:5000/openshift/jenkins-slave-nodejs:8',
+            resourceRequestCpu: '500m',
+            resourceLimitCpu: '1000m',
+            resourceRequestMemory: '1Gi',
+            resourceLimitMemory: '2Gi',
+            workingDir: '/tmp',
+            command: '',
+            args: '${computer.jnlpmac} ${computer.name}'
+        )
+    ])
+    {
+        node (nodejs_label) {
+            checkout scm
+            dir('coops-ui') {
+                try {
+                    sh '''
+                        node -v
+                        npm install
+                    '''
+                    stage("Run Jest tests") {
+                        def testResults = sh(script: "npm run test:unit", returnStatus: true)
+
+                        echo "Unit tests ran, returned ${testResults}"
+                        if (testResults > 0) {
+                            try {
+                                timeout(time: 1, unit: 'DAYS') {
+                                    input message: "Unit tests failed. Continue?", id: "1"
+                                }
+                            } catch (Exception e) {
+                                error('Abort')
+                            }
+                        }
+                    }
+                    stage("Check code quality (lint)") {
+                        def lintResults = sh(script: "npm run lint:nofix", returnStatus: true)
+
+                        echo "Linter ran, returned ${lintResults}"
+                        if (lintResults > 0) {
+                            try {
+                                timeout(time: 1, unit: 'DAYS') {
+                                    input message: "Linter failed. Continue?", id: "2"
+                                }
+                            } catch (Exception e) {
+                                error('Abort')
+                            }
+                        }
+                    }
+
+                } catch (Exception e) {
+                    error('Failure')
+                }
+
+            }
+        }
+    }
+
+
+  node {
 
     stage("Build ${BUILD_CONFIG}") {
       script {
@@ -94,7 +158,6 @@ node {
         }
       }
     }
-
 
     stage("Build ${IMAGESTREAM_NAME}") {
       script {
@@ -111,6 +174,7 @@ node {
         }
       }
     }
+
 
     stage("Deploy ${TAG_NAMES[0]}") {
       script {
@@ -145,11 +209,12 @@ node {
       }
     }
     */
+
   }
-  else {
+}
+else {
     stage('No Changes') {
       echo "No changes ..."
       currentBuild.result = 'SUCCESS'
     }
-  }
 }

--- a/coops-ui/Jenkinsfile-DevToTest
+++ b/coops-ui/Jenkinsfile-DevToTest
@@ -1,0 +1,16 @@
+def APP_NAME = 'coops-ui'
+def SOURCE_TAG = 'dev'
+def DESTINATION_TAG = 'test'
+
+node {
+    stage("Deploying ${APP_NAME} to ${DESTINATION_TAG}") {
+      script {
+        openshift.withCluster() {
+          openshift.withProject() {
+            echo "Tagging ${APP_NAME} for deployment to ${DESTINATION_TAG} ..."
+            openshift.tag("${APP_NAME}:${SOURCE_TAG}", "${APP_NAME}:${DESTINATION_TAG}")
+          }
+        }
+      }
+    }
+}

--- a/coops-ui/Jenkinsfile-TestToProd
+++ b/coops-ui/Jenkinsfile-TestToProd
@@ -1,0 +1,16 @@
+def APP_NAME = 'coops-ui'
+def SOURCE_TAG = 'test'
+def DESTINATION_TAG = 'prod'
+
+node {
+    stage("Deploying ${APP_NAME} to ${DESTINATION_TAG}") {
+      script {
+        openshift.withCluster() {
+          openshift.withProject() {
+            echo "Tagging ${APP_NAME} for deployment to ${DESTINATION_TAG} ..."
+            openshift.tag("${APP_NAME}:${SOURCE_TAG}", "${APP_NAME}:${DESTINATION_TAG}")
+          }
+        }
+      }
+    }
+}

--- a/coops-ui/package.json
+++ b/coops-ui/package.json
@@ -6,6 +6,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
+    "lint:nofix": "vue-cli-service lint --no-fix",
     "test:e2e": "vue-cli-service test:e2e",
     "test:unit": "vue-cli-service test:unit"
   },


### PR DESCRIPTION
*Issue #:* bcgov/entity#381

*Description of changes:*
Coops UI pipeline work:
- added jest tests to build pipeline
- added lint checking to build pipeline
- added test pipeline (move from dev to test)
- added prod pipeline (move from test to prod)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
