### PR TITLE
comment out command line psql, as not in base image

### DIFF
--- a/legal-api/pre-hook-update-db.sh
+++ b/legal-api/pre-hook-update-db.sh
@@ -4,7 +4,7 @@ export X_SCLS=rh-python35 httpd24
 export LD_LIBRARY_PATH=/opt/rh/rh-python35/root/usr/lib64:/opt/rh/httpd24/root/usr/lib64
 export PATH=/opt/app-root/bin:/opt/rh/rh-python35/root/usr/bin:/opt/rh/httpd24/root/usr/bin:/opt/rh/httpd24/root/usr/sbin:/opt/app-root/src/.local/bin/:/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-psql -U postgres -tc "SELECT 1 FROM pg_database WHERE datname = 'my_db'" | grep -q 1 || psql -U postgres -c "CREATE DATABASE my_db"
+# psql -U postgres -tc "SELECT 1 FROM pg_database WHERE datname = 'my_db'" | grep -q 1 || psql -U postgres -c "CREATE DATABASE my_db"
 
 cd /opt/app-root/src
 echo 'ensure database is created;


### PR DESCRIPTION
Signed-off-by: thor wolpert <thor@wolpert.ca>

*Issue #:* n/a

*Description of changes:*
comment out command line psql, as not in base image
left the psql check in there for future refernce

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
