### PR TITLE
adding first cut of legal_filings JSONSchema

### DIFF
--- a/legal-api/src/legal_api/schemas/legal_filings.json
+++ b/legal-api/src/legal_api/schemas/legal_filings.json
@@ -1,0 +1,231 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "address": {
+            "$id": "#address",
+            "type": "object",
+            "properties": {
+                "street_address": {
+                    "type": "string"
+                },
+                "city": {
+                    "type": "string"
+                },
+                "province": {
+                    "type": "string"
+                },
+                "postal_code": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "street_address",
+                "city",
+                "province",
+                "postal_code"
+            ]
+        },
+        "office": {
+            "properties": {
+                "shipping_address": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/address"
+                        },
+                        {
+                            "properties": {
+                                "type": {
+                                    "enum": [
+                                        "registered_office",
+                                        "legal_office"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "type"
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "person": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "director": {
+            "type": "object",
+            "properties": {
+                "officer": {
+                    "$ref": "#/definitions/person"
+                },
+                "mailing_address": {
+                    "$ref": "#/definitions/address"
+                },
+                "title": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "officer",
+                "mailing_address",
+                "title"
+            ]
+        },
+        "business_office": {
+            "type": "object",
+            "properties": {
+                "mailing_address": {
+                    "$ref": "#/definitions/address"
+                },
+                "legal_address": {
+                    "$ref": "#/definitions/office"
+                }
+            }
+        },
+        "filing_header": {
+            "$id": "#filing_header",
+            "type": "object",
+            "properties": {
+                "header": {
+                    "type": "object",
+                    "required": [
+                        "name",
+                        "date"
+                    ],
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "date": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    }
+                }
+            }
+        },
+        "business": {
+            "$id": "#business",
+            "type": "object",
+            "title": "The Business Schema",
+            "properties": {
+                "business_info": {
+                    "type": "object",
+                    "required": [
+                        "founding_date",
+                        "identifier",
+                        "legal_name"
+                    ],
+                    "properties": {
+                        "dissolution_date": {
+                            "type": "string",
+                            "format": "date-time",
+                            "title": "The Dissolution_date Schema",
+                            "default": "",
+                            "examples": [
+                                "1970-01-01T00:00:00+00:00"
+                            ]
+                        },
+                        "fiscal_year_end_date": {
+                            "type": "string",
+                            "format": "date-time",
+                            "title": "The Fiscal_year_end_date Schema",
+                            "default": "",
+                            "examples": [
+                                "1970-01-01T00:00:00+00:00"
+                            ]
+                        },
+                        "founding_date": {
+                            "type": "string",
+                            "format": "date",
+                            "title": "The Founding_date Schema",
+                            "default": "",
+                            "examples": [
+                                "1970-01-01"
+                            ]
+                        },
+                        "identifier": {
+                            "type": "string",
+                            "title": "The Identifier Schema",
+                            "default": "",
+                            "examples": [
+                                "CP1234567"
+                            ],
+                            "pattern": "^(CP)[0-9]{7}$"
+                        },
+                        "legal_name": {
+                            "type": "string",
+                            "title": "The Legal_name Schema",
+                            "default": "",
+                            "examples": [
+                                "legal_name"
+                            ],
+                            "pattern": "^(.*)$"
+                        },
+                        "tax_id": {
+                            "type": "string",
+                            "title": "The Tax_id Schema",
+                            "default": "",
+                            "examples": [
+                                "123456789"
+                            ],
+                            "pattern": "^[0-9]{9}$"
+                        }
+                    }
+                }
+            }
+        },
+        "annual_report": {
+            "$id": "#annual_report",
+            "type": "object",
+            "title": "Annual Report Filing",
+            "properties": {
+                "annual_report": {
+                    "type": "object",
+                    "required": [
+                        "annual_general_meeting_date",
+                        "certified_by",
+                        "email"
+                    ],
+                    "properties": {
+                        "annual_general_meeting_date": {
+                            "type": "string",
+                            "format": "date"
+                        },
+                        "certified_by": {
+                            "type": "string"
+                        },
+                        "email": {
+                            "type": "string",
+                            "format": "email"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "type": "object",
+    "title": "Registry Filings",
+    "properties": {
+        "filing": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/filing_header"
+                },
+                {
+                    "$ref": "#/definitions/business"
+                }
+            ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/annual_report"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: thor wolpert <thor@wolpert.ca>

*Issue #:* bcgov/entity#385

*Description of changes:*
Added the first cut of the JSONSchema for legal filings.
Contains definitions for address, person, director, filing_header, annual_report, and the filing schema'


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
