### PR TITLE
made the project a variable in the Makefile

### DIFF
--- a/Makefile.template
+++ b/Makefile.template
@@ -5,7 +5,7 @@
 isort isort-save stop docker-clean logs
 .PHONY: mac-cov pylint flake8
 
-project_name := legal_api
+project_name := YOUR_PROJECT_NAME_HERE
 
 SHELL:=/bin/bash
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))


### PR DESCRIPTION
Signed-off-by: thor wolpert <thor@wolpert.ca>

*Issue #:* n/a

*Description of changes:*
Added a template makefile to the root of the repo.
Changed the legal-api template so that the project directory is a variable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
