### PR TITLE
Added View Directors functionality plus basic UI for Add and Cease

### DIFF
--- a/coops-ui/src/App.vue
+++ b/coops-ui/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app class="app-container" id="app">
+  <v-app class="app-container theme--light" id="app">
     <std-header></std-header>
     <div class="app-body">
       <main>

--- a/coops-ui/src/components/ARSteps/Directors.vue
+++ b/coops-ui/src/components/ARSteps/Directors.vue
@@ -1,0 +1,617 @@
+<template>
+  <section :disabled="!agmEntered">
+    <header>
+      <h2>3. Directors</h2>
+      <p>Tell us who was elected or appointed and who ceased to be a director at your 2018 AGM.</p>
+      <v-expand-transition>
+        <div v-show="!showNewDirectorForm">
+          <v-btn class="new-director-btn" outline color="primary" :disabled="!agmEntered"
+            @click="addNewDirector">
+            <v-icon>add</v-icon>
+            <span>Appoint New Director</span>
+          </v-btn>
+        </div>
+      </v-expand-transition>
+
+    </header>
+
+    <v-card flat>
+
+      <!-- New Director Form -->
+      <v-expand-transition>
+        <ul class="list new-director" v-show="showNewDirectorForm">
+          <li class="container">
+            <div class="meta-container">
+              <label>Appoint New Director</label>
+              <div class="meta-container__inner">
+                <v-form ref="newDirectorForm" v-on:submit.prevent="addNewDirector" v-model="directorFormValid"
+                        lazy-validation>
+                  <div class="form__row three-column">
+                    <v-text-field box class="item" label="First Name"
+                      v-model="director.officer.firstName"
+                      :rules="directorFirstNameRules"
+                      required></v-text-field>
+                    <v-text-field box label="Initial" class="item director-initial"
+                      v-model="director.officer.middleInitial"
+                    ></v-text-field>
+                    <v-text-field box class="item" label="Last Name"
+                      v-model="director.officer.lastName"
+                      :rules="directorLastNameRules"
+                      required></v-text-field>
+                  </div>
+                  <div class="form__row">
+                    <v-text-field box label="Street Address"
+                      v-model="director.deliveryAddress.streetAddress"
+                      :rules="directorStreetRules"
+                      required>
+                      </v-text-field>
+                  </div>
+                  <div class="form__row three-column">
+                    <v-text-field class="item" box label="City"
+                      v-model="director.deliveryAddress.addressCity"
+                      :rules="directorCityRules"
+                      required>
+                    </v-text-field>
+                    <v-select class="item" box label="Province"
+                      :items="regionList"
+                      :rules="directorRegionRules"
+                      v-model="director.deliveryAddress.addressRegion">
+                    </v-select>
+                    <v-text-field class="item" box label="Postal Code"
+                      v-model="director.deliveryAddress.postalCode"
+                      :rules="directorPostalCodeRules"
+                      required>
+                    </v-text-field>
+                  </div>
+                  <div class="form__row">
+                    <v-select box label="Country"
+                      :items="countryList"
+                      v-model="director.deliveryAddress.addressCountry"
+                      :rules="directorCountryRules">
+                    </v-select>
+                  </div>
+                  <div class="form__row form__btns">
+                    <v-btn color="error" disabled>
+                      <span>Remove</span>
+                    </v-btn>
+                    <v-btn class="form-primary-btn" @click="validateNewDirectorForm" color="primary">Done</v-btn>
+                    <v-btn @click="cancelNewDirector">Cancel</v-btn>
+                  </div>
+                </v-form>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </v-expand-transition>
+
+      <!-- Current Director List -->
+      <ul class="list director-list">
+        <li class="container"
+          v-bind:class="{ 'remove' : !director.isDirectorActive }"
+          v-for="(director, index) in orderBy(directors, 'lastName')"
+          v-bind:key="index">
+          <div class="meta-container">
+            <label>
+              <span>{{director.officer.firstName}}</span>
+              <span>{{director.officer.middleInitial}}</span>
+              <span>{{director.officer.lastName}}</span>
+              <div class="director-status">
+                <v-scale-transition>
+                  <v-chip small label disabled color="blue" text-color="white" v-show="director.isNew">
+                    New
+                  </v-chip>
+                </v-scale-transition>
+                <v-scale-transition>
+                  <v-chip small label disabled v-show="!director.isDirectorActive">
+                    Ceased
+                  </v-chip>
+                </v-scale-transition>
+              </div>
+            </label>
+            <div class="meta-container__inner">
+              <v-expand-transition>
+                <div class="director-info" v-show="activeIndex !== index">
+                  <div class="address">
+                    <div class="address__row">{{director.deliveryAddress.streetAddress}}</div>
+                    <div class="address__row">{{director.deliveryAddress.streetAddressAdditional}}</div>
+                    <div class="address__row">
+                      <span>{{director.deliveryAddress.addressCity}}</span>
+                      <span>&nbsp;{{director.deliveryAddress.addressRegion}}</span>
+                      <span>&nbsp;{{director.deliveryAddress.postalCode}}</span>
+                    </div>
+                    <div class="address__row">{{director.deliveryAddress.addressCountry}}</div>
+                  </div>
+                    <div class="actions">
+                      <v-btn small flat color="primary" :disabled="!agmEntered"
+                        v-show="director.isNew"
+                        @click="editDirector(index)">
+                        <v-icon small>edit</v-icon>
+                        <span>Change</span>
+                      </v-btn>
+                      <v-btn small flat color="primary" :disabled="!agmEntered"
+                        v-show="!director.isNew"
+                        @click="removeDirector(director)">
+                        <v-icon small>{{director.isDirectorActive ? 'close':'undo'}}</v-icon>
+                        <span>{{director.isDirectorActive ? 'Cease':'Undo'}}</span>
+                      </v-btn>
+                    </div>
+                </div>
+              </v-expand-transition>
+
+              <!-- EDIT director form -->
+              <!-- note - this is only used to edit a NEW director; editing existing directors is not supported in the
+                  current release -->
+              <v-expand-transition>
+                <v-form ref="editDirectorForm"
+                  v-show="activeIndex === index"
+                  v-model="directorFormValid" lazy-validation>
+                  <div class="form__row three-column">
+                    <v-text-field box label="First Name" class="item"
+                      v-model="director.officer.firstName"
+                      :rules="directorFirstNameRules"
+                      required
+                    ></v-text-field>
+                    <v-text-field box label="Initial" class="item director-initial"
+                      v-model="director.officer.middleInitial"
+                    ></v-text-field>
+                    <v-text-field box label="Last Name" class="item"
+                      v-model="director.officer.lastName"
+                      :rules="directorLastNameRules"
+                    ></v-text-field>
+                  </div>
+                  <div class="form__row">
+                    <v-text-field box label="Street Address"
+                      v-model="director.deliveryAddress.streetAddress"
+                      :rules="directorStreetRules"
+                      required>
+                      </v-text-field>
+                  </div>
+                  <div class="form__row three-column">
+                    <v-text-field class="item" box label="City"
+                      v-model="director.deliveryAddress.addressCity"
+                      :rules="directorCityRules"
+                      required>
+                    </v-text-field>
+                    <v-select class="item" box label="Province"
+                      :items="regionList"
+                      :rules="directorRegionRules"
+                      v-model="director.deliveryAddress.addressRegion">
+                    </v-select>
+                    <v-text-field class="item" box label="Postal Code"
+                      v-model="director.deliveryAddress.postalCode"
+                      :rules="directorPostalCodeRules"
+                      required>
+                    </v-text-field>
+                  </div>
+                  <div class="form__row">
+                    <v-select box label="Country"
+                      :items="countryList"
+                      :rules="directorCountryRules"
+                      v-model="director.deliveryAddress.addressCountry" >
+                    </v-select>
+                  </div>
+                  <div class="form__row form__btns">
+                    <v-btn color="error"
+                      :disabled="!director.isNew"
+                      @click="deleteDirector(index)">
+                      <span>Remove</span>
+                    </v-btn>
+                    <v-btn class="form-primary-btn" color="primary"
+                      @click="cancelEditDirector(index)">
+                      Done</v-btn>
+                    <v-btn @click="cancelEditDirector(index)">Cancel</v-btn>
+                  </div>
+                </v-form>
+              </v-expand-transition>
+              <!-- END edit director form -->
+            </div>
+          </div>
+        </li>
+      </ul>
+
+    </v-card>
+  </section>
+</template>
+
+<script>
+import Vue2Filters from 'vue2-filters'
+import axios from '../../axios-auth'
+
+export default {
+  name: 'Directors.vue',
+  mixins: [Vue2Filters.mixin],
+  components: {
+  },
+  data () {
+    return {
+      directors: [],
+      directorsChangeCount: 0, // counter for directors change, to know whether to add fee
+      countryList: [
+        'Canada'
+      ],
+      regionList: [
+        'BC'
+      ],
+      showNewDirectorForm: false,
+      activeIndex: undefined,
+      isEditingDirector: false,
+      isDirectorActive: true,
+      director: {
+        id: '',
+        officer: { firstName: '', lastName: '', middleInitial: '' },
+        deliveryAddress: {
+          streetAddress: '',
+          streetAddressAdditional: '',
+          addressCity: '',
+          addressRegion: '',
+          postalCode: '',
+          addressCountry: ''
+        }
+      },
+      directorFormValid: true,
+      directorFirstNameRules: [
+        v => !!v || 'A first name is required'
+      ],
+      directorLastNameRules: [
+        v => !!v || 'A last name is required'
+      ],
+      directorStreetRules: [
+        v => !!v || 'A street address is required'
+      ],
+      directorCityRules: [
+        v => !!v || 'A city is required'
+      ],
+      directorRegionRules: [
+        v => !!v || 'A region is required'
+      ],
+      directorPostalCodeRules: [
+        v => !!v || 'A postal code is required'
+      ],
+      directorCountryRules: [
+        v => !!v || 'A country is required'
+      ]
+    }
+  },
+  computed: {
+    corpNum () {
+      return this.$store.state.corpNum
+    },
+    agmEntered () {
+      if (this.$store.state.agmDate) return true
+      else if (this.$store.state.noAGM) return true
+      else return false
+    },
+    directorsChange () {
+      if (this.directorsChangeCount > 0) return true
+      else return false
+    }
+  },
+  methods: {
+    getDirectors: function () {
+      if (this.corpNum !== null) {
+        console.log('got here 2')
+        var token = sessionStorage.getItem('KEYCLOAK_TOKEN')
+        var url = this.corpNum + '/directors' // todo - deal with year or date
+        console.log(url)
+        axios.get(url).then(response => {
+          console.log(response.data)
+          this.directors = response.data.directors
+          for (var i = 0; i < this.directors.length; i++) {
+            this.directors[i].id = i + 1
+            this.directors[i].isNew = false
+            this.directors[i].isDirectorActive = true
+          }
+        }).catch(error => {
+          console.log('getDirectors ERROR: ' + error + ' ' + axios.get)
+          // TODO - remove this stub data
+          this.directors = [
+            {
+              id: 1,
+              isNew: false,
+              isDirectorActive: true,
+              officer: { firstName: 'Alli', lastName: 'Myers', middleInitial: '' },
+              deliveryAddress: {
+                streetAddress: '1111 First Street',
+                streetAddressAdditional: '',
+                addressCity: 'Victoria',
+                addressRegion: 'BC',
+                postalCode: 'V8A 2G8',
+                addressCountry: 'Canada'
+              },
+              title: 'Pres'
+            },
+            {
+              id: 2,
+              isNew: false,
+              isDirectorActive: true,
+              officer: { firstName: 'Nora', lastName: 'Patton', middleInitial: '' },
+              deliveryAddress: {
+                streetAddress: '2222 Second Street',
+                streetAddressAdditional: '',
+                addressCity: 'Victoria',
+                addressRegion: 'BC',
+                postalCode: 'V8A 2G8',
+                addressCountry: 'Canada'
+              },
+              title: null
+            },
+            {
+              id: 3,
+              isNew: false,
+              isDirectorActive: true,
+              officer: { firstName: 'Phoebe', lastName: 'Jones', middleInitial: '' },
+              deliveryAddress: {
+                streetAddress: '3333 Third Street',
+                streetAddressAdditional: null,
+                addressCity: 'Victoria',
+                addressRegion: 'BC',
+                postalCode: 'V8A 2G8',
+                addressCountry: 'Canada'
+              },
+              title: null
+            },
+            {
+              id: 4,
+              isNew: false,
+              isDirectorActive: true,
+              officer: { firstName: 'Cole', lastName: 'Bryan', middleInitial: '' },
+              deliveryAddress: {
+                streetAddress: '4444 Fourth Street',
+                streetAddressAdditional: null,
+                addressCity: 'Victoria',
+                addressRegion: 'BC',
+                postalCode: 'V8A 2G8',
+                addressCountry: 'Canada'
+              },
+              title: 'Vice Pres'
+            }
+          ]
+        })
+      }
+    },
+
+    // Add New Director
+    addNewDirector: function () {
+      this.showNewDirectorForm = true
+      this.activeIndex = null
+    },
+
+    cancelNewDirector: function () {
+      this.showNewDirectorForm = false
+      this.$refs.newDirectorForm.reset()
+    },
+
+    deleteDirector: function (director, index) {
+      if (this.directors[index] === director) {
+        this.directors.splice(index, 1)
+      } else {
+        let found = this.directors.indexOf(director)
+        this.directors.splice(found, 1)
+        this.directorsChangeCount--
+      }
+    },
+
+    validateNewDirectorForm: function (index) {
+      if (this.$refs.newDirectorForm.validate()) {
+        this.pushNewDirectorData()
+        this.cancelNewDirector()
+        this.directorsChangeCount++
+      } else {
+        // do nothing - validator handles validation messaging
+      }
+    },
+
+    pushNewDirectorData: function (index) {
+      let newDirector = {
+        id: this.directors.length + 1,
+        isDirectorActive: true,
+        isNew: true,
+        officer: {
+          firstName: this.director.firstName,
+          middleInitial: this.director.middleInitial,
+          lastName: this.director.lastName
+        },
+        deliveryAddress: {
+          streetAddress: this.director.streetAddress,
+          streetAddressAdditional: this.director.streetAddressAdditional,
+          addressCity: this.director.addressCity,
+          addressRegion: this.director.addressRegion,
+          postalCode: this.director.postalCode,
+          addressCountry: this.director.addressCountry
+        }
+      }
+      this.directors.push(newDirector)
+    },
+
+    // Remove director
+    removeDirector: function (director) {
+      console.log('got to removeDirector()')
+      // if this is a Cease, add a fee count
+      // otherwise it's just undoing a cease or undoing a new director, so remove fee count
+      if (director.isDirectorActive) this.directorsChangeCount++
+      else this.directorsChangeCount--
+
+      director.isDirectorActive = !director.isDirectorActive
+    },
+
+    // Modify Existing Directors
+    editDirector: function (index) {
+      this.activeIndex = index
+      this.cancelNewDirector()
+    },
+
+    cancelEditDirector: function (index) {
+      this.activeIndex = undefined
+    }
+  },
+  watch: {
+    // if we have director changes (add or cease) add a single fee to the filing
+    // - when we've made one change, add the fee; when we've removed/undone all changes, remove the fee
+    directorsChange: function (val) {
+      // emit event back up to parent
+      this.$emit('directorsChange', val)
+    }
+  }
+}
+</script>
+
+<style lang="stylus" scoped>
+  @import "../../assets/styles/theme.styl"
+
+  article
+    .v-card
+      line-height 1.2rem
+      font-size 0.875rem
+
+    .v-btn
+      margin 0
+      text-transform none
+
+  section p
+    //font-size 0.875rem
+    color $gray6
+
+  section + section
+    margin-top 3rem
+
+  h2
+    margin-bottom 0.25rem
+
+  ul
+    margin 0
+    padding 0
+    list-style-type none
+
+  .meta-container
+    display flex
+    flex-flow column nowrap
+    position relative
+
+    > label:first-child
+      font-weight 500
+
+    &__inner
+      flex 1 1 auto
+
+    .actions
+      position absolute
+      top 0
+      right 0
+
+      .v-btn
+        min-width 4rem
+
+      .v-btn + .v-btn
+        margin-left 0.5rem
+
+  @media (min-width 768px)
+    .meta-container
+      flex-flow row nowrap
+
+      > label:first-child
+        flex 0 0 auto
+        padding-right: 2rem
+        width 12rem
+
+  // List Layout
+  .list
+    li
+      border-bottom 1px solid $gray3
+
+  .address-list .form
+    margin-top 1rem
+
+  @media (min-width 768px)
+    .address-list .form
+      margin-top 0
+
+  .form__row.three-column
+    display flex
+    flex-flow row nowrap
+    align-items stretch
+    margin-right -0.5rem
+    margin-left -0.5rem
+
+    .item
+      flex 1 1 auto
+      flex-basis 0
+      margin-right 0.5rem
+      margin-left 0.5rem
+
+  .inherit-checkbox
+    margin-top -3px
+    margin-left -3px
+    padding 0
+
+  // Address Block Layout
+  .address
+    display flex
+    flex-direction column
+
+  .address__row
+    flex 1 1 auto
+
+  // Registered Office Address
+  .registered-address-info
+    display flex
+
+    .status
+      flex 1 1 auto
+
+    .actions
+      flex 0 0 auto
+
+  .show-address-form
+    li:first-child
+      padding-bottom 0
+
+  // Director Display
+  .director-info
+    display flex
+
+    .status
+      flex 1 1 auto
+
+    .actions
+      flex 0 0 auto
+
+  .director-initial
+    max-width 6rem
+
+  .new-director-btn
+    margin-bottom 1.5rem !important
+
+    .v-icon
+      margin-left -0.5rem
+
+  // Filing Buttons
+  .ar-filing-buttons
+    padding-top 2rem
+    border-top: 1px solid $gray5
+    text-align right
+    .v-btn + .v-btn
+      margin-left 0.5rem
+
+  // V-chip customization
+  .v-chip--small
+    height 1.2rem !important
+    margin 0
+    margin-top 0.5rem
+    padding 0
+    text-transform uppercase
+    font-size 0.65rem
+    font-weight 700
+    vertical-align top
+
+    .v-chip__content
+      height 1.2rem !important
+      padding 0 0.5rem
+
+  .remove
+    color $gray5 !important
+
+  .agm-date
+    margin-left 0.25rem
+    font-weight 300
+
+</style>

--- a/coops-ui/src/components/ARSteps/RegisteredOfficeAddress.vue
+++ b/coops-ui/src/components/ARSteps/RegisteredOfficeAddress.vue
@@ -25,7 +25,7 @@
                     </div>
                     <div class="address-block__actions">
                       <v-btn id="reg-off-addr-change-btn"
-                             small outline color="blue" :disabled="agmEntered" @click="editAddress">
+                             small outline color="blue" :disabled="!agmEntered" @click="editAddress">
                         Change
                       </v-btn>
                       <br/>
@@ -331,8 +331,9 @@ export default {
 
   computed: {
     agmEntered () {
-      if (this.$store.state.agmDate) return false
-      else return !this.$store.state.noAGM
+      if (this.$store.state.agmDate) return true
+      else if (this.$store.state.noAGM) return true
+      else return false
     },
     regOffAddrChange () {
       return this.$store.state.regOffAddrChange

--- a/coops-ui/src/components/AnnualReport.vue
+++ b/coops-ui/src/components/AnnualReport.vue
@@ -9,20 +9,11 @@
       </div>
     </div>
 
-    <!-- Transition to Payment -->
-    <v-fade-transition>
-      <div class="loading-container" v-show="showLoading">
-        <div class="loading__content">
-          <v-progress-circular color="primary" :size="50" indeterminate></v-progress-circular>
-          <div class="loading-msg">{{this.loadingMsg}}</div>
-        </div>
-      </div>
-    </v-fade-transition>
-
     <v-container class="view-container">
       <article id="annual-report-article">
         <h1 id="AR-header">{{year}} Annual Report - <span style="font-style: italic">{{ reportState }}</span></h1>
-        <p>Select your Annual General Meeting (AGM) date, and verify or change your Registered office address and List of Directors as of your AGM.</p>
+        <p>Select your Annual General Meeting (AGM) date, and verify or change your Registered office address and List
+          of Directors as of your AGM.</p>
         <div v-if="filedDate == null">
           <section>
             <h3 id="AR-step-1-header">1. Enter your Annual General Meeting Date</h3>
@@ -36,6 +27,10 @@
               <RegisteredOfficeAddress/>
             </div>
           </section>
+
+          <!-- Director Information -->
+          <Directors ref="directors" @directorsChange="directorsChangeEventHandler" />
+
         </div>
         <div v-else>
           <ARComplete/>
@@ -53,6 +48,7 @@
 <script>
 import AGMDate from '@/components/ARSteps/AGMDate.vue'
 import RegisteredOfficeAddress from '@/components/ARSteps/RegisteredOfficeAddress.vue'
+import Directors from '@/components/ARSteps/Directors.vue'
 import ARComplete from '@/components/ARSteps/ARComplete.vue'
 import { Affix } from 'vue-affix'
 import SbcFeeSummary from 'sbc-common-components/src/components/SbcFeeSummary.vue'
@@ -62,12 +58,14 @@ export default {
   components: {
     AGMDate,
     RegisteredOfficeAddress,
+    Directors,
     ARComplete,
     SbcFeeSummary,
     Affix
   },
   data () {
     return {
+      directorsChange: false,
       filingData: []
     }
   },
@@ -95,6 +93,12 @@ export default {
   mounted () {
   },
   methods: {
+    directorsChangeEventHandler (val) {
+      this.directorsChange = val
+    },
+    getDirectors () {
+      this.$refs.directors.getDirectors()
+    },
     toggleFiling (setting, filing) {
       var added = false
       for (var i = 0; i < this.filingData.length; i++) {
@@ -131,6 +135,10 @@ export default {
       console.log('AnnualReport regOffAddrChange watcher fired: ', val)
       if (val) this.toggleFiling('add', 'OTADD')
       else this.toggleFiling('remove', 'OTADD')
+    },
+    directorsChange: function (val) {
+      if (val) this.toggleFiling('add', 'OTCDR')
+      else this.toggleFiling('remove', 'OTCDR')
     },
     filingData: function (val) {
       console.log('AnnualReport filingData watcher fired: ', val)

--- a/coops-ui/src/components/StdHeader.vue
+++ b/coops-ui/src/components/StdHeader.vue
@@ -6,8 +6,7 @@
           alt="Province of British Columbia Logo"
           title="Province of British Columbia"/>
       </router-link>
-      <span class="bcros" v-show="this.$route.name != 'PayBC'">BC Registries & Online Services</span>
-      <span class="paybc-logo" v-show="this.$route.name === 'PayBC'">Pay<strong>BC</strong></span>
+      <span class="bcros">BC Registries & Online Services</span>
       <div class="app-header__actions">
         <v-btn outline color="#ffffff"><span>Sign out</span></v-btn>
       </div>

--- a/coops-ui/src/views/Home.vue
+++ b/coops-ui/src/views/Home.vue
@@ -1,11 +1,21 @@
 <template>
   <div class="home">
 
+    <!-- Transition to Payment -->
+    <v-fade-transition>
+      <div class="loading-container" v-show="showLoading">
+        <div class="loading__content">
+          <v-progress-circular color="primary" :size="50" indeterminate></v-progress-circular>
+          <div class="loading-msg">{{this.loadingMsg}}</div>
+        </div>
+      </div>
+    </v-fade-transition>
+
     <EntityInfo/>
 
     <v-app>
       <v-container id="annual-report-container" class="view-container">
-        <AnnualReport/>
+        <AnnualReport ref="annualReport"/>
       </v-container>
       <v-container id="submit-container" class="view-container">
         <v-btn v-if="filedDate == null" id='ar-pay-btn' color="blue" :disabled="!validated" @click="submit">Pay</v-btn>
@@ -29,7 +39,9 @@ export default {
     return {
       lastARJson: null,
       entityInfoJson: null,
-      regOffAddrJson: null
+      regOffAddrJson: null,
+      showLoading: false,
+      loadingMsg: null
     }
   },
   computed: {
@@ -61,6 +73,7 @@ export default {
       this.getARInfo(this.corpNum)
       this.getEntityInfo(this.corpNum)
       this.getRegOffAddr(this.corpNum)
+      this.$refs.annualReport.getDirectors()
     }
   },
   methods: {
@@ -204,6 +217,7 @@ export default {
         this.getARInfo(val)
         this.getEntityInfo(val)
         this.getRegOffAddr(val)
+        this.$refs.annualReport.getDirectors()
       }
     },
     regOffAddrChange: function (val) {

--- a/coops-ui/tests/unit/Directors.spec.ts
+++ b/coops-ui/tests/unit/Directors.spec.ts
@@ -1,0 +1,244 @@
+import Vue from 'vue'
+import Vuetify from 'vuetify'
+
+import App from '@/App.vue'
+import Home from '@/views/Home.vue'
+import Directors from '@/components/ARSteps/Directors.vue'
+import store from '@/store'
+import sinon from 'sinon'
+import axios from '@/axios-auth.ts'
+import Vuelidate from 'vuelidate'
+Vue.use(Vuetify)
+Vue.use(Vuelidate)
+
+describe('Directors.vue', () => {
+  // just need a token that can get parsed properly (will be expired but doesn't matter for tests)
+  // note - the corp num in this token is CP0001191
+  sessionStorage.setItem('KEYCLOAK_TOKEN', 'eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJUbWdtZUk0MnVsdUZ0N' +
+    '3FQbmUtcTEzdDUwa0JDbjF3bHF6dHN0UGdUM1dFIn0.eyJqdGkiOiIxYzQ2YjIzOS02ZWY0LTQxYTQtYThmMy05N2M5M2IyNmNlMjAiLCJle' +
+    'HAiOjE1NTcxNzMyNTYsIm5iZiI6MCwiaWF0IjoxNTU3MTY5NjU2LCJpc3MiOiJodHRwczovL3Nzby1kZXYucGF0aGZpbmRlci5nb3YuYmMuY2' +
+    'EvYXV0aC9yZWFsbXMvZmNmMGtwcXIiLCJhdWQiOiJzYmMtYXV0aC13ZWIiLCJzdWIiOiIwMzZlN2I4Ny0zZTQxLTQ2MTMtYjFiYy04NWU5OTA' +
+    'xNTgzNzAiLCJ0eXAiOiJCZWFyZXIiLCJhenAiOiJzYmMtYXV0aC13ZWIiLCJhdXRoX3RpbWUiOjAsInNlc3Npb25fc3RhdGUiOiJkOGZmYjk4' +
+    'OS0zNzRlLTRhYTktODc4OS03YTRkODA1ZjNkOTAiLCJhY3IiOiIxIiwiYWxsb3dlZC1vcmlnaW5zIjpbImh0dHA6Ly8xOTIuMTY4LjAuMTM6O' +
+    'DA4MC8iLCIxOTIuMTY4LjAuMTMiLCIqIiwiaHR0cDovLzE5Mi4xNjguMC4xMzo4MDgwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJlZGl' +
+    '0IiwidW1hX2F1dGhvcml6YXRpb24iLCJiYXNpYyJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY' +
+    '291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sInByZWZlcnJlZF91c2VybmFtZSI6ImNwMDAwMTE5MSJ9.Ou' +
+    'JLtzYCnkp5KXSiudGFJY6hTSvdE3KokhkEzqU-icxAzQwZSTYbzZQdGsIScy4-DIWHahIGp9L-e6mYlQSQta2rK2Kte85MxThubyw0096UOtAE' +
+    'wnS9VURHXPUm4ZUyI4ECkyLlFywOPxAftNdeSYeJx26GHBCvo6uR9Zv6A3yTlJy3B1HJxBWk_6xTAzGPPDCLoyKGeIxGidGujKCKCAfXRMrjhX' +
+    'yBv90XzDgZ-To-6_jMjSjBX6Dtq7icdZYLWWDdrhjCpJA5CKS0PlSgeH1Yq4rHd8Ztp5cvVdJFxt87gIopIOQvcy4ji0gtaovgUhiyg07gXGl8' +
+    'dGZwn1tpLA')
+  let rootvm
+  let vm
+  let childvm
+
+  let click = function (id) {
+    console.log('ID: ', id)
+    let button = childvm.$el.querySelector(id)
+    let window = button.ownerDocument.defaultView
+    var click = new window.Event('click')
+    button.dispatchEvent(click)
+  }
+  beforeEach((done) => {
+    // reset store
+    store.state.agmDate = null
+    store.state.filedDate = null
+    store.state.validated = false
+    store.state.noAGM = false
+    store.state.corpNum = 'CP0001191'
+
+    // GET current directors list
+    sinon.stub(axios, 'get').withArgs('CP0001191/directors')
+      .returns(new Promise((resolve) => resolve({
+        data:
+          {
+            directors: [
+              {
+                'officer': {
+                  'firstName': 'Peter',
+                  'middleInitial': null,
+                  'lastName': 'Griffin'
+                },
+                'deliveryAddress': {
+                  'streetAddress': 'mailing_address - address line one',
+                  'streetAddressAdditional': null,
+                  'addressCity': 'mailing_address city',
+                  'addressCountry': 'mailing_address country',
+                  'postalCode': 'H0H0H0',
+                  'addressRegion': 'BC',
+                  'deliveryInstructions': null
+                },
+                'title': null
+              },
+              {
+                'officer': {
+                  'firstName': 'Joe',
+                  'middleInitial': 'P',
+                  'lastName': 'Swanson'
+                },
+                'deliveryAddress': {
+                  'streetAddress': 'mailing_address - address line #1',
+                  'streetAddressAdditional': 'Kirkintiloch',
+                  'addressCity': 'Glasgow',
+                  'addressCountry': 'UK',
+                  'postalCode': 'H0H 0H0',
+                  'addressRegion': 'Scotland',
+                  'deliveryInstructions': 'go to the back'
+                },
+                'title': 'Treasurer'
+              }
+            ]
+          }
+      })))
+
+    const RootConstructor = Vue.extend(App)
+    let rootInstance = new RootConstructor({ store: store })
+    rootvm = rootInstance.$mount()
+
+    const Constructor = Vue.extend(Home)
+    let instance = new Constructor({ store: store })
+    vm = instance.$mount()
+
+    const ChildConstructor = Vue.extend(Directors)
+    let childInstance = new ChildConstructor({ store: store })
+    childvm = childInstance.$mount()
+
+    // call getDirectors() since it won't be triggered from parent component
+    childvm.getDirectors()
+
+    setTimeout(() => {
+      done()
+    }, 100)
+  })
+
+  afterEach((done) => {
+    sinon.restore()
+    setTimeout(() => {
+      done()
+    }, 500)
+  })
+
+  it('initializes the director meta data properly', () => {
+    expect(childvm.directors.length).toEqual(2)
+    expect(childvm.directors[0].id).toEqual(1)
+    expect(childvm.directors[0].isNew).toEqual(false)
+    expect(childvm.directors[0].isDirectorActive).toEqual(true)
+    expect(childvm.directors[1].id).toEqual(2)
+    expect(childvm.directors[1].isNew).toEqual(false)
+    expect(childvm.directors[1].isDirectorActive).toEqual(true)
+  })
+
+  it('initializes the director name data properly', () => {
+    expect(childvm.directors.length).toEqual(2)
+    expect(childvm.directors[0].officer.firstName).toEqual('Peter')
+    expect(childvm.directors[0].officer.middleInitial).toBeNull()
+    expect(childvm.directors[0].officer.lastName).toEqual('Griffin')
+    expect(childvm.directors[0].title).toBeNull()
+    expect(childvm.directors[1].officer.firstName).toEqual('Joe')
+    expect(childvm.directors[1].officer.middleInitial).toEqual('P')
+    expect(childvm.directors[1].officer.lastName).toEqual('Swanson')
+    expect(childvm.directors[1].title).toEqual('Treasurer')
+  })
+
+  it('initializes the director address data properly', () => {
+    // check complete first address
+    expect(childvm.directors.length).toEqual(2)
+    expect(childvm.directors[0].deliveryAddress.streetAddress).toEqual('mailing_address - address line one')
+    expect(childvm.directors[0].deliveryAddress.streetAddressAdditional).toBeNull()
+    expect(childvm.directors[0].deliveryAddress.addressCity).toEqual('mailing_address city')
+    expect(childvm.directors[0].deliveryAddress.addressRegion).toEqual('BC')
+    expect(childvm.directors[0].deliveryAddress.addressCountry).toEqual('mailing_address country')
+    expect(childvm.directors[0].deliveryAddress.postalCode).toEqual('H0H0H0')
+    expect(childvm.directors[0].deliveryAddress.deliveryInstructions).toBeNull()
+
+    // spot-check second address
+    expect(childvm.directors[1].deliveryAddress.streetAddressAdditional).toEqual('Kirkintiloch')
+    expect(childvm.directors[1].deliveryAddress.deliveryInstructions).toEqual('go to the back')
+  })
+
+  it('displays the list of directors', () => {
+    var directorListUI = childvm.$el.querySelectorAll('.director-list .container')
+
+    // shows list of all directors in the UI
+    expect(directorListUI.length).toEqual(2)
+    expect(directorListUI[0].textContent).toContain('Griffin')
+    expect(directorListUI[0].textContent).toContain('mailing_address city')
+    expect(directorListUI[1].textContent).toContain('Joe')
+    expect(directorListUI[1].textContent).toContain('Glasgow')
+
+    // shows "cease" button, indicating this is an active director, ie: starting state for list
+    expect(directorListUI[0].innerHTML).toContain('<span>Cease</span>')
+    expect(directorListUI[1].innerHTML).toContain('<span>Cease</span>')
+  })
+
+  it('buttons/actions are disabled when the AGM date has not been set', () => {
+    var directorListUI = childvm.$el.querySelectorAll('.director-list .container')
+
+    // confirm that flag is set correctly
+    expect(childvm.agmEntered).toEqual(false)
+
+    // check that buttons are disabled (checks first button in first director, plus the Add New Director button)
+    expect(
+      directorListUI[0].querySelector('.actions .v-btn').attributes.getNamedItem('disabled').value
+    ).toEqual('disabled')
+    expect(
+      childvm.$el.querySelector('.new-director-btn').attributes.getNamedItem('disabled').value
+    ).toEqual('disabled')
+  })
+
+  it('buttons/actions are enabled when the AGM date has been set', () => {
+    var directorListUI = childvm.$el.querySelectorAll('.director-list .container')
+
+    // set AGM Date in AGMDate component
+    childvm.$store.state.agmDate = '2018-06-18'
+
+    setTimeout(() => {
+      // confirm that flag is set correctly
+      expect(childvm.agmEntered).toEqual(true)
+
+      // check that buttons are enabled (checks first button in first director, plus the Add New Director button)
+      expect(
+        directorListUI[0].querySelector('.actions .v-btn').attributes.getNamedItem('disabled')
+      ).toBeNull()
+      expect(
+        childvm.$el.querySelector('.new-director-btn').attributes.getNamedItem('disabled')
+      ).toBeNull()
+    }, 100)
+  })
+
+  it('buttons/actions are enabled when "No AGM" option set', () => {
+    var directorListUI = childvm.$el.querySelectorAll('.director-list .container')
+
+    // set "No AGM" in AGMDate component
+    childvm.$store.state.noAGM = true
+
+    setTimeout(() => {
+      // confirm that flag is set correctly
+      expect(childvm.agmEntered).toEqual(true)
+
+      // check that buttons are enabled (checks first button in first director, plus the Add New Director button)
+      expect(
+        directorListUI[0].querySelector('.actions .v-btn').attributes.getNamedItem('disabled')
+      ).toBeNull()
+      expect(
+        childvm.$el.querySelector('.new-director-btn').attributes.getNamedItem('disabled')
+      ).toBeNull()
+    }, 100)
+  })
+
+  it('displays Add New Director form when button clicked', () => {
+    // todo
+  })
+  it('handles "ceased" action', () => {
+    // todo
+  })
+  it('handles un-"ceased" action', () => {
+    // todo
+  })
+
+  it('adds a new director to list', () => {
+    // todo
+  })
+  it('can undo adding new director', () => {
+    // todo
+  })
+})


### PR DESCRIPTION
*Issue #:* bcgov/entity#547

*Description of changes:*
Added view UI functionality with jest tests; also added basic UI functionality of add and cease from prototype.

This code still includes hard-coded data, which will be removed once hooked up to lear, auth, and payment APIs correctly.

For testing - must have old/fake token in main.ts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
