### PR TITLE
make services a module

### DIFF
--- a/legal-api/src/legal_api/services/__init__.py
+++ b/legal-api/src/legal_api/services/__init__.py
@@ -1,0 +1,14 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This module wraps the calls to external services used by the API."""


### PR DESCRIPTION
Signed-off-by: thor wolpert <thor@wolpert.ca>

*Issue #:* n/a

*Description of changes:*
added plain __init__.py to the services module

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
