### PR TITLE
updated director schema to include appointment/cessation date

### DIFF
--- a/schemas/src/registry_schemas/schemas/directors.json
+++ b/schemas/src/registry_schemas/schemas/directors.json
@@ -36,11 +36,21 @@
                 },
                 "title": {
                     "type": "string"
+                },
+                "appointmentDate": {
+                    "type": "string",
+                    "format": "date"
+                },
+                "cessationDate": {
+                    "type": ["string", "null"],
+                    "format": "date"
                 }
             },
             "required": [
                 "officer",
-                "deliveryAddress"
+                "deliveryAddress",
+                "appointmentDate",
+                "cessationDate"
             ]
         }
     },


### PR DESCRIPTION
Signed-off-by: Kial Jinnah <kialj876@gmail.com>

*Issue #:NA*

*Description of changes:*
- added both appointment date and cessation date to director schema
- decision made to add these agreed upon by myself, thor and katie
- cessation date can be set to null

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
