### PR TITLE
added new targets. setup no longer recreates the requirements.txt file

### DIFF
--- a/legal-api/Makefile
+++ b/legal-api/Makefile
@@ -1,5 +1,5 @@
 .PHONY: license
-.PHONY: setup clean clean-build clean-pyc clean-test
+.PHONY: setup build-req clean clean-build clean-pyc clean-test
 
 .PHONY: docker-setup network build start qa style safety test test-travis flake8 \
 isort isort-save stop docker-clean logs
@@ -37,7 +37,9 @@ clean-test:
 	rm -f .coverage
 	rm -fr htmlcov/
 
-setup: clean venv/bin/activate install-dev
+build-req: clean venv/bin/activate
+
+setup: clean setup-venv install-dev
 
 venv/bin/activate: requirements/prod.txt requirements/dev.txt
 	rm -rf venv/
@@ -50,6 +52,13 @@ venv/bin/activate: requirements/prod.txt requirements/dev.txt
 	pip install -Ur requirements/repo-libraries.txt ;\
 	pip install -Ur requirements/dev.txt
 	touch venv/bin/activate  # update so it's as new as requirements/prod.txt
+
+setup-venv: requirements.txt
+	rm -rf venv/
+	test -f venv/bin/activate || python3 -m venv  $(current_abs_dir)/venv
+	. venv/bin/activate ;\
+	pip install --upgrade pip ;\
+	pip install -Ur requirements.txt
 
 .PHONY: install-dev
 install-dev: venv/bin/activate


### PR DESCRIPTION
Signed-off-by: thor wolpert <thor@wolpert.ca>

*Issue #:* n/a

*Description of changes:*
- added new targets.
- setup no longer recreates the requirements.txt file
- build-req creates a new requirements.txt of a clean requirements install

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
