### PR TITLE
POC for JSON schema validation in UI

### DIFF
--- a/coops-ui/package.json
+++ b/coops-ui/package.json
@@ -14,6 +14,8 @@
   "dependencies": {
     "@babel/polyfill": "^7.0.0-rc.1",
     "axios": "^0.18.0",
+    "core-js": "^3.1.4",
+    "regenerator-runtime": "^0.13.2",
     "register-service-worker": "^1.6.2",
     "sbc-common-components": "^0.0.22",
     "sinon": "^7.3.2",
@@ -22,8 +24,10 @@
     "vue-class-component": "^6.0.0",
     "vue-property-decorator": "^7.0.0",
     "vue-router": "^3.0.1",
+    "vue-vuelidate-jsonschema": "^0.13.4",
     "vue2-filters": "^0.6.0",
     "vuelidate": "^0.7.4",
+    "vuelidate-error-extractor": "^2.3.0",
     "vuetify": "^1.5.6",
     "vuex": "^3.0.1"
   },

--- a/coops-ui/public/config/configuration.json
+++ b/coops-ui/public/config/configuration.json
@@ -1,4 +1,5 @@
 {
+  "VUE_APP_BASE_URL": "http://localhost:8080",
   "API_URL": "https://mock-lear-tools.pathfinder.gov.bc.ca/rest/legal-api/0.74/api/v1/businesses/",
   "PAY_URL": "not used?",
   "AUTH_URL": "https://auth-ui-dev.pathfinder.gov.bc.ca/",

--- a/coops-ui/public/schemas/person.json
+++ b/coops-ui/public/schemas/person.json
@@ -1,0 +1,25 @@
+{
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/person",
+  "type": "object",
+  "title": "The Person Schema",
+  "properties": {
+    "firstName": {
+      "type": "string",
+      "maxLength": 5
+    },
+    "lastName": {
+      "type": "string",
+      "maxLength": 5
+    },
+    "middleInitial": {
+      "type": "string",
+      "maxLength": 1
+    }
+  },
+  "required": [
+    "firstName",
+    "lastName"
+  ]
+}

--- a/coops-ui/src/main.ts
+++ b/coops-ui/src/main.ts
@@ -1,15 +1,16 @@
-import '@babel/polyfill'
+// import '@babel/polyfill'
+import 'core-js/stable'
+import 'regenerator-runtime/runtime'
 import Vue from 'vue'
-import '@/plugins/vuetify'
-import App from '@/App.vue'
-import Vuelidate from 'vuelidate'
 import Vue2Filters from 'vue2-filters'
 import Affix from 'vue-affix'
+import '@/plugins/vuetify'
+import '@/plugins/vuelidate'
+import '@/registerServiceWorker'
+import App from '@/App.vue'
 import router from '@/router'
 import store from '@/store/store'
-import '@/registerServiceWorker'
 
-Vue.use(Vuelidate)
 Vue.use(Vue2Filters)
 Vue.use(Affix)
 Vue.config.productionTip = false

--- a/coops-ui/src/plugins/vuelidate.ts
+++ b/coops-ui/src/plugins/vuelidate.ts
@@ -1,0 +1,6 @@
+import Vue from 'vue'
+import VueVuelidateJsonschema from 'vue-vuelidate-jsonschema'
+import Vuelidate from 'vuelidate'
+
+Vue.use(VueVuelidateJsonschema)
+Vue.use(Vuelidate)

--- a/coops-ui/src/router.ts
+++ b/coops-ui/src/router.ts
@@ -7,6 +7,8 @@ import axios from '@/axios-auth'
 Vue.use(Router)
 var payURL
 var authURL
+var appBaseURL
+
 /* load configurations from file */
 var req = new XMLHttpRequest()
 // TODO - change request to async:true once UI is more complete - currently too quick because we jump straight to AR
@@ -22,6 +24,8 @@ req.onreadystatechange = function (response) {
       console.log('Set payURL to: ' + payURL)
       authURL = JSON.parse(req.responseText)['AUTH_URL']
       console.log('Set authURL to: ' + authURL)
+      appBaseURL = JSON.parse(req.responseText)['VUE_APP_BASE_URL']
+      console.log('Set appBaseURL to: ' + appBaseURL)
     } else {
       // nothing
       console.log('could not load configurations')
@@ -32,12 +36,9 @@ req.send()
 Vue.mixin({
   data: function () {
     return {
-      get payURL () {
-        return payURL
-      },
-      get authURL () {
-        return authURL
-      }
+      payURL,
+      authURL,
+      appBaseURL
     }
   }
 })


### PR DESCRIPTION
*Issue #:* https://github.com/bcgov/entity/issues/754

*Description of changes:*

This is a Proof Of Concept of JSON Schema Validation using the vue-vuelidate-jsonschema package (which basically configures things for vuelidate).

Please review this PR and offer your opinion on whether / how we should use this to implement validation in the UI using the server-side object schemas ... add appropriate comments to the linked Zenhub ticket.

~~Do not merge this PR at this time... How we will proceed depends on what you guys think of this.~~
**Please accept this merge into a new bcgov branch so we can get back to it some time in the future.**

This PR:
- adds the necessary packages and loads them
- adds 'person' schema file locally into the coops-ui project (for now)
- loads the JSON schema file for person validation (ie, for this POC)
- adds the sample UI code for this POC (including validation errors)
- adds the schema object that creates the vuelidate properties
- adds code to implement the 'required' property
- adds methods to validate or reset the subject controls


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
