### PR TITLE
Fixed auth error - UI app not setting keycloak, bouncing back to auth every time

### DIFF
--- a/coops-ui/public/config/configuration.json
+++ b/coops-ui/public/config/configuration.json
@@ -1,6 +1,6 @@
 {
   "API_URL": "https://mock-lear-tools.pathfinder.gov.bc.ca/rest/legal-api/0.74/api/v1/businesses/",   
-  "AUTH_URL": "https://auth-web-dev.pathfinder.gov.bc.ca/",
+  "AUTH_URL": "https://auth-web-dev.pathfinder.gov.bc.ca",
   "AUTH_API_URL": "https://auth-api-dev.pathfinder.gov.bc.ca/",
   "PAY_API_URL": "https://pay-api-dev.pathfinder.gov.bc.ca/", 
   "CP_CSS_URL": "http://ws1.postescanada-canadapost.ca/css/addresscomplete-2.00.min.css?key=",

--- a/coops-ui/src/App.vue
+++ b/coops-ui/src/App.vue
@@ -28,14 +28,14 @@ export default {
     // get Keycloak Token
     const token = sessionStorage.getItem('KEYCLOAK_TOKEN')
     if (!token) {
-      console.err('App error - Keycloak Token is null')
+      console.error('App error - Keycloak Token is null')
       return
     }
 
     // decode Username
     const username = this.parseJwt(token).preferred_username
     if (!username) {
-      console.err('App error - Username is null')
+      console.error('App error - Username is null')
       return
     }
 

--- a/coops-ui/src/router.ts
+++ b/coops-ui/src/router.ts
@@ -49,7 +49,11 @@ Vue.mixin({
 })
 
 window.addEventListener('message', function (e) {
+  console.log('got here 1')
+  console.log('e.origin=' + e.origin)
   if (e.origin === authURL) {
+    console.log('got here 2')
+    console.log(JSON.parse(e.data))
     const data = JSON.parse(e.data)
     sessionStorage.setItem('KEYCLOAK_TOKEN', data['access_token'])
     sessionStorage.setItem('KEYCLOAK_REFRESH_TOKEN', data['refresh_token'])

--- a/coops-ui/src/router.ts
+++ b/coops-ui/src/router.ts
@@ -49,11 +49,7 @@ Vue.mixin({
 })
 
 window.addEventListener('message', function (e) {
-  console.log('got here 1')
-  console.log('e.origin=' + e.origin)
-  if (e.origin === authURL) {
-    console.log('got here 2')
-    console.log(JSON.parse(e.data))
+  if (e.origin === authURL) { // assumes authURL does not have slash if referrer URL does not have slash
     const data = JSON.parse(e.data)
     sessionStorage.setItem('KEYCLOAK_TOKEN', data['access_token'])
     sessionStorage.setItem('KEYCLOAK_REFRESH_TOKEN', data['refresh_token'])

--- a/coops-ui/src/router.ts
+++ b/coops-ui/src/router.ts
@@ -51,9 +51,9 @@ Vue.mixin({
 window.addEventListener('message', function (e) {
   if (e.origin === authURL) {
     const data = JSON.parse(e.data)
-    sessionStorage.setItem('KEYCLOAK_TOKEN', data.access_token)
-    sessionStorage.setItem('KEYCLOAK_REFRESH_TOKEN', data.refresh_token)
-    sessionStorage.setItem('REGISTRIES_TRACE_ID', data.registries_trace_id)
+    sessionStorage.setItem('KEYCLOAK_TOKEN', data['access_token'])
+    sessionStorage.setItem('KEYCLOAK_REFRESH_TOKEN', data['refresh_token'])
+    sessionStorage.setItem('REGISTRIES_TRACE_ID', data['registries_trace_id'])
     sessionStorage.setItem('REDIRECTED', 'false')
   }
 })


### PR DESCRIPTION
*Issue #:* n/a

*Description of changes:*
The issue was actually a mismatch between the auth_url config and the referrer URL from the auth app - one had slash, the other didn't. Changed it in dev config map to fix in dev, changed here also with addition bug fix in related error messages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
