### PR TITLE
replaced deprecated @babel/polyfill package

### DIFF
--- a/coops-ui/package.json
+++ b/coops-ui/package.json
@@ -12,12 +12,13 @@
     "test:unit-silent": "vue-cli-service test:unit --silent"
   },
   "dependencies": {
-    "@babel/polyfill": "^7.0.0-rc.1",
     "axios": "^0.18.0",
+    "core-js": "^3.1.4",
+    "regenerator-runtime": "^0.13.3",
     "register-service-worker": "^1.6.2",
     "sbc-common-components": "^0.0.24",
     "sinon": "^7.3.2",
-    "vue": "^2.6.6",
+    "vue": "^2.6.10",
     "vue-affix": "^0.5.2",
     "vue-class-component": "^6.0.0",
     "vue-property-decorator": "^7.0.0",
@@ -48,6 +49,6 @@
     "ts-jest": "^23.0.0",
     "typescript": "^3.2.1",
     "vue-cli-plugin-vuetify": "^0.5.0",
-    "vue-template-compiler": "^2.5.21"
+    "vue-template-compiler": "^2.6.10"
   }
 }

--- a/coops-ui/src/main.ts
+++ b/coops-ui/src/main.ts
@@ -1,4 +1,5 @@
-import '@babel/polyfill'
+import 'core-js/stable' // to polyfill ECMAScript features
+import 'regenerator-runtime/runtime' // to use transpiled generator functions
 import Vue from 'vue'
 import '@/plugins/vuetify'
 import App from '@/App.vue'


### PR DESCRIPTION
*Issue #:* no ticket for this

*Description of changes:*

- replaced deprecated @babel/polyfill package (see https://babeljs.io/docs/en/babel-polyfill)
- also bumped vue and vue-template-compiler versions to latest
- npm run build passes
- npm run test:unit passes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
