### PR TITLE
Change token storage

### DIFF
--- a/coops-ui/package.json
+++ b/coops-ui/package.json
@@ -19,7 +19,7 @@
     "lodash.isempty": "^4.4.0",
     "regenerator-runtime": "^0.13.3",
     "register-service-worker": "^1.6.2",
-    "sbc-common-components": "^0.0.26",
+    "sbc-common-components": "^0.0.27",
     "sinon": "^7.3.2",
     "vue": "^2.6.10",
     "vue-affix": "^0.5.2",

--- a/coops-ui/public/config/configuration.json
+++ b/coops-ui/public/config/configuration.json
@@ -1,6 +1,6 @@
 {
   "API_URL": "https://mock-lear-tools.pathfinder.gov.bc.ca/rest/legal-api/0.77/api/v1/businesses/",
-  "AUTH_URL": "https://auth-web-dev.pathfinder.gov.bc.ca",
+  "AUTH_URL": "https://coops-dev.pathfinder.gov.bc.ca/auth/",
   "AUTH_API_URL": "https://auth-api-dev.pathfinder.gov.bc.ca/",
   "PAY_API_URL": "https://pay-api-dev.pathfinder.gov.bc.ca/",
   "ADDRESS_COMPLETE_KEY": "RZ86-BB54-CM96-EE26"

--- a/coops-ui/src/router.ts
+++ b/coops-ui/src/router.ts
@@ -61,18 +61,6 @@ Vue.mixin({
   }
 })
 
-/*
-window.addEventListener('message', function (e) {
-  if (e.origin === authURL) { // assumes authURL does not have slash if referrer URL does not have slash
-    const data = JSON.parse(e.data)
-    sessionStorage.setItem('KEYCLOAK_TOKEN', data['access_token'])
-    sessionStorage.setItem('KEYCLOAK_REFRESH_TOKEN', data['refresh_token'])
-    sessionStorage.setItem('REGISTRIES_TRACE_ID', data['registries_trace_id'])
-    sessionStorage.setItem('REDIRECTED', 'false')
-  }
-})
-*/
-
 let router = new VueRouter({
   mode: 'history',
   base: process.env.BASE_URL,

--- a/coops-ui/src/router.ts
+++ b/coops-ui/src/router.ts
@@ -61,6 +61,7 @@ Vue.mixin({
   }
 })
 
+/*
 window.addEventListener('message', function (e) {
   if (e.origin === authURL) { // assumes authURL does not have slash if referrer URL does not have slash
     const data = JSON.parse(e.data)
@@ -70,6 +71,7 @@ window.addEventListener('message', function (e) {
     sessionStorage.setItem('REDIRECTED', 'false')
   }
 })
+*/
 
 let router = new VueRouter({
   mode: 'history',


### PR DESCRIPTION
*Issue #:* n/a

*Description of changes:*
In coordination with relationships team - removed listener/setter for keycloak token session storage, since the coops app and auth app will now be on same domain, so it will be set by auth app and be available automatically in session storage for coops app.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
