### PR TITLE
Added actions list (empty) to get past schema validation failure.

### DIFF
--- a/coops-ui/src/components/AnnualReport/Directors.vue
+++ b/coops-ui/src/components/AnnualReport/Directors.vue
@@ -556,6 +556,8 @@ export default {
                 directors[i].isDirectorActive = true
                 directors[i].isFeeApplied = false
                 directors[i].isDirectorActionable = directors[i].cessationDate == null
+
+                directors[i].actions = []
               }
 
               // save to component data now that extra attributes are added

--- a/coops-ui/src/components/AnnualReport/RegisteredOfficeAddress.vue
+++ b/coops-ui/src/components/AnnualReport/RegisteredOfficeAddress.vue
@@ -321,6 +321,8 @@ export default class RegisteredOfficeAddress extends Vue {
           if (response && response.data) {
             const deliveryAddress = response.data.deliveryAddress
             if (deliveryAddress) {
+              deliveryAddress.actions = []
+
               this.deliveryAddressOriginal = { ...deliveryAddress }
               // If parent page loaded draft before this API call, don't overwrite draft delivery address.
               // Otherwise this API call finished before parent page loaded draft, or parent page won't
@@ -332,6 +334,8 @@ export default class RegisteredOfficeAddress extends Vue {
 
             const mailingAddress = response.data.mailingAddress
             if (mailingAddress) {
+              mailingAddress.actions = []
+
               this.mailingAddressOriginal = { ...mailingAddress }
               // If parent page loaded draft before this API call, don't overwrite draft mailng address
               // Otherwise this API call finished before parent page loaded draft, or parent page won't


### PR DESCRIPTION
*Issue #:* /bcgov/entity#1015

*Description of changes:*
Added actions list (empty) to get past schema validation failure.
This is WIP for the task - the very first step in the implementation, committed only to get past API validation failure based on not matching updated schema.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
