### PR TITLE
Fix - Appointed/Cease dates are spaced unevenly

### DIFF
--- a/coops-ui/src/components/AnnualReport/Directors.vue
+++ b/coops-ui/src/components/AnnualReport/Directors.vue
@@ -869,6 +869,7 @@ export default {
   .address
     display flex
     flex-direction column
+    width 10rem
 
   .address__row
     flex 1 1 auto


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*
Fix for the uneven spacing of appointed/ceased dates in directors component

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
