### PR TITLE
Fixed a linter warning - 500s are handled automatically (1012).

### DIFF
--- a/legal-api/src/legal_api/reports/__init__.py
+++ b/legal-api/src/legal_api/reports/__init__.py
@@ -9,8 +9,6 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-import sys
-from flask import current_app
 from http import HTTPStatus
 
 from .report import Report
@@ -22,7 +20,3 @@ def get_pdf(filing):
     except FileNotFoundError:
         # We don't have a template for it, so it must only be available on paper.
         return 'Available on paper only', HTTPStatus.NOT_FOUND
-    except:
-        current_app.logger.error("Unexpected error:", sys.exc_info())
-
-        return '', HTTPStatus.INTERNAL_SERVER_ERROR


### PR DESCRIPTION
*Issue #:* /bcgov/entity#1012

*Description of changes:* Fixed a linter warning about catching all exceptions. No need to do so to return a 500, this is done automatically by the subsystem.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
