### PR TITLE
add sentry.io in to track erred queue messages

### DIFF
--- a/entity-filer/.envrc
+++ b/entity-filer/.envrc
@@ -1,3 +1,6 @@
-while read -r line; do export $line; echo $line; done < .env
+while read -r line; do
+    echo $line
+    [[ "$line" =~ ^#.*$ ]] && continue
+    export $line
+done < .env
 source venv/bin/activate
-#source .env

--- a/entity-filer/k8s/templates/entity-filer-deploy.json
+++ b/entity-filer/k8s/templates/entity-filer-deploy.json
@@ -142,6 +142,15 @@
                                         }
                                     },
                                     {
+                                        "name": "SENTRY_DSN",
+                                        "valueFrom": {
+                                            "configMapKeyRef": {
+                                                "name": "${NAME}-${TAG_NAME}-config",
+                                                "key": "SENTRY_DSN"
+                                            }
+                                        }
+                                    },
+                                    {
                                         "name": "NATS_SERVERS",
                                         "valueFrom": {
                                             "configMapKeyRef": {
@@ -214,6 +223,7 @@
                 "DB_PORT": "5432",
                 "JWT_OIDC_JWKS_CACHE_TIMEOUT": "300",
                 "PAYMENT_SVC_URL": "${PAYMENT_SVC_URL}",
+                "SENTRY_DSN": "${SENTRY_DSN}",
                 "NATS_SERVERS": "${NATS_SERVERS}",
                 "NATS_CLUSTER_ID": "${NATS_CLUSTER_ID}",
                 "NATS_CLIENT_NAME": "${NATS_CLIENT_NAME}",
@@ -243,6 +253,13 @@
             "description": "A valid database name used by the service.",
             "required": true,
             "value": "lear"
+        },
+        {
+            "name": "SENTRY_DSN",
+            "displayName": "Sentry Init URL",
+            "description": "Sentry DSN URL to initialize the Sentry SDK",
+            "required": true,
+            "value": "https://account.sentry.ioo/project/id"
         },
         {
             "name": "PAYMENT_SVC_URL",

--- a/entity-filer/pay_filer.py
+++ b/entity-filer/pay_filer.py
@@ -17,9 +17,11 @@
 """s2i based launch script to run the service."""
 import asyncio
 
+from entity_filer.version import __version__
 from entity_filer.service import run
 
 if __name__ == '__main__':
+
     event_loop = asyncio.get_event_loop()
     event_loop.run_until_complete(run(event_loop))
     try:

--- a/entity-filer/requirements/dev.txt
+++ b/entity-filer/requirements/dev.txt
@@ -4,6 +4,7 @@
 # Testing
 pytest
 pytest-mock
+pytest-asyncio
 requests
 pyhamcrest
 dpath
@@ -25,4 +26,3 @@ pylint-flask
 # docker
 lovely-pytest-docker
 pytest_docker
-pytest-asyncio

--- a/entity-filer/src/entity_filer/service_utils/exceptions.py
+++ b/entity-filer/src/entity_filer/service_utils/exceptions.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Callbacks and utility functions used to support the service loop."""
-from .exceptions import QueueException
-from .handlers import closed_cb, error_cb, signal_handler
-from .run_version import get_run_version
-from .service_logger import logger
+"""Exceptions defined for the Queue Service."""
+
+
+class QueueException(Exception):
+    """Base exception for the Queue Services."""

--- a/entity-filer/src/entity_filer/service_utils/service_logger.py
+++ b/entity-filer/src/entity_filer/service_utils/service_logger.py
@@ -16,7 +16,29 @@
 # TODO: logging format should be moved to an external config file
 """
 import logging
+import os
 
+import sentry_sdk
+from sentry_sdk.integrations.logging import LoggingIntegration
+
+
+def before_breadcrumb(crumb, hint):  # pylint: disable=unused-argument; callback function signature from sentry
+    """Render nothing for the breadcrumb history."""
+    return None
+
+
+# Configure Sentry
+SENTRY_DSN = os.getenv('SENTRY_DSN', None)
+if SENTRY_DSN:
+
+    SENTRY_LOGGING = LoggingIntegration(
+        event_level=logging.ERROR  # Send errors as events
+    )
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,
+        integrations=[SENTRY_LOGGING],
+        before_breadcrumb=before_breadcrumb
+    )
 
 logging.basicConfig(
     level=logging.INFO,

--- a/entity-filer/tests/unit/__init__.py
+++ b/entity-filer/tests/unit/__init__.py
@@ -58,7 +58,8 @@ COA_FILING = {
                 'addressCountry': 'CA',
                 'addressRegion': 'BC',
                 'postalCode': 'T3S T3R',
-                'deliveryInstructions': 'Test address delivery'
+                'deliveryInstructions': 'Test address delivery',
+                'actions': []
             },
             'mailingAddress': {
                 'streetAddress': 'test lane',
@@ -67,7 +68,8 @@ COA_FILING = {
                 'addressCountry': 'CA',
                 'addressRegion': 'BC',
                 'postalCode': 'T3S T3R',
-                'deliveryInstructions': 'Test address mailing'
+                'deliveryInstructions': 'Test address mailing',
+                'actions': []
             },
             'certifiedBy': 'full name',
             'email': 'no_one@never.get'
@@ -108,6 +110,7 @@ COD_FILING = {
                         'postalCode': 'T3S T3R',
                         'deliveryInstructions': 'director1'
                     },
+                    'actions': []
                 },
                 {
                     'title': 'title',
@@ -127,6 +130,7 @@ COD_FILING = {
                         'postalCode': 'T3S T3R',
                         'deliveryInstructions': 'director2'
                     },
+                    'actions': []
                 },
                 {
                     'title': 'title',
@@ -146,6 +150,7 @@ COD_FILING = {
                         'postalCode': 'T3S T3R',
                         'deliveryInstructions': 'director3'
                     },
+                    'actions': []
                 },
                 {
                     'title': 'title',
@@ -165,6 +170,7 @@ COD_FILING = {
                         'postalCode': 'T3S T3R',
                         'deliveryInstructions': 'director4'
                     },
+                    'actions': []
                 }
             ],
             'certifiedBy': 'full name',

--- a/legal-api/.envrc
+++ b/legal-api/.envrc
@@ -1,3 +1,6 @@
-##while read -r line; do export $line; echo $line; done < .env
+while read -r line; do
+    echo $line
+    [[ "$line" =~ ^#.*$ ]] && continue
+    export $line
+done < .env
 source venv/bin/activate
-source .env

--- a/legal-api/k8s/templates/legal-api-deploy.json
+++ b/legal-api/k8s/templates/legal-api-deploy.json
@@ -175,15 +175,6 @@
                                         }
                                     },
                                     {
-                                        "name": "GO_LIVE_DATE",
-                                        "valueFrom": {
-                                            "configMapKeyRef": {
-                                                "name": "${NAME}-${TAG_NAME}-config",
-                                                "key": "GO_LIVE_DATE"
-                                            }
-                                        }
-                                    },
-                                    {
                                         "name": "DATABASE_HOST",
                                         "valueFrom": {
                                             "configMapKeyRef": {
@@ -198,6 +189,24 @@
                                             "configMapKeyRef": {
                                                 "name": "${NAME}-${TAG_NAME}-config",
                                                 "key": "DB_PORT"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "GO_LIVE_DATE",
+                                        "valueFrom": {
+                                            "configMapKeyRef": {
+                                                "name": "${NAME}-${TAG_NAME}-config",
+                                                "key": "GO_LIVE_DATE"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "SENTRY_DSN",
+                                        "valueFrom": {
+                                            "configMapKeyRef": {
+                                                "name": "${NAME}-${TAG_NAME}-config",
+                                                "key": "SENTRY_DSN"
                                             }
                                         }
                                     },
@@ -368,6 +377,7 @@
             },
             "data": {
                 "GO_LIVE_DATE": "${GO_LIVE_DATE}",
+                "SENTRY_DSN": "${SENTRY_DSN}",
                 "DATABASE_HOST": "postgresql-${TAG_NAME}",
                 "DATABASE_NAME": "${DATABASE_NAME}",
                 "DB_PORT": "${DB_PORT}",
@@ -485,6 +495,13 @@
             "description": "Go Live Date of the system, used for MVP for things such as blocking legacy filings.",
             "required": true,
             "value": "2019-08-12"
+        },
+        {
+            "name": "SENTRY_DSN",
+            "displayName": "Sentry Init URL",
+            "description": "Sentry DSN URL to initialize the Sentry SDK",
+            "required": true,
+            "value": "https://account.sentry.ioo/project/id"
         },
         {
             "name": "DB_PORT",


### PR DESCRIPTION
Signed-off-by: thor wolpert <thor@wolpert.ca>

*Issue #:* /bcgov/entity#1038

*Description of changes:*
- add sentry.io in to track msgs popped off the queue for errors to be managed manually.
- updated test data for actions[]
- updated legal-api to use the Sentry DSN

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
