### PR TITLE
changed package spec from git to https

### DIFF
--- a/coops-ui/package.json
+++ b/coops-ui/package.json
@@ -54,6 +54,6 @@
     "typescript": "^3.2.1",
     "vue-cli-plugin-vuetify": "^0.5.0",
     "vue-template-compiler": "^2.6.10",
-    "vue-test-utils-helpers": "git+ssh://git@github.com/AmpleOrganics/vue-test-utils-helpers.git"
+    "vue-test-utils-helpers": "git+https://github.com/AmpleOrganics/vue-test-utils-helpers.git"
   }
 }


### PR DESCRIPTION
*Description of changes:*
- changed the spec for a new (dev dependency) package from git+ssh to git+https
- this is because git+ssh works locally but not on the build server

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
