### PR TITLE
load Certified By on resume + unit tests

### DIFF
--- a/coops-ui/src/components/AnnualReport/Certify.vue
+++ b/coops-ui/src/components/AnnualReport/Certify.vue
@@ -1,35 +1,33 @@
 <template>
   <v-card flat id="AR-step-4-container">
     <div class="container">
-        <div class="certifiedby-container">
-            <label>
-            <span>Legal Name</span>
-            </label>
-            <div class="value certifiedby">
-            <v-text-field
-                id="certified-by-textfield"
-                v-model="certifiedBy"
-                label="Name of current director, officer, or lawyer of the association"
-                box
-            />
-            </div>
+      <div class="certifiedby-container">
+        <label>
+          <span>Legal Name</span>
+        </label>
+        <div class="value certifiedby">
+          <v-text-field
+            id="certified-by-textfield"
+            v-model="certifyTextField"
+            label="Name of current director, officer, or lawyer of the association"
+            box
+          />
         </div>
-        <v-checkbox v-model="certifyCheckbox">
-            <template slot="label">
-            <div class="certify-stmt">
-                I,
-                <b>{{displayCertifyName}}</b>, certify
-                that I have relevant knowledge of the association and that I am authorized to make
-                this filing.
-            </div>
-            </template>
-        </v-checkbox>
-        <p class="certify-clause">{{currentDate}}</p>
-        <p class="certify-clause">
-            Note: It is an offence to make a false or misleading statement in
-            respect of a material fact in a record submitted to the Corporate Registry for filing.
-            See section 200 of the Cooperatives Association Act.
-        </p>
+      </div>
+      <v-checkbox v-model="certifyCheckbox">
+        <template slot="label">
+          <div class="certify-stmt">
+            I, <b>{{trimmedCertifiedTextField || '[Legal Name]'}}</b>, certify that I have relevant knowledge of the
+            association and that I am authorized to make this filing.
+          </div>
+        </template>
+      </v-checkbox>
+      <p class="certify-clause">{{currentDate}}</p>
+      <p class="certify-clause">
+        Note: It is an offence to make a false or misleading statement in
+        respect of a material fact in a record submitted to the Corporate Registry for filing.
+        See section 200 of the Cooperatives Association Act.
+      </p>
     </div>
   </v-card>
 </template>
@@ -40,39 +38,45 @@ import { mapState } from 'vuex'
 export default {
   name: 'Certify',
 
+  props: {
+    certifiedBy: String,
+    isCertified: Boolean
+  },
+
   data () {
     return {
-      certifyCheckbox: false,
-      certifiedBy: ''
+      certifyTextField: '',
+      certifyCheckbox: false
     }
   },
 
   computed: {
     ...mapState(['currentDate']),
 
-    isCertifyValid () {
-      return this.certifyCheckbox && this.certifiedBy.trim() !== ''
+    trimmedCertifiedTextField () /* string */ {
+      return this.certifyTextField && this.certifyTextField.trim()
     },
 
-    displayCertifyName () {
-      return this.certifiedBy.trim() === ''
-        ? '[Legal Name]'
-        : this.certifiedBy.trim()
-    }
-  },
-
-  methods: {
-    getLegalName () {
-      return this.certifiedBy
+    isCertifyValid () /* boolean */ {
+      return !!(this.certifyCheckbox && this.trimmedCertifiedTextField)
     }
   },
 
   watch: {
-    isCertifyValid: function (val) {
-      this.$emit('certifyChange', val)
+    certifiedBy (val) {
+      this.certifyTextField = val
     },
-    certifiedBy: function (val) {
-      this.$emit('certifiedBy', this.getLegalName())
+
+    isCertified (val) {
+      this.certifyCheckbox = val
+    },
+
+    trimmedCertifiedTextField: function (val) {
+      this.$emit('update:certifiedBy', val)
+    },
+
+    isCertifyValid: function (val) {
+      this.$emit('update:isCertified', val)
     }
   }
 }

--- a/coops-ui/src/views/StandaloneDirectorsFiling.vue
+++ b/coops-ui/src/views/StandaloneDirectorsFiling.vue
@@ -119,7 +119,9 @@
                 <h2 id="AR-step-4-header">Certify Correct</h2>
                 <p>Enter the name of the current director, officer, or lawyer submitting this Annual Report.</p>
               </header>
-              <Certify @certifyChange="changeCertifyData" @certifiedBy="certifiedBy=$event" ref="certifyClause"/>
+              <Certify
+                :isCertified.sync="isCertified"
+                :certifiedBy.sync="certifiedBy" />
             </section>
           </div>
         </article>
@@ -203,8 +205,8 @@ export default {
       saveErrorDialog: false,
       paymentErrorDialog: false,
       lastFilingDate: 'your last filing',
-      certifyChange: false,
-      certifiedBy: null,
+      isCertified: false,
+      certifiedBy: '',
       directorFormValid: true,
       saving: false,
       savingResuming: false,
@@ -217,7 +219,7 @@ export default {
     ...mapState(['currentDate', 'corpNum', 'entityName', 'entityIncNo', 'entityFoundingDate']),
 
     validated () {
-      return (this.certifyChange && this.directorFormValid && this.filingData.length > 0)
+      return (this.isCertified && this.directorFormValid && this.filingData.length > 0)
     },
 
     saveButtonEnabled () {
@@ -282,11 +284,6 @@ export default {
       this.haveChanges = true
       // when directors change, update filing data
       this.toggleFiling(modified ? 'add' : 'remove', 'OTCDR')
-    },
-
-    changeCertifyData (val) {
-      this.haveChanges = true
-      this.certifyChange = val
     },
 
     async onClickSave () {
@@ -357,6 +354,7 @@ export default {
           changeOfDirectors: {
             certifiedBy: this.certifiedBy || '',
             email: 'no_one@never.get',
+            // TODO: change this to a local property
             directors: this.$refs.directorsList.getAllDirectors()
           }
         }
@@ -454,14 +452,19 @@ export default {
             const changeOfDirectors = filing.changeOfDirectors
             if (changeOfDirectors) {
               if (changeOfDirectors.directors && changeOfDirectors.directors.length > 0) {
-                this.$refs.directorsList.setAllDirectors(changeOfDirectors.directors)
+                if (this.$refs.directorsList.setAllDirectors) {
+                  this.$refs.directorsList.setAllDirectors(changeOfDirectors.directors)
+                }
+                this.certifiedBy = changeOfDirectors.certifiedBy
                 this.toggleFiling('add', 'OTCDR')
               } else {
                 throw new Error('invalid change of directors')
               }
             } else {
-              // To handle the condition of save as draft withouot change of director
-              this.$refs.directorsList.getDirectors()
+              // To handle the condition of save as draft without change of director
+              if (this.$refs.directorsList.getDirectors) {
+                this.$refs.directorsList.getDirectors()
+              }
             }
           } catch (err) {
             console.log(`fetchData() error - ${err.message}, filing =`, filing)
@@ -472,6 +475,16 @@ export default {
         console.error('fetchData() error =', error)
         this.resumeErrorDialog = true
       })
+    }
+  },
+
+  watch: {
+    isCertified (val) {
+      this.haveChanges = true
+    },
+
+    certifiedBy (val) {
+      this.haveChanges = true
     }
   }
 }

--- a/coops-ui/src/views/StandaloneOfficeAddressFiling.vue
+++ b/coops-ui/src/views/StandaloneOfficeAddressFiling.vue
@@ -115,7 +115,9 @@
                 <h2 id="AR-step-4-header">Certify Correct</h2>
                 <p>Enter the name of the current director, officer, or lawyer submitting this Annual Report.</p>
               </header>
-              <Certify @certifyChange="changeCertifyData" @certifiedBy="certifiedBy=$event" ref="certifyClause"/>
+              <Certify
+                :isCertified.sync="isCertified"
+                :certifiedBy.sync="certifiedBy" />
             </section>
           </div>
         </article>
@@ -200,8 +202,8 @@ export default {
       resumeErrorDialog: false,
       saveErrorDialog: false,
       paymentErrorDialog: false,
-      certifyChange: false,
-      certifiedBy: null,
+      isCertified: false,
+      certifiedBy: '',
       officeAddressFormValid: true,
       saving: false,
       savingResuming: false,
@@ -214,7 +216,7 @@ export default {
     ...mapState(['currentDate', 'corpNum', 'entityName', 'entityIncNo', 'entityFoundingDate']),
 
     validated () {
-      return (this.certifyChange && this.officeAddressFormValid && this.filingData.length > 0)
+      return (this.isCertified && this.officeAddressFormValid && this.filingData.length > 0)
     },
 
     saveAsDraftEnabled () {
@@ -313,6 +315,7 @@ export default {
                   deliveryAddress: changeOfAddress.deliveryAddress,
                   mailingAddress: changeOfAddress.mailingAddress
                 }
+                this.certifiedBy = changeOfAddress.certifiedBy
                 this.toggleFiling('add', 'OTADD')
               } else {
                 throw new Error('invalid change of address')
@@ -342,11 +345,6 @@ export default {
       this.haveChanges = true
       // when addresses change, update filing data
       this.toggleFiling(modified ? 'add' : 'remove', 'OTADD')
-    },
-
-    changeCertifyData (val) {
-      this.haveChanges = true
-      this.certifyChange = val
     },
 
     async onClickSave () {
@@ -496,6 +494,16 @@ export default {
       this.haveChanges = false
       this.dialog = false
       this.$router.push('/dashboard')
+    }
+  },
+
+  watch: {
+    isCertified (val) {
+      this.haveChanges = true
+    },
+
+    certifiedBy (val) {
+      this.haveChanges = true
     }
   }
 }

--- a/coops-ui/tests/unit/StandaloneDirectorsFiling.spec.ts
+++ b/coops-ui/tests/unit/StandaloneDirectorsFiling.spec.ts
@@ -13,7 +13,48 @@ import Certify from '@/components/AnnualReport/Certify.vue'
 Vue.use(Vuetify)
 Vue.use(Vuelidate)
 
-describe('Standalone Directors Filing - Part 1', () => {
+const sampleDirectors = [
+  {
+    'officer': {
+      'firstName': 'Peter',
+      'middleInitial': null,
+      'lastName': 'Griffin'
+    },
+    'deliveryAddress': {
+      'streetAddress': 'Peter Griffin delivery street address',
+      'streetAddressAdditional': null,
+      'addressCity': 'deliv address city',
+      'addressCountry': 'deliv country',
+      'postalCode': 'H0H0H0',
+      'addressRegion': 'BC',
+      'deliveryInstructions': null
+    },
+    'title': null,
+    'appointmentDate': '2015-10-11',
+    'cessationDate': null
+  },
+  {
+    'officer': {
+      'firstName': 'Joe',
+      'middleInitial': 'P',
+      'lastName': 'Swanson'
+    },
+    'deliveryAddress': {
+      'streetAddress': 'Joe Swanson delivery street address',
+      'streetAddressAdditional': 'Kirkintiloch',
+      'addressCity': 'Glasgow',
+      'addressCountry': 'UK',
+      'postalCode': 'H0H 0H0',
+      'addressRegion': 'Scotland',
+      'deliveryInstructions': 'go to the back'
+    },
+    'title': 'Treasurer',
+    'appointmentDate': '2015-10-11',
+    'cessationDate': '2019-07-22'
+  }
+]
+
+describe('Standalone Directors Filing - Part 1 - UI', () => {
   beforeEach(() => {
     // init store
     store.state.corpNum = 'CP0001191'
@@ -40,7 +81,7 @@ describe('Standalone Directors Filing - Part 1', () => {
 
     // set flags
     vm.directorFormValid = true
-    vm.changeCertifyData(true)
+    vm.isCertified = true
 
     // set stub list of filings
     vm.filingData.push({})
@@ -58,7 +99,7 @@ describe('Standalone Directors Filing - Part 1', () => {
 
     // set flags
     vm.directorFormValid = false
-    vm.changeCertifyData(true)
+    vm.isCertified = true
 
     // set stub list of filings
     vm.filingData.push({})
@@ -76,7 +117,7 @@ describe('Standalone Directors Filing - Part 1', () => {
 
     // set flags
     vm.directorFormValid = true
-    vm.changeCertifyData(false)
+    vm.isCertified = false
 
     // set stub list of filings
     vm.filingData.push({})
@@ -94,7 +135,7 @@ describe('Standalone Directors Filing - Part 1', () => {
 
     // set flags
     vm.directorFormValid = true
-    vm.changeCertifyData(true)
+    vm.isCertified = true
 
     // set stub list of filings
     vm.filingData = []
@@ -112,7 +153,7 @@ describe('Standalone Directors Filing - Part 1', () => {
 
     // set flag
     vm.directorFormValid = true
-    vm.changeCertifyData(true)
+    vm.isCertified = true
 
     // set stub list of filings
     vm.filingData.push({})
@@ -130,7 +171,7 @@ describe('Standalone Directors Filing - Part 1', () => {
 
     // set flag
     vm.directorFormValid = true
-    vm.changeCertifyData(false)
+    vm.isCertified = false
 
     // set stub list of filings
     vm.filingData.push({})
@@ -142,7 +183,66 @@ describe('Standalone Directors Filing - Part 1', () => {
   })
 })
 
-describe('Standalone Directors Filing - Part 2', () => {
+describe('Standalone Directors Filing - Part 2 - Resuming', () => {
+  beforeEach(async () => {
+    // init store
+    store.state.corpNum = 'CP0001191'
+    store.state.entityIncNo = 'CP0001191'
+    store.state.entityName = 'Legal Name - CP0001191'
+
+    // mock "fetch a draft filing" endpoint
+    sinon.stub(axios, 'get').withArgs('CP0001191/filings/123')
+      .returns(new Promise((resolve) => resolve({
+        data:
+          {
+            'filing': {
+              'changeOfDirectors': {
+                'directors': sampleDirectors,
+                'certifiedBy': 'Full Name',
+                'email': 'no_one@never.get'
+              },
+              'business': {
+                'cacheId': 1,
+                'foundingDate': '2007-04-08',
+                'identifier': 'CP0001191',
+                'lastLedgerTimestamp': '2019-04-15T20:05:49.068272+00:00',
+                'legalName': 'Legal Name - CP0001191'
+              },
+              'header': {
+                'name': 'changeOfDirectors',
+                'date': '2017-06-06',
+                'submitter': 'cp0001191',
+                'status': 'DRAFT',
+                'filingId': 123
+              }
+            }
+          }
+      })))
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it('fetches a draft AR filing', done => {
+    const $route = { params: { id: '123' } } // draft filing id
+    const wrapper = shallowMount(StandaloneDirectorsFiling, { store, mocks: { $route } })
+    const vm = wrapper.vm as any
+
+    Vue.nextTick(() => {
+      // verify that Certified By was restored
+      expect(vm.certifiedBy).toBe('Full Name')
+      expect(vm.isCertified).toBe(false)
+
+      // FUTURE - verify that changed directors were restored
+
+      wrapper.destroy()
+      done()
+    })
+  })
+})
+
+describe('Standalone Directors Filing - Part 3 - Submitting', () => {
   const { assign } = window.location
 
   beforeAll(() => {
@@ -160,47 +260,6 @@ describe('Standalone Directors Filing - Part 2', () => {
     store.state.corpNum = 'CP0001191'
     store.state.entityIncNo = 'CP0001191'
     store.state.entityName = 'Legal Name - CP0001191'
-
-    const sampleDirectors = [
-      {
-        'officer': {
-          'firstName': 'Peter',
-          'middleInitial': null,
-          'lastName': 'Griffin'
-        },
-        'deliveryAddress': {
-          'streetAddress': 'mailing_address - address line one',
-          'streetAddressAdditional': null,
-          'addressCity': 'mailing_address city',
-          'addressCountry': 'mailing_address country',
-          'postalCode': 'H0H0H0',
-          'addressRegion': 'BC',
-          'deliveryInstructions': null
-        },
-        'title': null,
-        'appointmentDate': '2015-10-11',
-        'cessationDate': null
-      },
-      {
-        'officer': {
-          'firstName': 'Joe',
-          'middleInitial': 'P',
-          'lastName': 'Swanson'
-        },
-        'deliveryAddress': {
-          'streetAddress': 'mailing_address - address line #1',
-          'streetAddressAdditional': 'Kirkintiloch',
-          'addressCity': 'Glasgow',
-          'addressCountry': 'UK',
-          'postalCode': 'H0H 0H0',
-          'addressRegion': 'Scotland',
-          'deliveryInstructions': 'go to the back'
-        },
-        'title': 'Treasurer',
-        'appointmentDate': '2015-10-11',
-        'cessationDate': '2019-07-22'
-      }
-    ]
 
     // mock "fetch a draft filing" endpoint
     sinon.stub(axios, 'get').withArgs('CP0001191/filings/123')
@@ -304,7 +363,7 @@ describe('Standalone Directors Filing - Part 2', () => {
 
       // make sure form is validated
       vm.directorFormValid = true
-      vm.changeCertifyData(true)
+      vm.isCertified = true
 
       // sanity check
       expect(jest.isMockFunction(window.location.assign)).toBe(true)
@@ -333,7 +392,7 @@ describe('Standalone Directors Filing - Part 2', () => {
 
     // make sure form is validated
     vm.directorFormValid = true
-    vm.changeCertifyData(true)
+    vm.isCertified = true
 
     // sanity check
     expect(jest.isMockFunction(window.location.assign)).toBe(true)
@@ -353,7 +412,7 @@ describe('Standalone Directors Filing - Part 2', () => {
   })
 })
 
-describe('Standalone Directors Filing - Part 3', () => {
+describe('Standalone Directors Filing - Part 4 - Saving', () => {
   const { assign } = window.location
 
   beforeAll(() => {
@@ -371,47 +430,6 @@ describe('Standalone Directors Filing - Part 3', () => {
     store.state.corpNum = 'CP0001191'
     store.state.entityIncNo = 'CP0001191'
     store.state.entityName = 'Legal Name - CP0001191'
-
-    const sampleDirectors = [
-      {
-        'officer': {
-          'firstName': 'Peter',
-          'middleInitial': null,
-          'lastName': 'Griffin'
-        },
-        'deliveryAddress': {
-          'streetAddress': 'mailing_address - address line one',
-          'streetAddressAdditional': null,
-          'addressCity': 'mailing_address city',
-          'addressCountry': 'mailing_address country',
-          'postalCode': 'H0H0H0',
-          'addressRegion': 'BC',
-          'deliveryInstructions': null
-        },
-        'title': null,
-        'appointmentDate': '2015-10-11',
-        'cessationDate': null
-      },
-      {
-        'officer': {
-          'firstName': 'Joe',
-          'middleInitial': 'P',
-          'lastName': 'Swanson'
-        },
-        'deliveryAddress': {
-          'streetAddress': 'mailing_address - address line #1',
-          'streetAddressAdditional': 'Kirkintiloch',
-          'addressCity': 'Glasgow',
-          'addressCountry': 'UK',
-          'postalCode': 'H0H 0H0',
-          'addressRegion': 'Scotland',
-          'deliveryInstructions': 'go to the back'
-        },
-        'title': 'Treasurer',
-        'appointmentDate': '2015-10-11',
-        'cessationDate': '2019-07-22'
-      }
-    ]
 
     // mock "save draft" endpoint
     sinon.stub(axios, 'post').withArgs('CP0001191/filings?draft=true')
@@ -455,7 +473,7 @@ describe('Standalone Directors Filing - Part 3', () => {
 
       // make sure form is validated
       vm.directorFormValid = true
-      vm.changeCertifyData(true)
+      vm.isCertified = true
 
       // sanity check
       expect(jest.isMockFunction(window.location.assign)).toBe(true)
@@ -482,7 +500,7 @@ describe('Standalone Directors Filing - Part 3', () => {
 
       // make sure form is validated
       vm.directorFormValid = true
-      vm.changeCertifyData(true)
+      vm.isCertified = true
 
       // sanity check
       expect(jest.isMockFunction(window.location.assign)).toBe(true)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#1160

*Description of changes:*
- used props and sync to bind data with Certify
- cleaned up Certify props, etc
- checked for ref functions before calling them to prevent errors in unit tests (temporary until components are refactored)
- cleaned up usage of Certify properties
- updated unit tests due to property change
- added unit test to verify draft resume data

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
