### PR TITLE
restored PWA package (needed for Service Worker)

### DIFF
--- a/coops-ui/package.json
+++ b/coops-ui/package.json
@@ -35,6 +35,7 @@
     "@types/jest": "^24.0.18",
     "@vue/cli-plugin-babel": "4.0.0-rc.0",
     "@vue/cli-plugin-eslint": "4.0.0-rc.0",
+    "@vue/cli-plugin-pwa": "4.0.0-rc.0",
     "@vue/cli-plugin-typescript": "4.0.0-rc.0",
     "@vue/cli-plugin-unit-jest": "4.0.0-rc.0",
     "@vue/cli-service": "4.0.0-rc.0",


### PR DESCRIPTION
*Issue #:* /bcgov/entity#1148

*Description of changes:*
- restored PWA package (needed for Service Worker)
- this is a bit of a test:
    - it should fix the console error in dev, "The script has an unsupported MIME type ('text/html'). Error during service worker registration: DOMException"
    - it should fix the issue in Dev Tools -> Application -> Service Workers where Status = redundant (ie, because it failed to install/activate)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
