### PR TITLE
added support for dynamic header height (per Jer)

### DIFF
--- a/coops-ui/src/App.vue
+++ b/coops-ui/src/App.vue
@@ -36,7 +36,7 @@
       </v-card>
     </v-dialog>
 
-    <sbc-header ref="sbcHeader" v-bind:authURL="authAPIURL" />
+    <sbc-header ref="sbcHeader" :authURL="authAPIURL" />
 
     <div class="app-body">
       <main v-if="dataLoaded">

--- a/coops-ui/src/assets/styles/layout.styl
+++ b/coops-ui/src/assets/styles/layout.styl
@@ -7,13 +7,14 @@ $app-header-height = 70px
   min-height 100vh
 
 .app-header
-  position fixed
+  position -webkit-sticky // Safari
+  position sticky
+  top 0
   width 100%
   z-index 2
 
 .app-body
   flex 1 1 auto
-  margin-top $app-header-height // Offset the height of the fixed header
 
 .app-container
   > .container:first-child


### PR DESCRIPTION
*Issue #:* Not Applicable

*Description of changes:*
- use position:sticky instead of position:fixed to have browser automatically calculate and handle dynamic header height
- this is because the header may contain a banner (eg, payment processing not available)
- note that 'sticky' is not supported in IE11 so the header will scroll off the screen (which is not really a big deal)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
