### PR TITLE
Simplify the Certify component and add tests (#1266)

### DIFF
--- a/coops-ui/src/components/AnnualReport/Certify.vue
+++ b/coops-ui/src/components/AnnualReport/Certify.vue
@@ -78,15 +78,15 @@ export default class Certify extends Vue {
   // Emit an update event.
   @Emit('update:isCertified')
   private emitIsCertified (val: boolean): boolean {
-    this.emitValid(this.certifiedBy && !!val)
+    this.emitValid(this.trimmedCertifiedBy && !!val)
 
-    return !!val
+    return val
   }
 
   // Emit an event indicating whether or not the form is valid.
   @Emit('valid')
   private emitValid (val: boolean): boolean {
-    return !!val
+    return val
   }
 }
 

--- a/coops-ui/src/components/AnnualReport/Certify.vue
+++ b/coops-ui/src/components/AnnualReport/Certify.vue
@@ -7,14 +7,18 @@
         </label>
         <div class="value certifiedby">
           <v-text-field
-            id="certified-by-textfield"
-            v-model="certifyTextField"
-            label="Name of current director, officer, or lawyer of the association"
             box
+            id="certified-by-textfield"
+            label="Name of current director, officer, or lawyer of the association"
+            :value="certifiedBy"
+            @input="emitCertifiedBy"
           />
         </div>
       </div>
-      <v-checkbox v-model="certifyCheckbox">
+      <v-checkbox
+        :value="isCertified"
+        @change="emitIsCertified"
+      >
         <template slot="label">
           <div class="certify-stmt">
             I, <b>{{trimmedCertifiedBy || '[Legal Name]'}}</b>, certify that I have relevant knowledge of the
@@ -33,24 +37,11 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue, Prop, Watch, Emit } from 'vue-property-decorator'
-import { mapState } from 'vuex'
 
-@Component({
-  computed: {
-    // Property definition for runtime environment.
-    ...mapState({ currentDate: 'currentDate' })
-  }
-})
+import { Component, Vue, Prop, Emit } from 'vue-property-decorator'
+
+@Component
 export default class Certify extends Vue {
-  // Local definition of computed property for static type checking.
-  // Use non-null assertion operator to allow use before assignment.
-  readonly currentDate!: string
-
-  // Model properties for the Text Field and Checkbox controls.
-  private certifyTextField: string = ''
-  private certifyCheckbox: boolean = false
-
   // Props passed into this component.
   @Prop({ default: '' })
   private certifiedBy: string
@@ -58,58 +49,47 @@ export default class Certify extends Vue {
   @Prop({ default: false })
   private isCertified: boolean
 
+  @Prop({ default: '' })
+  private currentDate: string
+
+  /**
+   * Lifecycle callback to always give the parent a "valid" event for its property values.
+   */
+  private created (): void {
+    this.emitValid(this.trimmedCertifiedBy && this.isCertified)
+  }
+
   /**
    * Computed value.
    * @return The trimmed "Certified By" string (may be '').
    */
   private get trimmedCertifiedBy (): string {
-    return this.certifyTextField && this.certifyTextField.trim()
-  }
-
-  /**
-   * Computed value.
-   * @return Whether or not this component (form) is valid.
-   */
-  private get isCertifyValid (): boolean {
-    return !!(this.certifyCheckbox && this.trimmedCertifiedBy)
-  }
-
-  // When prop changes, update text field.
-  @Watch('certifiedBy')
-  private onCertifiedByChanged (val): void {
-    this.certifyTextField = val
-  }
-
-  // When prop changes, update checkbox.
-  @Watch('isCertified')
-  private onIsCertifiedChanged (val): void {
-    this.certifyCheckbox = val
-  }
-
-  // When the trimmed "Certified By" string changes, signal the parent.
-  @Watch('trimmedCertifiedBy')
-  private ontrimmedCertifiedByChanged (val): void {
-    this.emitCertifiedBy(val)
-  }
-
-  // When this form's validity changes, signal the parent.
-  @Watch('isCertifyValid')
-  private onIsCertifyValidChanged (val): void {
-    this.emitIsCertified(val)
+    return this.certifiedBy && this.certifiedBy.trim()
   }
 
   // Emit an update event.
   @Emit('update:certifiedBy')
-  private emitCertifiedBy (val) {
+  private emitCertifiedBy (val: string): string {
+    this.emitValid(val && val.trim() && this.isCertified)
+
     return val
   }
 
   // Emit an update event.
   @Emit('update:isCertified')
-  private emitIsCertified (val) {
-    return val
+  private emitIsCertified (val: boolean): boolean {
+    this.emitValid(this.certifiedBy && !!val)
+
+    return !!val
+  }
+
+  // Emit an event indicating whether or not the form is valid.
+  @Emit('valid')
+  private emitValid (val: boolean): boolean {
+    return !!val
   }
 }
+
 </script>
 
 <style lang="stylus" scoped>

--- a/coops-ui/src/views/AnnualReport.vue
+++ b/coops-ui/src/views/AnnualReport.vue
@@ -150,7 +150,9 @@
               </header>
               <Certify
                 :isCertified.sync="isCertified"
-                :certifiedBy.sync="certifiedBy" />
+                :certifiedBy.sync="certifiedBy"
+                :currentDate="currentDate"
+                @valid="certifyValidEventHandler"/>
             </section>
           </div>
           <!-- <div v-else>
@@ -251,6 +253,7 @@ export default {
       paymentErrorDialog: false,
       isCertified: false,
       certifiedBy: '',
+      certifyFormValid: null,
       isSaveButtonEnabled: false,
       saving: false,
       savingResuming: false,
@@ -443,6 +446,15 @@ export default {
       this.toggleFiling(modified ? 'add' : 'remove', 'OTCDR')
     },
 
+    /**
+     * Callback method for the "valid" event from Certify.
+     *
+     * @param valid a boolean that is true if the certify form contains valid data.
+     */
+    certifyValidEventHandler (valid): void {
+      this.certifyFormValid = valid
+    },
+
     async onClickSave () {
       this.saving = true
       const filing = await this.saveFiling(true)
@@ -614,7 +626,7 @@ export default {
 
     setValidateFlag () {
       // compute the AR page's valid state
-      this.setValidated(this.agmDateValid && this.addressesFormValid && this.directorFormValid && this.isCertified)
+      this.setValidated(this.agmDateValid && this.addressesFormValid && this.directorFormValid && this.certifyFormValid)
       this.isSaveButtonEnabled = this.agmDateValid && this.addressesFormValid && this.directorFormValid
     }
   },

--- a/coops-ui/tests/unit/Certify.spec.ts
+++ b/coops-ui/tests/unit/Certify.spec.ts
@@ -20,11 +20,6 @@ import Certify from '@/components/AnnualReport/Certify.vue'
 
 Vue.use(Vuetify)
 
-// Boilerplate to prevent the complaint "[Vuetify] Unable to locate target [data-app]"
-const app: HTMLDivElement = document.createElement('div')
-app.setAttribute('data-app', 'true')
-document.body.append(app)
-
 // Input field selectors to test changes to the DOM elements.
 const certifiedBySelector: string = 'input[type=text]'
 const isCertifiedSelector: string = 'input[type=checkbox]'
@@ -67,14 +62,14 @@ function createComponent (certifiedBy: string = undefined, isCertified: boolean 
 }
 
 describe('Certified.vue', () => {
-  it('date is displayed', () => {
+  it('has date displayed', () => {
     const wrapper: Wrapper<Certify> = createComponent()
 
     // The text should contain the date.
     expect(wrapper.text()).toEqual(expect.stringMatching(new RegExp(defaultDate)))
   })
 
-  it('statement contains certifier', () => {
+  it('has statement with certifier', () => {
     const wrapper: Wrapper<Certify> = createComponent(someCertifier)
     const statement: Wrapper<Vue> = wrapper.find(statementSelector)
 
@@ -82,7 +77,7 @@ describe('Certified.vue', () => {
     expect(statement.text()).toEqual(expect.stringMatching(new RegExp(someCertifier)))
   })
 
-  it('statement contains trimmed certifier', () => {
+  it('has statement with trimmed certifier', () => {
     const untrimmedCertifier = '   ' + someCertifier + ' '
     const wrapper: Wrapper<Certify> = createComponent(untrimmedCertifier)
     const statement: Wrapper<Vue> = wrapper.find(statementSelector)
@@ -91,82 +86,89 @@ describe('Certified.vue', () => {
     expect(statement.text()).toEqual(expect.not.stringMatching(new RegExp(untrimmedCertifier)))
   })
 
-  it('invalid when no value', () => {
+  it('is invalid when no value', () => {
     const wrapper: Wrapper<Certify> = createComponent()
 
     // The last "valid" event should indicate that the form is not valid.
-    expect(wrapper.emitted().valid).toBeDefined()
     expect(getLastEvent(wrapper, 'valid')).not.toBeTruthy()
   })
 
-  it('invalid when just certifiedBy', () => {
+  it('is invalid when just certifiedBy', () => {
     const wrapper: Wrapper<Certify> = createComponent(someCertifier)
 
     // The last "valid" event should indicate that the form is not valid.
-    expect(wrapper.emitted().valid).toBeDefined()
     expect(getLastEvent(wrapper, 'valid')).not.toBeTruthy()
   })
 
-  it('invalid when just isCertified', () => {
+  it('is invalid when just isCertified', () => {
     const wrapper: Wrapper<Certify> = createComponent(null, true)
 
     // The last "valid" event should indicate that the form is not valid.
-    expect(wrapper.emitted().valid).toBeDefined()
     expect(getLastEvent(wrapper, 'valid')).not.toBeTruthy()
   })
 
-  it('invalid when name is space', () => {
+  it('is invalid when name is space', () => {
     const wrapper: Wrapper<Certify> = createComponent(' ', true)
 
     // The last "valid" event should indicate that the form is not valid.
-    expect(wrapper.emitted().valid).toBeDefined()
     expect(getLastEvent(wrapper, 'valid')).not.toBeTruthy()
   })
 
-  it('valid when props defined', () => {
+  it('is valid when props defined', () => {
     const wrapper: Wrapper<Certify> = createComponent(someCertifier, true)
 
     // The last "valid" event should indicate that the form is valid.
-    expect(wrapper.emitted().valid).toBeDefined()
     expect(getLastEvent(wrapper, 'valid')).toBeTruthy()
   })
 
-  it('valid when certifier untrimmed', () => {
+  it('is valid when certifier untrimmed', () => {
     const wrapper: Wrapper<Certify> = createComponent('  ' + someCertifier + ' ', true)
 
     // The last "valid" event should indicate that the form is valid.
-    expect(wrapper.emitted().valid).toBeDefined()
     expect(getLastEvent(wrapper, 'valid')).toBeTruthy()
   })
 
-  it('input event for certifiedBy', () => {
+  it('is invalid when certifier is whitespace', () => {
+    const wrapper: Wrapper<Certify> = createComponent('  ', true)
+
+    // The last "valid" event should indicate that the form is invalid.
+    expect(getLastEvent(wrapper, 'valid')).not.toBeTruthy()
+  })
+
+  it('is still invalid when certifier is whitespace', () => {
+    const wrapper: Wrapper<Certify> = createComponent('  ', false)
+    const checkboxElement: Wrapper<Vue> = wrapper.find(isCertifiedSelector)
+    checkboxElement.setChecked()
+
+    // The last "valid" event should indicate that the form is invalid.
+    expect(getLastEvent(wrapper, 'valid')).not.toBeTruthy()
+  })
+
+  it('has input event for certifiedBy', () => {
     const wrapper: Wrapper<Certify> = createComponent()
     const inputElement: Wrapper<Vue> = wrapper.find(certifiedBySelector)
     inputElement.setValue(someCertifier)
 
     // The last "update:certifiedBy" event should match the input.
-    expect(wrapper.emitted()['update:certifiedBy']).toBeDefined()
     expect(getLastEvent(wrapper, 'update:certifiedBy')).toMatch(someCertifier)
   })
 
-  it('untrimmed input event for certifiedBy', () => {
+  it('has untrimmed input event for certifiedBy', () => {
     const untrimmedCertifier = '   ' + someCertifier + ' '
     const wrapper: Wrapper<Certify> = createComponent()
     const inputElement: Wrapper<Vue> = wrapper.find(certifiedBySelector)
     inputElement.setValue(untrimmedCertifier)
 
     // The last "update:certifiedBy" event should be a trimmed version of the input.
-    expect(wrapper.emitted()['update:certifiedBy']).toBeDefined()
     expect(getLastEvent(wrapper, 'update:certifiedBy')).toMatch(untrimmedCertifier)
   })
 
-  it('input event for isCertified', () => {
+  it('has input event for isCertified', () => {
     const wrapper: Wrapper<Certify> = createComponent()
     const checkboxElement: Wrapper<Vue> = wrapper.find(isCertifiedSelector)
     checkboxElement.setChecked()
 
     // The last "update:isCertified" event should indicate that the checkbox is checked.
-    expect(wrapper.emitted()['update:isCertified']).toBeDefined()
     expect(getLastEvent(wrapper, 'update:isCertified')).toBeTruthy()
   })
 })

--- a/coops-ui/tests/unit/Certify.spec.ts
+++ b/coops-ui/tests/unit/Certify.spec.ts
@@ -1,0 +1,172 @@
+//
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+
+import Vue from 'vue'
+import Vuetify from 'vuetify'
+
+import { mount, Wrapper } from '@vue/test-utils'
+
+import Certify from '@/components/AnnualReport/Certify.vue'
+
+Vue.use(Vuetify)
+
+// Boilerplate to prevent the complaint "[Vuetify] Unable to locate target [data-app]"
+const app: HTMLDivElement = document.createElement('div')
+app.setAttribute('data-app', 'true')
+document.body.append(app)
+
+// Input field selectors to test changes to the DOM elements.
+const certifiedBySelector: string = 'input[type=text]'
+const isCertifiedSelector: string = 'input[type=checkbox]'
+const statementSelector: string = '.certify-stmt'
+
+const someCertifier = 'Some Certifier'
+const defaultDate = '2019-01-01'
+
+/**
+ * Returns the last event for a given name, to be used for testing event propagation in response to component changes.
+ *
+ * @param wrapper the wrapper for the component that is being tested.
+ * @param name the name of the event that is to be returned.
+ *
+ * @return the value of the last named event for the wrapper.
+ */
+function getLastEvent (wrapper: Wrapper<Certify>, name: string): any {
+  const eventsList: Array<any> = wrapper.emitted(name)
+  const events: Array<any> = eventsList[eventsList.length - 1]
+
+  return events[0]
+}
+
+/**
+ * Creates and mounts a component, so that it can be tested.
+ *
+ * @param certifiedBy the value to pass to the component for the name input. The default value is "undefined".
+ * @param isCertified the value to pass to the component for the checkbox. The default value is "undefined".
+ * @param currentDate the value to pass to the component for the static date. The default value is defaultDate.
+ *
+ * @return a Wrapper<Certify> object with the given parameters.
+ */
+function createComponent (certifiedBy: string = undefined, isCertified: boolean = undefined,
+  currentDate: string = defaultDate): Wrapper<Certify> {
+  return mount(Certify, { propsData: {
+    'certifiedBy': certifiedBy,
+    'currentDate': currentDate,
+    'isCertified': isCertified
+  } })
+}
+
+describe('Certified.vue', () => {
+  it('date is displayed', () => {
+    const wrapper: Wrapper<Certify> = createComponent()
+
+    // The text should contain the date.
+    expect(wrapper.text()).toEqual(expect.stringMatching(new RegExp(defaultDate)))
+  })
+
+  it('statement contains certifier', () => {
+    const wrapper: Wrapper<Certify> = createComponent(someCertifier)
+    const statement: Wrapper<Vue> = wrapper.find(statementSelector)
+
+    // The text should contain the certifier name.
+    expect(statement.text()).toEqual(expect.stringMatching(new RegExp(someCertifier)))
+  })
+
+  it('statement contains trimmed certifier', () => {
+    const untrimmedCertifier = '   ' + someCertifier + ' '
+    const wrapper: Wrapper<Certify> = createComponent(untrimmedCertifier)
+    const statement: Wrapper<Vue> = wrapper.find(statementSelector)
+
+    // The text should contain the certifier name.
+    expect(statement.text()).toEqual(expect.not.stringMatching(new RegExp(untrimmedCertifier)))
+  })
+
+  it('invalid when no value', () => {
+    const wrapper: Wrapper<Certify> = createComponent()
+
+    // The last "valid" event should indicate that the form is not valid.
+    expect(wrapper.emitted().valid).toBeDefined()
+    expect(getLastEvent(wrapper, 'valid')).not.toBeTruthy()
+  })
+
+  it('invalid when just certifiedBy', () => {
+    const wrapper: Wrapper<Certify> = createComponent(someCertifier)
+
+    // The last "valid" event should indicate that the form is not valid.
+    expect(wrapper.emitted().valid).toBeDefined()
+    expect(getLastEvent(wrapper, 'valid')).not.toBeTruthy()
+  })
+
+  it('invalid when just isCertified', () => {
+    const wrapper: Wrapper<Certify> = createComponent(null, true)
+
+    // The last "valid" event should indicate that the form is not valid.
+    expect(wrapper.emitted().valid).toBeDefined()
+    expect(getLastEvent(wrapper, 'valid')).not.toBeTruthy()
+  })
+
+  it('invalid when name is space', () => {
+    const wrapper: Wrapper<Certify> = createComponent(' ', true)
+
+    // The last "valid" event should indicate that the form is not valid.
+    expect(wrapper.emitted().valid).toBeDefined()
+    expect(getLastEvent(wrapper, 'valid')).not.toBeTruthy()
+  })
+
+  it('valid when props defined', () => {
+    const wrapper: Wrapper<Certify> = createComponent(someCertifier, true)
+
+    // The last "valid" event should indicate that the form is valid.
+    expect(wrapper.emitted().valid).toBeDefined()
+    expect(getLastEvent(wrapper, 'valid')).toBeTruthy()
+  })
+
+  it('valid when certifier untrimmed', () => {
+    const wrapper: Wrapper<Certify> = createComponent('  ' + someCertifier + ' ', true)
+
+    // The last "valid" event should indicate that the form is valid.
+    expect(wrapper.emitted().valid).toBeDefined()
+    expect(getLastEvent(wrapper, 'valid')).toBeTruthy()
+  })
+
+  it('input event for certifiedBy', () => {
+    const wrapper: Wrapper<Certify> = createComponent()
+    const inputElement: Wrapper<Vue> = wrapper.find(certifiedBySelector)
+    inputElement.setValue(someCertifier)
+
+    // The last "update:certifiedBy" event should match the input.
+    expect(wrapper.emitted()['update:certifiedBy']).toBeDefined()
+    expect(getLastEvent(wrapper, 'update:certifiedBy')).toMatch(someCertifier)
+  })
+
+  it('untrimmed input event for certifiedBy', () => {
+    const untrimmedCertifier = '   ' + someCertifier + ' '
+    const wrapper: Wrapper<Certify> = createComponent()
+    const inputElement: Wrapper<Vue> = wrapper.find(certifiedBySelector)
+    inputElement.setValue(untrimmedCertifier)
+
+    // The last "update:certifiedBy" event should be a trimmed version of the input.
+    expect(wrapper.emitted()['update:certifiedBy']).toBeDefined()
+    expect(getLastEvent(wrapper, 'update:certifiedBy')).toMatch(untrimmedCertifier)
+  })
+
+  it('input event for isCertified', () => {
+    const wrapper: Wrapper<Certify> = createComponent()
+    const checkboxElement: Wrapper<Vue> = wrapper.find(isCertifiedSelector)
+    checkboxElement.setChecked()
+
+    // The last "update:isCertified" event should indicate that the checkbox is checked.
+    expect(wrapper.emitted()['update:isCertified']).toBeDefined()
+    expect(getLastEvent(wrapper, 'update:isCertified')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
*Issue #:* /bcgov/entity#1266

*Description of Certify changes:*
  - Removed the shadow property fields to simplify the component.
  - All the watchers could be removed once above simplification done.
  - Added a property for the `currentDate`, so that (1) the component isn't tied to VueX, and (2) the parent component isn't required to have a specific named variable in the store for the current date.
  - Added a `valid` event so the parent component knows if the form is complete or not. Will be returned on create so that the parent knows if the properties are valid or not.
  - Added unit tests.

*Description of AnnualReport changes:*
  - Passing in `currentDate` as a property.
  - Added a `certifyFormValid` variable - there shouldn't be any need to store any of these in the store, but leaving the others as-is for now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).