### PR TITLE
updated filer for schema changes involving last_ar_date

### DIFF
--- a/entity-filer/requirements.txt
+++ b/entity-filer/requirements.txt
@@ -4,8 +4,8 @@ Flask==1.1.1
 Jinja2==2.10.1
 MarkupSafe==1.1.1
 SQLAlchemy-Continuum==1.3.9
-SQLAlchemy-Utils==0.34.1
-SQLAlchemy==1.3.7
+SQLAlchemy-Utils==0.34.2
+SQLAlchemy==1.3.8
 Werkzeug==0.15.5
 asyncio-nats-client==0.9.2
 asyncio-nats-streaming==0.4.0
@@ -19,13 +19,13 @@ itsdangerous==1.1.0
 jsonschema==3.0.2
 protobuf==3.9.1
 psycopg2-binary==2.8.3
-pyasn1==0.4.6
+pyasn1==0.4.7
 pycountry==19.8.18
 pyrsistent==0.15.4
 python-dotenv==0.10.3
 python-jose==3.0.1
 rsa==4.0
-sentry-sdk==0.10.2
+sentry-sdk==0.11.2
 six==1.12.0
 urllib3==1.25.3
 git+https://github.com/bcgov/lear.git#egg=registry_schemas&subdirectory=schemas

--- a/entity-filer/src/entity_filer/filing_processors/annual_report.py
+++ b/entity-filer/src/entity_filer/filing_processors/annual_report.py
@@ -16,11 +16,19 @@ import datetime
 
 from legal_api.models import Business, Filing
 
+from entity_filer.service_utils import logger
 
-def process(business: Business, filing: Filing, submission_date: datetime.datetime):
+
+def process(business: Business, filing: Filing):
     """Render the annual_report onto the business model objects."""
     agm_date = filing['annualReport'].get('annualGeneralMeetingDate')
+    ar_date = filing['annualReport'].get('annualReportDate')
     if agm_date:
         agm_date = datetime.date.fromisoformat(agm_date)
+    if ar_date:
+        ar_date = datetime.date.fromisoformat(ar_date)
+    else:
+        # should never get here (schema validation should prevent this from making it to the filer)
+        logger.error('No annualReportDate given for in annual report. Filing id: %s', filing.id)
     business.last_agm_date = agm_date
-    business.last_ar_date = submission_date
+    business.last_ar_date = ar_date

--- a/entity-filer/src/entity_filer/worker.py
+++ b/entity-filer/src/entity_filer/worker.py
@@ -87,7 +87,7 @@ def process_filing(payment_token, flask_app):
 
             for filing in legal_filings:
                 if filing.get('annualReport'):
-                    annual_report.process(business, filing, filing_submission.filing_date)
+                    annual_report.process(business, filing)
                 if filing.get('changeOfAddress'):
                     change_of_address.process(business, filing)
                 if filing.get('changeOfDirectors'):

--- a/entity-filer/tests/integration/test_worker_queue.py
+++ b/entity-filer/tests/integration/test_worker_queue.py
@@ -28,12 +28,13 @@ async def test_cb_subscription_handler(app, session, stan_server, event_loop, cl
     from entity_filer.worker import cb_subscription_handler
     from entity_filer.worker import get_filing_by_payment_id
     from legal_api.models import Business
-    from tests.unit import create_filing, AR_FILING, create_business, EPOCH_DATETIME
+    from tests.unit import create_filing, AR_FILING, create_business
 
     # vars
     payment_id = str(random.SystemRandom().getrandbits(0x58))
     identifier = 'CP1234567'
     agm_date = datetime.date.fromisoformat(AR_FILING['filing']['annualReport'].get('annualGeneralMeetingDate'))
+    ar_date = datetime.date.fromisoformat(AR_FILING['filing']['annualReport'].get('annualReportDate'))
 
     # setup
     business = create_business(identifier)
@@ -60,4 +61,4 @@ async def test_cb_subscription_handler(app, session, stan_server, event_loop, cl
     assert filing.transaction_id
     assert filing.business_id == business_id
     assert datetime.datetime.date(business.last_agm_date) == agm_date
-    assert business.last_ar_date.replace(tzinfo=None) == EPOCH_DATETIME
+    assert datetime.datetime.date(business.last_ar_date) == ar_date

--- a/entity-filer/tests/unit/__init__.py
+++ b/entity-filer/tests/unit/__init__.py
@@ -20,7 +20,9 @@ AR_FILING = {
     'filing': {
         'header': {
             'name': 'annualReport',
-            'date': '2001-08-05'
+            'date': '2001-08-05',
+            'certifiedBy': 'full name',
+            'email': 'no_one@never.get'
         },
         'business': {
             'cacheId': 1,
@@ -31,8 +33,7 @@ AR_FILING = {
         },
         'annualReport': {
             'annualGeneralMeetingDate': '2018-04-08',
-            'certifiedBy': 'full name',
-            'email': 'no_one@never.get',
+            'annualReportDate': '2018-04-08',
             'directors': [
                 {
                     'officer': {
@@ -93,7 +94,9 @@ COA_FILING = {
     'filing': {
         'header': {
             'name': 'changeOfAddress',
-            'date': '2019-07-30'
+            'date': '2019-07-30',
+            'certifiedBy': 'full name',
+            'email': 'no_one@never.get'
         },
         'business': {
             'cacheId': 1,
@@ -123,8 +126,6 @@ COA_FILING = {
                 'deliveryInstructions': 'Test address mailing',
                 'actions': ['addressChanged']
             },
-            'certifiedBy': 'full name',
-            'email': 'no_one@never.get'
         }
     }
 }
@@ -133,7 +134,9 @@ COD_FILING = {
     'filing': {
         'header': {
             'name': 'changeOfDirectors',
-            'date': '2019-07-29'
+            'date': '2019-07-29',
+            'certifiedBy': 'full name',
+            'email': 'no_one@never.get'
         },
         'business': {
             'cacheId': 1,
@@ -248,8 +251,6 @@ COD_FILING = {
                     'actions': ['appointed']
                 }
             ],
-            'certifiedBy': 'full name',
-            'email': 'no_one@never.get'
         }
     }
 }
@@ -258,7 +259,9 @@ COMBINED_FILING = {
     'filing': {
         'header': {
             'name': 'annualReport',
-            'date': '2019-07-28'
+            'date': '2019-07-28',
+            'certifiedBy': 'full name',
+            'email': 'no_one@never.get',
         },
         'business': {
             'cacheId': 1,
@@ -269,8 +272,10 @@ COMBINED_FILING = {
         },
         'annualReport': {
             'annualGeneralMeetingDate': '2019-04-08',
-            'certifiedBy': 'full name',
-            'email': 'no_one@never.get'
+            'annualReportDate': '2018-04-08',
+            'directors': COD_FILING['filing']['changeOfDirectors']['directors'],
+            'deliveryAddress': COA_FILING['filing']['changeOfAddress']['deliveryAddress'],
+            'mailingAddress': COA_FILING['filing']['changeOfAddress']['mailingAddress']
         },
         'changeOfAddress': COA_FILING['filing']['changeOfAddress'],
         'changeOfDirectors': COD_FILING['filing']['changeOfDirectors']

--- a/entity-filer/tests/unit/test_worker.py
+++ b/entity-filer/tests/unit/test_worker.py
@@ -18,7 +18,6 @@ import random
 
 import pytest
 
-from tests import EPOCH_DATETIME
 from tests.unit import AR_FILING, COA_FILING, COD_FILING, COMBINED_FILING, create_business, create_director, create_filing  # noqa I001, E501;
 
 
@@ -123,6 +122,7 @@ def test_process_ar_filing(app, session):
     payment_id = str(random.SystemRandom().getrandbits(0x58))
     identifier = 'CP1234567'
     agm_date = datetime.date.fromisoformat(AR_FILING['filing']['annualReport'].get('annualGeneralMeetingDate'))
+    ar_date = datetime.date.fromisoformat(COMBINED_FILING['filing']['annualReport'].get('annualReportDate'))
 
     # setup
     business = create_business(identifier)
@@ -142,7 +142,7 @@ def test_process_ar_filing(app, session):
     assert filing.business_id == business_id
     assert filing.status == Filing.Status.COMPLETED.value
     assert datetime.datetime.date(business.last_agm_date) == agm_date
-    assert business.last_ar_date.replace(tzinfo=None) == EPOCH_DATETIME
+    assert datetime.datetime.date(business.last_ar_date) == ar_date
 
 
 def test_process_coa_filing(app, session):
@@ -256,6 +256,7 @@ def test_process_combined_filing(app, session):
     payment_id = str(random.SystemRandom().getrandbits(0x58))
     identifier = 'CP1234567'
     agm_date = datetime.date.fromisoformat(COMBINED_FILING['filing']['annualReport'].get('annualGeneralMeetingDate'))
+    ar_date = datetime.date.fromisoformat(COMBINED_FILING['filing']['annualReport'].get('annualReportDate'))
     new_delivery_address = COMBINED_FILING['filing']['changeOfAddress']['deliveryAddress']
     new_mailing_address = COMBINED_FILING['filing']['changeOfAddress']['mailingAddress']
     end_date = datetime.datetime.utcnow().date()
@@ -305,7 +306,7 @@ def test_process_combined_filing(app, session):
     assert filing.business_id == business_id
     assert filing.status == Filing.Status.COMPLETED.value
     assert datetime.datetime.date(business.last_agm_date) == agm_date
-    assert business.last_ar_date.replace(tzinfo=None) == EPOCH_DATETIME
+    assert datetime.datetime.date(business.last_ar_date) == ar_date
 
     # check address filing
     delivery_address = business.delivery_address.one_or_none().json


### PR DESCRIPTION
Signed-off-by: Kial Jinnah <kialj876@gmail.com>

*Issue #:* /bcgov/entity#1171

*Description of changes:*
- last_ar_date column in the businesses table is now set to the 'annualReportDate' provided by the filing
- tests updated to reflect above + schema changes around annual report

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
