### PR TITLE
fixed bug - missing certified name in all PDFs

### DIFF
--- a/legal-api/report-templates/annualReport.html
+++ b/legal-api/report-templates/annualReport.html
@@ -266,7 +266,7 @@
           </div>
 
           <div class="section-data">
-            I, {{ annualReport.certifiedBy }}, certify that I have relevant knowledge of the cooperative, and that I am
+            I, {{ header.certifiedBy }}, certify that I have relevant knowledge of the cooperative, and that I am
             authorized to make this filing.
           </div>
         </div>

--- a/legal-api/report-templates/changeOfAddress.html
+++ b/legal-api/report-templates/changeOfAddress.html
@@ -227,7 +227,7 @@
           </div>
 
           <div class="section-data">
-            I, {{ changeOfAddress.certifiedBy }}, certify that I have relevant knowledge of the cooperative, and that I
+            I, {{ header.certifiedBy }}, certify that I have relevant knowledge of the cooperative, and that I
             am authorized to make this filing.
           </div>
         </div>

--- a/legal-api/report-templates/changeOfDirectors.html
+++ b/legal-api/report-templates/changeOfDirectors.html
@@ -226,7 +226,7 @@
           </div>
 
           <div class="section-data">
-            I, {{ changeOfDirectors.certifiedBy }}, certify that I have relevant knowledge of the cooperative, and that
+            I, {{ header.certifiedBy }}, certify that I have relevant knowledge of the cooperative, and that
             I am authorized to make this filing.
           </div>
         </div>


### PR DESCRIPTION
*Issue #:* /bcgov/entity#1276

*Description of changes:*
fixed bug - missing certified name in all PDFs - was due to schema change and this fix was missed in other fixes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
