### PR TITLE
imported Vue2Filters library needed for SbcFeeSummary component

### DIFF
--- a/coops-ui/src/main.ts
+++ b/coops-ui/src/main.ts
@@ -5,6 +5,7 @@ import Vuetify from 'vuetify'
 import 'vuetify/dist/vuetify.min.css'
 import App from '@/App.vue'
 import Vuelidate from 'vuelidate'
+import Vue2Filters from 'vue2-filters'
 import Affix from 'vue-affix'
 import router from '@/router'
 import store from '@/store/store'
@@ -13,6 +14,7 @@ import '@/registerServiceWorker'
 
 Vue.use(Vuetify, { iconfont: 'md' })
 Vue.use(Vuelidate)
+Vue.use(Vue2Filters)
 Vue.use(Affix)
 Vue.config.productionTip = false
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity1345

*Description of changes:*
The subject library import was removed in a previous ticket as it not directly needed for this project, however it is required for a SBC Common Component. This commit restores the library import.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
