### PR TITLE
added missing mixin declaration

### DIFF
--- a/coops-ui/src/components/AnnualReport/ARComplete.vue
+++ b/coops-ui/src/components/AnnualReport/ARComplete.vue
@@ -19,6 +19,8 @@ import DateMixin from '@/mixins/date-mixin'
 export default {
   name: 'ARComplete',
   computed: {
+    mixins: [DateMixin],
+
     ...mapState(['ARFilingYear']),
 
     // dummy value for now


### PR DESCRIPTION
*Issue #:* N/A

*Description of changes:*
A mixin declaration was missing from the ARComplete component. This did not create an error because this component was not used. This change adds in the missing mixin declaration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
