### PR TITLE
prevent double-saving

### DIFF
--- a/coops-ui/src/views/AnnualReport.vue
+++ b/coops-ui/src/views/AnnualReport.vue
@@ -9,7 +9,7 @@
 
     <SaveErrorDialog
       :dialog="saveErrorDialog"
-      :disableRetry="filingPaying"
+      :disableRetry="busySaving"
       :errors="saveErrors"
       :warnings="saveWarnings"
       @exit="navigateToDashboard"
@@ -120,14 +120,14 @@
         <div class="buttons-left">
           <v-btn id="ar-save-btn" large
             v-if="isAnnualReportEditable"
-            :disabled="!isSaveButtonEnabled || saving"
+            :disabled="!isSaveButtonEnabled || busySaving"
             :loading="saving"
             @click="onClickSave">
             Save
           </v-btn>
           <v-btn id="ar-save-resume-btn" large
             v-if="isAnnualReportEditable"
-            :disabled="!isSaveButtonEnabled || savingResuming"
+            :disabled="!isSaveButtonEnabled || busySaving"
             :loading="savingResuming"
             @click="onClickSaveResume">
             Save &amp; Resume Later
@@ -144,7 +144,7 @@
               large
               :depressed="isRoleStaff"
               :ripple="!isRoleStaff"
-              :disabled="!validated || filingPaying"
+              :disabled="!validated || busySaving"
               :loading="filingPaying"
               @click="onClickFilePay">
               File &amp; Pay
@@ -257,6 +257,10 @@ export default {
 
     validated () {
       return this.agmDateValid && this.addressesFormValid && this.directorFormValid && this.certifyFormValid
+    },
+
+    busySaving () {
+      return this.saving || this.savingResuming || this.filingPaying
     },
 
     isSaveButtonEnabled () {
@@ -415,6 +419,9 @@ export default {
     },
 
     async onClickSave () {
+      // prevent double saving
+      if (this.busySaving) return
+
       this.saving = true
       const filing = await this.saveFiling(true)
       if (filing) {
@@ -424,6 +431,9 @@ export default {
     },
 
     async onClickSaveResume () {
+      // prevent double saving
+      if (this.busySaving) return
+
       this.savingResuming = true
       const filing = await this.saveFiling(true)
       // on success, route to Home URL
@@ -436,6 +446,9 @@ export default {
     async onClickFilePay () {
       // staff are not allowed to file
       if (this.isRoleStaff) return false
+
+      // prevent double saving
+      if (this.busySaving) return true
 
       this.filingPaying = true
       const filing = await this.saveFiling(false)

--- a/coops-ui/src/views/StandaloneDirectorsFiling.vue
+++ b/coops-ui/src/views/StandaloneDirectorsFiling.vue
@@ -9,7 +9,7 @@
 
     <SaveErrorDialog
       :dialog="saveErrorDialog"
-      :disableRetry="filingPaying"
+      :disableRetry="busySaving"
       :errors="saveErrors"
       :warnings="saveWarnings"
       @exit="navigateToDashboard"
@@ -74,13 +74,13 @@
       <v-container id="buttons-container" class="list-item">
         <div class="buttons-left">
           <v-btn id="cod-save-btn" large
-            :disabled="!isSaveButtonEnabled || saving"
+            :disabled="!isSaveButtonEnabled || busySaving"
             :loading="saving"
             @click="onClickSave">
             Save
           </v-btn>
           <v-btn id="cod-save-resume-btn" large
-            :disabled="!isSaveButtonEnabled || savingResuming"
+            :disabled="!isSaveButtonEnabled || busySaving"
             :loading="savingResuming"
             @click="onClickSaveResume">
             Save &amp; Resume Later
@@ -96,7 +96,7 @@
               large
               :depressed="isRoleStaff"
               :ripple="!isRoleStaff"
-              :disabled="!validated || filingPaying"
+              :disabled="!validated || busySaving"
               :loading="filingPaying"
               @click="onClickFilePay">
               File &amp; Pay
@@ -175,6 +175,10 @@ export default {
       return (this.isCertified && this.directorFormValid && this.filingData.length > 0)
     },
 
+    busySaving () {
+      return this.saving || this.savingResuming || this.filingPaying
+    },
+
     isSaveButtonEnabled () {
       return (this.directorFormValid && this.filingData.length > 0)
     },
@@ -243,6 +247,9 @@ export default {
     },
 
     async onClickSave () {
+      // prevent double saving
+      if (this.busySaving) return
+
       this.saving = true
       const filing = await this.saveFiling(true)
       if (filing) {
@@ -252,6 +259,9 @@ export default {
     },
 
     async onClickSaveResume () {
+      // prevent double saving
+      if (this.busySaving) return
+
       this.savingResuming = true
       const filing = await this.saveFiling(true)
       // on success, redirect to Home URL
@@ -265,6 +275,9 @@ export default {
     async onClickFilePay () {
       // staff are not allowed to file
       if (this.isRoleStaff) return false
+
+      // prevent double saving
+      if (this.busySaving) return true
 
       this.filingPaying = true
       const filing = await this.saveFiling(false)

--- a/coops-ui/src/views/StandaloneOfficeAddressFiling.vue
+++ b/coops-ui/src/views/StandaloneOfficeAddressFiling.vue
@@ -9,7 +9,7 @@
 
     <SaveErrorDialog
       :dialog="saveErrorDialog"
-      :disableRetry="filingPaying"
+      :disableRetry="busySaving"
       :errors="saveErrors"
       :warnings="saveWarnings"
       @exit="navigateToDashboard"
@@ -69,13 +69,13 @@
       <v-container id="buttons-container" class="list-item">
         <div class="buttons-left">
           <v-btn id="coa-save-btn" large
-            :disabled="!saveAsDraftEnabled || saving"
+            :disabled="!saveAsDraftEnabled || busySaving"
             :loading="saving"
             @click="onClickSave">
             Save
           </v-btn>
           <v-btn id="coa-save-resume-btn" large
-            :disabled="!saveAsDraftEnabled || savingResuming"
+            :disabled="!saveAsDraftEnabled || busySaving"
             :loading="savingResuming"
             @click="onClickSaveResume">
             Save &amp; Resume Later
@@ -91,7 +91,7 @@
               large
               :depressed="isRoleStaff"
               :ripple="!isRoleStaff"
-              :disabled="!validated || filingPaying"
+              :disabled="!validated || busySaving"
               :loading="filingPaying"
               @click="onClickFilePay">
               File &amp; Pay
@@ -167,6 +167,10 @@ export default {
 
     validated () {
       return (this.isCertified && this.officeAddressFormValid && this.filingData.length > 0)
+    },
+
+    busySaving () {
+      return this.saving || this.savingResuming || this.filingPaying
     },
 
     saveAsDraftEnabled () {
@@ -302,6 +306,9 @@ export default {
     },
 
     async onClickSave () {
+      // prevent double saving
+      if (this.busySaving) return
+
       this.saving = true
       const filing = await this.saveFiling(true)
       if (filing) {
@@ -311,6 +318,9 @@ export default {
     },
 
     async onClickSaveResume () {
+      // prevent double saving
+      if (this.busySaving) return
+
       this.savingResuming = true
       const filing = await this.saveFiling(true)
       // on success, redirect to Home URL
@@ -324,6 +334,9 @@ export default {
     async onClickFilePay () {
       // staff are not allowed to file
       if (this.isRoleStaff) return false
+
+      // prevent double saving
+      if (this.busySaving) return true
 
       this.filingPaying = true
       const filing = await this.saveFiling(false)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#1381

*Description of changes:*
This code change disables all 3 save buttons (on all 3 filing pages) when any of them are in progress. As well, when any save function is already in progress then another save cannot be initiated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
