### PR TITLE
Validation fix

### DIFF
--- a/legal-api/src/legal_api/services/filings/validations/annual_report.py
+++ b/legal-api/src/legal_api/services/filings/validations/annual_report.py
@@ -111,7 +111,7 @@ def validate_agm_year(*, business: Business, annual_report: Dict) -> Tuple[int, 
     if ar_date.year == submission_date.year \
             and agm_date is None:
         return Error(HTTPStatus.BAD_REQUEST,
-                     [{'error': _('Annual General MeetingDate must be a valid date when '
+                     [{'error': _('Annual General Meeting Date must be a valid date when '
                                   'submitting an Annual Report in the current year.'),
                        'path': 'filing/annualReport/annualGeneralMeetingDate'}])
 
@@ -129,10 +129,10 @@ def validate_agm_year(*, business: Business, annual_report: Dict) -> Tuple[int, 
                                     'The business will be dissolved, unless an extension and an AGM are held.'),
                        'path': 'filing/annualReport/annualGeneralMeetingDate'}])
 
-    if agm_date and agm_date < date.fromisoformat(current_app.config.get('GO_LIVE_DATE')):
+    if agm_date and agm_date < datetime.date(business.last_ledger_timestamp):
         return Error(HTTPStatus.BAD_REQUEST,
-                     [{'error': 'Annual General Meeting Date is before 2019-08-12, '
-                                'so it must be submitted as a paper-filing.',
+                     [{'error': 'Annual General Meeting Date is before a previous filing filed on '
+                                f'{business.last_ledger_timestamp}, so it must be submitted as a paper-filing.',
                        'path': 'filing/annualReport/annualGeneralMeetingDate'}])
 
     return None

--- a/legal-api/src/legal_api/services/filings/validations/annual_report.py
+++ b/legal-api/src/legal_api/services/filings/validations/annual_report.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Validation for the Annual Report filing."""
-from datetime import date, datetime
+from datetime import datetime
 from http import HTTPStatus
 from typing import Dict, List, Tuple
 
 import datedelta
-from flask import current_app
 from flask_babel import _
 
 from legal_api.errors import Error
@@ -129,10 +128,11 @@ def validate_agm_year(*, business: Business, annual_report: Dict) -> Tuple[int, 
                                     'The business will be dissolved, unless an extension and an AGM are held.'),
                        'path': 'filing/annualReport/annualGeneralMeetingDate'}])
 
-    if agm_date and agm_date < datetime.date(business.last_ledger_timestamp):
+    last_filing_date = datetime.date(business.last_ledger_timestamp)
+    if agm_date and agm_date < last_filing_date:
         return Error(HTTPStatus.BAD_REQUEST,
                      [{'error': 'Annual General Meeting Date is before a previous filing filed on '
-                                f'{business.last_ledger_timestamp}, so it must be submitted as a paper-filing.',
+                                f'{last_filing_date}, so it must be submitted as a paper-filing.',
                        'path': 'filing/annualReport/annualGeneralMeetingDate'}])
 
     return None

--- a/legal-api/tests/unit/services/filings/validations/annual_report/test_validate_ar_year.py
+++ b/legal-api/tests/unit/services/filings/validations/annual_report/test_validate_ar_year.py
@@ -56,7 +56,7 @@ def test_validate_ar_year(app, test_name, current_ar_date, previous_ar_date, fou
     """Assert that ARs filing/annualReport/annualReportDate is valid."""
     # setup
     identifier = 'CP1234567'
-    business = Business(identifier=identifier)
+    business = Business(identifier=identifier, last_ledger_timestamp=previous_ar_date)
     business.founding_date = datetime.fromisoformat(founding_date)
 
     previous_ar = copy.deepcopy(ANNUAL_REPORT)

--- a/legal-api/tests/unit/services/filings/validations/annual_report/test_validation.py
+++ b/legal-api/tests/unit/services/filings/validations/annual_report/test_validation.py
@@ -35,7 +35,7 @@ def test_validate(session, test_name, now, ar_date, agm_date,
     # setup
     identifier = 'CP1234567'
     founding_date = ar_date - datedelta.YEAR
-    business = Business(identifier=identifier)
+    business = Business(identifier=identifier, last_ledger_timestamp=founding_date)
     business.founding_date = founding_date
 
     ar = copy.deepcopy(ANNUAL_REPORT)

--- a/legal-api/tests/unit/services/filings/validations/test_validation.py
+++ b/legal-api/tests/unit/services/filings/validations/test_validation.py
@@ -36,7 +36,7 @@ def test_validate_ar_basic(session, test_name, now, ar_date, agm_date,
     # setup
     identifier = 'CP1234567'
     founding_date = ar_date - datedelta.YEAR
-    business = Business(identifier=identifier)
+    business = Business(identifier=identifier, last_ledger_timestamp=founding_date)
     business.founding_date = founding_date
 
     ar = copy.deepcopy(ANNUAL_REPORT)
@@ -87,7 +87,7 @@ def test_validate_coa_basic(session, test_name, now, delivery_region, delivery_c
     # setup
     identifier = 'CP1234567'
     founding_date = now - datedelta.YEAR
-    business = Business(identifier=identifier)
+    business = Business(identifier=identifier, last_ledger_timestamp=founding_date)
     business.founding_date = founding_date
 
     f = copy.deepcopy(FILING_HEADER)
@@ -126,7 +126,7 @@ def test_validate_cod_basic(session, test_name, now, delivery_country_1, deliver
     # setup
     identifier = 'CP1234567'
     founding_date = now - datedelta.YEAR
-    business = Business(identifier=identifier)
+    business = Business(identifier=identifier, last_ledger_timestamp=founding_date)
     business.founding_date = founding_date
 
     f = copy.deepcopy(FILING_HEADER)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#N/A

*Description of changes:*
- legal-api was not letting a user file an AR with an AGM before the 'go-live-date'
- changed to validate based on their last filing (done by checking the last_ledger_timestamp)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
