### PR TITLE
bug fix - only disable to-do list line expansion for drafts

### DIFF
--- a/coops-ui/src/components/Dashboard/TodoList.vue
+++ b/coops-ui/src/components/Dashboard/TodoList.vue
@@ -15,7 +15,7 @@
         v-for="(item, index) in orderBy(taskItems, 'order')"
         v-bind:key="index"
         expand-icon=""
-        :class="{ 'disabled': !item.enabled }">
+        :class="{ 'disabled': !item.enabled, 'draft': isDraft(item) }">
 
         <template v-slot:header>
           <div class="list-item">
@@ -444,7 +444,7 @@ export default {
 <style lang="stylus">
 
   // disable expansion
-  .todo-list .v-expansion-panel__body
+  .todo-list.draft .v-expansion-panel__body
     display none
 
 </style>


### PR DESCRIPTION
*Issue #:* /bcgov/entity#1289

*Description of changes:*
For pending payments, allow expansion - shown on (i) click. For draft, disable because menu was causing the expansion, which looked wrong.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
