### PR TITLE
deployment of coops application in context root

### DIFF
--- a/coops-ui/.env
+++ b/coops-ui/.env
@@ -1,0 +1,1 @@
+VUE_APP_PATH = cooperatives

--- a/coops-ui/.env.production
+++ b/coops-ui/.env.production
@@ -1,0 +1,1 @@
+VUE_APP_PATH = cooperatives/auth

--- a/coops-ui/.env.production
+++ b/coops-ui/.env.production
@@ -1,1 +1,1 @@
-VUE_APP_PATH = cooperatives/auth
+VUE_APP_PATH = cooperatives

--- a/coops-ui/openshift/Caddyfile
+++ b/coops-ui/openshift/Caddyfile
@@ -1,0 +1,12 @@
+0.0.0.0:2015
+
+root /var/www/html
+
+log stdout
+
+errors stdout
+
+rewrite /auth {
+    regexp .*
+    to {path} /cooperatives/
+}

--- a/coops-ui/openshift/templates/coops-ui-bc.tools.json
+++ b/coops-ui/openshift/templates/coops-ui-bc.tools.json
@@ -29,7 +29,7 @@
                 "runPolicy": "Serial",
                 "source": {
                     "type": "Dockerfile",
-                    "dockerfile": "FROM bcgov-s2i-caddy\nCOPY dist /var/www/html/",
+                    "dockerfile": "FROM bcgov-s2i-caddy\nRUN mkdir /var/www/html/${WEB_APP_CONTEXT_PATH} \nCOPY dist /var/www/html/${WEB_APP_CONTEXT_PATH}",
                     "images": [
                         {
                             "from": {
@@ -70,6 +70,15 @@
             "status": {
                 "lastVersion": 0
             }
+        }
+    ],
+    "parameters": [
+        {
+            "name": "WEB_APP_CONTEXT_PATH",
+            "displayName": "WEB_APP_CONTEXT_PATH",
+            "description": "The path at which web application is deployed.Context root for the web applicaton",
+            "required": true,
+            "value": "cooperatives"
         }
     ]
 }

--- a/coops-ui/openshift/templates/coops-ui-dc.dev.json
+++ b/coops-ui/openshift/templates/coops-ui-dc.dev.json
@@ -105,7 +105,7 @@
                                     {
                                         "name": "coops-web-ui-configuration",
                                         "readOnly": true,
-                                        "mountPath": "/var/www/html/config"
+                                        "mountPath": "/var/www/html/${WEB_APP_CONTEXT_PATH}/config"
                                     }
                                 ],
                                 "terminationMessagePath": "/dev/termination-log",
@@ -129,6 +129,15 @@
                 "availableReplicas": 0,
                 "unavailableReplicas": 0
             }
+        }
+    ],
+    "parameters": [
+        {
+            "name": "WEB_APP_CONTEXT_PATH",
+            "displayName": "WEB_APP_CONTEXT_PATH",
+            "description": "The path at which web application is deployed.Context root for the web applicaton",
+            "required": true,
+            "value": "cooperatives"
         }
     ]
 }

--- a/coops-ui/openshift/templates/coops-ui-dc.prod.json
+++ b/coops-ui/openshift/templates/coops-ui-dc.prod.json
@@ -105,7 +105,7 @@
                                     {
                                         "name": "coops-web-ui-configuration",
                                         "readOnly": true,
-                                        "mountPath": "/var/www/html/config"
+                                        "mountPath": "/var/www/html/${WEB_APP_CONTEXT_PATH}/config"
                                     }
                                 ],
                                 "terminationMessagePath": "/dev/termination-log",
@@ -129,6 +129,15 @@
                 "availableReplicas": 0,
                 "unavailableReplicas": 0
             }
+        }
+    ],
+    "parameters": [
+        {
+            "name": "WEB_APP_CONTEXT_PATH",
+            "displayName": "WEB_APP_CONTEXT_PATH",
+            "description": "The path at which web application is deployed.Context root for the web applicaton",
+            "required": true,
+            "value": "cooperatives"
         }
     ]
 }

--- a/coops-ui/openshift/templates/coops-ui-dc.test.json
+++ b/coops-ui/openshift/templates/coops-ui-dc.test.json
@@ -105,7 +105,7 @@
                                     {
                                         "name": "coops-web-ui-configuration",
                                         "readOnly": true,
-                                        "mountPath": "/var/www/html/config"
+                                        "mountPath": "/var/www/html/${WEB_APP_CONTEXT_PATH}/config"
                                     }
                                 ],
                                 "terminationMessagePath": "/dev/termination-log",
@@ -129,6 +129,15 @@
                 "availableReplicas": 0,
                 "unavailableReplicas": 0
             }
+        }
+    ],
+    "parameters": [
+        {
+            "name": "WEB_APP_CONTEXT_PATH",
+            "displayName": "WEB_APP_CONTEXT_PATH",
+            "description": "The path at which web application is deployed.Context root for the web applicaton",
+            "required": true,
+            "value": "cooperatives"
         }
     ]
 }

--- a/coops-ui/src/utils/config-helper.ts
+++ b/coops-ui/src/utils/config-helper.ts
@@ -5,7 +5,7 @@ export default {
    * fetch config from API
    */
   fetchConfig () {
-    const url = '/config/configuration.json'
+    const url = `/${process.env.VUE_APP_PATH}/config/configuration.json`
     const headers = {
       'Accept': 'application/json',
       'ResponseType': 'application/json',

--- a/coops-ui/vue.config.js
+++ b/coops-ui/vue.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   configureWebpack: {
     devtool: 'source-map'
-  }
+  },
+  publicPath: process.env.VUE_APP_PATH
 }


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

https://github.com/bcgov/entity/issues/1349

*Description of changes:*

1. Public path Vue changes
         Used a process.env file so that the public path is not hardcoded vue.config.js 

2. Static assets which are read manually [ie config files etc] need to be read from the same context root. Or else it will cause inconsistencies

3. corrected erroneous extenstion of vue.config.ts to vue.config.js 

4. Openshift changes
          For caddy to serve in a context root , the built bundle has to be in a folder with the name of the context root. Changed openshift configs for this.Also caddy rules has to be changed to support context root




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
