### PR TITLE
Oracle pipeline update

### DIFF
--- a/oracle/Jenkinsfile-startup
+++ b/oracle/Jenkinsfile-startup
@@ -85,11 +85,12 @@ node {
                     podSelector.untilEach {
                         def pod = it.objects()[0].metadata.name
                         echo "pod: ${pod}"
-
+                        // count to prevent oc loop cache
+                        def count = 1
                         if (pod != OLD_POD && it.objects()[0].status.phase == 'Running' && it.objects()[0].status.containerStatuses[0].ready) {
                             echo "New pod: ${pod}"
                             sleep 10
-                            // todo: make this check if database is up (currently passes no matter what)
+                            echo "waited {count*10} seconds"
                             try {
                                 echo "${pod}"
                                 sequences = ['noncorp_event_seq', 'noncorp_address_seq', 'noncorp_party_seq']
@@ -122,6 +123,7 @@ node {
                                 return true
                             } catch (Exception e) {
                                 echo "${e}"
+                                count++
                                 return false
                             }
                         } else {

--- a/oracle/Jenkinsfile-startup
+++ b/oracle/Jenkinsfile-startup
@@ -82,11 +82,11 @@ node {
                     def podSelector = openshift.selector('pod', [ app:"${COMPONENT_NAME}-${COMPONENT_TAG}" ])
 
                     deploy.rollout().latest()
+                    // count to prevent oc loop cache
+                    def count = 1
                     podSelector.untilEach {
                         def pod = it.objects()[0].metadata.name
                         echo "pod: ${pod}"
-                        // count to prevent oc loop cache
-                        def count = 1
                         if (pod != OLD_POD && it.objects()[0].status.phase == 'Running' && it.objects()[0].status.containerStatuses[0].ready) {
                             echo "New pod: ${pod}"
                             sleep 10

--- a/oracle/Jenkinsfile-startup
+++ b/oracle/Jenkinsfile-startup
@@ -90,7 +90,7 @@ node {
                         if (pod != OLD_POD && it.objects()[0].status.phase == 'Running' && it.objects()[0].status.containerStatuses[0].ready) {
                             echo "New pod: ${pod}"
                             sleep 10
-                            echo "waited {count*10} seconds"
+                            echo "waited ${count*10} seconds"
                             try {
                                 echo "${pod}"
                                 sequences = ['noncorp_event_seq', 'noncorp_address_seq', 'noncorp_party_seq']

--- a/oracle/Jenkinsfile-startup
+++ b/oracle/Jenkinsfile-startup
@@ -88,22 +88,36 @@ node {
 
                         if (pod != OLD_POD && it.objects()[0].status.phase == 'Running' && it.objects()[0].status.containerStatuses[0].ready) {
                             echo "New pod: ${pod}"
-                            sleep 80
+                            sleep 10
                             // todo: make this check if database is up (currently passes no matter what)
                             try {
                                 echo "${pod}"
                                 sequences = ['noncorp_event_seq', 'noncorp_address_seq', 'noncorp_party_seq']
                                 for (seq in sequences) {
-                                    def set_seq_vals = openshift.exec(
+                                    def inc_seq_50 = openshift.exec(
                                         pod,
                                         '--',
                                         "bash -c ' \
                                         echo \"alter sequence C##CDEV.${seq} increment by 50;\"|\"\$ORACLE_HOME/bin/sqlplus\" / as sysdba \
+                                        '"
+                                    ).actions[0].out
+                                    echo inc_seq_50
+                                    def set_seq_val = openshift.exec(
+                                        pod,
+                                        '--',
+                                        "bash -c ' \
                                         echo \"select C##CDEV.${seq}.NEXTVAL from dual;\"|\"\$ORACLE_HOME/bin/sqlplus\" / as sysdba \
+                                        '"
+                                    ).actions[0].out
+                                    echo set_seq_val
+                                    def reset_seq_inc = openshift.exec(
+                                        pod,
+                                        '--',
+                                        "bash -c ' \
                                         echo \"alter sequence C##CDEV.${seq} increment by 1;\"|\"\$ORACLE_HOME/bin/sqlplus\" / as sysdba \
                                         '"
                                     ).actions[0].out
-                                    echo set_seq_vals
+                                    echo reset_seq_inc
                                 }
                                 return true
                             } catch (Exception e) {

--- a/oracle/Jenkinsfile-startup
+++ b/oracle/Jenkinsfile-startup
@@ -82,15 +82,14 @@ node {
                     def podSelector = openshift.selector('pod', [ app:"${COMPONENT_NAME}-${COMPONENT_TAG}" ])
 
                     deploy.rollout().latest()
-                    // count to prevent oc loop cache
                     def count = 1
                     podSelector.untilEach {
                         def pod = it.objects()[0].metadata.name
                         echo "pod: ${pod}"
                         if (pod != OLD_POD && it.objects()[0].status.phase == 'Running' && it.objects()[0].status.containerStatuses[0].ready) {
                             echo "New pod: ${pod}"
-                            sleep 10
-                            echo "waited ${count*10} seconds"
+                            sleep 80
+                            echo "waited ${count*80} seconds"
                             try {
                                 echo "${pod}"
                                 sequences = ['noncorp_event_seq', 'noncorp_address_seq', 'noncorp_party_seq']

--- a/oracle/Jenkinsfile-startup
+++ b/oracle/Jenkinsfile-startup
@@ -92,6 +92,19 @@ node {
                             // todo: make this check if database is up (currently passes no matter what)
                             try {
                                 echo "${pod}"
+                                sequences = ['noncorp_event_seq', 'noncorp_address_seq', 'noncorp_party_seq']
+                                for (seq in sequences) {
+                                    def set_seq_vals = openshift.exec(
+                                        OLD_POD,
+                                        '--',
+                                        "bash -c ' \
+                                        echo \"alter sequence C##CDEV.${seq} increment by 50;\"|\"\$ORACLE_HOME/bin/sqlplus\" / as sysdba \
+                                        echo \"select C##CDEV.${seq}.NEXTVAL from dual;\"|\"\$ORACLE_HOME/bin/sqlplus\" / as sysdba \
+                                        echo \"alter sequence C##CDEV.${seq} increment by 1;\"|\"\$ORACLE_HOME/bin/sqlplus\" / as sysdba \
+                                        '"
+                                    ).actions[0].out
+                                    echo set_seq_vals
+                                }
                                 return true
                             } catch (Exception e) {
                                 echo "${e}"

--- a/oracle/Jenkinsfile-startup
+++ b/oracle/Jenkinsfile-startup
@@ -95,7 +95,7 @@ node {
                                 sequences = ['noncorp_event_seq', 'noncorp_address_seq', 'noncorp_party_seq']
                                 for (seq in sequences) {
                                     def set_seq_vals = openshift.exec(
-                                        OLD_POD,
+                                        pod,
                                         '--',
                                         "bash -c ' \
                                         echo \"alter sequence C##CDEV.${seq} increment by 50;\"|\"\$ORACLE_HOME/bin/sqlplus\" / as sysdba \


### PR DESCRIPTION
*Issue #:* /bcgov/entity#n/a

*Description of changes:*
- oracle-forapi pod was restarting with bad sequence number which was causing duplicate ids for new events/directors/addresses
- updated startup oracle pipeline to set the sequences above current max values

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
