### PR TITLE
implemented additional Registered Office Address validation rules

### DIFF
--- a/coops-ui/package.json
+++ b/coops-ui/package.json
@@ -20,7 +20,7 @@
     "provinces": "^1.11.0",
     "regenerator-runtime": "^0.13.3",
     "register-service-worker": "^1.6.2",
-    "sbc-common-components": "1.0.16",
+    "sbc-common-components": "1.0.19",
     "sinon": "^7.3.2",
     "vue": "^2.6.10",
     "vue-affix": "^0.5.2",

--- a/coops-ui/src/components/AnnualReport/RegisteredOfficeAddress.vue
+++ b/coops-ui/src/components/AnnualReport/RegisteredOfficeAddress.vue
@@ -162,11 +162,14 @@ export default class RegisteredOfficeAddress extends Vue {
       maxLength: maxLength(40)
     },
     addressCountry: {
-      required
-      // isCanada: (val) => (val.toLower() === 'canada') // FUTURE
+      required,
+      // FUTURE: create new validation function isCountry('CA')
+      isCanada: (val) => Boolean(val === 'CA')
     },
     addressRegion: {
-      maxLength: maxLength(2)
+      maxLength: maxLength(2),
+      // FUTURE: create new validation function isRegion('BC')
+      isBC: (val) => Boolean(val === 'BC')
     },
     postalCode: {
       required,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#1191

*Description of changes:*
- added schema rules to Registered Office Address to require region=BC and country=CA
- updated sbc-common-components version to include latest changes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
