### PR TITLE
Changed addressRegion to allow null values; added more address tests.

### DIFF
--- a/schemas/src/registry_schemas/example_data/__init__.py
+++ b/schemas/src/registry_schemas/example_data/__init__.py
@@ -15,4 +15,4 @@
 
 These can be used in other tests as basis for the JSON filings.
 """
-from .schema_data import ANNUAL_REPORT, BUSINESS, CHANGE_OF_ADDRESS, CHANGE_OF_DIRECTORS, FILING_HEADER
+from .schema_data import ADDRESS, ANNUAL_REPORT, BUSINESS, CHANGE_OF_ADDRESS, CHANGE_OF_DIRECTORS, FILING_HEADER

--- a/schemas/src/registry_schemas/example_data/schema_data.py
+++ b/schemas/src/registry_schemas/example_data/schema_data.py
@@ -43,6 +43,16 @@ BUSINESS = {
     'legalType': 'CP'
 }
 
+ADDRESS = {
+    'streetAddress': 'delivery_address - address line one',
+    'streetAddressAdditional': 'line 2',
+    'addressCity': 'delivery_address city',
+    'addressCountry': 'delivery_address country',
+    'postalCode': 'H0H0H0',
+    'addressRegion': 'BC',
+    'deliveryInstructions': 'some delivery instructions'
+}
+
 ANNUAL_REPORT = {
     'filing': {
         'header': {

--- a/schemas/src/registry_schemas/schemas/address.json
+++ b/schemas/src/registry_schemas/schemas/address.json
@@ -21,7 +21,10 @@
             "type": "string"
         },
         "addressRegion": {
-            "type": "string",
+            "type": [
+                "string",
+                "null"
+            ],
             "maxLength": 2
         },
         "postalCode": {

--- a/schemas/tests/unit/test_addresses.py
+++ b/schemas/tests/unit/test_addresses.py
@@ -1,0 +1,78 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test Suite to ensure legal filing schemas are valid.
+
+This suite should have at least 1 test for every filing type allowed.
+"""
+import copy
+
+from registry_schemas import validate
+from registry_schemas.example_data import ADDRESS
+
+
+def test_valid_address():
+    """Assert that the schema is performing as expected."""
+    is_valid, errors = validate(ADDRESS, 'address')
+
+    if errors:
+        for err in errors:
+            print(err.message)
+    print(errors)
+
+    assert is_valid
+
+
+def test_valid_address_null_region():
+    """Assert that region is allowed to be null."""
+    address = copy.deepcopy(ADDRESS)
+    address['addressRegion'] = None
+
+    is_valid, errors = validate(address, 'address')
+
+    if errors:
+        for err in errors:
+            print(err.message)
+    print(errors)
+
+    assert is_valid
+
+
+def test_invalid_address():
+    """Assert that an invalid address fails."""
+    address = copy.deepcopy(ADDRESS)
+    address['streetAddress'] = 'This is a really long string, over the 50 char maximum'
+
+    is_valid, errors = validate(address, 'address')
+
+    if errors:
+        for err in errors:
+            print(err.message)
+    print(errors)
+
+    assert not is_valid
+
+
+def test_invalid_address_missing_region():
+    """Assert that an invalid address fails - missing required field addressRegion."""
+    address = copy.deepcopy(ADDRESS)
+    del address['addressRegion']
+
+    is_valid, errors = validate(address, 'address')
+
+    if errors:
+        for err in errors:
+            print(err.message)
+    print(errors)
+
+    assert not is_valid


### PR DESCRIPTION
*Issue #:* /bcgov/entity#1445

*Description of changes:*
Changed addressRegion to allow null values, for the case where region (province) doesn't apply to a country, ie: any country not Canada, USA, and a few others.

**This PR is pointing at story branch address-validation.**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
