### PR TITLE
Bug fix #1032 - Clicking 'Same as Delivery Address' should not add filing fee

### DIFF
--- a/coops-ui/src/components/AnnualReport/RegisteredOfficeAddress.vue
+++ b/coops-ui/src/components/AnnualReport/RegisteredOfficeAddress.vue
@@ -328,12 +328,11 @@ export default class RegisteredOfficeAddress extends Vue {
    */
   private sameAddress (address1: object, address2: object): boolean {
     const json1 = JSON.stringify(address1, (name: string, val: any) : any => {
-      return val !== '' && name !== 'actions' ? val : undefined
+      return val !== '' && name !== 'actions' && name !== 'addressType' ? val : undefined
     })
     const json2 = JSON.stringify(address2, (name: string, val: any) : any => {
-      return val !== '' && name !== 'actions' ? val : undefined
+      return val !== '' && name !== 'actions' && name !== 'addressType' ? val : undefined
     })
-
     return json1 === json2
   }
 
@@ -362,13 +361,15 @@ export default class RegisteredOfficeAddress extends Vue {
    * Updates the address data using what was entered on the forms.
    */
   private updateAddress (): void {
-    if (this.inheritDeliveryAddress) {
-      this.mailingAddress = { ...this.deliveryAddress }
+    if (!(this.sameAddress(this.mailingAddress, this.mailingAddressOriginal) &&
+          this.sameAddress(this.deliveryAddress, this.deliveryAddressOriginal))) {
+      if (this.inheritDeliveryAddress) {
+        this.mailingAddress = { ...this.deliveryAddress }
+      }
+      this.emitAddresses()
+      this.emitModified()
     }
-
     this.showAddressForm = false
-    this.emitAddresses()
-    this.emitModified()
   }
 
   /**

--- a/coops-ui/src/components/AnnualReport/RegisteredOfficeAddress.vue
+++ b/coops-ui/src/components/AnnualReport/RegisteredOfficeAddress.vue
@@ -328,10 +328,10 @@ export default class RegisteredOfficeAddress extends Vue {
    */
   private sameAddress (address1: object, address2: object): boolean {
     const json1 = JSON.stringify(address1, (name: string, val: any) : any => {
-      return val !== '' && name !== 'actions' && name !== 'addressType' ? val : undefined
+      return (val !== '' && name !== 'actions' && name !== 'addressType') ? val : undefined
     })
     const json2 = JSON.stringify(address2, (name: string, val: any) : any => {
-      return val !== '' && name !== 'actions' && name !== 'addressType' ? val : undefined
+      return (val !== '' && name !== 'actions' && name !== 'addressType') ? val : undefined
     })
     return json1 === json2
   }

--- a/coops-ui/src/components/AnnualReport/RegisteredOfficeAddress.vue
+++ b/coops-ui/src/components/AnnualReport/RegisteredOfficeAddress.vue
@@ -361,15 +361,12 @@ export default class RegisteredOfficeAddress extends Vue {
    * Updates the address data using what was entered on the forms.
    */
   private updateAddress (): void {
-    if (!(this.sameAddress(this.mailingAddress, this.mailingAddressOriginal) &&
-          this.sameAddress(this.deliveryAddress, this.deliveryAddressOriginal))) {
-      if (this.inheritDeliveryAddress) {
-        this.mailingAddress = { ...this.deliveryAddress }
-      }
-      this.emitAddresses()
-      this.emitModified()
+    if (this.inheritDeliveryAddress) {
+      this.mailingAddress = { ...this.deliveryAddress }
     }
     this.showAddressForm = false
+    this.emitAddresses()
+    this.emitModified()
   }
 
   /**


### PR DESCRIPTION
*Issue #:* /bcgov/entity#1032

*Description of changes:*
 Modified the sameaddress method to exclude address type while comparing the addresses

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
