### PR TITLE
Fix queue problem - when filing not found, add msg back to queue

### DIFF
--- a/entity-filer/src/entity_filer/service.py
+++ b/entity-filer/src/entity_filer/service.py
@@ -36,7 +36,6 @@ class ServiceWorker():
 
     @staticmethod
     def get_instance():
-        logger.debug('in get_instance')
         return ServiceWorker._instance
 
     def __init__(self, *,
@@ -136,11 +135,9 @@ class ServiceWorker():
 
     async def publish(self, payload):
         """Publish to the queue."""
-        logger.debug('got to publish()')
         try:
             self.sc.publish(subject=self.config.SUBSCRIPTION_OPTIONS.get('subject'),
                              payload=payload.encode('utf-8'))
-            logger.debug('done publishing')
 
         except Exception as err:  # pylint: disable=broad-except; catch all errors to log out when closing the service.
             logger.debug('error in ServiceWorker.publish(): %s', err, stack_info=True)
@@ -154,11 +151,8 @@ class ServiceWorker():
             logger.debug('error when closing the streams: %s', err, stack_info=True)
 
 async def publish_message(payload):
-    logger.debug('got to publish_message()')
     service = ServiceWorker.get_instance()
-    logger.debug('service=' + service)
     service.publish(payload)
-    logger.debug('done publish_message()')
 
 async def run(loop):  # pylint: disable=too-many-locals
     """Run the main application loop for the service.

--- a/entity-filer/src/entity_filer/service.py
+++ b/entity-filer/src/entity_filer/service.py
@@ -32,6 +32,13 @@ from entity_filer.worker import cb_subscription_handler  # noqa I001; sort issue
 class ServiceWorker():
     """Wrap a service that will listen to the Queue Stream."""
 
+    _instance = None
+
+    @staticmethod
+    def get_instance():
+        logger.debug('in get_instance')
+        return ServiceWorker._instance
+
     def __init__(self, *,
                  loop=None,
                  cb_handler=None,
@@ -62,6 +69,7 @@ class ServiceWorker():
                     continue
                 break
         self._stan_conn_lost_cb = conn_lost_cb
+        _instance = self
 
     @property
     async def is_healthy(self):
@@ -126,6 +134,15 @@ class ServiceWorker():
                     subscription_options.get('cb').__name__ if subscription_options.get('cb') else 'no_call_back',
                     subscription_options.get('queue'))
 
+    async def publish(self, payload):
+        """Publish to the queue."""
+        try:
+            self.sc.publish(subject=self.config.SUBSCRIPTION_OPTIONS.get('subject'),
+                             payload=payload.encode('utf-8'))
+
+        except Exception as err:  # pylint: disable=broad-except; catch all errors to log out when closing the service.
+            logger.debug('error when closing the streams: %s', err, stack_info=True)
+
     async def close(self):
         """Close the stream and nats connections."""
         try:
@@ -134,6 +151,9 @@ class ServiceWorker():
         except Exception as err:  # pylint: disable=broad-except; catch all errors to log out when closing the service.
             logger.debug('error when closing the streams: %s', err, stack_info=True)
 
+async def publish_message(payload):
+    service = ServiceWorker.get_instance()
+    service.publish(payload)
 
 async def run(loop):  # pylint: disable=too-many-locals
     """Run the main application loop for the service.

--- a/entity-filer/src/entity_filer/service.py
+++ b/entity-filer/src/entity_filer/service.py
@@ -136,12 +136,14 @@ class ServiceWorker():
 
     async def publish(self, payload):
         """Publish to the queue."""
+        logger.debug('got to publish()')
         try:
             self.sc.publish(subject=self.config.SUBSCRIPTION_OPTIONS.get('subject'),
                              payload=payload.encode('utf-8'))
+            logger.debug('done publishing')
 
         except Exception as err:  # pylint: disable=broad-except; catch all errors to log out when closing the service.
-            logger.debug('error when closing the streams: %s', err, stack_info=True)
+            logger.debug('error in ServiceWorker.publish(): %s', err, stack_info=True)
 
     async def close(self):
         """Close the stream and nats connections."""
@@ -152,8 +154,11 @@ class ServiceWorker():
             logger.debug('error when closing the streams: %s', err, stack_info=True)
 
 async def publish_message(payload):
+    logger.debug('got to publish_message()')
     service = ServiceWorker.get_instance()
+    logger.debug('service=' + service)
     service.publish(payload)
+    logger.debug('done publish_message()')
 
 async def run(loop):  # pylint: disable=too-many-locals
     """Run the main application loop for the service.

--- a/entity-filer/src/entity_filer/service_utils/__init__.py
+++ b/entity-filer/src/entity_filer/service_utils/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Callbacks and utility functions used to support the service loop."""
-from .exceptions import QueueException
+from .exceptions import FilingException, QueueException
 from .handlers import error_cb, signal_handler
 from .run_version import get_run_version
 from .service_logger import logger

--- a/entity-filer/src/entity_filer/service_utils/exceptions.py
+++ b/entity-filer/src/entity_filer/service_utils/exceptions.py
@@ -16,3 +16,6 @@
 
 class QueueException(Exception):
     """Base exception for the Queue Services."""
+
+class FilingException(Exception):
+    """No filing found to match queue payload."""

--- a/entity-filer/src/entity_filer/worker.py
+++ b/entity-filer/src/entity_filer/worker.py
@@ -126,7 +126,7 @@ async def cb_subscription_handler(msg: nats.aio.client.Msg):
     except FilingException:
         logger.debug('got FilingException, now going to call publish_message with payment_token:')
         logger.debug(payment_token)
-        service.publish_message(payment_token)
+        await service.publish_message(payment_token)
         capture_message('Queue Filing Error:' + json.dumps(payment_token), level='error')
         logger.error('Queue Filing Error: %s', json.dumps(payment_token), exc_info=True)
     except (QueueException, Exception):  # pylint: disable=broad-except

--- a/entity-filer/src/entity_filer/worker.py
+++ b/entity-filer/src/entity_filer/worker.py
@@ -124,6 +124,8 @@ async def cb_subscription_handler(msg: nats.aio.client.Msg):
         logger.error('Queue Blocked - Database Issue: %s', json.dumps(payment_token), exc_info=True)
         raise err  # We don't want to handle the error, as a DB down would drain the queue
     except FilingException:
+        logger.debug('got FilingException, now going to call publish_message with payment_token:')
+        logger.debug(payment_token)
         service.publish_message(payment_token)
         capture_message('Queue Filing Error:' + json.dumps(payment_token), level='error')
         logger.error('Queue Filing Error: %s', json.dumps(payment_token), exc_info=True)

--- a/entity-filer/src/entity_filer/worker.py
+++ b/entity-filer/src/entity_filer/worker.py
@@ -48,7 +48,7 @@ def extract_payment_token(msg: nats.aio.client.Msg) -> dict:
 
 def get_filing_by_payment_id(payment_id: int) -> Filing:
     """Return the outcome of Filing.get_filing_by_payment_token."""
-    filing = Filing.get_filing_by_payment_token(str(payment_id))
+    return Filing.get_filing_by_payment_token(str(payment_id))
 
 
 def process_filing(payment_token, flask_app):
@@ -58,10 +58,17 @@ def process_filing(payment_token, flask_app):
 
     with flask_app.app_context():
         filing_submission = get_filing_by_payment_id(payment_token['paymentToken'].get('id'))
-        try:
-            status = filing_submission.status
-        except AttributeError:
+        logger.debug('------------------->>>')
+        logger.debug(filing_submission)
+        if not filing_submission:
+            logger.debug('------------------->>> Its NONE')
             raise FilingException
+        logger.debug('------------------->>> Not NONE')
+
+        # try:
+        #     status = filing_submission.status
+        # except AttributeError:
+        #     raise FilingException
 
 
         if filing_submission.status == Filing.Status.COMPLETED.value:


### PR DESCRIPTION
*Issue #:* /bcgov/entity#1164

*Description of changes:*
This handles a timing issue with most free filings - the payment token is put on the queue for processing before the it is sent back to Legal API and saved to the filing. So the Entity Filer picks up the payment token (invoice) off the queue, looks for the filing associated with it, and fails.

This solution simply adds it back to the queue for reprocessing if this failure happens. Better long-term solution may exist. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
