### PR TITLE
replaced AUTH_URL config with env key

### DIFF
--- a/coops-ui/.env
+++ b/coops-ui/.env
@@ -1,1 +1,2 @@
 VUE_APP_PATH = cooperatives
+VUE_APP_AUTH_PATH = cooperatives/auth

--- a/coops-ui/.env.production
+++ b/coops-ui/.env.production
@@ -1,1 +1,2 @@
 VUE_APP_PATH = cooperatives
+VUE_APP_AUTH_PATH = cooperatives/auth

--- a/coops-ui/public/config/configuration.json
+++ b/coops-ui/public/config/configuration.json
@@ -1,6 +1,5 @@
 {
   "API_URL": "https://legal-api-dev.pathfinder.gov.bc.ca/api/v1/businesses/",
-  "AUTH_URL": "auth/",
   "AUTH_API_URL": "https://auth-api-dev.pathfinder.gov.bc.ca/api/v1/",
   "PAY_API_URL": "https://pay-api-dev.pathfinder.gov.bc.ca/api/v1/",
   "ADDRESS_COMPLETE_KEY": "RH99-RN99-GB72-FW86"

--- a/coops-ui/public/config/local-configuration.json
+++ b/coops-ui/public/config/local-configuration.json
@@ -1,6 +1,5 @@
 {
   "API_URL": "http://localhost:2015/api/v1/businesses/",
-  "AUTH_URL": "auth/",
   "AUTH_API_URL": "https://auth-api-dev.pathfinder.gov.bc.ca/api/v1/",
   "PAY_API_URL": "https://pay-api-test.pathfinder.gov.bc.ca/api/v1/",
   "ADDRESS_COMPLETE_KEY": "RH99-RN99-GB72-FW86"

--- a/coops-ui/src/components/Dashboard/TodoList.vue
+++ b/coops-ui/src/components/Dashboard/TodoList.vue
@@ -355,10 +355,9 @@ export default {
       const filingId = item.id
       const paymentToken = item.paymentToken
 
-      const origin = sessionStorage.getItem('ORIGIN') || ''
-      const authStub = sessionStorage.getItem('AUTH_STUB') || ''
-      const authUrl = origin + authStub
-      const returnURL = encodeURIComponent(origin + 'dashboard?filing_id=' + filingId)
+      const baseUrl = sessionStorage.getItem('BASE_URL')
+      const returnURL = encodeURIComponent(baseUrl + 'dashboard?filing_id=' + filingId)
+      const authUrl = sessionStorage.getItem('AUTH_URL')
       const payURL = authUrl + 'makepayment/' + paymentToken + '/' + returnURL
 
       // assume Pay URL is always reachable

--- a/coops-ui/src/components/EntityInfo.vue
+++ b/coops-ui/src/components/EntityInfo.vue
@@ -89,9 +89,8 @@ export default class EntityInfo extends Vue {
    * Redirects the user to the Auth UI to update their business profile.
    */
   private editBusinessProfile (): void {
-    const origin = sessionStorage.getItem('ORIGIN') || ''
-    const authStub = sessionStorage.getItem('AUTH_STUB') || ''
-    const businessProfileUrl = origin + authStub + 'businessprofile'
+    const authUrl = sessionStorage.getItem('AUTH_URL')
+    const businessProfileUrl = authUrl + 'businessprofile'
 
     // assume Business Profile URL is always reachable
     window.location.assign(businessProfileUrl)

--- a/coops-ui/src/utils/config-helper.ts
+++ b/coops-ui/src/utils/config-helper.ts
@@ -12,25 +12,20 @@ export default {
       'Cache-Control': 'no-cache'
     }
 
-    // get 'origin' just once for the app
-    {
-      const root = window.location.origin || ''
-      const path = process.env.VUE_APP_PATH
-      const origin = `${root}/${path}/`
-      sessionStorage.setItem('ORIGIN', origin)
-      console.log('Set Origin to: ' + origin)
-    }
+    const baseUrl = `${window.location.origin}/${process.env.VUE_APP_PATH}/`
+    sessionStorage.setItem('BASE_URL', baseUrl)
+    console.log('Set Base URL to: ' + baseUrl)
+
+    const authUrl = `${window.location.origin}/${process.env.VUE_APP_AUTH_PATH}/`
+    sessionStorage.setItem('AUTH_URL', authUrl)
+    console.log('Set Auth URL to: ' + authUrl)
 
     return axios
       .get(url, { headers })
       .then(response => {
         const apiUrl = response.data['API_URL']
         axios.defaults.baseURL = apiUrl
-        console.log('Set Base URL to: ' + apiUrl)
-
-        const authStub = response.data['AUTH_URL']
-        sessionStorage.setItem('AUTH_STUB', authStub)
-        console.log('Set Auth Stub to: ' + authStub)
+        console.log('Set Legal API URL to: ' + apiUrl)
 
         const authApiUrl = response.data['AUTH_API_URL']
         sessionStorage.setItem('AUTH_API_URL', authApiUrl)
@@ -42,7 +37,7 @@ export default {
 
         const addressCompleteKey = response.data['ADDRESS_COMPLETE_KEY']
         window['addressCompleteKey'] = addressCompleteKey
-        console.log('Set Address Complete Key')
+        console.log('Set Address Complete Key.')
       })
   }
 }

--- a/coops-ui/src/views/AnnualReport.vue
+++ b/coops-ui/src/views/AnnualReport.vue
@@ -509,10 +509,9 @@ export default {
         const filingId = +filing.header.filingId
         const paymentToken = filing.header.paymentToken
 
-        const origin = sessionStorage.getItem('ORIGIN') || ''
-        const authStub = sessionStorage.getItem('AUTH_STUB') || ''
-        const authUrl = origin + authStub
-        const returnURL = encodeURIComponent(origin + 'dashboard?filing_id=' + filingId)
+        const baseUrl = sessionStorage.getItem('BASE_URL')
+        const returnURL = encodeURIComponent(baseUrl + 'dashboard?filing_id=' + filingId)
+        const authUrl = sessionStorage.getItem('AUTH_URL')
         const payURL = authUrl + 'makepayment/' + paymentToken + '/' + returnURL
 
         // assume Pay URL is always reachable

--- a/coops-ui/src/views/StandaloneDirectorsFiling.vue
+++ b/coops-ui/src/views/StandaloneDirectorsFiling.vue
@@ -314,10 +314,9 @@ export default {
 
         // if filing needs to be paid, redirect to Pay URL
         if (this.isPaidFiling) {
-          const origin = sessionStorage.getItem('ORIGIN') || ''
-          const authStub = sessionStorage.getItem('AUTH_STUB') || ''
-          const authUrl = origin + authStub
-          const returnURL = encodeURIComponent(origin + 'dashboard?filing_id=' + filingId)
+          const baseUrl = sessionStorage.getItem('BASE_URL')
+          const returnURL = encodeURIComponent(baseUrl + 'dashboard?filing_id=' + filingId)
+          const authUrl = sessionStorage.getItem('AUTH_URL')
           const payURL = authUrl + 'makepayment/' + paymentToken + '/' + returnURL
 
           // assume Pay URL is always reachable

--- a/coops-ui/src/views/StandaloneOfficeAddressFiling.vue
+++ b/coops-ui/src/views/StandaloneOfficeAddressFiling.vue
@@ -351,10 +351,9 @@ export default {
         const filingId = +filing.header.filingId
         const paymentToken = filing.header.paymentToken
 
-        const origin = sessionStorage.getItem('ORIGIN') || ''
-        const authStub = sessionStorage.getItem('AUTH_STUB') || ''
-        const authUrl = origin + authStub
-        const returnURL = encodeURIComponent(origin + 'dashboard?filing_id=' + filingId)
+        const baseUrl = sessionStorage.getItem('BASE_URL')
+        const returnURL = encodeURIComponent(baseUrl + 'dashboard?filing_id=' + filingId)
+        const authUrl = sessionStorage.getItem('AUTH_URL')
         const payURL = authUrl + 'makepayment/' + paymentToken + '/' + returnURL
 
         // assume Pay URL is always reachable

--- a/coops-ui/tests/unit/AnnualReport.spec.ts
+++ b/coops-ui/tests/unit/AnnualReport.spec.ts
@@ -560,6 +560,10 @@ describe('AnnualReport - Part 3 - Submitting', () => {
 
   it('saves a new filing and redirects to Pay URL when this is a new AR and the File & Pay button is clicked',
     async () => {
+      // set necessary session variables
+      sessionStorage.setItem('BASE_URL', `myhost/${process.env.VUE_APP_PATH}/`)
+      sessionStorage.setItem('AUTH_URL', `myhost/${process.env.VUE_AUTH_PATH}/`)
+
       const localVue = createLocalVue()
       localVue.use(VueRouter)
       const router = mockRouter.mock()
@@ -610,7 +614,8 @@ describe('AnnualReport - Part 3 - Submitting', () => {
       expect(await vm.onClickFilePay()).toBe(true)
 
       // verify redirection
-      const payURL = 'makepayment/321/' + encodeURIComponent('dashboard?filing_id=123')
+      const payURL = 'myhost/cooperatives/auth/makepayment/321/' +
+        encodeURIComponent('myhost/cooperatives/dashboard?filing_id=123')
       expect(window.location.assign).toHaveBeenCalledWith(payURL)
 
       wrapper.destroy()
@@ -620,6 +625,10 @@ describe('AnnualReport - Part 3 - Submitting', () => {
     'updates an existing filing and redirects to Pay URL when this is a draft AR and the ' +
       'File & Pay button is clicked',
     async () => {
+      // set necessary session variables
+      sessionStorage.setItem('BASE_URL', `myhost/${process.env.VUE_APP_PATH}/`)
+      sessionStorage.setItem('AUTH_URL', `myhost/${process.env.VUE_AUTH_PATH}/`)
+
       const localVue = createLocalVue()
       localVue.use(VueRouter)
       const router = mockRouter.mock()
@@ -669,7 +678,8 @@ describe('AnnualReport - Part 3 - Submitting', () => {
       expect(await vm.onClickFilePay()).toBe(true)
 
       // verify redirection
-      const payURL = 'makepayment/321/' + encodeURIComponent('dashboard?filing_id=123')
+      const payURL = 'myhost/cooperatives/auth/makepayment/321/' +
+        encodeURIComponent('myhost/cooperatives/dashboard?filing_id=123')
       expect(window.location.assign).toHaveBeenCalledWith(payURL)
 
       wrapper.destroy()

--- a/coops-ui/tests/unit/StandaloneDirectorsFiling.spec.ts
+++ b/coops-ui/tests/unit/StandaloneDirectorsFiling.spec.ts
@@ -402,6 +402,10 @@ describe('Standalone Directors Filing - Part 3 - Submitting', () => {
 
   it('saves a new filing and redirects to Pay URL when this is a new AR and the File & Pay button is clicked',
     async () => {
+      // set necessary session variables
+      sessionStorage.setItem('BASE_URL', `myhost/${process.env.VUE_APP_PATH}/`)
+      sessionStorage.setItem('AUTH_URL', `myhost/${process.env.VUE_AUTH_PATH}/`)
+
       const localVue = createLocalVue()
       localVue.use(VueRouter)
       const router = mockRouter.mock()
@@ -450,7 +454,8 @@ describe('Standalone Directors Filing - Part 3 - Submitting', () => {
       // expect(tooltipText).toContain('There is no opportunity to change information beyond this point.')
 
       // verify redirection
-      const payURL = 'makepayment/321/' + encodeURIComponent('dashboard?filing_id=123')
+      const payURL = 'myhost/cooperatives/auth/makepayment/321/' +
+        encodeURIComponent('myhost/cooperatives/dashboard?filing_id=123')
       expect(window.location.assign).toHaveBeenCalledWith(payURL)
 
       wrapper.destroy()
@@ -460,6 +465,10 @@ describe('Standalone Directors Filing - Part 3 - Submitting', () => {
   it('updates an existing filing and redirects to Pay URL when this is a draft filing and the ' +
     'File & Pay button is clicked',
   async () => {
+    // set necessary session variables
+    sessionStorage.setItem('BASE_URL', `myhost/${process.env.VUE_APP_PATH}/`)
+    sessionStorage.setItem('AUTH_URL', `myhost/${process.env.VUE_AUTH_PATH}/`)
+
     const localVue = createLocalVue()
     localVue.use(VueRouter)
     const router = mockRouter.mock()
@@ -507,7 +516,8 @@ describe('Standalone Directors Filing - Part 3 - Submitting', () => {
     // expect(tooltipText).toContain('There is no opportunity to change information beyond this point.')
 
     // verify redirection
-    const payURL = 'makepayment/321/' + encodeURIComponent('dashboard?filing_id=123')
+    const payURL = 'myhost/cooperatives/auth/makepayment/321/' +
+      encodeURIComponent('myhost/cooperatives/dashboard?filing_id=123')
     expect(window.location.assign).toHaveBeenCalledWith(payURL)
 
     wrapper.destroy()

--- a/coops-ui/tests/unit/StandaloneOfficeAddressFiling.spec.ts
+++ b/coops-ui/tests/unit/StandaloneOfficeAddressFiling.spec.ts
@@ -371,6 +371,10 @@ describe('Standalone Office Address Filing - Part 3 - Submitting', () => {
 
   it('saves a new filing and redirects to Pay URL when this is a new AR and the File & Pay button is clicked',
     async () => {
+      // set necessary session variables
+      sessionStorage.setItem('BASE_URL', `myhost/${process.env.VUE_APP_PATH}/`)
+      sessionStorage.setItem('AUTH_URL', `myhost/${process.env.VUE_AUTH_PATH}/`)
+
       const localVue = createLocalVue()
       localVue.use(VueRouter)
       const router = mockRouter.mock()
@@ -420,7 +424,8 @@ describe('Standalone Office Address Filing - Part 3 - Submitting', () => {
       // expect(tooltipText).toContain('There is no opportunity to change information beyond this point.')
 
       // verify redirection
-      const payURL = 'makepayment/321/' + encodeURIComponent('dashboard?filing_id=123')
+      const payURL = 'myhost/cooperatives/auth/makepayment/321/' +
+        encodeURIComponent('myhost/cooperatives/dashboard?filing_id=123')
       expect(window.location.assign).toHaveBeenCalledWith(payURL)
 
       wrapper.destroy()
@@ -430,6 +435,10 @@ describe('Standalone Office Address Filing - Part 3 - Submitting', () => {
   it('updates an existing filing and redirects to Pay URL when this is a draft filing and the ' +
     'File & Pay button is clicked',
   async () => {
+    // set necessary session variables
+    sessionStorage.setItem('BASE_URL', `myhost/${process.env.VUE_APP_PATH}/`)
+    sessionStorage.setItem('AUTH_URL', `myhost/${process.env.VUE_AUTH_PATH}/`)
+
     const localVue = createLocalVue()
     localVue.use(VueRouter)
     const router = mockRouter.mock()
@@ -478,7 +487,8 @@ describe('Standalone Office Address Filing - Part 3 - Submitting', () => {
     // expect(tooltipText).toContain('There is no opportunity to change information beyond this point.')
 
     // verify redirection
-    const payURL = 'makepayment/321/' + encodeURIComponent('dashboard?filing_id=123')
+    const payURL = 'myhost/cooperatives/auth/makepayment/321/' +
+      encodeURIComponent('myhost/cooperatives/dashboard?filing_id=123')
     expect(window.location.assign).toHaveBeenCalledWith(payURL)
 
     wrapper.destroy()

--- a/coops-ui/tests/unit/TodoList.spec.ts
+++ b/coops-ui/tests/unit/TodoList.spec.ts
@@ -603,6 +603,10 @@ describe('TodoList - Click Tests', () => {
   })
 
   it('redirects to Pay URL when \'Resume Payment\' is clicked', done => {
+    // set necessary session variables
+    sessionStorage.setItem('BASE_URL', `myhost/${process.env.VUE_APP_PATH}/`)
+    sessionStorage.setItem('AUTH_URL', `myhost/${process.env.VUE_AUTH_PATH}/`)
+
     // init store
     store.state.tasks = [
       {
@@ -641,7 +645,8 @@ describe('TodoList - Click Tests', () => {
       await button.click()
 
       // verify redirection
-      const payURL = 'makepayment/654/' + encodeURIComponent('dashboard?filing_id=456')
+      const payURL = 'myhost/cooperatives/auth/makepayment/654/' +
+        encodeURIComponent('myhost/cooperatives/dashboard?filing_id=456')
       expect(window.location.assign).toHaveBeenCalledWith(payURL)
 
       wrapper.destroy()
@@ -650,6 +655,10 @@ describe('TodoList - Click Tests', () => {
   })
 
   it('redirects to Pay URL when \'Retry Payment\' is clicked', done => {
+    // set necessary session variables
+    sessionStorage.setItem('BASE_URL', `myhost/${process.env.VUE_APP_PATH}/`)
+    sessionStorage.setItem('AUTH_URL', `myhost/${process.env.VUE_AUTH_PATH}/`)
+
     // init store
     store.state.tasks = [
       {
@@ -686,7 +695,8 @@ describe('TodoList - Click Tests', () => {
       await button.click()
 
       // verify redirection
-      const payURL = 'makepayment/987/' + encodeURIComponent('dashboard?filing_id=789')
+      const payURL = 'myhost/cooperatives/auth/makepayment/987/' +
+        encodeURIComponent('myhost/cooperatives/dashboard?filing_id=789')
       expect(window.location.assign).toHaveBeenCalledWith(payURL)
 
       wrapper.destroy()


### PR DESCRIPTION
*Issue #:* /bcgov/entity#1572

*Description of changes:*
- deleted config for AUTH_URL (this can also be done in OCP config maps -- I think it's obsolete now)
- added VUE_APP_AUTH_URL key to env files
- updated config helper to store URLs accordingly
- updated components that use URLs
- updated unit tests to used more complete config


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
