### PR TITLE
fixed typos in unit tests

### DIFF
--- a/coops-ui/tests/unit/AnnualReport.spec.ts
+++ b/coops-ui/tests/unit/AnnualReport.spec.ts
@@ -562,7 +562,7 @@ describe('AnnualReport - Part 3 - Submitting', () => {
     async () => {
       // set necessary session variables
       sessionStorage.setItem('BASE_URL', `myhost/${process.env.VUE_APP_PATH}/`)
-      sessionStorage.setItem('AUTH_URL', `myhost/${process.env.VUE_AUTH_PATH}/`)
+      sessionStorage.setItem('AUTH_URL', `myhost/${process.env.VUE_APP_AUTH_PATH}/`)
 
       const localVue = createLocalVue()
       localVue.use(VueRouter)
@@ -627,7 +627,7 @@ describe('AnnualReport - Part 3 - Submitting', () => {
     async () => {
       // set necessary session variables
       sessionStorage.setItem('BASE_URL', `myhost/${process.env.VUE_APP_PATH}/`)
-      sessionStorage.setItem('AUTH_URL', `myhost/${process.env.VUE_AUTH_PATH}/`)
+      sessionStorage.setItem('AUTH_URL', `myhost/${process.env.VUE_APP_AUTH_PATH}/`)
 
       const localVue = createLocalVue()
       localVue.use(VueRouter)

--- a/coops-ui/tests/unit/StandaloneDirectorsFiling.spec.ts
+++ b/coops-ui/tests/unit/StandaloneDirectorsFiling.spec.ts
@@ -404,7 +404,7 @@ describe('Standalone Directors Filing - Part 3 - Submitting', () => {
     async () => {
       // set necessary session variables
       sessionStorage.setItem('BASE_URL', `myhost/${process.env.VUE_APP_PATH}/`)
-      sessionStorage.setItem('AUTH_URL', `myhost/${process.env.VUE_AUTH_PATH}/`)
+      sessionStorage.setItem('AUTH_URL', `myhost/${process.env.VUE_APP_AUTH_PATH}/`)
 
       const localVue = createLocalVue()
       localVue.use(VueRouter)
@@ -467,7 +467,7 @@ describe('Standalone Directors Filing - Part 3 - Submitting', () => {
   async () => {
     // set necessary session variables
     sessionStorage.setItem('BASE_URL', `myhost/${process.env.VUE_APP_PATH}/`)
-    sessionStorage.setItem('AUTH_URL', `myhost/${process.env.VUE_AUTH_PATH}/`)
+    sessionStorage.setItem('AUTH_URL', `myhost/${process.env.VUE_APP_AUTH_PATH}/`)
 
     const localVue = createLocalVue()
     localVue.use(VueRouter)

--- a/coops-ui/tests/unit/StandaloneOfficeAddressFiling.spec.ts
+++ b/coops-ui/tests/unit/StandaloneOfficeAddressFiling.spec.ts
@@ -373,7 +373,7 @@ describe('Standalone Office Address Filing - Part 3 - Submitting', () => {
     async () => {
       // set necessary session variables
       sessionStorage.setItem('BASE_URL', `myhost/${process.env.VUE_APP_PATH}/`)
-      sessionStorage.setItem('AUTH_URL', `myhost/${process.env.VUE_AUTH_PATH}/`)
+      sessionStorage.setItem('AUTH_URL', `myhost/${process.env.VUE_APP_AUTH_PATH}/`)
 
       const localVue = createLocalVue()
       localVue.use(VueRouter)
@@ -437,7 +437,7 @@ describe('Standalone Office Address Filing - Part 3 - Submitting', () => {
   async () => {
     // set necessary session variables
     sessionStorage.setItem('BASE_URL', `myhost/${process.env.VUE_APP_PATH}/`)
-    sessionStorage.setItem('AUTH_URL', `myhost/${process.env.VUE_AUTH_PATH}/`)
+    sessionStorage.setItem('AUTH_URL', `myhost/${process.env.VUE_APP_AUTH_PATH}/`)
 
     const localVue = createLocalVue()
     localVue.use(VueRouter)

--- a/coops-ui/tests/unit/TodoList.spec.ts
+++ b/coops-ui/tests/unit/TodoList.spec.ts
@@ -605,7 +605,7 @@ describe('TodoList - Click Tests', () => {
   it('redirects to Pay URL when \'Resume Payment\' is clicked', done => {
     // set necessary session variables
     sessionStorage.setItem('BASE_URL', `myhost/${process.env.VUE_APP_PATH}/`)
-    sessionStorage.setItem('AUTH_URL', `myhost/${process.env.VUE_AUTH_PATH}/`)
+    sessionStorage.setItem('AUTH_URL', `myhost/${process.env.VUE_APP_AUTH_PATH}/`)
 
     // init store
     store.state.tasks = [
@@ -657,7 +657,7 @@ describe('TodoList - Click Tests', () => {
   it('redirects to Pay URL when \'Retry Payment\' is clicked', done => {
     // set necessary session variables
     sessionStorage.setItem('BASE_URL', `myhost/${process.env.VUE_APP_PATH}/`)
-    sessionStorage.setItem('AUTH_URL', `myhost/${process.env.VUE_AUTH_PATH}/`)
+    sessionStorage.setItem('AUTH_URL', `myhost/${process.env.VUE_APP_AUTH_PATH}/`)
 
     // init store
     store.state.tasks = [


### PR DESCRIPTION
*Issue #:* None

*Description of changes:*
I forgot to rename an env variable in the unit tests, causing them to fail to get the env variable and causing 8 tests to fail. This PR fixes that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
