### PR TITLE
reload dashboard when we return too quickly from completed filing

### DIFF
--- a/coops-ui/src/components/Dashboard/FilingHistoryList.vue
+++ b/coops-ui/src/components/Dashboard/FilingHistoryList.vue
@@ -147,6 +147,7 @@ export default {
       }
 
       this.$emit('filed-count', this.filedItems.length)
+      this.$emit('filings-list', this.filedItems)
 
       // if needed, highlight a specific filing
       // NB: use unary plus operator to cast string to number
@@ -161,6 +162,7 @@ export default {
           const agmYear = +date.substring(0, 4)
           const item = {
             name: `Annual Report (${agmYear})`,
+            filingId: filing.header.filingId,
             filingAuthor: filing.header.certifiedBy,
             filingDate: filing.header.date,
             paymentToken: filing.header.paymentToken,
@@ -183,6 +185,7 @@ export default {
       if (filing.changeOfDirectors) {
         const item = {
           name: 'Director Change',
+          filingId: filing.header.filingId,
           filingAuthor: filing.header.certifiedBy,
           filingDate: filing.header.date,
           paymentToken: filing.header.paymentToken,
@@ -202,6 +205,7 @@ export default {
       if (filing.changeOfAddress) {
         const item = {
           name: 'Address Change',
+          filingId: filing.header.filingId,
           filingAuthor: filing.header.certifiedBy,
           filingDate: filing.header.date,
           paymentToken: filing.header.paymentToken,

--- a/coops-ui/src/components/Dashboard/TodoList.vue
+++ b/coops-ui/src/components/Dashboard/TodoList.vue
@@ -31,7 +31,8 @@
               </div>
 
               <div class="list-item__status2">
-                <span v-if="isPending(item)">
+                <span v-if="inProcessFiling === item.id && item.id !== undefined">PROCESSING...</span>
+                <span v-else-if="isPending(item)">
                   PAYMENT INCOMPLETE<v-btn text icon color="black"><v-icon>mdi-information-outline</v-icon></v-btn>
                 </span>
                 <span v-else-if="isError(item)">
@@ -41,7 +42,12 @@
             </template>
 
             <div class="list-item__actions">
-              <span v-if="isDraft(item)">
+              <span v-if="inProcessFiling === item.id && item.id !== undefined">
+                <!-- hidden button to maintain layout -->
+                <v-btn style="visibility: hidden"></v-btn>
+              </span>
+
+              <span v-else-if="isDraft(item)">
                 <v-btn id="btn-draft-resume"
                   color="primary"
                   :disabled="!item.enabled"
@@ -161,6 +167,10 @@ export default {
     }
   },
 
+  props: {
+    inProcessFiling: null
+  },
+
   computed: {
     ...mapState(['tasks', 'entityIncNo']),
 
@@ -190,6 +200,7 @@ export default {
       })
 
       this.$emit('todo-count', this.taskItems.length)
+      this.$emit('todo-filings', this.taskItems)
 
       // if this is a draft/pending/error item, emit the has-blocker-filings event to the parent component
       // this indicates that a new filing cannot be started because this one has to be completed first

--- a/coops-ui/src/views/Dashboard.vue
+++ b/coops-ui/src/views/Dashboard.vue
@@ -12,14 +12,15 @@
               <header>
                 <h2>To Do <span class="text-muted">({{todoCount}})</span></h2>
               </header>
-              <todo-list @todo-count="todoCount = $event" @has-blocker-filing="hasBlockerFiling = $event" />
+              <todo-list @todo-count="todoCount = $event" @has-blocker-filing="hasBlockerFiling = $event"
+                         @todo-filings="todoListFilings = $event" :inProcessFiling="inProcessFiling" />
             </section>
 
             <section>
               <header>
                 <h2>Recent Filing History <span class="text-muted">({{filedCount}})</span></h2>
               </header>
-              <filing-history-list @filed-count="filedCount = $event"/>
+              <filing-history-list @filed-count="filedCount = $event" @filings-list="historyFilings = $event" />
             </section>
           </div>
 
@@ -59,6 +60,7 @@
 </template>
 
 <script>
+import axios from '@/axios-auth'
 import TodoList from '@/components/Dashboard/TodoList.vue'
 import FilingHistoryList from '@/components/Dashboard/FilingHistoryList.vue'
 import AddressListSm from '@/components/Dashboard/AddressListSm.vue'
@@ -79,12 +81,21 @@ export default {
     return {
       todoCount: 0,
       hasBlockerFiling: false,
-      filedCount: 0
+      filedCount: 0,
+      historyFilings: [],
+      todoListFilings: [],
+      refreshTimer: null,
+      checkFilingStatusCount: 0,
+      inProcessFiling: null
     }
   },
 
+  computed: {
+    ...mapState(['entityIncNo'])
+  },
+
   methods: {
-    ...mapActions(['setCurrentFilingStatus']),
+    ...mapActions(['setCurrentFilingStatus', 'setTriggerDashboardReload']),
 
     goToStandaloneDirectors () {
       this.setCurrentFilingStatus('NEW')
@@ -94,7 +105,84 @@ export default {
     goToStandaloneAddresses () {
       this.setCurrentFilingStatus('NEW')
       this.$router.push({ name: 'standalone-addresses', params: { id: 0 } }) // 0 means "new COA filing"
+    },
+
+    checkToReloadDashboard () {
+      // cancel any existing timer so we can start fresh here
+      clearTimeout(this.refreshTimer)
+
+      let filingId = null
+      if (this.$route !== undefined) filingId = +this.$route.query.filing_id // if missing, this is NaN
+
+      // only consider refreshing the dashboard if we came from a filing
+      if (!filingId) return
+
+      let isInFilingHistory = this.historyFilings.filter(el => el.filingId === filingId).length > 0
+      let isInTodoList = this.todoListFilings.filter(el => el.id === filingId).length > 0
+
+      // if this filing is NOT in the to-do list and IS in the filing history list, do nothing - there is no problem
+      if (!isInTodoList && isInFilingHistory) return
+
+      // if this filing is in the to-do list, mark it as in-progress for to-do list to format differently
+      if (isInTodoList) {
+        this.inProcessFiling = filingId
+      }
+
+      // check for updated status to reload dashboard
+      this.checkFilingStatusCount = 0
+      this.checkFilingStatus(filingId)
+    },
+
+    checkFilingStatus (filingId) {
+      // check whether this filing's status has changed - recursive, runs approx. every 1 second for up to 10 seconds
+
+      this.checkFilingStatusCount++
+
+      // stop this cycle after 10 iterations
+      if (this.checkFilingStatusCount > 10) {
+        this.inProcessFiling = null
+        return
+      }
+
+      // get current filing status
+      let url = this.entityIncNo + '/filings/' + filingId
+      axios.get(url).then(res => {
+        if (!res) {
+          // quietly fail - this error is not worth showing the customer an error
+          return false
+        }
+        // if the filing status is now COMPLETE, reload the dashboard
+        if (res.data.filing.header.status === 'COMPLETED') {
+          this.setTriggerDashboardReload(true)
+        } else {
+          // call this function again in 1 second
+          let vue = this
+          this.refreshTimer = setTimeout(() => {
+            vue.checkFilingStatus(filingId)
+          }, 1000)
+        }
+      }).catch(() => {
+        // quietly fail - this error is not worth showing the customer an error
+        return false
+      })
     }
+  },
+  mounted () {
+    this.checkToReloadDashboard()
+  },
+  watch: {
+    historyFilings () {
+      console.log('historyFilings watched')
+      this.checkToReloadDashboard()
+    },
+    todoListFilings () {
+      console.log('todoListFilings watched')
+      this.checkToReloadDashboard()
+    }
+  },
+  destroyed () {
+    // kill the refresh timer if it is running
+    clearTimeout(this.refreshTimer)
   }
 }
 </script>

--- a/coops-ui/tests/unit/Dashboard.spec.ts
+++ b/coops-ui/tests/unit/Dashboard.spec.ts
@@ -69,6 +69,33 @@ describe('Dashboard - UI', () => {
     expect(wrapper.vm.$el.querySelector('#btn-standalone-directors')
       .getAttribute('disabled')).toBeTruthy()
   })
+
+  it('marks filing as PROCESSING when expecting completed filing', () => {
+    const localVue = createLocalVue()
+    localVue.use(VueRouter)
+    const router = mockRouter.mock()
+    router.push({ name: 'dashboard', query: { filing_id: '123' } })
+    const wrapper = mount(Dashboard, { localVue, store, router, vuetify })
+    const vm = wrapper.vm as any
+
+    // push filing ID in URL to indicate that we've returned from the dashboard from a filing (file pay, not save draft)
+    expect(vm.$route.query.filing_id).toBe('123')
+
+    // emit to-do list from to-do component with the filing marked as pending
+    wrapper.find(TodoList).vm.$emit('todo-filings', [
+      {
+        'type': 'changeOfDirectors',
+        'id': 123,
+        'status': 'PENDING',
+        'enabled': true,
+        'order': 1
+      }])
+
+    // emit filing list from Filing History component without the completed filing
+    wrapper.find(FilingHistoryList).vm.$emit('filings-list', [{}])
+
+    expect(vm.inProcessFiling).toEqual(123)
+  })
 })
 
 describe('Dashboard - Click Tests', () => {

--- a/coops-ui/tests/unit/TodoList.spec.ts
+++ b/coops-ui/tests/unit/TodoList.spec.ts
@@ -393,6 +393,53 @@ describe('TodoList - UI', () => {
     })
   })
 
+  it('displays a PROCESSING message on a filing that is expected to be complete', done => {
+    // init store
+    store.state.tasks = [
+      {
+        'task': {
+          'filing': {
+            'header': {
+              'name': 'changeOfDirectors',
+              'status': 'PENDING',
+              'paymentToken': 12345678,
+              'filingId': 123
+            },
+            'changeOfDirectors': { }
+          }
+        },
+        'enabled': true,
+        'order': 1
+      }
+    ]
+
+    const wrapper = mount(TodoList, { store, vuetify })
+    const vm = wrapper.vm as any
+
+    wrapper.setProps({ inProcessFiling: 123 })
+
+    Vue.nextTick(() => {
+      expect(vm.taskItems.length).toEqual(1)
+      expect(vm.$el.querySelectorAll('.todo-list').length).toEqual(1)
+      expect(wrapper.emitted('todo-count')).toEqual([[1]])
+      expect(wrapper.emitted('has-blocker-filing')).toEqual([[true]])
+      expect(vm.$el.querySelector('.no-results')).toBeNull()
+
+      const item = vm.$el.querySelector('.list-item')
+      expect(vm.taskItems[0].id).toEqual(wrapper.props('inProcessFiling'))
+      expect(item.querySelector('.list-item__title').textContent).toEqual('File Director Change')
+      expect(item.querySelector('.list-item__subtitle')).toBeNull()
+      expect(item.querySelector('.list-item__status1').textContent).toContain('FILING PENDING')
+      expect(item.querySelector('.list-item__status2').textContent).toContain('PROCESSING...')
+
+      const button = item.querySelector('.list-item__actions .v-btn')
+      expect(button.getAttribute('style')).toContain('visibility: hidden')
+
+      wrapper.destroy()
+      done()
+    })
+  })
+
   it('disables Resume Payment button if user has \'staff\' role', done => {
     // init store
     store.state.keycloakRoles = ['staff']


### PR DESCRIPTION
*Issue #:* /bcgov/entity#1117

*Description of changes:*
Reload dashboard when we return too quickly from completed filing.
This covers several scenarios, especially around free/unpaid filings that do not redirect to payment system.

Steps to reproduce and (rough) acceptance criteria (as proposed solution) are in ticket.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
