### PR TITLE
Reload dashboard when we return too quickly from completed filing.

### DIFF
--- a/coops-ui/src/components/Dashboard/FilingHistoryList.vue
+++ b/coops-ui/src/components/Dashboard/FilingHistoryList.vue
@@ -149,6 +149,7 @@ export default {
       }
 
       this.$emit('filed-count', this.filedItems.length)
+      this.$emit('filings-list', this.filedItems)
 
       // if needed, highlight a specific filing
       // NB: use unary plus operator to cast string to number
@@ -163,6 +164,7 @@ export default {
           const agmYear = +date.substring(0, 4)
           const item = {
             name: `Annual Report (${agmYear})`,
+            filingId: filing.header.filingId,
             filingAuthor: filing.header.certifiedBy,
             filingDate: filing.header.date,
             paymentToken: filing.header.paymentToken,
@@ -185,6 +187,7 @@ export default {
       if (filing.changeOfDirectors) {
         const item = {
           name: 'Director Change',
+          filingId: filing.header.filingId,
           filingAuthor: filing.header.certifiedBy,
           filingDate: filing.header.date,
           paymentToken: filing.header.paymentToken,
@@ -204,6 +207,7 @@ export default {
       if (filing.changeOfAddress) {
         const item = {
           name: 'Address Change',
+          filingId: filing.header.filingId,
           filingAuthor: filing.header.certifiedBy,
           filingDate: filing.header.date,
           paymentToken: filing.header.paymentToken,

--- a/coops-ui/src/components/Dashboard/TodoList.vue
+++ b/coops-ui/src/components/Dashboard/TodoList.vue
@@ -32,6 +32,11 @@
                 <span v-else-if="isPending(item)">FILING PENDING</span>
                 <span v-else-if="isError(item)">FILING PENDING</span>
               </div>
+              <div class="filing-status-2" v-if="inProcessFiling === item.id && item.id !== undefined">
+                <span>
+                  PROCESSING...
+                </span>
+              </div>
               <div class="filing-status-2" v-if="isPending(item)">
                 <span>
                   PAYMENT INCOMPLETE
@@ -47,7 +52,12 @@
             </template>
 
             <div class="list-item__actions">
-              <span v-if="isDraft(item)">
+              <span v-if="inProcessFiling === item.id && item.id !== undefined">
+                <!-- hidden button to maintain layout -->
+                <v-btn style="visibility: hidden"></v-btn>
+              </span>
+
+              <span v-else-if="isDraft(item)">
                 <v-btn id="btn-draft-resume"
                   color="primary"
                   :disabled="!item.enabled"
@@ -167,6 +177,10 @@ export default {
     }
   },
 
+  props: {
+    inProcessFiling: null
+  },
+
   computed: {
     ...mapState(['tasks', 'entityIncNo']),
 
@@ -196,6 +210,7 @@ export default {
       })
 
       this.$emit('todo-count', this.taskItems.length)
+      this.$emit('todo-filings', this.taskItems)
 
       // if this is a draft/pending/error item, emit the has-blocker-filings event to the parent component
       // this indicates that a new filing cannot be started because this one has to be completed first

--- a/coops-ui/tests/unit/Dashboard.spec.ts
+++ b/coops-ui/tests/unit/Dashboard.spec.ts
@@ -69,6 +69,61 @@ describe('Dashboard - UI', () => {
     expect(wrapper.vm.$el.querySelector('#btn-standalone-directors')
       .getAttribute('disabled')).toBeTruthy()
   })
+
+  it('marks filing as PROCESSING when expecting completed filing and dashboard does not reflect this', () => {
+    const localVue = createLocalVue()
+    localVue.use(VueRouter)
+    const router = mockRouter.mock()
+    router.push({ name: 'dashboard', query: { filing_id: '123' } })
+    const wrapper = mount(Dashboard, { localVue, store, router, vuetify })
+    const vm = wrapper.vm as any
+
+    // push filing ID in URL to indicate that we've returned from the dashboard from a filing (file pay, not save draft)
+    expect(vm.$route.query.filing_id).toBe('123')
+
+    // emit to-do list from to-do component with the filing marked as pending
+    wrapper.find(TodoList).vm.$emit('todo-filings', [
+      {
+        'type': 'changeOfDirectors',
+        'id': 123,
+        'status': 'PENDING',
+        'enabled': true,
+        'order': 1
+      }])
+
+    // emit filing list from Filing History component without the completed filing
+    wrapper.find(FilingHistoryList).vm.$emit('filings-list', [])
+
+    expect(vm.inProcessFiling).toEqual(123)
+  })
+
+  it('does not mark filing as PROCESSING when expecting completed filing and dashboard reflects this', () => {
+    const localVue = createLocalVue()
+    localVue.use(VueRouter)
+    const router = mockRouter.mock()
+    router.push({ name: 'dashboard', query: { filing_id: '123' } })
+    const wrapper = mount(Dashboard, { localVue, store, router, vuetify })
+    const vm = wrapper.vm as any
+
+    // push filing ID in URL to indicate that we've returned from the dashboard from a filing (file pay, not save draft)
+    expect(vm.$route.query.filing_id).toBe('123')
+
+    // emit to-do list from to-do component without the filing marked as pending
+    wrapper.find(TodoList).vm.$emit('todo-filings', [])
+
+    // emit filing list from Filing History component with the completed filing
+    wrapper.find(FilingHistoryList).vm.$emit('filings-list', [
+      {
+        'name':'Director Change',
+        'filingId':123,
+        'filingAuthor':'fS',
+        'filingDate':'2019-10-17',
+        'paymentToken':'661'
+      }
+    ])
+
+    expect(vm.inProcessFiling).toBeNull()
+  })
 })
 
 describe('Dashboard - Click Tests', () => {

--- a/coops-ui/tests/unit/TodoList.spec.ts
+++ b/coops-ui/tests/unit/TodoList.spec.ts
@@ -393,6 +393,100 @@ describe('TodoList - UI', () => {
     })
   })
 
+  it('displays a PROCESSING message on a filing that is expected to be complete', done => {
+    // init store
+    store.state.tasks = [
+      {
+        'task': {
+          'filing': {
+            'header': {
+              'name': 'changeOfDirectors',
+              'status': 'PENDING',
+              'paymentToken': 12345678,
+              'filingId': 123
+            },
+            'changeOfDirectors': { }
+          }
+        },
+        'enabled': true,
+        'order': 1
+      }
+    ]
+
+    const wrapper = mount(TodoList, { store, vuetify })
+    const vm = wrapper.vm as any
+
+    wrapper.setProps({ inProcessFiling: 123 })
+
+    Vue.nextTick(() => {
+      expect(vm.taskItems.length).toEqual(1)
+      expect(vm.$el.querySelectorAll('.todo-list').length).toEqual(1)
+      expect(wrapper.emitted('todo-count')).toEqual([[1]])
+      expect(wrapper.emitted('has-blocker-filing')).toEqual([[true]])
+      expect(vm.$el.querySelector('.no-results')).toBeNull()
+
+      const item = vm.$el.querySelector('.list-item')
+      expect(vm.taskItems[0].id).toEqual(wrapper.props('inProcessFiling'))
+      expect(item.querySelector('.list-item__title').textContent).toEqual('File Director Change')
+      expect(item.querySelector('.list-item__subtitle')).toBeNull()
+      expect(item.querySelector('.filing-status-1').textContent).toContain('FILING PENDING')
+      expect(item.querySelector('.filing-status-2').textContent).toContain('PROCESSING...')
+
+      const button = item.querySelector('.list-item__actions .v-btn')
+      expect(button.getAttribute('style')).toContain('visibility: hidden')
+
+      wrapper.destroy()
+      done()
+    })
+  })
+  it('does not break if a filing is marked as processing, that is not in the to-do list', done => {
+    // init store
+    store.state.tasks = [
+      {
+        'task': {
+          'filing': {
+            'header': {
+              'name': 'changeOfDirectors',
+              'status': 'PENDING',
+              'paymentToken': 12345678,
+              'filingId': 123
+            },
+            'changeOfDirectors': { }
+          }
+        },
+        'enabled': true,
+        'order': 1
+      }
+    ]
+
+    const wrapper = mount(TodoList, { store, vuetify })
+    const vm = wrapper.vm as any
+
+    wrapper.setProps({ inProcessFiling: 456 })
+
+    Vue.nextTick(() => {
+      expect(vm.taskItems.length).toEqual(1)
+      expect(vm.$el.querySelectorAll('.todo-list').length).toEqual(1)
+      expect(wrapper.emitted('todo-count')).toEqual([[1]])
+      expect(wrapper.emitted('has-blocker-filing')).toEqual([[true]])
+      expect(vm.$el.querySelector('.no-results')).toBeNull()
+
+      const item = vm.$el.querySelector('.list-item')
+      expect(vm.taskItems[0].id).not.toEqual(wrapper.props('inProcessFiling'))
+      expect(item.querySelector('.list-item__title').textContent).toEqual('File Director Change')
+      expect(item.querySelector('.list-item__subtitle')).toBeNull()
+      expect(item.querySelector('.filing-status-1').textContent).toContain('FILING PENDING')
+      expect(item.querySelector('.filing-status-2').textContent).toContain('PAYMENT INCOMPLETE')
+
+      const button = item.querySelector('.list-item__actions .v-btn')
+      expect(button.disabled).toBe(false)
+      expect(button.querySelector('.v-btn__content').textContent).toContain('Resume Payment')
+
+      wrapper.destroy()
+      done()
+    })
+  })
+
   it('disables Resume Payment button if user has \'staff\' role', done => {
     // init store
     store.state.keycloakRoles = ['staff']


### PR DESCRIPTION
*Issue #:* /bcgov/entity#1117

*Description of changes:*
Reload dashboard when we return too quickly from completed filing.
This covers several scenarios, especially around free/unpaid filings that do not redirect to payment system.

The steps to reproduce and (rough) acceptance criteria - as described solution, not formal AC - are in the ticket.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
