### PR TITLE
fix entity filer bug - overloading queue

### DIFF
--- a/entity-filer/src/entity_filer/service.py
+++ b/entity-filer/src/entity_filer/service.py
@@ -32,13 +32,6 @@ from entity_filer.worker import cb_subscription_handler  # noqa I001; sort issue
 class ServiceWorker():
     """Wrap a service that will listen to the Queue Stream."""
 
-    _instance = None
-
-    @staticmethod
-    def get_instance():
-        """Get this ServiceWorker instance."""
-        return ServiceWorker._instance
-
     def __init__(self, *,
                  loop=None,
                  cb_handler=None,
@@ -69,7 +62,6 @@ class ServiceWorker():
                     continue
                 break
         self._stan_conn_lost_cb = conn_lost_cb
-        _instance = self  # noqa: F841
 
     @property
     async def is_healthy(self):
@@ -134,14 +126,6 @@ class ServiceWorker():
                     subscription_options.get('cb').__name__ if subscription_options.get('cb') else 'no_call_back',
                     subscription_options.get('queue'))
 
-    async def publish(self, payload):
-        """Publish to the queue."""
-        try:
-            self.sc.publish(subject=self.config.SUBSCRIPTION_OPTIONS.get('subject'), payload=payload.encode('utf-8'))
-
-        except Exception as err:  # pylint: disable=broad-except; catch all errors to log out when closing the service.
-            logger.debug('error in ServiceWorker.publish(): %s', err, stack_info=True)
-
     async def close(self):
         """Close the stream and nats connections."""
         try:
@@ -149,12 +133,6 @@ class ServiceWorker():
             await self.nc.close()
         except Exception as err:  # pylint: disable=broad-except; catch all errors to log out when closing the service.
             logger.debug('error when closing the streams: %s', err, stack_info=True)
-
-
-async def publish_message(payload):
-    """Publish to the queue."""
-    service = ServiceWorker.get_instance()
-    service.publish(payload)
 
 
 async def run(loop):  # pylint: disable=too-many-locals

--- a/entity-filer/src/entity_filer/worker.py
+++ b/entity-filer/src/entity_filer/worker.py
@@ -41,8 +41,6 @@ from entity_filer.config import get_named_config
 from entity_filer.filing_processors import annual_report, change_of_address, change_of_directors
 from entity_filer.service_utils import FilingException, QueueException, logger
 
-from . import service
-
 
 def extract_payment_token(msg: nats.aio.client.Msg) -> dict:
     """Return a dict of the json string in the Msg.data."""
@@ -130,10 +128,11 @@ async def cb_subscription_handler(msg: nats.aio.client.Msg):
     except OperationalError as err:
         logger.error('Queue Blocked - Database Issue: %s', json.dumps(payment_token), exc_info=True)
         raise err  # We don't want to handle the error, as a DB down would drain the queue
-    except FilingException:
-        capture_message('Queue Filing Error:' + json.dumps(payment_token), level='error')
-        logger.error('Queue Filing Error: %s', json.dumps(payment_token), exc_info=True)
-        await service.publish_message(payment_token)
+    except FilingException as err:
+        logger.error('Queue Error - cannot find filing: %s'
+                     '\n\nThis message has been put back on the queue for reprocessing.',
+                     json.dumps(payment_token), exc_info=True)
+        raise err  # we don't want to handle the error, so that the message gets put back on the queue
     except (QueueException, Exception):  # pylint: disable=broad-except
         # Catch Exception so that any error is still caught and the message is removed from the queue
         capture_message('Queue Error:' + json.dumps(payment_token), level='error')


### PR DESCRIPTION
*Issue #:* n/a

*Description of changes:*
Do not catch error, just log it and allow it to trickle up. When that happens, the message is automatically added back to the queue without need for code (which was causing queue overload).

**NOTE: already running in dev from my branch; when this gets merged, the build config needs to be changed back to lear/master instead of katiemcgoff/branch.** 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
