### PR TITLE
updated dependency to latest sbc-common-components

### DIFF
--- a/coops-ui/package.json
+++ b/coops-ui/package.json
@@ -20,7 +20,7 @@
     "lodash.omit": "^4.4.0",
     "regenerator-runtime": "^0.13.3",
     "register-service-worker": "^1.6.2",
-    "sbc-common-components": "2.0.6",
+    "sbc-common-components": "2.0.11",
     "sinon": "^7.3.2",
     "vue": "^2.6.10",
     "vue-affix": "^0.5.2",


### PR DESCRIPTION
*Issue #:* None

*Description of changes:*
This is so everyone can use the latest sbc-common-components (this change was already done in 'release-2.1.0' branch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
