### PR TITLE
Changes to accept and pass routing slip number to pay api in case of …

### DIFF
--- a/legal-api/src/legal_api/resources/business/business_filings.py
+++ b/legal-api/src/legal_api/resources/business/business_filings.py
@@ -31,8 +31,9 @@ import legal_api.reports
 from legal_api.exceptions import BusinessException
 from legal_api.models import Business, Filing, User, db
 from legal_api.schemas import rsbc_schemas
-from legal_api.services import COLIN_SVC_ROLE, authorized, queue
+from legal_api.services import COLIN_SVC_ROLE, STAFF_ROLE, authorized, queue
 from legal_api.services.filings import validate
+from legal_api.services.filings.utils import get_str
 from legal_api.utils.auth import jwt
 from legal_api.utils.util import cors_preflight
 
@@ -344,6 +345,11 @@ class ListFilingResource(Resource):
                 'filingTypes': filing_types
             }
         }
+
+        if user_jwt.validate_roles([STAFF_ROLE]):
+            routing_slip_number = get_str(filing.filing_json, 'filing/header/routingSlipNumber')
+            if routing_slip_number:
+                payload['accountInfo'] = {'routingSlip': routing_slip_number}
         try:
             token = user_jwt.get_token_auth_header()
             headers = {'Authorization': 'Bearer ' + token}

--- a/legal-api/tests/unit/api/test_business_filings.py
+++ b/legal-api/tests/unit/api/test_business_filings.py
@@ -272,7 +272,7 @@ def test_post_only_validate_ar_invalid_routing_slip(session, client, jwt):
     factory_business(identifier)
 
     ar = copy.deepcopy(ANNUAL_REPORT)
-    ar['filing']['header']['routingSlipNumber'] = '12313133299'
+    ar['filing']['header']['routingSlipNumber'] = '1231313329988888'
 
     rv = client.post(f'/api/v1/businesses/{identifier}/filings?only_validate=true',
                      json=ar,
@@ -281,7 +281,17 @@ def test_post_only_validate_ar_invalid_routing_slip(session, client, jwt):
 
     assert rv.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
     assert rv.json.get('errors')
-    assert rv.json['errors'][0]['error'] == "'12313133299' is too long"
+    assert rv.json['errors'][0]['error'] == "'1231313329988888' is too long"
+
+    ar['filing']['header']['routingSlipNumber'] = '1'
+
+    rv = client.post(f'/api/v1/businesses/{identifier}/filings?only_validate=true',
+                     json=ar,
+                     headers=create_header(jwt, [STAFF_ROLE], identifier)
+                     )
+
+    assert rv.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert rv.json.get('errors')
 
 
 def test_post_validate_ar_valid_routing_slip(session, client, jwt):

--- a/legal-api/tests/unit/api/test_business_filings.py
+++ b/legal-api/tests/unit/api/test_business_filings.py
@@ -265,6 +265,46 @@ def test_post_only_validate_error_ar(session, client, jwt):
     assert rv.json['errors'][0]['error'] == "'name' is a required property"
 
 
+def test_post_only_validate_ar_invalid_routing_slip(session, client, jwt):
+    """Assert that a unpaid filing can be posted."""
+    import copy
+    identifier = 'CP7654321'
+    factory_business(identifier)
+
+    ar = copy.deepcopy(ANNUAL_REPORT)
+    ar['filing']['header']['routingSlipNumber'] = '12313133299'
+
+    rv = client.post(f'/api/v1/businesses/{identifier}/filings?only_validate=true',
+                     json=ar,
+                     headers=create_header(jwt, [STAFF_ROLE], identifier)
+                     )
+
+    assert rv.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert rv.json.get('errors')
+    assert rv.json['errors'][0]['error'] == "'12313133299' is too long"
+
+
+def test_post_validate_ar_valid_routing_slip(session, client, jwt):
+    """Assert that a unpaid filing can be posted."""
+    identifier = 'CP7654321'
+    factory_business(identifier,
+                     last_ar_date=(datetime.utcnow() - datedelta.YEAR),  # last ar date = last year
+                     founding_date=(datetime.utcnow() - datedelta.YEAR - datedelta.YEAR)  # founding date = 2 years ago
+                     )
+    ar = copy.deepcopy(ANNUAL_REPORT)
+    ar['filing']['annualReport']['annualReportDate'] = datetime.utcnow().date().isoformat()
+    ar['filing']['annualReport']['annualGeneralMeetingDate'] = datetime.utcnow().date().isoformat()
+    ar['filing']['header']['routingSlipNumber'] = '123131332'
+
+    rv = client.post(f'/api/v1/businesses/{identifier}/filings?only_validate=true',
+                     json=ar,
+                     headers=create_header(jwt, [STAFF_ROLE], identifier)
+                     )
+
+    assert rv.status_code == HTTPStatus.OK
+    assert not rv.json.get('errors')
+
+
 @integration_payment
 def test_post_valid_ar(session, client, jwt):
     """Assert that a filing can be completed up to payment."""
@@ -277,6 +317,38 @@ def test_post_valid_ar(session, client, jwt):
     ar = copy.deepcopy(ANNUAL_REPORT)
     ar['filing']['annualReport']['annualReportDate'] = datetime.utcnow().date().isoformat()
     ar['filing']['annualReport']['annualGeneralMeetingDate'] = datetime.utcnow().date().isoformat()
+
+    rv = client.post(f'/api/v1/businesses/{identifier}/filings',
+                     json=ar,
+                     headers=create_header(jwt, [STAFF_ROLE], identifier)
+                     )
+
+    # check return
+    assert rv.status_code == HTTPStatus.CREATED
+    assert not rv.json.get('errors')
+    assert rv.json['filing']['header']['filingId']
+    assert rv.json['filing']['header']['paymentToken']
+    assert rv.json['filing']['header']['paymentToken'] == '153'
+
+    # check stored filing
+    filing = Filing.get_filing_by_payment_token(rv.json['filing']['header']['paymentToken'])
+    assert filing
+    assert filing.status == Filing.Status.PENDING.value
+
+
+@integration_payment
+def test_post_valid_ar_with_routing_slip(session, client, jwt):
+    """Assert that a filing can be completed up to payment."""
+    from legal_api.models import Filing
+    identifier = 'CP7654321'
+    business = factory_business(identifier,
+                                founding_date=(datetime.utcnow() - datedelta.YEAR)
+                                )
+    factory_business_mailing_address(business)
+    ar = copy.deepcopy(ANNUAL_REPORT)
+    ar['filing']['annualReport']['annualReportDate'] = datetime.utcnow().date().isoformat()
+    ar['filing']['annualReport']['annualGeneralMeetingDate'] = datetime.utcnow().date().isoformat()
+    ar['filing']['header']['routingSlipNumber'] = '123131332'
 
     rv = client.post(f'/api/v1/businesses/{identifier}/filings',
                      json=ar,

--- a/schemas/src/registry_schemas/example_data/schema_data.py
+++ b/schemas/src/registry_schemas/example_data/schema_data.py
@@ -24,7 +24,8 @@ FILING_HEADER = {
             'date': '2019-04-08',
             'certifiedBy': 'full name',
             'email': 'no_one@never.get',
-            'filingId': 1
+            'filingId': 1,
+            'routingSlipNumber': '123456789'
         },
         'business': {
             'cacheId': 1,

--- a/schemas/src/registry_schemas/schemas/filing.json
+++ b/schemas/src/registry_schemas/schemas/filing.json
@@ -105,7 +105,8 @@
                         "routingSlipNumber": {
                             "type": "string",
                             "title": "A valid routing slip number in case of a staff filing.",
-                            "maxLength": 9
+                            "maxLength": 9,
+                            "pattern": "^[0-9]+$"
                         },
                         "submitter": {
                             "type": "string",

--- a/schemas/src/registry_schemas/schemas/filing.json
+++ b/schemas/src/registry_schemas/schemas/filing.json
@@ -102,6 +102,11 @@
                             "type": "string",
                             "title": "A valid payment token for this filing against this business."
                         },
+                        "routingSlipNumber": {
+                            "type": "string",
+                            "title": "A valid routing slip number in case of a staff filing.",
+                            "maxLength": 9
+                        },
                         "submitter": {
                             "type": "string",
                             "title": "Account name of the person submitting this filing."

--- a/schemas/src/registry_schemas/schemas/filing.json
+++ b/schemas/src/registry_schemas/schemas/filing.json
@@ -106,7 +106,7 @@
                             "type": "string",
                             "title": "A valid routing slip number in case of a staff filing.",
                             "maxLength": 9,
-                            "pattern": "^[0-9]+$"
+                            "pattern": "^\\d{9}$"
                         },
                         "submitter": {
                             "type": "string",


### PR DESCRIPTION
…a staff filing

*Issue #:* /bcgov/entity#1565, /bcgov/entity#1622

*Description of changes:*
Modified filing schema to include a new property in the header
Modified the invoice creation method to include routing slip if the token has a staff role + routing slip number is present in the request
Added tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
