### PR TITLE
explicitly added package and forced it to be transpiled

### DIFF
--- a/coops-ui/package.json
+++ b/coops-ui/package.json
@@ -54,6 +54,7 @@
     "typescript": "<3.6.0",
     "vue-class-component": "^7.1.0",
     "vue-cli-plugin-vuetify": "^0.5.0",
+    "vue-plugin-helper-decorator": "^0.0.11",
     "vue-property-decorator": "^8.2.2",
     "vue-template-compiler": "^2.6.10",
     "vue-test-utils-helpers": "git+https://github.com/AmpleOrganics/vue-test-utils-helpers.git",

--- a/coops-ui/vue.config.js
+++ b/coops-ui/vue.config.js
@@ -2,7 +2,10 @@ module.exports = {
   configureWebpack: {
     devtool: 'source-map'
   },
-  transpileDependencies: ['vuex-persist', 'vuetify'],
+  transpileDependencies: [
+    'vue-plugin-helper-decorator',
+    'vuetify'
+  ],
   publicPath: process.env.VUE_APP_PATH,
   pwa: {
     workboxPluginMode: 'InjectManifest',


### PR DESCRIPTION
*Issue #:* /bcgov/entity#1689

*Description of changes:*
A package used by sbc-common-components was not being transpiled (to ES5) and IE11 did not recognize some of the new syntax.
This package was added to coops-ui (as it could be used there in the future and it's only a dev dependency) and Vue was configured to always transpile it. This solves the problem.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
