### PR TITLE
stored Entity Founding date-time instead of just date

### DIFF
--- a/coops-ui/src/App.vue
+++ b/coops-ui/src/App.vue
@@ -244,8 +244,7 @@ export default {
         this.setEntityIncNo(response.data.business.identifier)
         this.setLastPreLoadFilingDate(response.data.business.lastLedgerTimestamp
           ? response.data.business.lastLedgerTimestamp.split('T')[0] : null)
-        this.setEntityFoundingDate(response.data.business.foundingDate
-          ? response.data.business.foundingDate.split('T')[0] : null)
+        this.setEntityFoundingDate(response.data.business.foundingDate) // datetime
         const date = response.data.business.lastAnnualGeneralMeetingDate
         if (
           date &&

--- a/coops-ui/tests/unit/App.spec.ts
+++ b/coops-ui/tests/unit/App.spec.ts
@@ -287,7 +287,7 @@ describe('App', () => {
     expect(vm.$store.state.entityBusinessNo).toBe('123456789')
     expect(vm.$store.state.entityIncNo).toBe('CP0001867')
     expect(vm.$store.state.lastPreLoadFilingDate).toBe('2019-08-14')
-    expect(vm.$store.state.entityFoundingDate).toBe('2000-07-13')
+    expect(vm.$store.state.entityFoundingDate).toBe('2000-07-13T00:00:00+00:00')
     expect(vm.$store.state.lastAgmDate).toBe('2019-08-16')
   })
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#1750

*Description of changes:*
The stored Entity Founding date was changed from a date to a date-time string, so that it is in the correct format when filing an AR/COD/COA.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
