### PR TITLE
added code safety check for IE11

### DIFF
--- a/coops-ui/src/registerServiceWorker.ts
+++ b/coops-ui/src/registerServiceWorker.ts
@@ -40,9 +40,12 @@ if (process.env.NODE_ENV === 'production') {
   })
 
   let refreshing
-  navigator.serviceWorker.addEventListener('controllerchange', e => {
-    if (refreshing) return
-    window.location.reload()
-    refreshing = true
-  })
+  // safety check for IE11
+  if (navigator && navigator.serviceWorker) {
+    navigator.serviceWorker.addEventListener('controllerchange', e => {
+      if (refreshing) return
+      window.location.reload()
+      refreshing = true
+    })
+  }
 }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#1775

*Description of changes:*
This PR adds a null check for objects to prevent an error in IE11. The service worker/PWA code does not work for IE11 anyway so this doesn't break anything.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
