### PR TITLE
Bugfix - Filings completed after 4pm show as the next day, Report has wrong Datetime

### DIFF
--- a/coops-ui/src/components/Dashboard/FilingHistoryList.vue
+++ b/coops-ui/src/components/Dashboard/FilingHistoryList.vue
@@ -131,7 +131,8 @@ export default {
       for (let i = 0; i < this.filings.length; i++) {
         const filing = this.filings[i].filing
         if (filing && filing.header) {
-          if (filing.header.date < '2019-03-08' || filing.header.availableOnPaperOnly) {
+          let filingDate = filing.header.date.slice(0, 10)
+          if (filingDate < '2019-03-08' || filing.header.availableOnPaperOnly) {
             this.loadPaperFiling(filing)
           } else {
             switch (filing.header.name) {

--- a/coops-ui/src/components/Dashboard/FilingHistoryList.vue
+++ b/coops-ui/src/components/Dashboard/FilingHistoryList.vue
@@ -174,18 +174,20 @@ export default {
     loadAnnualReport (filing) {
       if (filing.annualReport) {
         const date = filing.annualReport.annualGeneralMeetingDate
+        const filingDate = filing.header.date.slice(0, 10)
         if (date) {
           const agmYear = +date.substring(0, 4)
           const item = {
             name: `Annual Report (${agmYear})`,
             filingId: filing.header.filingId,
             filingAuthor: filing.header.certifiedBy,
-            filingDate: filing.header.date,
+            filingDateTime: filing.header.date,
+            filingDate: filingDate,
             paymentToken: filing.header.paymentToken,
             filingDocuments: [{
               filingId: filing.header.filingId,
               name: 'Annual Report',
-              documentName: `${this.entityIncNo} - Annual Report (${agmYear}) - ${filing.header.date}.pdf`
+              documentName: `${this.entityIncNo} - Annual Report (${agmYear}) - ${filingDate}.pdf`
             }],
             paperOnly: false
           }
@@ -200,16 +202,18 @@ export default {
 
     loadReport (title, filing, section) {
       if (section) {
+        const filingDate = filing.header.date.slice(0, 10)
         const item = {
           name: title,
           filingId: filing.header.filingId,
           filingAuthor: filing.header.certifiedBy,
-          filingDate: filing.header.date,
+          filingDateTime: filing.header.date,
+          filingDate: filingDate,
           paymentToken: filing.header.paymentToken,
           filingDocuments: [{
             filingId: filing.header.filingId,
             name: title,
-            documentName: `${this.entityIncNo} - ${title} - ${filing.header.date}.pdf`
+            documentName: `${this.entityIncNo} - ${title} - ${filingDate}.pdf`
           }],
           paperOnly: false
         }
@@ -226,7 +230,7 @@ export default {
       const item = {
         name: name,
         filingAuthor: 'Registry Staff',
-        filingDate: filing.header.date,
+        filingDate: filing.header.date.slice(0, 10),
         filingYear: filing.header.date.slice(0, 4),
         paymentToken: null,
         filingDocuments: [{
@@ -294,6 +298,17 @@ export default {
       })
     },
 
+    convertISOToCommonTime (isoTime) {
+      const groups = isoTime.split('T')
+      const date = groups[0]
+      var timeString = groups[1].split('.')[0]
+      var H = +timeString.substr(0, 2)
+      var h = H % 12 || 12
+      var ampm = (H < 12 || H === 24) ? 'AM' : 'PM'
+      timeString = h + timeString.substr(2, 3) + ampm
+      return date + ' ' + timeString
+    },
+
     async downloadReceipt (filing) {
       this.loadingReceipt = true
       await this.downloadOneReceipt(filing)
@@ -304,7 +319,7 @@ export default {
       const url = filing.paymentToken + '/receipts'
       const data = {
         corpName: this.entityName,
-        filingDateTime: filing.filingDate, // TODO: format as needed
+        filingDateTime: this.convertISOToCommonTime(filing.filingDateTime), // TODO: format as needed
         fileName: 'receipt' // not used
       }
       const config = {

--- a/coops-ui/src/mixins/date-mixin.ts
+++ b/coops-ui/src/mixins/date-mixin.ts
@@ -69,4 +69,20 @@ export default class DateMixin extends Vue {
     const regex = / (?!.* )/
     return formatDate.slice(1).join(' ').replace(regex, ', ')
   }
+
+  /**
+     * API always returns the UTC date time in ISO format. This needs to be
+     * converted to local time zone. Consistently in API and UI, America/Vancouver
+     * is the timezone to be used.
+     */
+  convertUTCTimeToLocalTime (date: string): String {
+    var dateTimeArray = date.split('.')
+    let UTCTime:string = dateTimeArray[0] + '.' + dateTimeArray[1].slice(0, 3) + 'Z'
+    return new Date(UTCTime).toLocaleDateString('en', {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+      timeZone: 'America/Vancouver'
+    })
+  }
 }

--- a/coops-ui/src/store/getters.ts
+++ b/coops-ui/src/store/getters.ts
@@ -29,9 +29,10 @@ export default {
 
     for (let i = 0; i < state.filings.length; i++) {
       let filing = state.filings[i].filing
+      let filingDate = filing.header.date.slice(0, 10)
       if (filing.hasOwnProperty('changeOfDirectors')) {
-        if (lastCOD === null || filing.header.date.split('-').join('') > lastCOD.split('-').join('')) {
-          lastCOD = filing.header.date
+        if (lastCOD === null || filingDate.split('-').join('') > lastCOD.split('-').join('')) {
+          lastCOD = filingDate
         }
       }
     }
@@ -44,9 +45,10 @@ export default {
 
     for (let i = 0; i < state.filings.length; i++) {
       let filing = state.filings[i].filing
+      let filingDate = filing.header.date.slice(0, 10)
       if (filing.hasOwnProperty('changeOfAddress')) {
-        if (lastCOA === null || filing.header.date.split('-').join('') > lastCOA.split('-').join('')) {
-          lastCOA = filing.header.date
+        if (lastCOA === null || filingDate.split('-').join('') > lastCOA.split('-').join('')) {
+          lastCOA = filingDate
         }
       }
     }
@@ -59,8 +61,9 @@ export default {
 
     for (let i = 0; i < state.filings.length; i++) {
       let filing = state.filings[i].filing
-      if (lastFilingDate === null || filing.header.date.split('-').join('') > lastFilingDate.split('-').join('')) {
-        lastFilingDate = filing.header.date
+      let filingDate = filing.header.date.slice(0, 10)
+      if (lastFilingDate === null || filingDate.split('-').join('') > lastFilingDate.split('-').join('')) {
+        lastFilingDate = filingDate
       }
     }
     return lastFilingDate

--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -213,7 +213,7 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes; allowin
         """Return a json representation of this object."""
         try:
             json_submission = copy.deepcopy(self.filing_json)
-            json_submission['filing']['header']['date'] = datetime.date(self.filing_date).isoformat()
+            json_submission['filing']['header']['date'] = self._filing_date.isoformat()
             json_submission['filing']['header']['filingId'] = self.id
             json_submission['filing']['header']['name'] = self.filing_type
             json_submission['filing']['header']['colinId'] = self.colin_event_id

--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -58,10 +58,10 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes; allowin
 
     id = db.Column(db.Integer, primary_key=True)
     _completion_date = db.Column('completion_date', db.DateTime(timezone=True))
-    _filing_date = db.Column('filing_date', db.DateTime(timezone=True), default=datetime.utcnow)
+    _filing_date = db.Column('filing_date', db.DateTime(timezone=True), default=datetime.now)
     _filing_type = db.Column('filing_type', db.String(30))
     _filing_json = db.Column('filing_json', JSONB)
-    effective_date = db.Column('effective_date', db.DateTime(timezone=True), default=datetime.utcnow)
+    effective_date = db.Column('effective_date', db.DateTime(timezone=True), default=datetime.now)
     _payment_token = db.Column('payment_id', db.String(4096))
     _payment_completion_date = db.Column('payment_completion_date', db.DateTime(timezone=True))
     colin_event_id = db.Column('colin_event_id', db.Integer)
@@ -198,7 +198,7 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes; allowin
     def set_processed(self):
         """Assign the completion date, unless it is already set."""
         if not self._completion_date:
-            self._completion_date = datetime.utcnow()
+            self._completion_date = datetime.now()
 
     @staticmethod
     def _raise_default_lock_exception():

--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -58,10 +58,10 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes; allowin
 
     id = db.Column(db.Integer, primary_key=True)
     _completion_date = db.Column('completion_date', db.DateTime(timezone=True))
-    _filing_date = db.Column('filing_date', db.DateTime(timezone=True), default=datetime.now)
+    _filing_date = db.Column('filing_date', db.DateTime(timezone=True), default=datetime.utcnow)
     _filing_type = db.Column('filing_type', db.String(30))
     _filing_json = db.Column('filing_json', JSONB)
-    effective_date = db.Column('effective_date', db.DateTime(timezone=True), default=datetime.now)
+    effective_date = db.Column('effective_date', db.DateTime(timezone=True), default=datetime.utcnow)
     _payment_token = db.Column('payment_id', db.String(4096))
     _payment_completion_date = db.Column('payment_completion_date', db.DateTime(timezone=True))
     colin_event_id = db.Column('colin_event_id', db.Integer)
@@ -198,7 +198,7 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes; allowin
     def set_processed(self):
         """Assign the completion date, unless it is already set."""
         if not self._completion_date:
-            self._completion_date = datetime.now()
+            self._completion_date = datetime.utcnow()
 
     @staticmethod
     def _raise_default_lock_exception():

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -163,9 +163,9 @@ class Report:  # pylint: disable=too-few-public-methods
 
         # Get the string for the filing date and time - do not use a leading zero on the hour (04:30 PM) as it looks
         # too much like the 24 hour 4:30 AM. Also, we can't use "%-I" on Windows.
-        filing_datetime = self._filing.filing_date.replace(tzinfo=timezone.utc).astimezone(tz=None)
-        # hour = filing_datetime.strftime('%I').lstrip('0')
-        filing['filing_date_time'] = filing_datetime.strftime(f'%B %d, %Y {filing_datetime.hour}:%M %p Pacific Time')
+        filing_datetime = self._filing.filing_date
+        hour = filing_datetime.strftime('%I').lstrip('0')
+        filing['filing_date_time'] = filing_datetime.strftime(f'%B %d, %Y {hour}:%M %p Pacific Time')
 
         # Get the effective date - TODO 'effective date' doesn't exist yet but will in future; for now use filing date
         effective_date = self._filing.filing_date.replace(tzinfo=timezone.utc).astimezone(tz=None)

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -17,6 +17,7 @@ from datetime import datetime, timezone
 from http import HTTPStatus
 from pathlib import Path
 
+import pytz
 import requests
 from flask import current_app, jsonify
 
@@ -163,7 +164,8 @@ class Report:  # pylint: disable=too-few-public-methods
 
         # Get the string for the filing date and time - do not use a leading zero on the hour (04:30 PM) as it looks
         # too much like the 24 hour 4:30 AM. Also, we can't use "%-I" on Windows.
-        filing_datetime = self._filing.filing_date
+        local_timezone = pytz.timezone('America/Vancouver')
+        filing_datetime = self._filing.filing_date.astimezone(local_timezone)
         hour = filing_datetime.strftime('%I').lstrip('0')
         filing['filing_date_time'] = filing_datetime.strftime(f'%B %d, %Y {hour}:%M %p Pacific Time')
 

--- a/legal-api/src/legal_api/resources/business/business_filings.py
+++ b/legal-api/src/legal_api/resources/business/business_filings.py
@@ -285,7 +285,7 @@ class ListFilingResource(Resource):
                                              business.identifier)
                     return None, None, {'message': 'missing filing/header values'}, HTTPStatus.BAD_REQUEST
             else:
-                filing.filing_date = datetime.datetime.utcnow()
+                filing.filing_date = datetime.datetime.now()
             filing.save()
         except BusinessException as err:
             return None, None, {'error': err.error}, err.status_code

--- a/legal-api/src/legal_api/resources/business/business_filings.py
+++ b/legal-api/src/legal_api/resources/business/business_filings.py
@@ -285,7 +285,7 @@ class ListFilingResource(Resource):
                                              business.identifier)
                     return None, None, {'message': 'missing filing/header values'}, HTTPStatus.BAD_REQUEST
             else:
-                filing.filing_date = datetime.datetime.now()
+                filing.filing_date = datetime.datetime.utcnow()
             filing.save()
         except BusinessException as err:
             return None, None, {'error': err.error}, err.status_code


### PR DESCRIPTION
*Issue #:* /bcgov/entity#1818, /bcgov/entity#1405

*Description of changes:*
Changes to use local timezone datetime for filing_date and completion_date rather than utc 
Changes to correct the date time in reports
Changes to pass time to receipt

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
