### PR TITLE
updated sbc-common-components dependency

### DIFF
--- a/coops-ui/package.json
+++ b/coops-ui/package.json
@@ -23,7 +23,7 @@
     "provinces": "^1.11.0",
     "regenerator-runtime": "^0.13.3",
     "register-service-worker": "^1.6.2",
-    "sbc-common-components": "2.0.18",
+    "sbc-common-components": "2.0.22",
     "sinon": "^7.3.2",
     "vue": "^2.6.10",
     "vue-affix": "^0.5.2",


### PR DESCRIPTION
*Issue #:* none

*Description of changes:*
- the sbc-common-component icon issue has been resolved, so coops-ui can now use the latest version
- I verified the changes in sbc-common-components since the previous version we were using (18) and they looks OK locally
- note that /bcgov/entity#1673 will now be testable (I will update the ticket accordingly)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
