### PR TITLE
loader - include entities without AR filings.

### DIFF
--- a/colin-api/colin_api/models/business.py
+++ b/colin-api/colin_api/models/business.py
@@ -68,11 +68,10 @@ class Business:
                 join CORP_OP_STATE on CORP_OP_STATE.state_typ_cd = CORP_STATE.state_typ_cd
                 left join JURISDICTION on JURISDICTION.corp_num = corp.corp_num
                 join event on corp.corp_num = event.corp_num
-                join filing on event.event_id = filing.event_id
+                left join filing on event.event_id = filing.event_id and filing.filing_typ_cd = 'OTANN'
                 where corp_typ_cd = 'CP'
-                and corp.CORP_NUM=:corp_num
-                and filing.filing_typ_cd = 'OTANN'
-                order by filing.period_end_dt desc nulls last""", corp_num=identifier)
+                and corp.CORP_NUM=:corp_num                
+                order by last_ar_date desc nulls last""", corp_num=identifier)
             business = cursor.fetchone()
 
             if not business:

--- a/lear-db/test_data/load_coop_2019.py
+++ b/lear-db/test_data/load_coop_2019.py
@@ -51,7 +51,8 @@ def create_business(db, business_json):
     business.last_ledger_timestamp = business_json['business']['lastLedgerTimestamp']
     business.legal_name = business_json['business']['legalName']
     business.founding_date = business_json['business']['foundingDate']
-    business.last_agm_date = datetime.date.fromisoformat(business_json['business']['lastAgmDate'])
+    business.last_agm_date = datetime.date.fromisoformat(business_json['business']['lastAgmDate']) \
+        if business_json['business']['lastAgmDate'] else None
     business.last_ar_date = datetime.date.fromisoformat(business_json['business']['lastArDate'])\
         if business_json['business']['lastArDate'] else business.last_agm_date
     business.legal_type = business_json['business']['legalType']


### PR DESCRIPTION
*Issue #:* /bcgov/entity#1886

*Description of changes:*
Original version assumed AR filing existed but not true for recently-incorporated entities.

This has already been run in DEV (local colin api, running loader pointed to dev postgres).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
