### PR TITLE
bug fix - when no filings exist, use founding year to calculate owed ARs.

### DIFF
--- a/legal-api/src/legal_api/resources/business/business_tasks.py
+++ b/legal-api/src/legal_api/resources/business/business_tasks.py
@@ -65,8 +65,9 @@ class TaskListResource(Resource):
         tasks = []
         order = 1
         check_agm = validations.annual_report.requires_agm(business)
-        # If no filings exist in legal API db this year will be used as the start year.
-        todo_start_date = (datetime(2019, 1, 1)).date() if check_agm else business.next_anniversary.date()
+
+        # If no filings exist in legal API db (set after this line), use the business' next anniversary date
+        todo_start_date = business.next_anniversary.date()
 
         # Retrieve filings that are either incomplete, or drafts
         pending_filings = Filing.get_filings_by_status(business.id, [Filing.Status.DRAFT.value,

--- a/legal-api/tests/unit/api/test_business_tasks.py
+++ b/legal-api/tests/unit/api/test_business_tasks.py
@@ -68,13 +68,13 @@ AR_FILING_PREVIOUS_YEAR = {
 
 
 def test_get_tasks_no_filings(session, client):
-    """Assert that to-do for the current year is returned when there are no filings."""
+    """Assert that to-do for the year after incorporation is returned when there are no filings."""
     identifier = 'CP7654321'
-    factory_business(identifier)
+    factory_business(identifier, founding_date='2017-02-01 00:00:00-00')  # incorporation in 2017
 
     rv = client.get(f'/api/v1/businesses/{identifier}/tasks')
     assert rv.status_code == HTTPStatus.OK
-    assert len(rv.json.get('tasks')) == 1  # To-do for the current year
+    assert 2 == len(rv.json.get('tasks'))  # To-do are 2018, 2019
 
 
 def test_bcorps_get_tasks_no_filings(session, client):


### PR DESCRIPTION
*Issue #:* /bcgov/entity#1915

*Description of changes:*
bug fix - when no filings exist, use founding year to calculate owed ARs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
