### PR TITLE
fixed indent in Directors PDF template

### DIFF
--- a/legal-api/report-templates/template-parts/directors.html
+++ b/legal-api/report-templates/template-parts/directors.html
@@ -1,7 +1,7 @@
 {# only show Appointed and Ceased directors if filing did not come from Colin #}
 {% if colin_event_id is None %}
 
-  {% if listOfDirectors is defined %}
+{% if listOfDirectors is defined %}
 
     {# APPOINTED #}
 


### PR DESCRIPTION
*Issue #:* none

*Description of changes:*
- removed indentation that is the likely cause of a server error when fetching a PDF

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
