### PR TITLE
bug fix - for Legal UI-sourced filings, show apointed and ceased sections...

### DIFF
--- a/legal-api/report-templates/template-parts/directors.html
+++ b/legal-api/report-templates/template-parts/directors.html
@@ -1,7 +1,7 @@
 {% if listOfDirectors is defined %}
 
 {# only show Appointed and Ceased directors if filing did not come from Colin #}
-{% if colin_event_id is undefined %}
+{% if colin_event_id is none %}
 
     {# APPOINTED #}
 


### PR DESCRIPTION
*Issue #:* n/a

*Description of changes:*
bug fix - for Legal UI-sourced filings, show apointed and ceased sections of COD filing output.
Continue to hide for Colin-sourced filings.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
