### PR TITLE
UI - allow spaces in director names, but do not allow empty spaces only

### DIFF
--- a/coops-ui/src/components/AnnualReport/Directors.vue
+++ b/coops-ui/src/components/AnnualReport/Directors.vue
@@ -598,7 +598,7 @@ export default class Directors extends Mixins(DateMixin, ExternalMixin, EntityFi
   private get directorFirstNameRules (): Array<Function> {
     return [
       v => !!v || 'A first name is required',
-      v => !/\s/g.test(v) || 'Invalid spaces'
+      v => v.trim() !== '' || 'Invalid spaces'
     ]
   }
 
@@ -609,7 +609,7 @@ export default class Directors extends Mixins(DateMixin, ExternalMixin, EntityFi
   private get directorLastNameRules (): Array<Function> {
     return [
       v => !!v || 'A last name is required',
-      v => !/\s/g.test(v) || 'Invalid spaces'
+      v => v.trim() !== '' || 'Invalid spaces'
     ]
   }
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#1824

*Description of changes:*
Allow spaces in name (such as "H. Mary") but do not allow only spaces (" ").

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
