### PR TITLE
fixed effective date for historic filings - put in json header (inste…

### DIFF
--- a/colin-api/colin_api/models/filing.py
+++ b/colin-api/colin_api/models/filing.py
@@ -578,15 +578,15 @@ class Filing:
                     filing.header = {
                         'date': date,
                         'name': filing_info['filing_type'],
+                        'effectiveDate': convert_to_json_date(filing_info['effective_dt']),
+                        'historic': True,
                         'availableOnPaperOnly': True
                     }
                     filing.body = {
                         filing_info['filing_type']: {
                             'eventId': filing_info['event_id'],
-                            'eventDate': date,
-                            'effectiveDate': convert_to_json_date(filing_info['effective_dt']),
-                            'periodEndDate': convert_to_json_date(filing_info['period_end_dt']),
-                            'agmDate': convert_to_json_date(filing_info['agm_date'])
+                            'annualReportDate': convert_to_json_date(filing_info['period_end_dt']),
+                            'annualGeneralMeetingDate': convert_to_json_date(filing_info['agm_date'])
                         }
                     }
                     historic_filings.append(filing.as_dict())

--- a/lear-db/test_data/load_coop_2019.py
+++ b/lear-db/test_data/load_coop_2019.py
@@ -234,6 +234,8 @@ with open('coops.csv', 'r') as csvfile:
                                 filing_type = historic_filing['filing']['header']['name']
                                 filing.colin_event_id = historic_filing['filing'][filing_type]['eventId']
                                 filing.paper_only = True
+                                filing.effective_date = datetime.datetime.strptime(
+                                    historic_filing['filing']['header']['effectiveDate'], '%Y-%m-%d')
                                 db.session.add(filing)
                                 db.session.commit()
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#1998

*Description of changes:*
fixed effective date for historic filings - put in json header (instead of body) and set in db column.

Also added unrelated "historic" flag in json for easier data debugging, and renamed AR-specific fields to match schema.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
