### PR TITLE
set default order for get_filings_by_status to submission date and then effective_date

### DIFF
--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -19,6 +19,7 @@ from http import HTTPStatus
 from typing import List
 
 from sqlalchemy import desc, event, inspect
+# from sqlalchemy.dialects import postgresql  # pylint: disable=unused-import; used when debugging
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import backref
@@ -258,10 +259,14 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
         query = db.session.query(Filing). \
             filter(Filing.business_id == business_id). \
             filter(Filing._status.in_(status)). \
-            order_by(desc(Filing.filing_date))
+            order_by(Filing.filing_date.desc(), Filing.effective_date.desc())  # pylint: disable=no-member;
+        # member provided via SQLAlchemy
 
         if after_date:
             query = query.filter(Filing._filing_date >= after_date)
+
+        # un-comment if you need to see the SQL sent to postgres in debug-mode
+        # query_str = str(query.statement.compile(dialect=postgresql.dialect()))
 
         return query.all()
 

--- a/legal-api/tests/unit/models/test_filing.py
+++ b/legal-api/tests/unit/models/test_filing.py
@@ -24,7 +24,8 @@ from http import HTTPStatus
 import datedelta
 import pytest
 from flask import current_app
-from registry_schemas.example_data import ANNUAL_REPORT
+from freezegun import freeze_time
+from registry_schemas.example_data import ANNUAL_REPORT, FILING_HEADER, SPECIAL_RESOLUTION
 from sqlalchemy_continuum import versioning_manager
 
 from legal_api.exceptions import BusinessException
@@ -331,6 +332,53 @@ def test_get_filings_by_status(session):
 
     assert rv
     assert rv[0].status == Filing.Status.COMPLETED.value
+
+
+def test_get_filings_by_status__default_order(session):
+    """Assert that a filing can be retrieved by status and is returned in the default order.
+
+    default order is submission_date, and then effective_date.
+    """
+    # setup
+    base_filing = copy.deepcopy(FILING_HEADER)
+    base_filing['specialResolution'] = SPECIAL_RESOLUTION
+    uow = versioning_manager.unit_of_work(session)
+    business = factory_business('CP1234567')
+
+    completion_date = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
+
+    # setup - create multiple filings on the same day & time
+    filing_ids = []
+    file_counter = -1
+    with freeze_time(completion_date):
+        for i in range(0, 5):
+            transaction = uow.create_transaction(session)
+            payment_token = str(i)
+            effective_date = f'200{i}-04-15T00:00:00+00:00'
+
+            base_filing['filing']['header']['effectiveDate'] = effective_date
+            filing = Filing()
+            filing._filing_date = completion_date
+            filing.business_id = business.id
+            filing.filing_json = base_filing
+            filing.effective_date = datetime.datetime.fromisoformat(effective_date)
+            filing.payment_token = payment_token
+            filing.transaction_id = transaction.id
+            filing.payment_completion_date = completion_date
+            filing.save()
+
+            filing_ids.append(filing.id)
+            file_counter += 1
+
+    # test
+    rv = Filing.get_filings_by_status(business.id, [Filing.Status.COMPLETED.value])
+
+    # check
+    assert rv
+    # filings should be in newest to oldest effective date order
+    for filing in rv:
+        assert filing.id == filing_ids[file_counter]
+        file_counter -= 1
 
 
 # testdata pattern is ({str: environment}, {expected return value})


### PR DESCRIPTION
Signed-off-by: thor wolpert <thor@wolpert.ca>

*Issue #:* /bcgov/entity#1997

*Description of changes:*
- set the default order for get_filings_by_status to submission date and then effective_date


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
