### PR TITLE
assign office.business_id in one-time script for office creation

### DIFF
--- a/lear-db/test_data/add_offices.py
+++ b/lear-db/test_data/add_offices.py
@@ -38,6 +38,7 @@ def add_business_office_records():
             office.office_type = 'registeredOffice'
             office.addresses = [business.mailing_address.one_or_none(),
                                 business.delivery_address.one_or_none()]
+            office.business_id = business.id
             db.session.add(office) #pylint: disable=no-member; needed by SQLAlchemy
             db.session.add(business) #pylint: disable=no-member; needed by SQLAlchemy
             db.session.commit() #pylint: disable=no-member; needed by SQLAlchemy


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*
Assign office.business_id in one-time script for office creation. Otherwise it's null in office table.

@peter-freshworks please validate - I discovered this by running this script in e2e environment and saw column was all nulls. Whereas in dev the column was filled in. I've made this change and run the script over e2e again and got the results I think should be there.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
