### PR TITLE
Directors Summary Filtering Update

### DIFF
--- a/coops-ui/src/components/common/SummaryDirectors.vue
+++ b/coops-ui/src/components/common/SummaryDirectors.vue
@@ -214,8 +214,8 @@ export default class SummaryDirectors extends Mixins(DateMixin, EntityFilterMixi
     */
   @Watch('directors', { deep: true, immediate: true })
   private onDirectorsChanged (val: Array<Director>): void {
-    this.directorSummary = val.filter(d => !d.actions.includes(CEASED))
-    this.directorsCeased = val.filter(d => d.actions.includes(CEASED))
+    this.directorSummary = val.filter(d => !d.actions || !d.actions.includes(CEASED))
+    this.directorsCeased = val.filter(d => d.actions && d.actions.includes(CEASED))
   }
 
   /**


### PR DESCRIPTION
*Description of changes:*

* Updated filtering logic on directors list to validate the `actions` property before filtering by it. 
* Should correctly display a list of directors in the Bcomps Annual Report directors summary list.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
