### PR TITLE
Changing the logic to look at the last AR date and cod date only

### DIFF
--- a/coops-ui/src/components/StandaloneDirectorChange/CODDate.vue
+++ b/coops-ui/src/components/StandaloneDirectorChange/CODDate.vue
@@ -58,8 +58,8 @@ import DateMixin from '@/mixins/date-mixin'
   mixins: [DateMixin],
   computed: {
     // Property definitions for runtime environment.
-    ...mapState(['currentDate', 'lastPreLoadFilingDate']),
-    ...mapGetters(['lastFilingDate', 'lastCODFilingDate'])
+    ...mapState(['currentDate', 'lastAnnualReportDate']),
+    ...mapGetters(['lastCODFilingDate'])
   },
   validations: {
     dateFormatted: { isNotNull, isValidFormat, isValidCODDate }
@@ -78,8 +78,7 @@ export default class CODDate extends Mixins(DateMixin) {
   // Local definitions of computed properties for static type checking.
   // Use non-null assertion operator to allow use before assignment.
   readonly currentDate!: string
-  readonly lastPreLoadFilingDate!: string
-  readonly lastFilingDate!: string
+  readonly lastAnnualReportDate!: string
   readonly lastCODFilingDate!: string
 
   /**
@@ -111,11 +110,9 @@ export default class CODDate extends Mixins(DateMixin) {
      * - the last AR filing in filing history (from the Legal DB)
      * - the last pre-load Cobrs filing
      */
-    const lastFilingDate = this.lastFilingDate == null ? 0 : +this.lastFilingDate.split('-').join('')
+    const lastARFilingDate = this.lastAnnualReportDate == null ? 0 : +this.lastAnnualReportDate.split('-').join('')
     const lastCODFilingDate = this.lastCODFilingDate == null ? 0 : +this.lastCODFilingDate.split('-').join('')
-    const lastPreLoadFilingDate = this.lastPreLoadFilingDate == null ? 0
-      : +this.lastPreLoadFilingDate.split('-').join('')
-    const minCODDate = Math.max(lastFilingDate, lastCODFilingDate, lastPreLoadFilingDate)
+    const minCODDate = Math.max(lastARFilingDate, lastCODFilingDate)
     return this.numToUsableString(minCODDate)
   }
 

--- a/coops-ui/tests/unit/CODDate.spec.ts
+++ b/coops-ui/tests/unit/CODDate.spec.ts
@@ -64,14 +64,10 @@ describe('CODDate', () => {
 
     // set Last Filing Date and verify new Min Date
     store.state.filings = [
-      { filing: { header: { date: '2019-02-01' } } },
-      { filing: { header: { effectiveDate: '2019-03-01' } } }
+      { filing: { header: { date: '2019-02-01' }, changeOfDirectors: {} } },
+      { filing: { header: { effectiveDate: '2019-03-01' }, changeOfDirectors: {} } }
     ]
     expect(vm.minDate).toBe('2019-03-01')
-
-    // set Last Pre-Load Filing Date and verify new date
-    store.state.lastPreLoadFilingDate = '2019-04-01'
-    expect(vm.minDate).toBe('2019-04-01')
 
     // cleanup
     store.state.filings = []


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*
Changing the logic to look at the last AR date and cod date only
Updated tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
