### PR TITLE
Paid filings should be returned in filing history, not in task list

### DIFF
--- a/legal-api/src/legal_api/resources/business/business_filings.py
+++ b/legal-api/src/legal_api/resources/business/business_filings.py
@@ -78,7 +78,7 @@ class ListFilingResource(Resource):
                 HTTPStatus.NOT_ACCEPTABLE
 
         rv = []
-        filings = Filing.get_filings_by_status(business.id, [Filing.Status.COMPLETED.value])
+        filings = Filing.get_filings_by_status(business.id, [Filing.Status.COMPLETED.value, Filing.Status.PAID.value])
         for filing in filings:
             rv.append(filing.json)
 

--- a/legal-api/src/legal_api/resources/business/business_tasks.py
+++ b/legal-api/src/legal_api/resources/business/business_tasks.py
@@ -72,8 +72,7 @@ class TaskListResource(Resource):
         # Retrieve filings that are either incomplete, or drafts
         pending_filings = Filing.get_filings_by_status(business.id, [Filing.Status.DRAFT.value,
                                                                      Filing.Status.PENDING.value,
-                                                                     Filing.Status.ERROR.value,
-                                                                     Filing.Status.PAID.value])
+                                                                     Filing.Status.ERROR.value])
         # Create a todo item for each pending filing
         for filing in pending_filings:
             task = {'task': filing.json, 'order': order, 'enabled': True}


### PR DESCRIPTION
*Issue #:* /bcgov/entity#2071

*Description of changes:*
Paid filings were being returned in the task list as a to-do item. Moved to the get business filings endpoint

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
