### PR TITLE
Removed functionality to add failed msg back to queue upon failure.

### DIFF
--- a/queue_services/entity-pay/src/entity_pay/worker.py
+++ b/queue_services/entity-pay/src/entity_pay/worker.py
@@ -137,11 +137,10 @@ async def cb_subscription_handler(msg: nats.aio.client.Msg):
     except OperationalError as err:
         logger.error('Queue Blocked - Database Issue: %s', json.dumps(payment_token), exc_info=True)
         raise err  # We don't want to handle the error, as a DB down would drain the queue
-    except FilingException as err:
-        logger.error('Queue Error - cannot find filing: %s'
-                     '\n\nThis message has been put back on the queue for reprocessing.',
+    except FilingException:
+        # log to sentry and absorb the error, ie: do NOT raise it, otherwise the message would be put back on the queue
+        logger.error('Queue Error - cannot find filing: %s',
                      json.dumps(payment_token), exc_info=True)
-        raise err  # we don't want to handle the error, so that the message gets put back on the queue
     except (QueueException, Exception):  # pylint: disable=broad-except
         # Catch Exception so that any error is still caught and the message is removed from the queue
         capture_message('Queue Error:' + json.dumps(payment_token), level='error')

--- a/queue_services/entity-pay/src/entity_pay/worker.py
+++ b/queue_services/entity-pay/src/entity_pay/worker.py
@@ -139,8 +139,8 @@ async def cb_subscription_handler(msg: nats.aio.client.Msg):
         raise err  # We don't want to handle the error, as a DB down would drain the queue
     except FilingException:
         # log to sentry and absorb the error, ie: do NOT raise it, otherwise the message would be put back on the queue
-        logger.error('Queue Error - cannot find filing: %s',
-                     json.dumps(payment_token), exc_info=True)
+        capture_message('Queue Error: cannot find filing: %s' % json.dumps(payment_token), level='error')
+        logger.error('Queue Error - cannot find filing: %s', json.dumps(payment_token), exc_info=True)
     except (QueueException, Exception):  # pylint: disable=broad-except
         # Catch Exception so that any error is still caught and the message is removed from the queue
         capture_message('Queue Error:' + json.dumps(payment_token), level='error')


### PR DESCRIPTION
*Issue #:* /bcgov/entity#1615

*Description of changes:*
Removed functionality to add failed msg back to queue upon failure. It will end up in sentry anyway, that's enough - having it added back to the queue gets us no good functionality, just bad.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
