### PR TITLE
removed hasLiablities from required list in volunt. diss. schema

### DIFF
--- a/schemas/src/registry_schemas/schemas/voluntary_dissolution.json
+++ b/schemas/src/registry_schemas/schemas/voluntary_dissolution.json
@@ -11,8 +11,7 @@
         "voluntaryDissolution": {
             "type": "object",
             "required": [
-                "dissolutionDate",
-                "hasLiabilities"
+                "dissolutionDate"
             ],
             "properties": {
                 "dissolutionDate": {


### PR DESCRIPTION
Signed-off-by: Kial Jinnah <kialj876@gmail.com>

*Issue #:* /bcgov/entity###

*Description of changes:*
- these are failing to come across because there's no info in colin on whether or not they still have liabilities so this flag is never being included in the json

- 1 bcorp pytest is failing from before

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
