### PR TITLE
P1 fixes for unable to save filing + error dialog not showing up

### DIFF
--- a/coops-ui/src/App.vue
+++ b/coops-ui/src/App.vue
@@ -258,7 +258,7 @@ export default {
         this.setEntityIncNo(response.data.business.identifier)
         this.setLastPreLoadFilingDate(response.data.business.lastLedgerTimestamp
           ? response.data.business.lastLedgerTimestamp.split('T')[0] : null)
-        this.setEntityFoundingDate(response.data.business.foundingDate.split('T')[0]) // datetime
+        this.setEntityFoundingDate(response.data.business.foundingDate) // datetime
         this.setLastAnnualReportDate(response.data.business.lastAnnualReport)
         this.storeConfigObject(response.data.business.legalType)
         const date = response.data.business.lastAnnualGeneralMeetingDate

--- a/coops-ui/src/components/AnnualReport/Directors.vue
+++ b/coops-ui/src/components/AnnualReport/Directors.vue
@@ -725,11 +725,11 @@ export default class Directors extends Mixins(DateMixin, ExternalMixin, EntityFi
   private get earliestDateToSet (): string {
     let earliestDateToSet = null
 
-    if (this.lastCODFilingDate == null && this.lastAnnualReportDate == null) {
-      earliestDateToSet = this.entityFoundingDate
+    if (!this.lastCODFilingDate && !this.lastAnnualReportDate) {
+      earliestDateToSet = this.entityFoundingDate.split('T')[0]
     } else {
-      const lastARFilingDate = this.lastAnnualReportDate == null ? 0 : +this.lastAnnualReportDate.split('-').join('')
-      const lastCODFilingDate = this.lastCODFilingDate == null ? 0 : +this.lastCODFilingDate.split('-').join('')
+      const lastARFilingDate = !this.lastAnnualReportDate ? 0 : +this.lastAnnualReportDate.split('-').join('')
+      const lastCODFilingDate = !this.lastCODFilingDate ? 0 : +this.lastCODFilingDate.split('-').join('')
       const minCODDate = Math.max(lastARFilingDate, lastCODFilingDate)
       earliestDateToSet = this.numToUsableString(minCODDate)
     }

--- a/coops-ui/src/components/StandaloneDirectorChange/CODDate.vue
+++ b/coops-ui/src/components/StandaloneDirectorChange/CODDate.vue
@@ -113,11 +113,11 @@ export default class CODDate extends Mixins(DateMixin) {
      * If the entity has no filing history, the founding date will be used.
      */
     let minDate = null
-    if (this.lastCODFilingDate == null && this.lastAnnualReportDate == null) {
-      minDate = this.entityFoundingDate
+    if (!this.lastCODFilingDate && !this.lastAnnualReportDate) {
+      minDate = this.entityFoundingDate.split('T')[0]
     } else {
-      const lastARFilingDate = this.lastAnnualReportDate == null ? 0 : +this.lastAnnualReportDate.split('-').join('')
-      const lastCODFilingDate = this.lastCODFilingDate == null ? 0 : +this.lastCODFilingDate.split('-').join('')
+      const lastARFilingDate = !this.lastAnnualReportDate ? 0 : +this.lastAnnualReportDate.split('-').join('')
+      const lastCODFilingDate = !this.lastCODFilingDate ? 0 : +this.lastCODFilingDate.split('-').join('')
       const minCODDate = Math.max(lastARFilingDate, lastCODFilingDate)
       minDate = this.numToUsableString(minCODDate)
     }

--- a/coops-ui/src/views/AnnualReport.vue
+++ b/coops-ui/src/views/AnnualReport.vue
@@ -2,13 +2,13 @@
   <div id="annual-report">
     <ConfirmDialog
       ref="confirm"
-      attach="annual-report"
+      attach="#annual-report"
     />
 
     <ResumeErrorDialog
       :dialog="resumeErrorDialog"
       @exit="navigateToDashboard"
-      attach="annual-report"
+      attach="#annual-report"
     />
 
     <SaveErrorDialog
@@ -20,13 +20,13 @@
       @exit="navigateToDashboard"
       @retry="onClickFilePay"
       @okay="resetErrors"
-      attach="annual-report"
+      attach="#annual-report"
     />
 
     <PaymentErrorDialog
       :dialog="paymentErrorDialog"
       @exit="navigateToDashboard"
-      attach="annual-report"
+      attach="#annual-report"
     />
 
     <!-- Initial Page Load Transition -->

--- a/coops-ui/src/views/StandaloneDirectorsFiling.vue
+++ b/coops-ui/src/views/StandaloneDirectorsFiling.vue
@@ -2,13 +2,13 @@
   <div id="standalone-directors">
     <ConfirmDialog
       ref="confirm"
-      attach="standalone-directors"
+      attach="#standalone-directors"
     />
 
     <ResumeErrorDialog
       :dialog="resumeErrorDialog"
       @exit="navigateToDashboard"
-      attach="standalone-directors"
+      attach="#standalone-directors"
     />
 
     <SaveErrorDialog
@@ -20,13 +20,13 @@
       @exit="navigateToDashboard"
       @retry="onClickFilePay"
       @okay="resetErrors"
-      attach="standalone-directors"
+      attach="#standalone-directors"
     />
 
     <PaymentErrorDialog
       :dialog="paymentErrorDialog"
       @exit="navigateToDashboard"
-      attach="standalone-directors"
+      attach="#standalone-directors"
     />
 
     <!-- Initial Page Load Transition -->

--- a/coops-ui/src/views/StandaloneOfficeAddressFiling.vue
+++ b/coops-ui/src/views/StandaloneOfficeAddressFiling.vue
@@ -2,13 +2,13 @@
   <div id="standalone-office-address">
     <ConfirmDialog
       ref="confirm"
-      attach="standalone-office-address"
+      attach="#standalone-office-address"
     />
 
     <ResumeErrorDialog
       :dialog="resumeErrorDialog"
       @exit="navigateToDashboard"
-      attach="standalone-office-address"
+      attach="#standalone-office-address"
     />
 
     <SaveErrorDialog
@@ -20,13 +20,13 @@
       @exit="navigateToDashboard"
       @retry="onClickFilePay"
       @okay="resetErrors"
-      attach="standalone-office-address"
+      attach="#standalone-office-address"
     />
 
     <PaymentErrorDialog
       :dialog="paymentErrorDialog"
       @exit="navigateToDashboard"
-      attach="standalone-office-address"
+      attach="#standalone-office-address"
     />
 
     <!-- Initial Page Load Transition -->

--- a/coops-ui/tests/unit/App.spec.ts
+++ b/coops-ui/tests/unit/App.spec.ts
@@ -296,7 +296,7 @@ describe('App as a COOP', () => {
     expect(vm.$store.state.entityBusinessNo).toBe('123456789')
     expect(vm.$store.state.entityIncNo).toBe('CP0001867')
     expect(vm.$store.state.lastPreLoadFilingDate).toBe('2019-08-14')
-    expect(vm.$store.state.entityFoundingDate).toBe('2000-07-13')
+    expect(vm.$store.state.entityFoundingDate).toBe('2000-07-13T00:00:00+00:00')
     expect(vm.$store.state.lastAgmDate).toBe('2019-08-16')
   })
 
@@ -637,7 +637,7 @@ describe('BCOMP APP', () => {
     expect(vm.$store.state.entityBusinessNo).toBe('123456789')
     expect(vm.$store.state.entityIncNo).toBe('BC0007291')
     expect(vm.$store.state.lastPreLoadFilingDate).toBe('2019-08-14')
-    expect(vm.$store.state.entityFoundingDate).toBe('2000-07-13')
+    expect(vm.$store.state.entityFoundingDate).toBe('2000-07-13T00:00:00+00:00')
     expect(vm.$store.state.lastAgmDate).toBe('2019-08-16')
   })
 

--- a/coops-ui/tests/unit/CODDate.spec.ts
+++ b/coops-ui/tests/unit/CODDate.spec.ts
@@ -27,6 +27,9 @@ describe('CODDate', () => {
     // init store
     store.state.currentDate = '2019/07/15'
 
+    // set Last Filing Date and verify new Min Date
+    store.state.entityFoundingDate = '2018-03-01T00:00:00'
+
     wrapper = mount(CODDate, { store, vuetify })
     vm = wrapper.vm as any
   })
@@ -60,7 +63,7 @@ describe('CODDate', () => {
     expect(vm.$store.state.lastPreLoadFilingDate).toBeNull()
 
     // verify default Min Date
-    expect(vm.minDate).toBe(null)
+    expect(vm.minDate).toBe('2018-03-01')
 
     // set Last Filing Date and verify new Min Date
     store.state.filings = [
@@ -77,17 +80,8 @@ describe('CODDate', () => {
   it('sets Min Date to entity founding date if no filings are present', () => {
     // verify initial state
     expect(vm.$store.state.filings).toEqual([])
-  
-    // verify default Min Date
-    expect(vm.minDate).toBe(null)
-
-    // set Last Filing Date and verify new Min Date
-    store.state.entityFoundingDate = '2018-03-01'
 
     expect(vm.minDate).toBe('2018-03-01')
-
-    // cleanup    
-    store.state.entityFoundingDate = null
   })
 
   it('sets Max Date to current date in store', () => {

--- a/coops-ui/tests/unit/Directors.spec.ts
+++ b/coops-ui/tests/unit/Directors.spec.ts
@@ -47,6 +47,7 @@ describe('Directors as a COOP', () => {
     // init store
     store.state.entityIncNo = 'CP0001191'
     store.state.entityType = EntityTypes.COOP
+    store.state.entityFoundingDate = '2018-03-01T00:00:00'
 
     // GET directors
     sinon.stub(axios, 'get').withArgs('CP0001191/directors?date=2019-04-01')

--- a/coops-ui/tests/unit/StandaloneDirectorsFiling.spec.ts
+++ b/coops-ui/tests/unit/StandaloneDirectorsFiling.spec.ts
@@ -74,6 +74,8 @@ describe('Standalone Directors Filing - Part 1 - UI', () => {
     // init store
     store.state.entityIncNo = 'CP0001191'
     store.state.currentDate = '2019/07/15'
+    // set Last Filing Date and verify new Min Date
+    store.state.entityFoundingDate = '2018-03-01T00:00:00'
   })
 
   it('renders the filing sub-components properly', () => {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#2160, /bcgov/entity#2149

*Description of changes:* 
1. Priority one fixes for
     Unable to save filing due to entity founding date not datetime
     Error dialog not showing up for filing/ other errors (incorrect attach selectors)
2. Code refactoring
3. Test updates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
