### PR TITLE
Mark two unit tests as integration with payment, so they can be skipped

### DIFF
--- a/legal-api/tests/unit/api/test_business_filings.py
+++ b/legal-api/tests/unit/api/test_business_filings.py
@@ -766,6 +766,7 @@ def test_get_correct_fee_codes(session):
     assert free_cod_fee_code == 'OTFDR'
 
 
+@integration_payment
 def test_coa_future_effective(session, client, jwt):
     """Assert future effective changes do not affect Coops, and that BCORP change of address if future-effective."""
     import pytz

--- a/legal-api/tests/unit/api/test_business_tasks.py
+++ b/legal-api/tests/unit/api/test_business_tasks.py
@@ -22,6 +22,7 @@ from http import HTTPStatus
 import datedelta
 
 from legal_api.services.authz import STAFF_ROLE
+from tests import integration_payment
 from tests.unit.models import factory_business, factory_filing, factory_pending_filing, factory_business_mailing_address
 from tests.unit.services.utils import create_header
 
@@ -93,6 +94,7 @@ def test_bcorps_get_tasks_no_filings(session, client):
     assert len(rv.json.get('tasks')) == 0  # To-do for the current year
 
 
+@integration_payment
 def test_bcorps_get_tasks_pending_filings(session, client, jwt):
     """Assert the correct number of todo items are returned when there is an AR filing pending."""
     identifier = 'CP7654321'


### PR DESCRIPTION
*Issue #:* n/a

*Description of changes:*
Mark two unit tests as integration with payment, so they can be skipped correctly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
