### PR TITLE
removed inter word spacing validation for director names

### DIFF
--- a/coops-ui/jest.config.js
+++ b/coops-ui/jest.config.js
@@ -13,9 +13,7 @@ module.exports = {
     '^.+\\.tsx?$': 'ts-jest',
     '^.+\\.(js|jsx)?$': 'babel-jest'
   },
-  transformIgnorePatterns: [
-    '/node_modules/(?!sbc-common-components/.*)'
-  ],
+  transformIgnorePatterns: [],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1'
   },

--- a/coops-ui/src/components/AnnualReport/Directors.vue
+++ b/coops-ui/src/components/AnnualReport/Directors.vue
@@ -607,31 +607,34 @@ export default class Directors extends Mixins(DateMixin, ExternalMixin, EntityFi
 
   /**
    * The array of validations rules for a director's first name.
+   * NB: do not validate inter word spacing because the Legal db needs to support
+   *     such records in order to correctly update Colin
    */
   private readonly directorFirstNameRules: Array<Function> = [
     v => !!v || 'A first name is required',
     v => !/^\s/g.test(v) || 'Invalid spaces', // leading spaces
-    v => !/\s$/g.test(v) || 'Invalid spaces', // trailing spaces
-    v => !/\s\s/g.test(v) || 'Invalid word spacing' // multiple inline spaces
+    v => !/\s$/g.test(v) || 'Invalid spaces' // trailing spaces
   ]
 
   /**
    * The array of validations rules for a director's middle initial.
+   * NB: do not validate inter word spacing because the Legal db needs to support
+   *     such records in order to correctly update Colin
    */
   private readonly directorMiddleInitialRules: Array<Function> = [
     v => !/^\s/g.test(v) || 'Invalid spaces', // leading spaces
-    v => !/\s$/g.test(v) || 'Invalid spaces', // trailing spaces
-    v => !/\s\s/g.test(v) || 'Invalid word spacing' // multiple inline spaces
+    v => !/\s$/g.test(v) || 'Invalid spaces' // trailing spaces
   ]
 
   /**
    * The array of validations rules for a director's last name.
+   * NB: do not validate inter word spacing because the Legal db needs to support
+   *     such records in order to correctly update Colin
    */
   private readonly directorLastNameRules: Array<Function> = [
     v => !!v || 'A last name is required',
     v => !/^\s/g.test(v) || 'Invalid spaces', // leading spaces
-    v => !/\s$/g.test(v) || 'Invalid spaces', // trailing spaces
-    v => !/\s\s/g.test(v) || 'Invalid word spacing' // multiple inline spaces
+    v => !/\s$/g.test(v) || 'Invalid spaces' // trailing spaces
   ]
 
   // Local definitions of computed properties for static type checking.

--- a/coops-ui/tests/unit/Directors.spec.ts
+++ b/coops-ui/tests/unit/Directors.spec.ts
@@ -698,13 +698,13 @@ describe('Appoint New Director tests', () => {
     }, 250)
   })
 
-  it('displays error for invalid First Name - multiple inline spaces', done => {
+  it('allows First Name with multiple inline spaces', done => {
     setValue(vm, '#new-director__first-name', 'First  First')
     expect(vm.director.officer.firstName).toBe('First  First')
 
-    // verify that validation error is displayed
+    // verify that validation error is not displayed
     setTimeout(() => {
-      expect(vm.$el.querySelectorAll('.v-messages')[0].textContent).toContain('Invalid word spacing')
+      expect(vm.$el.querySelectorAll('.v-messages')[0].textContent).toBe('')
       done()
     }, 250)
   })
@@ -742,13 +742,13 @@ describe('Appoint New Director tests', () => {
     }, 250)
   })
 
-  it('displays error for invalid Middle Initial - multiple inline spaces', done => {
+  it('allows Middle Initial with multiple inline spaces', done => {
     setValue(vm, '#new-director__middle-initial', 'M  M')
     expect(vm.director.officer.middleInitial).toBe('M  M')
 
     // verify that validation error is displayed
     setTimeout(() => {
-      expect(vm.$el.querySelectorAll('.v-messages')[1].textContent).toContain('Invalid word spacing')
+      expect(vm.$el.querySelectorAll('.v-messages')[1].textContent).toBe('')
       done()
     }, 250)
   })
@@ -786,13 +786,13 @@ describe('Appoint New Director tests', () => {
     }, 250)
   })
 
-  it('displays error for invalid Last Name - multiple inline spaces', done => {
+  it('allows Last Name with multiple inline spaces', done => {
     setValue(vm, '#new-director__last-name', 'Last  Last')
     expect(vm.director.officer.lastName).toBe('Last  Last')
 
     // verify that validation error is displayed
     setTimeout(() => {
-      expect(vm.$el.querySelectorAll('.v-messages')[2].textContent).toContain('Invalid word spacing')
+      expect(vm.$el.querySelectorAll('.v-messages')[2].textContent).toBe('')
       done()
     }, 250)
   })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#2257

*Description of changes:*
- removed inter word spacing validation for director names
- updated unit tests
- forced sbc-common-components to be transformed in tests (ie, don't ignore it)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).