### PR TITLE
fixed director multiple forms issue

### DIFF
--- a/coops-ui/src/components/AnnualReport/Directors.vue
+++ b/coops-ui/src/components/AnnualReport/Directors.vue
@@ -326,9 +326,12 @@
 
               <!-- Edit director form -->
               <v-expand-transition>
+                <!-- only render the form for the active director -->
                 <v-form ref="editDirectorForm"
-                  v-show="activeIndex === index"
-                  v-model="directorFormValid" lazy-validation>
+                  v-if="activeIndex === index"
+                  v-model="directorFormValid"
+                  lazy-validation
+                >
                   <div class="form__row three-column" v-show="editFormShowHide.showName">
                     <v-text-field filled class="item edit-director__first-name"
                       label="First Name"
@@ -508,11 +511,14 @@ export default class Directors extends Mixins(DateMixin, ExternalMixin, EntityFi
   // To fix "property X does not exist on type Y" errors, annotate types for referenced components.
   // ref: https://github.com/vuejs/vetur/issues/1414
   $refs!: {
+    // form and components to appoint a new director:
     newDirectorForm: FormType,
     baseAddressNew: BaseAddressType,
     mailAddressNew: BaseAddressType,
+    // form and components to edit an existing director:
+    // (there is only 1 at a time but it's still an array)
     editDirectorForm: Array<FormType>,
-    baseAddressEdit: Array<BaseAddressType>
+    baseAddressEdit: Array<BaseAddressType>,
     mailAddressEdit: Array<BaseAddressType>
   }
 
@@ -1047,11 +1053,11 @@ export default class Directors extends Mixins(DateMixin, ExternalMixin, EntityFi
     // get current director
     let director = this.directors[id - 1]
 
-    var mainFormIsValid = this.$refs.editDirectorForm[index].validate()
-    var addressFormIsValid = this.$refs.baseAddressEdit[index].$refs.addressForm.validate()
+    var mainFormIsValid = this.$refs.editDirectorForm[0].validate()
+    var addressFormIsValid = this.$refs.baseAddressEdit[0].$refs.addressForm.validate()
 
-    if (this.$refs.mailAddressEdit && this.$refs.mailAddressEdit[index]) {
-      var mailAddressFormIsValid = this.$refs.mailAddressEdit[index].$refs.addressForm.validate()
+    if (this.$refs.mailAddressEdit && this.$refs.mailAddressEdit[0]) {
+      var mailAddressFormIsValid = this.$refs.mailAddressEdit[0].$refs.addressForm.validate()
       if (!mailAddressFormIsValid) {
         addressFormIsValid = mailAddressFormIsValid
       }

--- a/coops-ui/src/interfaces/address-interfaces.ts
+++ b/coops-ui/src/interfaces/address-interfaces.ts
@@ -1,29 +1,29 @@
 import Vue from 'vue'
 
 export interface BaseAddressType extends Vue {
-  $refs: any
+  $refs: any;
 }
 
 // Base address Interface to match the address.json schema and it's optional fields.
 export interface AddressIF extends Vue {
-  actions?: string[],
-  addressCity: string
-  addressCountry: string
-  addressRegion: string
-  deliveryInstructions?: string
-  postalCode: string
-  streetAddress: string
-  streetAddressAdditional?: string
+  actions?: string[];
+  addressCity: string;
+  addressCountry: string;
+  addressRegion: string;
+  deliveryInstructions?: string;
+  postalCode: string;
+  streetAddress: string;
+  streetAddressAdditional?: string;
 }
 
 // Interface to define the joint base address response
 export interface BaseAddressObjIF extends Vue {
-  deliveryAddress: AddressIF,
-  mailingAddress: AddressIF
+  deliveryAddress: AddressIF;
+  mailingAddress: AddressIF;
 }
 
 // Interface to define the Bcorps address response
 export interface BcorpAddressIf extends Vue {
-  registeredOffice: BaseAddressObjIF,
-  recordsOffice: BaseAddressObjIF
+  registeredOffice: BaseAddressObjIF;
+  recordsOffice: BaseAddressObjIF;
 }

--- a/coops-ui/src/interfaces/filingData-interfaces.ts
+++ b/coops-ui/src/interfaces/filingData-interfaces.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 
 export interface FilingData extends Vue {
-  filingTypeCode: string,
-  entityType: string
+  filingTypeCode: string;
+  entityType: string;
 }

--- a/coops-ui/src/interfaces/form-interfaces.ts
+++ b/coops-ui/src/interfaces/form-interfaces.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 
 export interface FormType extends Vue {
-  reset(): void
-  validate(): boolean
+  reset(): void;
+  validate(): boolean;
 }

--- a/coops-ui/tests/unit/Directors.spec.ts
+++ b/coops-ui/tests/unit/Directors.spec.ts
@@ -173,14 +173,14 @@ describe('Directors as a COOP', () => {
     expect(directorListUI[1].innerHTML).toContain('<span>Cease</span>')
   })
 
-  it('displays the edit Director form when enabled', () => {
+  it('displays the edit Director form when enabled', async () => {
     // Open the edit director
-    vm.editDirectorName(0)
+    await vm.editDirectorName(0)
 
     // Verify the correct data in the text input field
     expect(vm.$el.querySelectorAll('.edit-director__first-name input')[0].value).toBe('Joe')
 
-    // Verify all the form field value
+    // Verify that only Change Name component is shown
     expect(vm.editFormShowHide.showAddress).toEqual(false)
     expect(vm.editFormShowHide.showName).toEqual(true)
     expect(vm.editFormShowHide.showDates).toEqual(false)
@@ -188,13 +188,13 @@ describe('Directors as a COOP', () => {
 
   it('displays the edit Director form when enabled and stores the updated value', async () => {
     // Open the edit director
-    vm.editDirectorName(0)
+    await vm.editDirectorName(0)
 
     // Verify the correct data in the text input field
     expect(vm.$el.querySelectorAll('.edit-director__first-name input')[0].value).toBe('Joe')
 
     // Change the text input
-    vm.$el.querySelectorAll('.edit-director__first-name input')[0].value = 'Steve'
+    setValue(vm, '.edit-director__first-name input', 'Steve')
 
     // Click and save the updated data
     await vm.saveEditDirector(1, 2)
@@ -202,31 +202,30 @@ describe('Directors as a COOP', () => {
     // Verify the updated text field value
     expect(vm.$el.querySelectorAll('.edit-director__first-name input')[0].value).toBe('Steve')
 
-    // Verify all the form field value
-    expect(vm.editFormShowHide.showAddress).toEqual(true)
+    // Verify that only Change Name component is shown
+    expect(vm.editFormShowHide.showAddress).toEqual(false)
     expect(vm.editFormShowHide.showName).toEqual(true)
-    expect(vm.editFormShowHide.showDates).toEqual(true)
+    expect(vm.editFormShowHide.showDates).toEqual(false)
   })
 
   it('restores the directors name to its original value when the Cancel Edit Btn is clicked', async () => {
     // Open the edit director
-    vm.editDirectorName(0)
+    await vm.editDirectorName(0)
 
     // Verify the correct data in the text input field
     expect(vm.$el.querySelectorAll('.edit-director__first-name input')[0].value).toBe('Joe')
 
-    // Change the text input and mock save it
-    vm.$el.querySelectorAll('.edit-director__first-name input')[0].value = 'Steve'
-    vm.directors[1].officer.firstName = 'Steve'
+    // Change the text input
+    setValue(vm, '.edit-director__first-name input', 'Steve')
 
-    // Verify the saved data
+    // Verify the name is updated
     expect(vm.directors[1].officer.firstName).toBe('Steve')
 
     // Cancel Director edit and verify the name is back to its base name
     await vm.$el.querySelectorAll('.cancel-edit-btn')[0].click()
     expect(vm.directors[1].officer.firstName).toBe('Joe')
 
-    // // Verify the edit form is closed.
+    // Verify the edit form is closed.
     expect(vm.editFormShowHide.showAddress).toEqual(true)
     expect(vm.editFormShowHide.showName).toEqual(true)
     expect(vm.editFormShowHide.showDates).toEqual(true)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#2271

*Description of changes:*
- only render 1 set of edit forms when editing a director
- fixed syntax for interfaces properties
- fixed unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
