### PR TITLE
removed the address validation for Directors, that enforced their delivery address to BC

### DIFF
--- a/legal-api/src/legal_api/services/filings/validations/change_of_directors.py
+++ b/legal-api/src/legal_api/services/filings/validations/change_of_directors.py
@@ -45,7 +45,10 @@ def validate(business: Business, cod: Dict) -> Error:
 
 
 def validate_directors_addresses(cod: Dict) -> List:
-    """Return an error message if the directors address are invalid."""
+    """Return an error message if the directors address are invalid.
+
+    Address must contain a valid ISO-2 valid country.
+    """
     msg = []
 
     directors = cod['filing']['changeOfDirectors']['directors']
@@ -56,15 +59,6 @@ def validate_directors_addresses(cod: Dict) -> List:
                 try:
                     country = get_str(director, f'/{address_type}/addressCountry')
                     _ = pycountry.countries.search_fuzzy(country)[0].alpha_2
-
-                    if address_type == Address.JSON_DELIVERY:
-                        if country != 'CA':
-                            msg.append({'error': babel('Director Delivery country must be in CA.'),
-                                        'path': f'/filing/changeOfDirectors/directors/{idx}/{address_type}/addressCountry'})  # noqa: E501; line length too long
-
-                        if get_str(director, f'/{address_type}/addressRegion') != 'BC':
-                            msg.append({'error': babel('Director Delivery region must be in BC.'),
-                                        'path': f'/filing/changeOfDirectors/directors/{idx}/{address_type}/addressRegion'})  # noqa: E501; line length too long
 
                 except LookupError:
                     msg.append({'error': babel('Address Country must resolve to a valid ISO-2 country.'),

--- a/legal-api/tests/unit/services/filings/validations/change_of_director/test_validation_basic.py
+++ b/legal-api/tests/unit/services/filings/validations/change_of_director/test_validation_basic.py
@@ -34,6 +34,9 @@ from tests.unit.services.filings.validations import lists_are_equal
         ('SUCCESS', datetime(2001, 8, 5, 0, 0, 0, 0, tzinfo=timezone.utc),
          'BC', 'CA', 'BC', 'CA',
          None, None),
+        ('SUCCESS-NON_CA_COUNTRY', datetime(2001, 8, 5, 0, 0, 0, 0, tzinfo=timezone.utc),
+         'AM', 'DE', 'AM', 'DE',
+         None, None),
         ('Director[1] Nonsense Country', datetime(2001, 8, 5, 0, 0, 0, 0, tzinfo=timezone.utc),
          'BC', 'CA', 'BC', 'nonsense',
          HTTPStatus.BAD_REQUEST, [


### PR DESCRIPTION
Signed-off-by: thor wolpert <thor@wolpert.ca>

*Issue #:* /bcgov/entity#2278

*Description of changes:*
- removed the address validation for Directors, that enforced their delivery address to BC

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
