### PR TITLE
Fixes for release 2.4

### DIFF
--- a/coops-ui/src/components/Dashboard/TodoList.vue
+++ b/coops-ui/src/components/Dashboard/TodoList.vue
@@ -378,8 +378,8 @@ export default {
       let date
       const filing = task.task.filing
       if (filing && filing.header && filing.annualReport) {
-        filing.annualReport.annualGeneralMeetingDate
-          ? date = filing.annualReport.annualGeneralMeetingDate
+        filing.annualReport.annualReportDate
+          ? date = filing.annualReport.annualReportDate
           : date = filing.annualReport.nextARDate
         if (date) {
           const ARFilingYear = +date.substring(0, 4)

--- a/coops-ui/src/views/AnnualReport.vue
+++ b/coops-ui/src/views/AnnualReport.vue
@@ -680,7 +680,9 @@ export default {
           name: 'annualReport',
           certifiedBy: this.certifiedBy || '',
           email: 'no_one@never.get',
-          date: this.currentDate
+          date: this.currentDate,
+          effectiveDate: this.agmDate ? this.agmDate + 'T00:00:00+00:00'
+            : this.annualReportDate + 'T00:00:00+00:00'
         }
       }
       // only save this if it's not null

--- a/coops-ui/tests/unit/TodoList.spec.ts
+++ b/coops-ui/tests/unit/TodoList.spec.ts
@@ -807,7 +807,8 @@ describe('TodoList - UI - BCOMP', () => {
               'paymentToken': 12345678
             },
             'annualReport': {
-              'annualGeneralMeetingDate': '2019-07-15'
+              'annualGeneralMeetingDate': '2019-07-15',
+              'annualReportDate': '2019-07-15'
             },
             'changeOfAddress': { },
             'changeOfDirectors': { }
@@ -1053,7 +1054,8 @@ describe('TodoList - Click Tests', () => {
               'filingId': 123
             },
             'annualReport': {
-              'annualGeneralMeetingDate': '2019-07-15'
+              'annualGeneralMeetingDate': '2019-07-15',
+              'annualReportDate': '2019-07-15'
             },
             'changeOfAddress': { },
             'changeOfDirectors': { }
@@ -1110,7 +1112,8 @@ describe('TodoList - Click Tests', () => {
               'paymentToken': 654
             },
             'annualReport': {
-              'annualGeneralMeetingDate': '2019-07-15'
+              'annualGeneralMeetingDate': '2019-07-15',
+              'annualReportDate': '2019-07-15'
             },
             'changeOfAddress': { },
             'changeOfDirectors': { }
@@ -1162,7 +1165,8 @@ describe('TodoList - Click Tests', () => {
               'paymentToken': 987
             },
             'annualReport': {
-              'annualGeneralMeetingDate': '2019-07-15'
+              'annualGeneralMeetingDate': '2019-07-15',
+              'annualReportDate': '2019-07-15'
             },
             'changeOfAddress': { },
             'changeOfDirectors': { }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#2323

Todo list is broken for save as draft for a no agm filing 
Any AR filing for previous year blocks director changes for all future AR filings

*Description of changes:*
Changes to the Todolist to look at the AnnualReportDate instead of AGM date to take care of the no agm scenario

Changes to pass the effective date for Annual Report like Standalone Director filing. The value of effective date will be AGM date for a normal filing / annual report date for a no AGM filing


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
