### PR TITLE
Filer fix to set last AR date correctly

### DIFF
--- a/queue_services/entity-filer/src/entity_filer/filing_processors/annual_report.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/annual_report.py
@@ -34,4 +34,8 @@ def process(business: Business, filing: Dict):
 
     if agm_date is not None:
         business.last_agm_date = agm_date
-    business.last_ar_date = ar_date
+
+    if agm_date is not None:
+        business.last_ar_date = agm_date
+    else:
+        business.last_ar_date = ar_date

--- a/queue_services/entity-filer/tests/unit/test_worker.py
+++ b/queue_services/entity-filer/tests/unit/test_worker.py
@@ -120,7 +120,7 @@ def test_process_ar_filing(app, session):
     assert filing.business_id == business_id
     assert filing.status == Filing.Status.COMPLETED.value
     assert datetime.datetime.date(business.last_agm_date) == agm_date
-    assert datetime.datetime.date(business.last_ar_date) == ar_date
+    assert datetime.datetime.date(business.last_ar_date) == agm_date
 
 
 def test_process_coa_filing(app, session):

--- a/queue_services/entity-filer/tests/unit/test_worker.py
+++ b/queue_services/entity-filer/tests/unit/test_worker.py
@@ -158,7 +158,7 @@ def test_process_ar_filing_no_agm(app, session):
     assert filing.transaction_id
     assert filing.business_id == business_id
     assert filing.status == Filing.Status.COMPLETED.value
-    assert datetime.datetime.date(business.last_agm_date) == agm_date
+    assert business.last_agm_date == agm_date
     assert datetime.datetime.date(business.last_ar_date) == ar_date
 
 
@@ -397,7 +397,7 @@ def test_process_combined_filing(app, session):
     assert filing.business_id == business_id
     assert filing.status == Filing.Status.COMPLETED.value
     assert datetime.datetime.date(business.last_agm_date) == agm_date
-    assert datetime.datetime.date(business.last_ar_date) == ar_date
+    assert datetime.datetime.date(business.last_ar_date) == agm_date
 
     # check address filing
     delivery_address = business.delivery_address.one_or_none().json

--- a/queue_services/entity-filer/tests/unit/test_worker.py
+++ b/queue_services/entity-filer/tests/unit/test_worker.py
@@ -123,6 +123,45 @@ def test_process_ar_filing(app, session):
     assert datetime.datetime.date(business.last_ar_date) == agm_date
 
 
+def test_process_ar_filing_no_agm(app, session):
+    """Assert that an AR filling can be applied to the model correctly."""
+    from entity_filer.worker import process_filing
+    from legal_api.models import Business, Filing
+
+    # vars
+    payment_id = str(random.SystemRandom().getrandbits(0x58))
+    identifier = 'CP1234567'
+
+    # setup
+    business = create_business(identifier)
+    business_id = business.id
+    now = datetime.date(2020, 9, 17)
+    ar_date = datetime.date(2020, 8, 5)
+    agm_date = None
+    ar = copy.deepcopy(ANNUAL_REPORT)
+    ar['filing']['business']['identifier'] = identifier
+    ar['filing']['annualReport']['annualReportDate'] = ar_date.isoformat()
+    ar['filing']['annualReport']['annualGeneralMeetingDate'] = None
+
+    # TEST
+    with freeze_time(now):
+        filing = create_filing(payment_id, ar, business.id)
+        filing_id = filing.id
+        filing_msg = {'filing': {'id': filing_id}}
+        process_filing(filing_msg, app)
+
+    # Get modified data
+    filing = Filing.find_by_id(filing_id)
+    business = Business.find_by_internal_id(business_id)
+
+    # check it out
+    assert filing.transaction_id
+    assert filing.business_id == business_id
+    assert filing.status == Filing.Status.COMPLETED.value
+    assert datetime.datetime.date(business.last_agm_date) == agm_date
+    assert datetime.datetime.date(business.last_ar_date) == ar_date
+
+
 def test_process_coa_filing(app, session):
     """Assert that an AR filling can be applied to the model correctly."""
     from entity_filer.worker import process_filing


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*
Filer fix to consider agm date as the last_ar_date of the business. For no agm scenarios last AR date will be the annualReportDate

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
