### PR TITLE
duplicate fail safe for failed filings

### DIFF
--- a/jobs/update-colin-filings/update_colin_filings.py
+++ b/jobs/update-colin-filings/update_colin_filings.py
@@ -151,12 +151,15 @@ def run():
             for filing in filings:
                 filing_id = filing['filingId']
                 colin_id = send_filing(app=application, filing=filing, filing_id=filing_id)
-                if colin_id:
-                    update = update_colin_id(app=application, filing_id=filing_id, colin_id=colin_id, token=token)
-                    if update:
-                        application.logger.debug(f'Successfully updated filing {filing_id}')
-                    else:
-                        application.logger.error(f'Failed to update filing {filing_id}')
+                # this will prevent duplicates of the failed filings from being sent to colin
+                if not colin_id:
+                    colin_id = 0
+                update = update_colin_id(app=application, filing_id=filing_id, colin_id=colin_id, token=token)
+                if update and colin_id > 0:
+                    application.logger.debug(f'Successfully updated filing {filing_id}')
+                else:
+                    application.logger.error(f'Failed to update filing {filing_id} with colin event id.')
+
         except Exception as err:
             application.logger.error(err)
 


### PR DESCRIPTION
Signed-off-by: Kial Jinnah <kialj876@gmail.com>

*Issue #:* /bcgov/entity#1147

*Description of changes:*
set colin event id to 0 for filings that tried and failed to be sent across to colin (prevents duplicates getting created)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
