### PR TITLE
enable majority directors rule for coops, fix majority calculation

### DIFF
--- a/coops-ui/src/mixins/resource-lookup-mixin.ts
+++ b/coops-ui/src/mixins/resource-lookup-mixin.ts
@@ -59,8 +59,11 @@ export default class ResourceLookupMixin extends Vue {
       }
 
       if (configSection.canadianResident) {
-        if (directors.filter(x => (x.deliveryAddress.addressCountry !== 'CA' ||
-        (x.mailingAddress && x.mailingAddress.addressRegion !== 'BC'))).length === directors.length) {
+        const count = directors.length
+        const notCanadian = directors.filter(x => (x.deliveryAddress.addressCountry !== 'CA' ||
+        (x.mailingAddress && x.mailingAddress.addressCountry !== 'CA'))).length
+
+        if (notCanadian / count > 0.5) {
           errors.push({ 'title': configSection.canadianResident.title, 'msg': configSection.canadianResident.message })
         }
       }

--- a/coops-ui/src/resources/business-config.ts
+++ b/coops-ui/src/resources/business-config.ts
@@ -78,14 +78,14 @@ export const configJson = [{
             'Association Act (Section 72). You can continue your filing, but you must become compliant ' +
             'with the Cooperative Association Act as soon as possible.'
         },
-        _bcResident: {
+        bcResident: {
           title: 'BC Resident Director Required',
           message: 'One of the directors of the association is required to be an ' +
             'individual ordinarily resident in British Columbia, to be in compliance ' +
             'with the Cooperative Association Act (Section 72). You can continue your filing, ' +
             'but you must become compliant with the Cooperative Association Act as soon as possible.'
         },
-        _canadianResident: {
+        canadianResident: {
           title: 'Canadian Resident Directors Required',
           message: 'A majority of the directors of the association are required to be individuals ordinarily ' +
             'resident in Canada, to be in compliance with the Cooperative Association Act (Section 72). ' +

--- a/coops-ui/tests/unit/Directors.spec.ts
+++ b/coops-ui/tests/unit/Directors.spec.ts
@@ -68,7 +68,7 @@ describe('Directors as a COOP', () => {
                   'streetAddress': 'mailing_address - address line one',
                   'streetAddressAdditional': null,
                   'addressCity': 'mailing_address city',
-                  'addressCountry': 'mailing_address country',
+                  'addressCountry': 'CA',
                   'postalCode': 'H0H0H0',
                   'addressRegion': 'BC',
                   'deliveryInstructions': null
@@ -127,6 +127,62 @@ describe('Directors as a COOP', () => {
     expect(vm.complianceMsg.msg).toEqual(warning.minDirectors.message)
   })
 
+  it('check the default warning message for too few Canadian directors', () => {
+    vm.directors.push({
+      'actions': [],
+      'officer': {
+        'firstName': 'Peter',
+        'middleInitial': 'P',
+        'lastName': 'Parker'
+      },
+      'id': '3',
+      'deliveryAddress': {
+        'streetAddress': 'mailing_address - address line #1',
+        'streetAddressAdditional': 'Kirkintiloch',
+        'addressCity': 'Nanaimo',
+        'addressCountry': 'CA',
+        'postalCode': 'V1V 1V1',
+        'addressRegion': 'BC',
+        'deliveryInstructions': 'go to the back'
+      },
+      'title': 'Treasurer'
+    })
+
+    expect(vm.complianceMsg).toBeNull()
+    vm.directors[2].deliveryAddress.addressCountry = 'UK'
+    const warning = store.state.configObject.flows.find(x => x.feeCode === 'OTCDR').warnings
+    expect(vm.complianceMsg.msg).toEqual(warning.canadianResident.message)
+  })
+
+  it('check the default warning message for too few directors from B.C', () => {
+    vm.directors.push({
+      'actions': [],
+      'officer': {
+        'firstName': 'Peter',
+        'middleInitial': 'P',
+        'lastName': 'Parker'
+      },
+      'id': '3',
+      'deliveryAddress': {
+        'streetAddress': 'mailing_address - address line #1',
+        'streetAddressAdditional': 'Kirkintiloch',
+        'addressCity': 'Nanaimo',
+        'addressCountry': 'CA',
+        'postalCode': 'V1V 1V1',
+        'addressRegion': 'BC',
+        'deliveryInstructions': 'go to the back'
+      },
+      'title': 'Treasurer'
+    })
+
+    expect(vm.complianceMsg).toBeNull()
+    vm.directors[0].deliveryAddress.addressRegion = 'ON'
+    vm.directors[1].deliveryAddress.addressRegion = 'ON'
+    vm.directors[2].deliveryAddress.addressRegion = 'ON'
+    const warning = store.state.configObject.flows.find(x => x.feeCode === 'OTCDR').warnings
+    expect(vm.complianceMsg.msg).toEqual(warning.bcResident.message)
+  })
+
   it('initializes the director name data properly', () => {
     expect(vm.directors.length).toEqual(2)
     expect(vm.directors[0].officer.firstName).toEqual('Peter')
@@ -146,7 +202,7 @@ describe('Directors as a COOP', () => {
     expect(vm.directors[0].deliveryAddress.streetAddressAdditional).toEqual('')
     expect(vm.directors[0].deliveryAddress.addressCity).toEqual('mailing_address city')
     expect(vm.directors[0].deliveryAddress.addressRegion).toEqual('BC')
-    expect(vm.directors[0].deliveryAddress.addressCountry).toEqual('mailing_address country')
+    expect(vm.directors[0].deliveryAddress.addressCountry).toEqual('CA')
     expect(vm.directors[0].deliveryAddress.postalCode).toEqual('H0H0H0')
     expect(vm.directors[0].deliveryAddress.deliveryInstructions).toEqual('')
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#1448

*Description of changes:*
Enable Canadian resident and BC resident rules for Coop (originally thought to be out-of-scope for 1448)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
