### PR TITLE
Using sbc common version 36 as 37 is not stable and build is failing

### DIFF
--- a/coops-ui/package.json
+++ b/coops-ui/package.json
@@ -23,7 +23,7 @@
     "provinces": "^1.11.0",
     "regenerator-runtime": "^0.13.3",
     "register-service-worker": "^1.6.2",
-    "sbc-common-components": "2.0.37",
+    "sbc-common-components": "2.0.36",
     "vue": "^2.6.10",
     "vue-affix": "^0.5.2",
     "vue-router": "^3.0.3",


### PR DESCRIPTION
*Issue #:* /bcgov/entity#2370

*Description of changes:* Changing common components version to 36. 37 is not stable and has multiple issues that causes build failure


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
