### PR TITLE
merge release 2.5.1 back into master

### DIFF
--- a/coops-ui/package.json
+++ b/coops-ui/package.json
@@ -23,7 +23,7 @@
     "provinces": "^1.11.0",
     "regenerator-runtime": "^0.13.3",
     "register-service-worker": "^1.6.2",
-    "sbc-common-components": "2.0.36",
+    "sbc-common-components": "2.0.40",
     "vue": "^2.6.10",
     "vue-affix": "^0.5.2",
     "vue-router": "^3.0.3",
@@ -60,6 +60,7 @@
     "vue-plugin-helper-decorator": "^0.0.12",
     "vue-property-decorator": "^8.2.2",
     "vue-template-compiler": "^2.6.10",
-    "vue-test-utils-helpers": "git+https://github.com/AmpleOrganics/vue-test-utils-helpers.git"
+    "vue-test-utils-helpers": "git+https://github.com/AmpleOrganics/vue-test-utils-helpers.git",
+    "vuex-module-decorators": "^0.11.0"
   }
 }

--- a/coops-ui/package.json
+++ b/coops-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coops-ui",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
@@ -23,7 +23,7 @@
     "provinces": "^1.11.0",
     "regenerator-runtime": "^0.13.3",
     "register-service-worker": "^1.6.2",
-    "sbc-common-components": "2.0.32",
+    "sbc-common-components": "2.0.37",
     "vue": "^2.6.10",
     "vue-affix": "^0.5.2",
     "vue-router": "^3.0.3",

--- a/coops-ui/package.json
+++ b/coops-ui/package.json
@@ -23,7 +23,7 @@
     "provinces": "^1.11.0",
     "regenerator-runtime": "^0.13.3",
     "register-service-worker": "^1.6.2",
-    "sbc-common-components": "2.0.37",
+    "sbc-common-components": "2.0.36",
     "vue": "^2.6.10",
     "vue-affix": "^0.5.2",
     "vue-router": "^3.0.3",

--- a/coops-ui/src/components/common/OfficeAddresses.vue
+++ b/coops-ui/src/components/common/OfficeAddresses.vue
@@ -393,7 +393,7 @@ export default class OfficeAddresses extends Mixins(CommonMixin, EntityFilterMix
    */
   @Watch('addresses')
   onAddressesChanged (): void {
-    if (this.addresses) {
+    if (this.addresses && this.addresses.recordsOffice) {
       this.inheritRegisteredAddress =
         this.isSame(this.addresses.registeredOffice.deliveryAddress,
           this.addresses.recordsOffice.deliveryAddress, 'actions') &&


### PR DESCRIPTION
*Issue #:* /bcgov/entity#2482

*Description of changes:*
- Update sbc-common to version 37
- Using sbc common version 36 as 37 is not stable and build is failing
- Updating common components version to 40
- Added Jest flag to fix ts-jest problem
- Updated sbc-common-components to latest (41)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
