### PR TITLE
Add office type column to the spreadsheet of the data reset tool

### DIFF
--- a/colin-api/src/colin_api/models/address.py
+++ b/colin-api/src/colin_api/models/address.py
@@ -87,13 +87,14 @@ class Address:  # pylint: disable=too-many-instance-attributes; need all these f
         return address_obj
 
     @classmethod
-    def get_by_address_id(cls, address_id: str = None):
+    def get_by_address_id(cls, cursor, address_id: str = None):
         """Return single address associated with given addr_id."""
         if not address_id:
             return None
 
         try:
-            cursor = DB.connection.cursor()
+            if not cursor:
+                cursor = DB.connection.cursor()
             cursor.execute("""
                 select ADDR_ID, ADDR_LINE_1, ADDR_LINE_2, ADDR_LINE_3, CITY, PROVINCE, COUNTRY_TYPE.FULL_DESC,
                 POSTAL_CD, DELIVERY_INSTRUCTIONS

--- a/colin-api/src/colin_api/models/business.py
+++ b/colin-api/src/colin_api/models/business.py
@@ -201,26 +201,39 @@ class Business:
             raise err
 
     @classmethod
-    def update_corporation(cls, cursor, corp_num: str = None, date: str = None):
+    def update_corporation(cls, cursor, corp_num: str = None, date: str = None, annual_report: bool = False):
         """Update corporation record.
 
         :param cursor: oracle cursor
         :param corp_num: (str) corporation number
         :param date: (str) last agm date
+        :param annual_report: (bool) whether or not this was an annual report
         """
         try:
-            if date:
-                cursor.execute("""
-                    UPDATE corporation
-                    SET
-                        LAST_AR_FILED_DT = sysdate,
-                        LAST_AGM_DATE = TO_DATE(:agm_date, 'YYYY-mm-dd'),
-                        LAST_LEDGER_DT = sysdate
-                    WHERE corp_num = :corp_num
-                    """,
-                               agm_date=date,
-                               corp_num=corp_num
-                               )
+            if annual_report:
+                if date:
+                    cursor.execute("""
+                        UPDATE corporation
+                        SET
+                            LAST_AR_FILED_DT = sysdate,
+                            LAST_AGM_DATE = TO_DATE(:agm_date, 'YYYY-mm-dd'),
+                            LAST_LEDGER_DT = sysdate
+                        WHERE corp_num = :corp_num
+                        """,
+                                   agm_date=date,
+                                   corp_num=corp_num
+                                   )
+                else:
+                    cursor.execute("""
+                        UPDATE corporation
+                        SET
+                            LAST_AR_FILED_DT = sysdate,
+                            LAST_LEDGER_DT = sysdate
+                        WHERE corp_num = :corp_num
+                        """,
+                                   agm_date=date,
+                                   corp_num=corp_num
+                                   )
 
             else:
                 cursor.execute("""

--- a/colin-api/src/colin_api/models/business.py
+++ b/colin-api/src/colin_api/models/business.py
@@ -77,6 +77,7 @@ class Business:
                 # if there are no ARs for this coop then use date of incorporation
                 if row['filing_typ_cd'] == 'OTINC' and 'agm_date' not in dates:
                     dates['agm_date'] = row['event_timestmp']
+                    dates['ar_filed_date'] = row['event_timestmp']
 
             dates_by_corp_num.append(dates)
         return dates_by_corp_num

--- a/colin-api/src/colin_api/models/director.py
+++ b/colin-api/src/colin_api/models/director.py
@@ -250,7 +250,6 @@ class Director:  # pylint: disable=too-many-instance-attributes; need all these 
                            last_nme=director['officer']['lastName'],
                            middle_nme=director['officer'].get('middleInitial', ''),
                            first_nme=director['officer']['firstName'],
-                           business_nme=business['business']['legalName'],
                            bus_company_num=business['business']['businessNumber']
                            )
         except Exception as err:

--- a/colin-api/src/colin_api/models/entity_name.py
+++ b/colin-api/src/colin_api/models/entity_name.py
@@ -57,7 +57,7 @@ class EntityName:
         return name_obj
 
     @classmethod
-    def get_current(cls, identifier: str = None):
+    def get_current(cls, cursor, identifier: str = None):
         """Get current entity name."""
         if not identifier:
             return None
@@ -69,7 +69,8 @@ class EntityName:
             """)
 
         try:
-            cursor = DB.connection.cursor()
+            if not cursor:
+                cursor = DB.connection.cursor()
             cursor.execute(querystring, identifier=identifier)
 
             return cls._create_name_obj(cursor=cursor, identifier=identifier)
@@ -79,7 +80,7 @@ class EntityName:
             raise err
 
     @classmethod
-    def get_by_event(cls, identifier: str = None, event_id: str = None):
+    def get_by_event(cls, cursor, identifier: str = None, event_id: str = None):
         """Get the entity name corresponding with the given event id."""
         if not identifier or not event_id:
             return None
@@ -91,7 +92,8 @@ class EntityName:
             """)
 
         try:
-            cursor = DB.connection.cursor()
+            if not cursor:
+                cursor = DB.connection.cursor()
             cursor.execute(querystring, identifier=identifier, event_id=event_id)
 
             return cls._create_name_obj(cursor=cursor, identifier=identifier)

--- a/colin-api/src/colin_api/models/filing.py
+++ b/colin-api/src/colin_api/models/filing.py
@@ -708,7 +708,7 @@ class Filing:
                 cls._create_filing(cursor, event_id, corp_num, ar_date, agm_date, filing_type_cd)
 
                 # update corporation record
-                Business.update_corporation(cursor, corp_num, agm_date)
+                Business.update_corporation(cursor, corp_num, agm_date, True)
 
                 # update corp_state TO ACT (active) if it is in good standing. From CRUD:
                 # - the current corp_state != 'ACT' and,

--- a/colin-api/src/colin_api/models/filing.py
+++ b/colin-api/src/colin_api/models/filing.py
@@ -116,13 +116,14 @@ class Filing:
         return event_id
 
     @classmethod
-    def _get_events(cls, identifier: str = None, filing_type_code: str = None):
+    def _get_events(cls, cursor, identifier: str = None, filing_type_code: str = None):
         """Get all event ids of filings for given filing type for this corp."""
         if not identifier or not filing_type_code:
             return None
 
         try:
-            cursor = DB.connection.cursor()
+            if not cursor:
+                cursor = DB.connection.cursor()
             cursor.execute(
                 """
                 select event.event_id, event.event_timestmp, filing.period_end_dt
@@ -239,7 +240,7 @@ class Filing:
             raise err
 
     @classmethod
-    def _get_filing_event_info(cls,  # pylint: disable=too-many-arguments,too-many-branches;
+    def _get_filing_event_info(cls, cursor,  # pylint: disable=too-many-arguments,too-many-branches;
                                identifier: str = None, event_id: str = None, filing_type_cd: str = None,
                                year: int = None):
         """Get the basic filing info that we care about for all filings."""
@@ -265,7 +266,8 @@ class Filing:
         querystring += ' order by EVENT_TIMESTMP desc'
 
         try:
-            cursor = DB.connection.cursor()
+            if not cursor:
+                cursor = DB.connection.cursor()
             if event_id:
                 if year:
                     cursor.execute(querystring, identifier=identifier, event_id=event_id,
@@ -311,11 +313,11 @@ class Filing:
             raise err
 
     @classmethod
-    def _get_ar(cls, identifier: str = None, filing_event_info: dict = None):
+    def _get_ar(cls, cursor, identifier: str = None, filing_event_info: dict = None):
         """Return annual report filing."""
         # get directors and registered office as of this filing
-        director_events = cls._get_events(identifier=identifier, filing_type_code='OTCDR')
-        office_events = cls._get_events(identifier=identifier, filing_type_code='OTADD')
+        director_events = cls._get_events(identifier=identifier, filing_type_code='OTCDR', cursor=cursor)
+        office_events = cls._get_events(identifier=identifier, filing_type_code='OTADD', cursor=cursor)
         director_event_id = None
         office_event_id = None
 
@@ -333,26 +335,26 @@ class Filing:
         recreated_dirs_and_office = True
         if director_event_id:
             try:
-                directors = Director.get_by_event(identifier=identifier, event_id=director_event_id)
+                directors = Director.get_by_event(identifier=identifier, event_id=director_event_id, cursor=cursor)
             except:  # noqa B901; pylint: disable=bare-except;
                 # should only get here if agm was before the bob date
                 recreated_dirs_and_office = False
-                directors = Director.get_current(identifier=identifier)
+                directors = Director.get_current(identifier=identifier, cursor=cursor)
         else:
-            directors = Director.get_current(identifier=identifier)
+            directors = Director.get_current(identifier=identifier, cursor=cursor)
         directors = [x.as_dict() for x in directors]
         if office_event_id:
             try:
-                office_obj_list = (Office.get_by_event(event_id=office_event_id)).as_dict()
+                office_obj_list = (Office.get_by_event(event_id=office_event_id, cursor=cursor)).as_dict()
                 offices = Office.convert_obj_list(office_obj_list)
             except:  # noqa B901; pylint: disable=bare-except;
                 # should only get here if agm was before the bob date
                 recreated_dirs_and_office = False
-                office_obj_list = Office.get_current(identifier=identifier)
+                office_obj_list = Office.get_current(identifier=identifier, cursor=cursor)
                 offices = Office.convert_obj_list(office_obj_list)
 
         else:
-            office_obj_list = Office.get_current(identifier=identifier)
+            office_obj_list = Office.get_current(identifier=identifier, cursor=cursor)
             offices = Office.convert_obj_list(office_obj_list)
 
         filing_obj = Filing()
@@ -370,9 +372,9 @@ class Filing:
         return filing_obj
 
     @classmethod
-    def _get_coa(cls, identifier: str = None, filing_event_info: dict = None):
+    def _get_coa(cls, cursor, identifier: str = None, filing_event_info: dict = None):
         """Get change of address filing for registered and/or records office."""
-        office_obj_list = Office.get_by_event(filing_event_info['event_id'])
+        office_obj_list = Office.get_by_event(cursor, filing_event_info['event_id'])
         if not office_obj_list:
             raise FilingNotFoundException(identifier=identifier, filing_type='change_of_address',
                                           event_id=filing_event_info['event_id'])
@@ -381,7 +383,7 @@ class Filing:
 
         # check to see if this filing was made with an AR -> if it was then set the AR date as the effective date
         effective_date = filing_event_info['event_timestmp']
-        annual_reports = cls._get_events(identifier=identifier, filing_type_code='OTANN')
+        annual_reports = cls._get_events(cursor=cursor, identifier=identifier, filing_type_code='OTANN')
         for filing in annual_reports:
             if convert_to_json_date(filing['date']) == convert_to_json_date(effective_date):
                 effective_date = filing['annualReportDate']
@@ -399,15 +401,15 @@ class Filing:
         return filing_obj
 
     @classmethod
-    def _get_cod(cls, identifier: str = None, filing_event_info: dict = None):
+    def _get_cod(cls, cursor, identifier: str = None, filing_event_info: dict = None):
         """Get change of directors filing."""
-        director_objs = Director.get_by_event(identifier, filing_event_info['event_id'])
+        director_objs = Director.get_by_event(cursor, identifier, filing_event_info['event_id'])
         if len(director_objs) < 3:
             current_app.logger.error('Less than 3 directors for {}'.format(identifier))
 
         # check to see if this filing was made with an AR -> if it was then set the AR date as the effective date
         effective_date = filing_event_info['event_timestmp']
-        annual_reports = cls._get_events(identifier=identifier, filing_type_code='OTANN')
+        annual_reports = cls._get_events(cursor=cursor, identifier=identifier, filing_type_code='OTANN')
         for filing in annual_reports:
             if convert_to_json_date(filing['date']) == convert_to_json_date(effective_date):
                 effective_date = filing['annualReportDate']
@@ -425,9 +427,9 @@ class Filing:
         return filing_obj
 
     @classmethod
-    def _get_con(cls, identifier: str = None, filing_event_info: dict = None):
+    def _get_con(cls, cursor, identifier: str = None, filing_event_info: dict = None):
         """Get change of name filing."""
-        name_obj = EntityName.get_by_event(identifier=identifier, event_id=filing_event_info['event_id'])
+        name_obj = EntityName.get_by_event(identifier=identifier, event_id=filing_event_info['event_id'], cursor=cursor)
         if not name_obj:
             raise FilingNotFoundException(identifier=identifier, filing_type='change_of_name',
                                           event_id=filing_event_info['event_id'])
@@ -443,7 +445,7 @@ class Filing:
         return filing_obj
 
     @classmethod
-    def _get_sr(cls, identifier: str = None, filing_event_info: dict = None):
+    def _get_sr(cls, cursor, identifier: str = None, filing_event_info: dict = None):
         """Get special resolution filing."""
         querystring = ("""
             select filing.event_id, filing.effective_dt, ledger_text.notation
@@ -453,7 +455,6 @@ class Filing:
             """)
 
         try:
-            cursor = DB.connection.cursor()
             cursor.execute(querystring, event_id=filing_event_info['event_id'])
             sr_info = cursor.fetchone()
             if not sr_info:
@@ -480,7 +481,7 @@ class Filing:
             raise err
 
     @classmethod
-    def _get_vd(cls, identifier: str = None, filing_event_info: dict = None):
+    def _get_vd(cls, cursor, identifier: str = None, filing_event_info: dict = None):
         """Get voluntary dissolution filing."""
         querystring = ("""
                 select filing.event_id, filing.effective_dt
@@ -489,7 +490,6 @@ class Filing:
                 """)
 
         try:
-            cursor = DB.connection.cursor()
             cursor.execute(querystring, event_id=filing_event_info['event_id'])
             vd_info = cursor.fetchone()
             if not vd_info:
@@ -515,7 +515,7 @@ class Filing:
             raise err
 
     @classmethod
-    def _get_other(cls, identifier: str = None, filing_event_info: dict = None):
+    def _get_other(cls, cursor, identifier: str = None, filing_event_info: dict = None):
         """Get basic info for a filing we aren't handling yet."""
         querystring = ("""
             select filing.event_id, filing.effective_dt, ledger_text.notation
@@ -525,7 +525,6 @@ class Filing:
             """)
 
         try:
-            cursor = DB.connection.cursor()
             cursor.execute(querystring, event_id=filing_event_info['event_id'])
             filing_info = cursor.fetchone()
             if not filing_info:
@@ -553,12 +552,17 @@ class Filing:
             raise err
 
     @classmethod
-    def get_filing(cls, business: Business = None, event_id: str = None, filing_type: str = None, year: int = None):
+    def get_filing(cls, con=None,  # pylint: disable=too-many-arguments, too-many-branches;
+                   business: Business = None, event_id: str = None, filing_type: str = None, year: int = None):
         """Get a Filing."""
         if not business or not filing_type:
             return None
 
         try:
+            if not con:
+                con = DB.connection
+                con.begin()
+            cursor = con.cursor()
             identifier = business.get_corp_num()
 
             # get the filing types corresponding filing code
@@ -568,31 +572,31 @@ class Filing:
 
             # get the filing event info
             filing_event_info = cls._get_filing_event_info(identifier=identifier, event_id=event_id,
-                                                           filing_type_cd=code[0], year=year)
+                                                           filing_type_cd=code[0], year=year, cursor=cursor)
             if not filing_event_info:
                 raise FilingNotFoundException(identifier=identifier, filing_type=filing_type, event_id=event_id)
 
             if filing_type == 'annualReport':
-                filing_obj = cls._get_ar(identifier=identifier, filing_event_info=filing_event_info)
+                filing_obj = cls._get_ar(identifier=identifier, filing_event_info=filing_event_info, cursor=cursor)
 
             elif filing_type == 'changeOfAddress':
-                filing_obj = cls._get_coa(identifier=identifier, filing_event_info=filing_event_info)
+                filing_obj = cls._get_coa(identifier=identifier, filing_event_info=filing_event_info, cursor=cursor)
 
             elif filing_type == 'changeOfDirectors':
-                filing_obj = cls._get_cod(identifier=identifier, filing_event_info=filing_event_info)
+                filing_obj = cls._get_cod(identifier=identifier, filing_event_info=filing_event_info, cursor=cursor)
 
             elif filing_type == 'changeOfName':
-                filing_obj = cls._get_con(identifier=identifier, filing_event_info=filing_event_info)
+                filing_obj = cls._get_con(identifier=identifier, filing_event_info=filing_event_info, cursor=cursor)
 
             elif filing_type == 'specialResolution':
-                filing_obj = cls._get_sr(identifier=identifier, filing_event_info=filing_event_info)
+                filing_obj = cls._get_sr(identifier=identifier, filing_event_info=filing_event_info, cursor=cursor)
 
             elif filing_type == 'voluntaryDissolution':
-                filing_obj = cls._get_vd(identifier=identifier, filing_event_info=filing_event_info)
+                filing_obj = cls._get_vd(identifier=identifier, filing_event_info=filing_event_info, cursor=cursor)
 
             else:
                 # uncomment to bring in other filings as available on paper only
-                # filing_obj = cls._get_other(identifier=identifier, filing_event_info=filing_event_info)
+                # filing_obj = cls._get_other(identifier=identifier, filing_event_info=filing_event_info, cursor=cursor)
                 raise InvalidFilingTypeException(filing_type=filing_type)
 
             filing_obj.header = {

--- a/colin-api/src/colin_api/resources/directors.py
+++ b/colin-api/src/colin_api/resources/directors.py
@@ -20,6 +20,7 @@ from flask_restplus import Resource, cors
 
 from colin_api.exceptions import GenericException
 from colin_api.models import Director
+from colin_api.models.filing import DB
 from colin_api.resources.business import API
 from colin_api.utils.util import cors_preflight
 
@@ -37,7 +38,8 @@ class DirectorsInfo(Resource):
             return jsonify({'message': 'Identifier required'}), 404
 
         try:
-            directors = Director.get_current(identifier)
+            cursor = DB.connection.cursor()
+            directors = Director.get_current(cursor=cursor, identifier=identifier)
             if not directors:
                 return jsonify({'message': f'directors for {identifier} not found'}), 404
             if len(directors) < 3:

--- a/colin-api/src/colin_api/resources/filing.py
+++ b/colin-api/src/colin_api/resources/filing.py
@@ -21,7 +21,7 @@ from registry_schemas import validate
 
 from colin_api.exceptions import FilingNotFoundException, GenericException
 from colin_api.models import Business
-from colin_api.models.filing import Filing, DB
+from colin_api.models.filing import DB, Filing
 from colin_api.resources.business import API
 from colin_api.utils.util import cors_preflight
 
@@ -117,8 +117,8 @@ class FilingInfo(Resource):
                 completed_filing.business = Business.find_by_identifier(identifier)
                 completed_filing.body = {}
                 for filing_info in filings_added:
-                    filing = Filing.get_filing(business=completed_filing.business, event_id=filing_info['event_id'],
-                                               filing_type=filing_info['filing_type'])
+                    filing = Filing.get_filing(con=con, business=completed_filing.business,
+                                               event_id=filing_info['event_id'], filing_type=filing_info['filing_type'])
                     if not filing:
                         raise FilingNotFoundException(identifier=identifier, filing_type=filing_info['filing_type'],
                                                       event_id=filing_info['event_id'])

--- a/colin-api/src/colin_api/resources/office.py
+++ b/colin-api/src/colin_api/resources/office.py
@@ -21,6 +21,7 @@ from flask_restplus import Resource, cors
 
 from colin_api.exceptions import GenericException
 from colin_api.models import Office
+from colin_api.models.filing import DB
 from colin_api.resources.business import API
 from colin_api.utils.util import cors_preflight
 
@@ -38,8 +39,9 @@ class OfficeInfo(Resource):
             return jsonify({'message': 'Identifier required'}), 404
 
         try:
+            cursor = DB.connection.cursor()
             offices = {}
-            office_obj_list = Office.get_current(identifier=identifier)
+            office_obj_list = Office.get_current(cursor=cursor, identifier=identifier)
             for office_obj in office_obj_list:
                 if office_obj.office_type not in offices.keys():
                     offices.update(office_obj.as_dict())

--- a/colin-api/tests/unit/api/test_directors.py
+++ b/colin-api/tests/unit/api/test_directors.py
@@ -115,7 +115,7 @@ def test_post_invalid_cod_fail(client):
     fake_filing = FILING_HEADER
     fake_filing['filing']['header']['name'] = 'changeOfDirectors'
     fake_filing['filing']['business']['identifier'] = 'CP0001965'
-    fake_filing['filing']['changeOfDirectors'] = CHANGE_OF_DIRECTORS
+    fake_filing['filing']['changeOfDirectors'] = {}
 
     rv = client.post('/api/v1/businesses/CP0001965/filings/changeOfDirectors',
                      data=json.dumps(fake_filing), headers=headers)

--- a/data-reset-tool/src/data_reset_tool/converter/ExcelWriter.py
+++ b/data-reset-tool/src/data_reset_tool/converter/ExcelWriter.py
@@ -64,6 +64,7 @@ class ExcelWriter:  # pylint: disable=too-few-public-methods
 
         business_address_sheet_headings = [
             'business',
+            'office_type',
             'address_type',
             'street',
             'street_additional',

--- a/jobs/update-colin-filings/update_colin_filings.py
+++ b/jobs/update-colin-filings/update_colin_filings.py
@@ -103,7 +103,6 @@ def send_filing(app: Flask = None, filing: dict = None, filing_id: str = None):
                           f'{filing_type}', json=filing)
         if not r or r.status_code != 201:
             app.logger.error(f'Filing {filing_id} not created in colin {filing["filing"]["business"]["identifier"]}.')
-            print(r.json())
             # raise Exception
             return None
         # if it's an AR containing multiple filings it will have multiple colinIds
@@ -132,6 +131,14 @@ def clean_none(dictionary: dict = None):
             dictionary[key] = ''
 
 
+def is_bcomp(identifier: str):
+    return 'bc' in identifier.lower()
+
+
+def is_test_coop(identifier: str):
+    return 'CP1' in identifier
+
+
 def run():
     application = create_app()
     corps_with_failed_filing = []
@@ -150,9 +157,9 @@ def run():
             if not filings:
                 application.logger.debug(f'No completed filings to send to colin.')
             for filing in filings:
-                print(filing['filing']['header']['date'])
                 filing_id = filing['filingId']
-                if filing["filing"]["business"]["identifier"] in corps_with_failed_filing:
+                identifier = filing['filing']['business']['identifier']
+                if identifier in corps_with_failed_filing or is_bcomp(identifier) or is_test_coop(identifier):
                     application.logger.debug(f'Skipping filing {filing_id} for'
                                              f' {filing["filing"]["business"]["identifier"]}.')
                 else:

--- a/jobs/update-colin-filings/update_colin_filings.py
+++ b/jobs/update-colin-filings/update_colin_filings.py
@@ -103,6 +103,7 @@ def send_filing(app: Flask = None, filing: dict = None, filing_id: str = None):
                           f'{filing_type}', json=filing)
         if not r or r.status_code != 201:
             app.logger.error(f'Filing {filing_id} not created in colin {filing["filing"]["business"]["identifier"]}.')
+            print(r.json())
             # raise Exception
             return None
         # if it's an AR containing multiple filings it will have multiple colinIds

--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -336,7 +336,7 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
         """Return the filings with statuses in the status array input."""
         filings = db.session.query(Filing). \
             filter(Filing.colin_event_ids == None,  # pylint: disable=singleton-comparison # noqa: E711;
-                   Filing._status == Filing.Status.COMPLETED.value).all()
+                   Filing._status == Filing.Status.COMPLETED.value).order_by(Filing.filing_date).all()
         return filings
 
     @staticmethod

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/change_of_directors.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/change_of_directors.py
@@ -29,7 +29,7 @@ def process(business: Business, filing: Dict):  # pylint: disable=too-many-branc
 
     for new_director in new_directors:  # pylint: disable=too-many-nested-blocks;
         # Applies only for filings coming from colin.
-        if filing.get('colinId'):
+        if filing.get('colinIds'):
             director_found = False
             current_new_director_name = \
                 new_director['officer'].get('firstName') + new_director['officer'].get('middleInitial', '') + \
@@ -95,7 +95,7 @@ def process(business: Business, filing: Dict):  # pylint: disable=too-many-branc
                     update_director(director, new_director)
                     break
 
-    if filing.get('colinId'):
+    if filing.get('colinIds'):
         for director in business.directors:
             # get name of director in database for comparison *
             director_name = director.first_name + director.middle_initial + director.last_name

--- a/queue_services/entity-filer/src/entity_filer/worker.py
+++ b/queue_services/entity-filer/src/entity_filer/worker.py
@@ -123,7 +123,7 @@ def process_filing(filing_msg: Dict, flask_app: Flask):
                     change_of_address.process(business, filing)
 
                 elif filing.get('changeOfDirectors'):
-                    filing['colinId'] = filing_submission.colin_event_id
+                    filing['colinIds'] = filing_submission.colin_event_ids
                     change_of_directors.process(business, filing)
 
                 elif filing.get('changeOfName'):

--- a/queue_services/entity-filer/tests/unit/__init__.py
+++ b/queue_services/entity-filer/tests/unit/__init__.py
@@ -350,7 +350,7 @@ COMBINED_FILING = {
         },
         'annualReport': {
             'annualGeneralMeetingDate': '2019-04-08',
-            'annualReportDate': '2018-04-08',
+            'annualReportDate': '2019-04-08',
             'directors': COD_FILING['filing']['changeOfDirectors']['directors'],
             'offices': COA_FILING['filing']['changeOfAddress']['offices']
         },

--- a/queue_services/entity-filer/tests/unit/test_worker.py
+++ b/queue_services/entity-filer/tests/unit/test_worker.py
@@ -397,7 +397,7 @@ def test_process_combined_filing(app, session):
     assert filing.business_id == business_id
     assert filing.status == Filing.Status.COMPLETED.value
     assert datetime.datetime.date(business.last_agm_date) == agm_date
-    assert datetime.datetime.date(business.last_ar_date) == agm_date
+    assert datetime.datetime.date(business.last_ar_date) == ar_date
 
     # check address filing
     delivery_address = business.delivery_address.one_or_none().json


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*
The additional Bcomp office types were successfully added to the reset tool. The only part missing was adding the new column name to the business addresses tab.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
