### PR TITLE
bumped versions

### DIFF
--- a/colin-api/src/colin_api/models/director.py
+++ b/colin-api/src/colin_api/models/director.py
@@ -220,6 +220,8 @@ class Director:  # pylint: disable=too-many-instance-attributes; need all these 
             mailing_addr_id = Address.create_new_address(cursor=cursor, address_info=director['mailingAddress'])
         # create new corp party entry
         try:
+
+            print(1)
             cursor.execute("""select noncorp_party_seq.NEXTVAL from dual""")
             row = cursor.fetchone()
             corp_party_id = int(row[0])

--- a/colin-api/src/colin_api/models/director.py
+++ b/colin-api/src/colin_api/models/director.py
@@ -220,8 +220,6 @@ class Director:  # pylint: disable=too-many-instance-attributes; need all these 
             mailing_addr_id = Address.create_new_address(cursor=cursor, address_info=director['mailingAddress'])
         # create new corp party entry
         try:
-
-            print(1)
             cursor.execute("""select noncorp_party_seq.NEXTVAL from dual""")
             row = cursor.fetchone()
             corp_party_id = int(row[0])

--- a/colin-api/src/colin_api/version.py
+++ b/colin-api/src/colin_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.4.0'  # pylint: disable=invalid-name
+__version__ = '2.5.2'  # pylint: disable=invalid-name

--- a/legal-api/src/legal_api/version.py
+++ b/legal-api/src/legal_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.5.0'  # pylint: disable=invalid-name
+__version__ = '2.5.2'  # pylint: disable=invalid-name

--- a/queue_services/entity-filer/src/entity_filer/version.py
+++ b/queue_services/entity-filer/src/entity_filer/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.5.0'  # pylint: disable=invalid-name
+__version__ = '2.5.2'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*
- legal-api, colin-api, entity-filer version numbers updated to 2.5.2
- legal/colin updaters don't have version numbers

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
