### PR TITLE
changed Exit to redirect to Businesses page

### DIFF
--- a/coops-ui/src/App.vue
+++ b/coops-ui/src/App.vue
@@ -329,7 +329,9 @@ export default {
     },
 
     onClickExit () {
-      this.$refs.sbcHeader.logout()
+      const businessesUrl = sessionStorage.getItem('BUSINESSES_URL') || ''
+      // assume Businesses URL is always reachable
+      businessesUrl && window.location.assign(businessesUrl)
     },
 
     onClickRetry () {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#2599

*Description of changes:*
- on clicking Exit from "Dashboard Unavailable" dialog, redirect to Businesses page (instead of logging out)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
