### PR TITLE
changed AGM Date to have no default

### DIFF
--- a/coops-ui/package.json
+++ b/coops-ui/package.json
@@ -8,7 +8,7 @@
     "lint": "vue-cli-service lint",
     "lint:nofix": "vue-cli-service lint --no-fix",
     "test:e2e": "vue-cli-service test:e2e",
-    "test:unit": "vue-cli-service test:unit --testPathPattern=.",
+    "test:unit": "vue-cli-service test:unit --testPathPattern",
     "test:unit-silent": "vue-cli-service test:unit --silent",
     "test:debug": "node --inspect-brk node_modules/.bin/vue-cli-service test:unit --testPathPattern --no-cache --watch --runInBand"
   },

--- a/coops-ui/src/components/AnnualReport/Directors.vue
+++ b/coops-ui/src/components/AnnualReport/Directors.vue
@@ -551,6 +551,9 @@ export default class Directors extends Mixins(DateMixin, CommonMixin,
   @Prop()
   private asOfDate: string
 
+  /**
+   * Indicates whether this component should be enabled or not.
+   */
   @Prop({ default: true })
   private componentEnabled: boolean
 
@@ -1652,7 +1655,7 @@ ul {
 
 .complianceSection {
   font-size: 0.9rem;
-  color:rgba(0,0,0,0.87);
+  color: rgba(0,0,0,0.87);
 }
 
 ::v-deep .v-alert.icon-blue {

--- a/coops-ui/src/components/common/OfficeAddresses.vue
+++ b/coops-ui/src/components/common/OfficeAddresses.vue
@@ -35,7 +35,7 @@
                     id="reg-off-addr-change-btn"
                     small
                     v-if="!showAddressForm"
-                    :disabled="changeButtonDisabled"
+                    :disabled="!componentEnabled"
                     @click="editAddress()"
                   >
                     <v-icon small>mdi-pencil</v-icon>
@@ -225,10 +225,10 @@ import { EntityTypes } from '@/enums'
 })
 export default class OfficeAddresses extends Mixins(CommonMixin, EntityFilterMixin) {
   /**
-   * Indicates whether the change button should be disabled or not
+   * Indicates whether this component should be enabled or not.
    */
-  @Prop({ default: false })
-  readonly changeButtonDisabled: boolean
+  @Prop({ default: true })
+  readonly componentEnabled: boolean
 
   /**
    * Addresses object from the parent page.

--- a/coops-ui/src/enums/filingCodes.ts
+++ b/coops-ui/src/enums/filingCodes.ts
@@ -1,7 +1,7 @@
 export enum FilingCodes {
-  ANNUAL_REPORT_BC = 'ANNBC', // BCOMPs Annual Report Code
-  ANNUAL_REPORT_OT = 'OTANN', // Others Annual Report Code
-  ADDRESS_CHANGE_OT = 'OTADD', // Others Change of Address Code
-  DIRECTOR_CHANGE_OT = 'OTCDR', // Others Change of Directors
-  FREE_DIRECTOR_CHANGE_OT = 'OTFDR' // Others Free Change of Directors
+  ANNUAL_REPORT_BC = 'BCANN', // BCOMP - Annual Report
+  ANNUAL_REPORT_OT = 'OTANN', // Others - Annual Report
+  ADDRESS_CHANGE_OT = 'OTADD', // Others - Change of Address
+  DIRECTOR_CHANGE_OT = 'OTCDR', // Others - Change of Directors
+  FREE_DIRECTOR_CHANGE_OT = 'OTFDR' // Others - Free Change of Directors
 }

--- a/coops-ui/src/resources/business-config.ts
+++ b/coops-ui/src/resources/business-config.ts
@@ -1,3 +1,5 @@
+import { EntityTypes, FilingCodes } from '@/enums'
+
 export class Flow {
   feeCode: string
   displayName: string
@@ -11,25 +13,25 @@ export class Business {
 }
 
 export const configJson = [{
-  typeEnum: 'BC',
+  typeEnum: EntityTypes.BCOMP,
   displayName: 'Benefit Company',
   flows: [
     {
-      feeCode: 'OTADD',
+      feeCode: FilingCodes.ADDRESS_CHANGE_OT,
       displayName: 'Change Of Address',
       certifyText: 'Note: It is an offence to make a false or misleading statement in ' +
            'respect of a material fact in a record submitted to the Corporate Registry for filing. ' +
            'See Sections 35 and 36 of the Business Corporations Act.'
     },
     {
-      feeCode: 'OTANN',
+      feeCode: FilingCodes.ANNUAL_REPORT_BC,
       displayName: 'Annual Report',
       certifyText: 'Note: It is an offence to make a false or misleading statement in ' +
            'respect of a material fact in a record submitted to the Corporate Registry for filing. ' +
            'See Section 51 of the Business Corporations Act.'
     },
     {
-      feeCode: 'OTCDR',
+      feeCode: FilingCodes.DIRECTOR_CHANGE_OT,
       displayName: 'Change Of Directors',
       certifyText: 'Note: It is an offence to make a false or misleading statement in ' +
            'respect of a material fact in a record submitted to the Corporate Registry for filing. ' +
@@ -47,25 +49,25 @@ export const configJson = [{
   ]
 },
 {
-  typeEnum: 'CP',
+  typeEnum: EntityTypes.COOP,
   displayName: 'Cooperative',
   flows: [
     {
-      feeCode: 'OTADD',
+      feeCode: FilingCodes.ADDRESS_CHANGE_OT,
       displayName: 'Change Of Address',
       certifyText: 'Note: It is an offence to make a false or misleading statement in ' +
            'respect of a material fact in a record submitted to the Corporate Registry for filing. ' +
            'See Section 27 of the Cooperative Association Act.'
     },
     {
-      feeCode: 'OTANN',
+      feeCode: FilingCodes.ANNUAL_REPORT_OT,
       displayName: 'Annual Report',
       certifyText: 'Note: It is an offence to make a false or misleading statement in ' +
            'respect of a material fact in a record submitted to the Corporate Registry for filing. ' +
            'See Section 126 of the Cooperative Association Act.'
     },
     {
-      feeCode: 'OTCDR',
+      feeCode: FilingCodes.DIRECTOR_CHANGE_OT,
       displayName: 'Change Of Directors',
       certifyText: 'Note: It is an offence to make a false or misleading statement in ' +
            'respect of a material fact in a record submitted to the Corporate Registry for filing. ' +

--- a/coops-ui/src/views/StandaloneOfficeAddressFiling.vue
+++ b/coops-ui/src/views/StandaloneOfficeAddressFiling.vue
@@ -62,7 +62,6 @@
             <!-- Office Addresses -->
             <section>
               <OfficeAddresses
-                :changeButtonDisabled="false"
                 :addresses.sync="addresses"
                 :registeredAddress.sync="registeredAddress"
                 :recordsAddress.sync="recordsAddress"

--- a/coops-ui/tests/unit/AnnualReport.spec.ts
+++ b/coops-ui/tests/unit/AnnualReport.spec.ts
@@ -1498,8 +1498,7 @@ describe('AnnualReport - Part 5 - Data', () => {
     store.state.currentDate = '2019-03-03'
 
     // set No AGM
-    vm.noAGM = true
-    vm.agmDate = null
+    vm.didNotHoldAgm = true
 
     // click the Save button
     wrapper.find('#ar-save-btn').trigger('click')

--- a/coops-ui/tests/unit/OfficeAddresses.spec.ts
+++ b/coops-ui/tests/unit/OfficeAddresses.spec.ts
@@ -232,7 +232,7 @@ describe('OfficeAddresses as a COOP', () => {
     const wrapper: Wrapper<OfficeAddresses> = mount(OfficeAddresses, {
       sync: false,
       propsData: {
-        changeButtonDisabled: false,
+        componentEnabled: true,
         registeredAddress: store.state.registeredAddress
       },
       store,
@@ -248,7 +248,7 @@ describe('OfficeAddresses as a COOP', () => {
     const wrapper: Wrapper<OfficeAddresses> = mount(OfficeAddresses, {
       sync: false,
       propsData: {
-        changeButtonDisabled: true,
+        componentEnabled: false,
         registeredAddress: store.state.registeredAddress
       },
       store,
@@ -505,7 +505,7 @@ describe('OfficeAddresses as a BCOMP', () => {
     const wrapper: Wrapper<OfficeAddresses> = mount(OfficeAddresses, {
       sync: false,
       propsData: {
-        changeButtonDisabled: false,
+        componentEnabled: true,
         registeredAddress: store.state.registeredAddress,
         recordsAddress: store.state.recordsAddress
       },
@@ -520,7 +520,7 @@ describe('OfficeAddresses as a BCOMP', () => {
     const wrapper: Wrapper<OfficeAddresses> = mount(OfficeAddresses, {
       sync: false,
       propsData: {
-        changeButtonDisabled: true,
+        componentEnabled: false,
         registeredAddress: store.state.registeredAddress,
         recordsAddress: store.state.recordsAddress
       },


### PR DESCRIPTION
*Issue #:* /bcgov/entity#2569

*Description of changes:*
- redesigned and refactored/simplified AGMDate component
- updated testPathPattern for easier cli testing
- updated OfficeAddresses disabled prop to same as Directors component
- updated BCANN filing code (was previous TODO) and its usage
- used enums in business config JSON
- refactored AnnualReport page re: AGM Date props and events
- hid AnnualReport sections that are invalid when AGMDate is invalid
- updated Annual Report Date to Dec 31 (per discussion with Scott, Linda and Cameron W.)
- updated unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).