### PR TITLE
fix for empty string in AGM Date

### DIFF
--- a/coops-ui/src/views/AnnualReport.vue
+++ b/coops-ui/src/views/AnnualReport.vue
@@ -513,15 +513,11 @@ export default {
                 this.$refs.directorsList.setDraftDate(annualReport.annualGeneralMeetingDate)
               }
               if (this.entityFilter(EntityTypes.COOP)) {
-                // set the new AGM date in the AGM Date component
-                // (this value is empty if user did not enter an AGM date)
-                this.newAgmDate = annualReport.annualGeneralMeetingDate
-                // set the new No AGM flag in the AGM Date component
-                this.newNoAgm = annualReport.didNotHoldAgm
+                // set the new AGM date in the AGM Date component (may be null or empty)
+                this.newAgmDate = annualReport.annualGeneralMeetingDate || ''
+                // set the new No AGM flag in the AGM Date component (may be undefined)
+                this.newNoAgm = annualReport.didNotHoldAgm || false
               }
-              // set appropriate filing code
-              this.entityFilter(EntityTypes.COOP) && this.toggleFiling('add', FilingCodes.ANNUAL_REPORT_OT)
-              this.entityFilter(EntityTypes.BCOMP) && this.toggleFiling('add', FilingCodes.ANNUAL_REPORT_BC)
             } else {
               throw new Error('missing annual report')
             }
@@ -729,8 +725,8 @@ export default {
       if (this.entityFilter(EntityTypes.COOP)) {
         annualReport = {
           annualReport: {
-            annualGeneralMeetingDate: this.agmDate,
-            didNotHoldAgm: this.noAgm,
+            annualGeneralMeetingDate: this.agmDate || null, // API doesn't validate empty string
+            didNotHoldAgm: this.noAgm || false,
             annualReportDate: this.annualReportDate,
             offices: {
               registeredOffice: {
@@ -929,6 +925,12 @@ export default {
       }
       return hasPendingItems
     }
+  },
+
+  mounted () {
+    // for BComp, add AR filing code now
+    // for Coop, code is added when AGM Date becomes valid
+    this.entityFilter(EntityTypes.BCOMP) && this.toggleFiling('add', FilingCodes.ANNUAL_REPORT_BC)
   },
 
   watch: {

--- a/coops-ui/tests/unit/AGMDate.spec.ts
+++ b/coops-ui/tests/unit/AGMDate.spec.ts
@@ -55,8 +55,15 @@ describe('AGMDate', () => {
     expect(vm.$data.datePicker).toBe('2019-07-15')
     expect(vm.$data.noAgm).toBe(false)
 
-    // verify that checkbox is not rendered (in current year)
+    // verify that checkbox is _not_ rendered (in current year)
     expect(vm.$el.querySelector('#agm-checkbox')).toBeNull()
+  })
+
+  it('renders checkbox in past year', () => {
+    store.state.ARFilingYear = 2018
+
+    // verify that checkbox is rendered
+    expect(vm.$el.querySelector('#agm-checkbox')).not.toBeNull()
   })
 
   it('sets Min Date properly', () => {
@@ -95,14 +102,52 @@ describe('AGMDate', () => {
     expect(vm.maxDate).toBe('2019-07-15')
   })
 
-  it('renders checkbox in past year', () => {
-    store.state.ARFilingYear = 2018
+  it('sets AGM Date when date picker is set', () => {
+    wrapper.setData({ datePicker: '2019-05-10' })
+    vm.onDatePickerChanged('2019-05-10')
 
-    // verify that checkbox is rendered
-    expect(vm.$el.querySelector('#agm-checkbox')).not.toBeNull()
+    // verify local variables
+    expect(vm.$data.dateText).toBe('2019-05-10')
+    expect(vm.$data.datePicker).toBe('2019-05-10')
+    expect(vm.$data.noAgm).toBe(false)
+
+    // verify emitted AGM Dates
+    const agmDates = wrapper.emitted('agmDate')
+    expect(agmDates.length).toBe(1)
+    expect(agmDates[0]).toEqual(['2019-05-10'])
+
+    // verify emitted Valids
+    const valids = wrapper.emitted('valid')
+    expect(valids.length).toBe(1)
+    expect(valids[0]).toEqual([true])
   })
 
-  it('loads variables properly when new AGM Date is set to a date', () => {
+  it('sets No AGM when checkbox is checked', () => {
+    wrapper.setData({ noAgm: true })
+    vm.onCheckboxChanged(true)
+
+    // verify local variables
+    expect(vm.$data.dateText).toBe('')
+    expect(vm.$data.datePicker).toBe('2019-07-15')
+    expect(vm.$data.noAgm).toBe(true)
+
+    // verify emitted AGM Dates
+    const agmDates = wrapper.emitted('agmDate')
+    expect(agmDates.length).toBe(1)
+    expect(agmDates[0]).toEqual([''])
+
+    // verify emitted No AGMs
+    const noAgms = wrapper.emitted('noAgm')
+    expect(noAgms.length).toBe(1)
+    expect(noAgms[0]).toEqual([true])
+
+    // verify emitted Valids
+    const valids = wrapper.emitted('valid')
+    expect(valids.length).toBe(1)
+    expect(valids[0]).toEqual([true])
+  })
+
+  it('sets AGM Date when AGM Date prop is set to a date', () => {
     wrapper.setProps({ newAgmDate: '2019-05-10' })
 
     // verify local variables
@@ -121,7 +166,7 @@ describe('AGMDate', () => {
     expect(valids[0]).toEqual([true])
   })
 
-  it('loads variables properly when new AGM Date is set to empty', () => {
+  it('clears AGM Date when AGM Date prop is set to empty', () => {
     wrapper.setProps({ newAgmDate: '' })
 
     // verify local variables
@@ -140,7 +185,7 @@ describe('AGMDate', () => {
     expect(valids[0]).toEqual([false])
   })
 
-  it('loads variables properly when No AGM is set to true', () => {
+  it('sets No AGM when No AGM prop is set to true', () => {
     wrapper.setProps({ newNoAgm: true })
 
     // verify local variables
@@ -152,26 +197,6 @@ describe('AGMDate', () => {
     const noAgms = wrapper.emitted('noAgm')
     expect(noAgms.length).toBe(1)
     expect(noAgms[0]).toEqual([true])
-
-    // verify emitted Valids
-    const valids = wrapper.emitted('valid')
-    expect(valids.length).toBe(1)
-    expect(valids[0]).toEqual([true])
-  })
-
-  it('sets text field when date picker is set', () => {
-    wrapper.setData({ datePicker: '2019-05-10' })
-    vm.onDatePickerChanged('2019-05-10')
-
-    // verify local variables
-    expect(vm.$data.dateText).toBe('2019-05-10')
-    expect(vm.$data.datePicker).toBe('2019-05-10')
-    expect(vm.$data.noAgm).toBe(false)
-
-    // verify emitted AGM Dates
-    const agmDates = wrapper.emitted('agmDate')
-    expect(agmDates.length).toBe(1)
-    expect(agmDates[0]).toEqual(['2019-05-10'])
 
     // verify emitted Valids
     const valids = wrapper.emitted('valid')


### PR DESCRIPTION
*Issue #:* /bcgov/entity#2569

*Description of changes:*
- a "cleanup" commit was omitted from the initial PR and is now included here:
    - better initialization of filing codes
    - added unit test (+ cleanup)
- explicity set AGM Date to null because API doesn't handle empty string

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).