### PR TITLE
exclude corrections from colin updater

### DIFF
--- a/legal-api/requirements.txt
+++ b/legal-api/requirements.txt
@@ -59,4 +59,4 @@ strict-rfc3339==0.7
 typing==3.7.4.1
 urllib3==1.25.6
 zipp==0.6.0
-git+https://github.com/bcgov/business-schemas.git@2.5.3#egg=registry_schemas
+git+https://github.com/bcgov/business-schemas.git@2.5.4#egg=registry_schemas

--- a/legal-api/requirements/bcregistry-libraries.txt
+++ b/legal-api/requirements/bcregistry-libraries.txt
@@ -1,1 +1,1 @@
-git+https://github.com/bcgov/business-schemas.git@2.5.3#egg=registry_schemas
+git+https://github.com/bcgov/business-schemas.git@2.5.4#egg=registry_schemas

--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -64,6 +64,7 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
                'changeOfName': {'name': 'changeOfName', 'title': 'Change of Name Filing'},
                'specialResolution': {'name': 'specialResolution', 'title': 'Special Resolution'},
                'voluntaryDissolution': {'name': 'voluntaryDissolution', 'title': 'Voluntary Dissolution'},
+               'correction': {'name': 'correction', 'title': 'Correction'},
                'incorporationApplication': {'name': 'incorporationApplication', 'title': 'Incorporation Application'}
                }
 
@@ -345,7 +346,9 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
         """Return the filings with statuses in the status array input."""
         filings = db.session.query(Filing). \
             filter(Filing.colin_event_ids == None,  # pylint: disable=singleton-comparison # noqa: E711;
-                   Filing._status == Filing.Status.COMPLETED.value).order_by(Filing.filing_date).all()
+                   Filing._status == Filing.Status.COMPLETED.value,
+                   Filing._filing_type != Filing.FILINGS['correction'].get('name'))\
+            .order_by(Filing.filing_date).all()
         return filings
 
     @staticmethod

--- a/legal-api/tests/unit/api/test_business_filings_internal.py
+++ b/legal-api/tests/unit/api/test_business_filings_internal.py
@@ -25,7 +25,7 @@ from http import HTTPStatus
 import datedelta
 import dpath.util
 import pytest
-from registry_schemas.example_data import ANNUAL_REPORT, CHANGE_OF_ADDRESS, FILING_HEADER
+from registry_schemas.example_data import ANNUAL_REPORT, CHANGE_OF_ADDRESS, CORRECTION_AR, FILING_HEADER
 
 from legal_api.services import QueueService
 from legal_api.services.authz import COLIN_SVC_ROLE, STAFF_ROLE
@@ -179,6 +179,7 @@ def test_get_internal_filings(session, client, jwt):
     filing3 = factory_pending_filing(b, ANNUAL_REPORT)
     filing4 = factory_filing(b, ANNUAL_REPORT)
     filing5 = factory_error_filing(b, ANNUAL_REPORT)
+    filing6 = factory_completed_filing(b, CORRECTION_AR)
 
     assert filing1.status == Filing.Status.COMPLETED.value
     # completed with colin_event_id
@@ -196,8 +197,10 @@ def test_get_internal_filings(session, client, jwt):
     assert filing4.status == Filing.Status.DRAFT.value
     # error with no colin_event_ids
     assert filing5.status == Filing.Status.PAID.value
+    # completed correction with no colin_event_ids
+    assert filing6.status == Filing.Status.COMPLETED.value
 
-    # test endpoint returned filing1 only (completed with no colin id set)
+    # test endpoint returned filing1 only (completed, no corrections, with no colin id set)
     rv = client.get(f'/api/v1/businesses/internal/filings')
     assert rv.status_code == HTTPStatus.OK
     assert len(rv.json) == 1


### PR DESCRIPTION
*Issue #:* /bcgov/entity#2638

*Description of changes:*
exclude corrections from colin updater; this is a change in legal api in the internal filings GET that returns filings to be sent to COLIN.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
