### PR TITLE
Change to configuration to narrow down the scanning scope

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,1 +1,18 @@
+sonar.projectName=lear
+sonar.projectVersion=Autoscan
 
+# Path to sources
+sonar.sources=colin-api/src,legal-api/src,data-reset-tool/src,jobs/**/src,queue_services/**/src
+sonar.exclusions=coops-ui.deprecated,schemas.deprecated
+#sonar.inclusions=
+
+# Path to tests
+sonar.tests=colin-api/tests,legal-api/tests,data-reset-tool/test,jobs/**/tests,queue_services/**/tests
+#sonar.test.exclusions=
+#sonar.test.inclusions=
+
+# Source encoding
+sonar.sourceEncoding=UTF-8
+
+# Exclusions for copy-paste detection
+#sonar.cpd.exclusions=

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -7,7 +7,7 @@ sonar.exclusions=coops-ui.deprecated,schemas.deprecated
 #sonar.inclusions=
 
 # Path to tests
-sonar.tests=colin-api/tests,legal-api/tests,data-reset-tool/test,jobs/**/tests,queue_services/**/tests
+sonar.tests=colin-api/tests,legal-api/tests,jobs/**/tests,queue_services/**/tests
 #sonar.test.exclusions=
 #sonar.test.inclusions=
 


### PR DESCRIPTION
The deprecated directories have been excluded and scanning has been focused on the files that matter the most.

*Issue #:* /bcgov/entity###

*Description of changes:*
Adding more specific guidance in the sonarcloud properties file so that "red herring" issues are not clouding the feedback. More spcifically, I have excluded the 2 deprecated directories from the scanning scope.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
