### PR TITLE
Empty src directories with a sub-directory are causing issues with Sonar

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -2,7 +2,7 @@ sonar.projectName=lear
 sonar.projectVersion=Autoscan
 
 # Path to sources
-sonar.sources=colin-api/src,legal-api/src,data-reset-tool/src,jobs/**/src,queue_services/**/src
+sonar.sources=colin-api/src/**,legal-api/src/**,data-reset-tool/src/**,jobs/**/src/**,queue_services/**/src/**
 sonar.exclusions=coops-ui.deprecated,schemas.deprecated
 #sonar.inclusions=
 


### PR DESCRIPTION
Building in wildcards to get to the level where the actual sources are.

*Issue #:* /bcgov/entity###

*Description of changes:*
The src structure in this repository has more layers causing me to need more wildcards to get down to the right layers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
