### PR TITLE
Bring it back to basics but excluded the deprecated code

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -2,12 +2,12 @@ sonar.projectName=lear
 sonar.projectVersion=Autoscan
 
 # Path to sources
-sonar.sources=colin-api/src/**/*,legal-api/src/**/*,data_reset_tool/src/**/*,jobs/**/*,queue_services/**/src/**/*
+#sonar.sources=colin-api/src/**/*,legal-api/src/**/*,data_reset_tool/src/**/*,jobs/**/*,queue_services/**/src/**/*
 sonar.exclusions=coops-ui.deprecated,schemas.deprecated
 #sonar.inclusions=
 
 # Path to tests
-sonar.tests=colin-api/tests/unit/**/*,legal-api/tests/unit/**/*
+#sonar.tests=colin-api/tests/unit/**/*,legal-api/tests/unit/**/*
 #sonar.test.exclusions=
 #sonar.test.inclusions=
 


### PR DESCRIPTION
The paths do not seem to work properly, I want to bring it back to basics and meet the original goal, which was the elimination noise when scanning the deprecated code.

*Issue #:* /bcgov/entity###

*Description of changes:*
See above, commenting out the source and test locations, leaving only the exclusions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
