### PR TITLE
Added comments and updated incorp postman tests.

### DIFF
--- a/data-reset-tool/src/data_reset_tool/converter/JsonConverter.py
+++ b/data-reset-tool/src/data_reset_tool/converter/JsonConverter.py
@@ -92,6 +92,7 @@ class JsonConverter:  # pylint: disable=too-few-public-methods
             d = {
                 'completionDate': format_date(filing._completion_date),  # pylint: disable=protected-access
                 'filingDate': format_date(filing._filing_date),  # pylint: disable=protected-access
+                'filingId': filing.id,
                 'filingType': format_non_date(filing._filing_type),  # pylint: disable=protected-access
                 'effectiveDate': format_date(filing.effective_date),
                 'paymentToken': format_non_date(filing._payment_token),  # pylint: disable=protected-access

--- a/legal-api/tests/postman/legal-api.postman_collection.json
+++ b/legal-api/tests/postman/legal-api.postman_collection.json
@@ -1,8 +1,8 @@
 {
 	"info": {
-		"_postman_id": "6028cbff-308e-439f-8928-9cac53098ead",
+		"_postman_id": "009226c5-9c09-4f0b-aed1-4d5b6a2634a3",
 		"name": "legal-api",
-		"description": "version=2.0.1 - This is a Legal API description",
+		"description": "version=2.7 - Legal API Postman Tests",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
@@ -187,7 +187,12 @@
 									"pm.test(\"Status code is 200\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
-									""
+									"",
+									"// save last filing id for CP1000001, for comments tests",
+									"var jsonData = pm.response.json();",
+									"comment_filing_id = jsonData.businesses[0].filings[jsonData.businesses[0].filings.length -1].filingId",
+									"",
+									"pm.environment.set(\"comment_filing_id\", comment_filing_id);"
 								],
 								"type": "text/javascript"
 							}
@@ -1068,63 +1073,6 @@
 					},
 					"response": [
 						{
-							"name": "get-business/addresses - CP1000005",
-							"originalRequest": {
-								"method": "GET",
-								"header": [],
-								"url": {
-									"raw": "{{url}}/api/v1/businesses/:id/addresses",
-									"host": [
-										"{{url}}"
-									],
-									"path": [
-										"api",
-										"v1",
-										"businesses",
-										":id",
-										"addresses"
-									],
-									"variable": [
-										{
-											"key": "id",
-											"value": "CP1000005"
-										}
-									]
-								}
-							},
-							"status": "OK",
-							"code": 200,
-							"_postman_previewlanguage": "json",
-							"header": [
-								{
-									"key": "Date",
-									"value": "Wed, 26 Jun 2019 20:26:08 GMT"
-								},
-								{
-									"key": "Server",
-									"value": "gunicorn/19.9.0"
-								},
-								{
-									"key": "API",
-									"value": "legal_api/0.1.0a0.dev-962c1dd270b61e1588b4558cc697de777db05834"
-								},
-								{
-									"key": "Access-Control-Allow-Origin",
-									"value": "*"
-								},
-								{
-									"key": "Access-Control-Allow-Methods",
-									"value": "GET, HEAD, OPTIONS"
-								},
-								{
-									"key": "Content-Type",
-									"value": "application/json"
-								}
-							],
-							"cookie": [],
-							"body": "{\n    \"mailingAddress\": {\n        \"addressCity\": \"Victoria\",\n        \"addressCountry\": \"CANADA\",\n        \"addressRegion\": \"BC\",\n        \"addressType\": \"mailing\",\n        \"deliveryInstructions\": \"mailing address for CP1000005\",\n        \"postalCode\": \"T3S3T3\",\n        \"streetAddress\": \"2106 North Street\",\n        \"streetAddressAdditional\": \"apt 2106\"\n    },\n    \"deliveryAddress\": {\n        \"addressCity\": \"Victoria\",\n        \"addressCountry\": \"CANADA\",\n        \"addressRegion\": \"BC\",\n        \"addressType\": \"mailing\",\n        \"deliveryInstructions\": \"delivery address for CP1000005\",\n        \"postalCode\": \"T3S3T3\",\n        \"streetAddress\": \"2106 West Avenue\",\n        \"streetAddressAdditional\": \"suite 2106\"\n    }\n}"
-						},
-						{
 							"name": "get-business/addresses - CP1000004",
 							"originalRequest": {
 								"method": "GET",
@@ -1182,7 +1130,7 @@
 							"body": "{\n    \"mailingAddress\": {\n        \"addressCity\": \"Victoria\",\n        \"addressCountry\": \"CANADA\",\n        \"addressRegion\": \"BC\",\n        \"addressType\": \"mailing\",\n        \"deliveryInstructions\": \"mailing address for CP1000004\",\n        \"postalCode\": \"T3S3T3\",\n        \"streetAddress\": \"2103 North Street\",\n        \"streetAddressAdditional\": \"apt 2103\"\n    },\n    \"deliveryAddress\": {\n        \"addressCity\": \"Victoria\",\n        \"addressCountry\": \"CANADA\",\n        \"addressRegion\": \"BC\",\n        \"addressType\": \"mailing\",\n        \"deliveryInstructions\": \"delivery address for CP1000004\",\n        \"postalCode\": \"T3S3T3\",\n        \"streetAddress\": \"2103 West Avenue\",\n        \"streetAddressAdditional\": \"suite 2103\"\n    }\n}"
 						},
 						{
-							"name": "get-business/addresses - CP1000003",
+							"name": "get-business/addresses - CP1000005",
 							"originalRequest": {
 								"method": "GET",
 								"header": [],
@@ -1201,7 +1149,7 @@
 									"variable": [
 										{
 											"key": "id",
-											"value": "CP1000003"
+											"value": "CP1000005"
 										}
 									]
 								}
@@ -1211,12 +1159,16 @@
 							"_postman_previewlanguage": "json",
 							"header": [
 								{
+									"key": "Date",
+									"value": "Wed, 26 Jun 2019 20:26:08 GMT"
+								},
+								{
 									"key": "Server",
 									"value": "gunicorn/19.9.0"
 								},
 								{
-									"key": "Content-Type",
-									"value": "application/json"
+									"key": "API",
+									"value": "legal_api/0.1.0a0.dev-962c1dd270b61e1588b4558cc697de777db05834"
 								},
 								{
 									"key": "Access-Control-Allow-Origin",
@@ -1227,12 +1179,12 @@
 									"value": "GET, HEAD, OPTIONS"
 								},
 								{
-									"key": "API",
-									"value": "legal_api/0.1.0a0.dev-962c1dd270b61e1588b4558cc697de777db05834"
+									"key": "Content-Type",
+									"value": "application/json"
 								}
 							],
 							"cookie": [],
-							"body": "{\n    \"mailingAddress\": {\n        \"addressCity\": \"Victoria\",\n        \"addressCountry\": \"CANADA\",\n        \"addressRegion\": \"BC\",\n        \"addressType\": \"mailing\",\n        \"deliveryInstructions\": \"mailing address for CP1000003\",\n        \"postalCode\": \"T3S3T3\",\n        \"streetAddress\": \"2098 North Street\",\n        \"streetAddressAdditional\": \"apt 2098\"\n    },\n    \"deliveryAddress\": {\n        \"addressCity\": \"Victoria\",\n        \"addressCountry\": \"CANADA\",\n        \"addressRegion\": \"BC\",\n        \"addressType\": \"mailing\",\n        \"deliveryInstructions\": \"delivery address for CP1000003\",\n        \"postalCode\": \"T3S3T3\",\n        \"streetAddress\": \"2098 West Avenue\",\n        \"streetAddressAdditional\": \"suite 2098\"\n    }\n}"
+							"body": "{\n    \"mailingAddress\": {\n        \"addressCity\": \"Victoria\",\n        \"addressCountry\": \"CANADA\",\n        \"addressRegion\": \"BC\",\n        \"addressType\": \"mailing\",\n        \"deliveryInstructions\": \"mailing address for CP1000005\",\n        \"postalCode\": \"T3S3T3\",\n        \"streetAddress\": \"2106 North Street\",\n        \"streetAddressAdditional\": \"apt 2106\"\n    },\n    \"deliveryAddress\": {\n        \"addressCity\": \"Victoria\",\n        \"addressCountry\": \"CANADA\",\n        \"addressRegion\": \"BC\",\n        \"addressType\": \"mailing\",\n        \"deliveryInstructions\": \"delivery address for CP1000005\",\n        \"postalCode\": \"T3S3T3\",\n        \"streetAddress\": \"2106 West Avenue\",\n        \"streetAddressAdditional\": \"suite 2106\"\n    }\n}"
 						},
 						{
 							"name": "get-businesses - addresses CP1000001",
@@ -1298,6 +1250,59 @@
 							],
 							"cookie": [],
 							"body": "{\n    \"deliveryAddress\": {\n        \"addressCity\": \"RICHMOND\",\n        \"addressCountry\": \"CA\",\n        \"addressRegion\": \"BC\",\n        \"addressType\": \"delivery\",\n        \"deliveryInstructions\": \"\",\n        \"postalCode\": \"V8N 4R7\",\n        \"streetAddress\": \"41-10771 GILBERT RD\",\n        \"streetAddressAdditional\": \"\"\n    },\n    \"mailingAddress\": {\n        \"addressCity\": \"RICHMOND\",\n        \"addressCountry\": \"CA\",\n        \"addressRegion\": \"BC\",\n        \"addressType\": \"mailing\",\n        \"deliveryInstructions\": \"\",\n        \"postalCode\": \"V8N 4R7\",\n        \"streetAddress\": \"41-10771 GILBERT RD\",\n        \"streetAddressAdditional\": \"\"\n    }\n}"
+						},
+						{
+							"name": "get-business/addresses - CP1000003",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{url}}/api/v1/businesses/:id/addresses",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"businesses",
+										":id",
+										"addresses"
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "CP1000003"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Server",
+									"value": "gunicorn/19.9.0"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Access-Control-Allow-Origin",
+									"value": "*"
+								},
+								{
+									"key": "Access-Control-Allow-Methods",
+									"value": "GET, HEAD, OPTIONS"
+								},
+								{
+									"key": "API",
+									"value": "legal_api/0.1.0a0.dev-962c1dd270b61e1588b4558cc697de777db05834"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"mailingAddress\": {\n        \"addressCity\": \"Victoria\",\n        \"addressCountry\": \"CANADA\",\n        \"addressRegion\": \"BC\",\n        \"addressType\": \"mailing\",\n        \"deliveryInstructions\": \"mailing address for CP1000003\",\n        \"postalCode\": \"T3S3T3\",\n        \"streetAddress\": \"2098 North Street\",\n        \"streetAddressAdditional\": \"apt 2098\"\n    },\n    \"deliveryAddress\": {\n        \"addressCity\": \"Victoria\",\n        \"addressCountry\": \"CANADA\",\n        \"addressRegion\": \"BC\",\n        \"addressType\": \"mailing\",\n        \"deliveryInstructions\": \"delivery address for CP1000003\",\n        \"postalCode\": \"T3S3T3\",\n        \"streetAddress\": \"2098 West Avenue\",\n        \"streetAddressAdditional\": \"suite 2098\"\n    }\n}"
 						}
 					]
 				},
@@ -1775,75 +1780,6 @@
 							"body": "{\r\n  \"tasks\": [\r\n    {\r\n      \"task\": {\r\n        \"todo\": {\r\n          \"business\": {\r\n            \"cacheId\": 1,\r\n            \"foundingDate\": \"2007-04-08\",\r\n            \"identifier\": \"CP1000003\",\r\n            \"lastLedgerTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n\t\t\t\"lastPreBobFilingTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n            \"legalName\": \"Legal Name CP1000003\"\r\n          },\r\n          \"header\": {\r\n            \"name\": \"annualReport\",\r\n            \"ARFilingYear\": 2019,\r\n            \"status\": \"NEW\"\r\n          }\r\n        }\r\n      },\r\n      \"order\": 2,\r\n      \"enabled\": false\r\n    },\r\n    {\r\n      \"task\": {\r\n        \"filing\": {\r\n          \"annualReport\": {\r\n            \"annualGeneralMeetingDate\": \"2018-07-15\",\r\n            \"certifiedBy\": \"full1 name1\",\r\n            \"email\": \"no_one@never.get\",\r\n\t\t    \"directors\": [\r\n\t\t        {\r\n\t\t            \"officer\": {\r\n                        \"prevFirstName\": \"\",\r\n                        \"prevMiddleInitial\": \"\",\r\n                        \"prevLastName\": \"\",\r\n\t\t                \"firstName\": \"Scott2\",\r\n\t\t                \"lastName\": \"Johnson2\"\r\n\t\t            },\r\n\t\t            \"deliveryAddress\": {\r\n\t\t                \"streetAddress\": \"3950A Helen Road\",\r\n\t\t                \"addressCity\": \"Edmonton\",\r\n\t\t                \"addressCountry\": \"CA\",\r\n\t\t                \"postalCode\": \"V5Z 8C8\",\r\n\t\t                \"addressRegion\": \"AB\"\r\n\t\t            },\r\n\t\t            \"appointmentDate\": \"2015-10-12\",\r\n\t\t            \"cessationDate\": null\r\n\t\t        }\r\n\t\t    ],\r\n\t\t    \"mailingAddress\": {\r\n\t\t        \"addressCity\": \"Victoria\",\r\n\t\t        \"addressCountry\": \"CANADA\",\r\n\t\t        \"addressRegion\": \"BC\",\r\n\t\t        \"addressType\": \"mailing\",\r\n\t\t        \"deliveryInstructions\": \"draft filing\",\r\n\t\t        \"postalCode\": \"T3S3T3\",\r\n\t\t        \"streetAddress\": \"2098 North Street\",\r\n\t\t        \"streetAddressAdditional\": \"apt 2098\"\r\n\t\t    },\r\n\t\t    \"deliveryAddress\": {\r\n\t\t        \"addressCity\": \"Victoria\",\r\n\t\t        \"addressCountry\": \"CANADA\",\r\n\t\t        \"addressRegion\": \"BC\",\r\n\t\t        \"addressType\": \"mailing\",\r\n\t\t        \"deliveryInstructions\": \"draft filing\",\r\n\t\t        \"postalCode\": \"T3S3T3\",\r\n\t\t        \"streetAddress\": \"2098 West Avenue\",\r\n\t\t        \"streetAddressAdditional\": \"suite 2098\"\r\n\t\t    }\r\n          },\r\n          \"changeOfAddress\": {\r\n            \"certifiedBy\": \"full2 name2\",\r\n            \"email\": \"no_one@never.get\",\r\n\t\t    \"mailingAddress\": {\r\n\t            \"actions\": [\"addressChanged\"],\r\n\t\t        \"addressCity\": \"Victoria\",\r\n\t\t        \"addressCountry\": \"CANADA\",\r\n\t\t        \"addressRegion\": \"BC\",\r\n\t\t        \"addressType\": \"mailing\",\r\n\t\t        \"deliveryInstructions\": \"draft filing\",\r\n\t\t        \"postalCode\": \"T3S3T3\",\r\n\t\t        \"streetAddress\": \"2098 North Street\",\r\n\t\t        \"streetAddressAdditional\": \"apt 2098\"\r\n\t\t    },\r\n\t\t    \"deliveryAddress\": {\r\n\t            \"actions\": [],\r\n\t\t        \"addressCity\": \"Victoria\",\r\n\t\t        \"addressCountry\": \"CANADA\",\r\n\t\t        \"addressRegion\": \"BC\",\r\n\t\t        \"addressType\": \"mailing\",\r\n\t\t        \"deliveryInstructions\": \"draft filing\",\r\n\t\t        \"postalCode\": \"T3S3T3\",\r\n\t\t        \"streetAddress\": \"2098 West Avenue\",\r\n\t\t        \"streetAddressAdditional\": \"suite 2098\"\r\n\t\t    }\r\n          },\r\n          \"changeOfDirectors\": {\r\n            \"certifiedBy\": \"full3 name3\",\r\n            \"email\": \"no_one@never.get\",\r\n\t\t    \"directors\": [\r\n\t\t        {\r\n\t\t            \"actions\": [\"appointed\"],\r\n\t\t            \"officer\": {\r\n                        \"prevFirstName\": \"\",\r\n                        \"prevMiddleInitial\": \"\",\r\n                        \"prevLastName\": \"\",\r\n\t\t                \"firstName\": \"Scott2\",\r\n\t\t                \"lastName\": \"Johnson2\"\r\n\t\t            },\r\n\t\t            \"deliveryAddress\": {\r\n\t\t                \"streetAddress\": \"3950A Helen Road\",\r\n\t\t                \"addressCity\": \"Edmonton\",\r\n\t\t                \"addressCountry\": \"CA\",\r\n\t\t                \"postalCode\": \"V5Z 8C8\",\r\n\t\t                \"addressRegion\": \"AB\"\r\n\t\t            },\r\n\t\t            \"appointmentDate\": \"2015-10-12\",\r\n\t\t            \"cessationDate\": null\r\n\t\t        }\r\n\t\t    ]\r\n          },\r\n          \"business\": {\r\n            \"cacheId\": 1,\r\n            \"foundingDate\": \"2007-04-08\",\r\n            \"identifier\": \"CP1000003\",\r\n            \"lastLedgerTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n\t\t\t\"lastPreBobFilingTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n            \"legalName\": \"Legal Name CP1000003\"\r\n          },\r\n          \"header\": {\r\n            \"date\": \"2017-06-06\",\r\n            \"filingId\": 4,\r\n            \"name\": \"annualReport\",\r\n            \"status\": \"DRAFT\"\r\n          }\r\n        }\r\n      },\r\n      \"order\": 1,\r\n      \"enabled\": true\r\n    }\r\n  ]\r\n}"
 						},
 						{
-							"name": "get-business-tasks - CP1000004",
-							"originalRequest": {
-								"method": "GET",
-								"header": [],
-								"url": {
-									"raw": "{{url}}/api/v1/businesses/:id/tasks",
-									"host": [
-										"{{url}}"
-									],
-									"path": [
-										"api",
-										"v1",
-										"businesses",
-										":id",
-										"tasks"
-									],
-									"variable": [
-										{
-											"key": "id",
-											"value": "CP1000004"
-										}
-									]
-								}
-							},
-							"status": "OK",
-							"code": 200,
-							"_postman_previewlanguage": "json",
-							"header": [
-								{
-									"key": "X-Application-Context",
-									"value": "application:prod",
-									"description": "",
-									"type": "text"
-								},
-								{
-									"key": "Access-Control-Allow-Origin",
-									"value": "*",
-									"description": "",
-									"type": "text"
-								},
-								{
-									"key": "API",
-									"value": "legal_api/0.1.0a0.dev",
-									"description": "",
-									"type": "text"
-								},
-								{
-									"key": "Server",
-									"value": "Werkzeug/0.15.4 Python/3.7.3",
-									"description": "",
-									"type": "text"
-								},
-								{
-									"key": "Access-Control-Allow-Methods",
-									"value": "HEAD, GET, OPTIONS, DELETE, POST, PUT",
-									"description": "",
-									"type": "text"
-								},
-								{
-									"key": "Content-Type",
-									"value": "application/json",
-									"description": "",
-									"type": "text"
-								}
-							],
-							"cookie": [],
-							"body": "{\r\n\t\"tasks\": [\r\n\t\t{\r\n\t\t\t\"task\": {\r\n\t\t\t\t\"todo\": {\r\n\t\t\t\t\t\"business\": {\r\n\t\t\t\t\t\t\"foundingDate\": \"2019-06-10T00:00:00+00:00\",\r\n\t\t\t\t\t\t\"identifier\": \"CP1000004\",\r\n\t\t\t\t\t\t\"lastModified\": \"2019-06-10T22:35:19.652478+00:00\",\r\n\t\t\t\t\t\t\"lastAnnualGeneralMeetingDate\": \"2018-04-08\",\r\n\t\t\t\t\t\t\"lastAnnualReport\": \"2018-04-08\",\r\n\t\t\t            \"lastPreBobFilingTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n\t\t\t\t\t\t\"legalName\": \"Legal Name CP1000004\",\r\n\t\t\t\t\t\t\"status\": \"PENDINGDISSOLUTION\",\r\n\t\t\t\t\t\t\"taxId\": \"21032103\"\r\n\t\t\t\t\t},\r\n\t\t\t\t\t\"header\": {\r\n\t\t\t\t\t\t\"name\": \"annualReport\",\r\n\t\t\t\t\t\t\"ARFilingYear\": 2019,\r\n\t\t\t\t\t\t\"status\": \"NEW\"\r\n\t\t\t\t\t}\r\n\t\t\t\t}\r\n\t\t\t},\r\n\t\t\t\"order\": 1,\r\n\t\t\t\"enabled\": true\r\n\t\t}\r\n\t]\r\n}"
-						},
-						{
 							"name": "get-business-tasks - CP1000005",
 							"originalRequest": {
 								"method": "GET",
@@ -1911,6 +1847,75 @@
 							],
 							"cookie": [],
 							"body": "{\r\n\t\"tasks\": [\r\n\t\t{\r\n\t\t\t\"task\": {\r\n\t\t\t\t\"filing\": {\r\n\t\t\t\t\t\"changeOfAddress\": {\r\n\t\t\t\t\t\t\"certifiedBy\": \"full2 name2\",\r\n\t\t\t\t\t\t\"email\": \"no_one@never.get\",\r\n\t\t\t\t\t    \"deliveryAddress\": {\r\n\t\t\t\t\t        \"streetAddress\": \"delivery_address - address line one\",\r\n\t\t\t\t\t        \"addressCity\": \"delivery_address city\",\r\n\t\t\t\t\t        \"addressCountry\": \"delivery_address country\",\r\n\t\t\t\t\t        \"postalCode\": \"H0H0H0\",\r\n\t\t\t\t\t        \"addressRegion\": \"BC\",\r\n\t\t\t\t\t        \"actions\": []\r\n\t\t\t\t\t    },\r\n\t\t\t\t\t    \"mailingAddress\": {\r\n\t\t\t\t\t        \"streetAddress\": \"mailing_address - address line one\",\r\n\t\t\t\t\t        \"addressCity\": \"mailing_address city\",\r\n\t\t\t\t\t        \"addressCountry\": \"mailing_address country\",\r\n\t\t\t\t\t        \"postalCode\": \"H0H0H0\",\r\n\t\t\t\t\t        \"addressRegion\": \"BC\",\r\n\t\t\t\t\t        \"actions\": [\"addressChanged\"]\r\n\t\t\t\t\t    }\r\n\t\t\t\t\t},\r\n\t\t\t\t    \"business\": {\r\n\t\t\t\t        \"foundingDate\": \"2019-06-10T00:00:00+00:00\",\r\n\t\t\t\t        \"identifier\": \"CP1000005\",\r\n\t\t\t\t        \"lastModified\": \"2019-06-10T22:35:19.652478+00:00\",\r\n\t\t\t\t        \"lastAnnualGeneralMeetingDate\": \"2019-04-08\",\r\n\t\t\t\t        \"lastAnnualReport\": \"2019-04-08\",\r\n\t\t\t            \"lastPreBobFilingTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n\t\t\t\t        \"legalName\": \"Legal Name CP1000005\",\r\n\t\t\t\t        \"status\": \"NOTINCOMPLIANCE\",\r\n\t\t\t\t        \"taxId\": \"21062106\"\r\n\t\t\t\t    },\r\n\t\t\t\t\t\"header\": {\r\n\t\t\t\t\t\t\"date\": \"2017-06-06\",\r\n\t\t\t\t\t\t\"filingId\": 456,\r\n\t\t\t\t\t\t\"name\": \"changeOfAddress\",\r\n\t\t\t\t\t\t\"status\": \"ERROR\"\r\n\t\t\t\t\t}\r\n\t\t\t\t}\r\n\t\t\t},\r\n\t\t\t\"order\": 2,\r\n\t\t\t\"enabled\": false\r\n\t\t},\r\n\t\t{\r\n\t\t\t\"task\": {\r\n\t\t\t\t\"filing\": {\r\n\t\t\t\t\t\"changeOfDirectors\": {\r\n\t\t\t\t\t\t\"certifiedBy\": \"full3 name3\",\r\n\t\t\t\t\t\t\"email\": \"no_one@never.get\",\r\n\t\t\t            \"directors\": [\r\n\t\t\t                {\r\n\t\t\t                \t\"actions\": [],\r\n\t\t\t                    \"officer\": {\r\n\t\t\t\t                    \"prevFirstName\": \"\",\r\n\t\t\t\t                    \"prevMiddleInitial\": \"\",\r\n\t\t\t\t                    \"prevLastName\": \"\",\r\n\t\t\t                        \"firstName\": \"Peter\",\r\n\t\t\t                        \"middleInitial\": \"G\",\r\n\t\t\t                        \"lastName\": \"Griffin\"\r\n\t\t\t                    },\r\n\t\t\t                    \"deliveryAddress\": {\r\n\t\t\t                        \"streetAddress\": \"2729 Belmont Ave\",\r\n\t\t\t                        \"additionalStreetAddress\": \"Back door\",\r\n\t\t\t                        \"addressCity\": \"Victoria\",\r\n\t\t\t                        \"addressCountry\": \"CA\",\r\n\t\t\t                        \"postalCode\": \"H0H0H0\",\r\n\t\t\t                        \"addressRegion\": \"BC\",\r\n\t\t\t                        \"deliveryInstructions\": \"Send to back\"\r\n\t\t\t                    },\r\n\t\t\t                    \"title\": \"President\",\r\n\t\t\t                    \"appointmentDate\": \"2014-03-30\",\r\n\t\t\t                    \"cessationDate\": null\r\n\t\t\t                },\r\n\t\t\t                {\r\n\t\t\t                \t\"actions\": [\"ceased\"],\r\n\t\t\t                    \"officer\": {\r\n\t\t\t                        \"prevFirstName\": \"\",\r\n\t\t\t                        \"prevMiddleInitial\": \"\",\r\n\t\t\t                        \"prevLastName\": \"\",\r\n\t\t\t                        \"firstName\": \"Joe\",\r\n\t\t\t                        \"middleInitial\": \"P\",\r\n\t\t\t                        \"lastName\": \"Swanson\"\r\n\t\t\t                    },\r\n\t\t\t                    \"deliveryAddress\": {\r\n\t\t\t                        \"streetAddress\": \"1020 Douglas Street\",\r\n\t\t\t                        \"additionalStreetAddress\": \"Kirkintiloch\",\r\n\t\t\t                        \"addressCity\": \"Glasgow\",\r\n\t\t\t                        \"addressCountry\": \"UK\",\r\n\t\t\t                        \"postalCode\": \"H0H 0H0\",\r\n\t\t\t                        \"addressRegion\": \"SC\",\r\n\t\t\t                        \"deliveryInstructions\": \"Please call 250-812-2445.\"\r\n\t\t\t                    },\r\n\t\t\t                    \"title\": \"Treasurer\",\r\n\t\t\t                    \"appointmentDate\": \"2014-03-30\",\r\n\t\t\t                    \"cessationDate\": \"2019-01-01\"\r\n\t\t\t                }\r\n\t\t\t\t\t\t]\r\n\t\t\t\t\t},\r\n\t\t\t\t    \"business\": {\r\n\t\t\t\t        \"foundingDate\": \"2019-06-10T00:00:00+00:00\",\r\n\t\t\t\t        \"identifier\": \"CP1000005\",\r\n\t\t\t\t        \"lastModified\": \"2019-06-10T22:35:19.652478+00:00\",\r\n\t\t\t\t        \"lastAnnualGeneralMeetingDate\": \"2019-04-08\",\r\n\t\t\t\t        \"lastAnnualReport\": \"2019-04-08\",\r\n\t\t\t            \"lastPreBobFilingTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n\t\t\t\t        \"legalName\": \"Legal Name CP1000005\",\r\n\t\t\t\t        \"status\": \"NOTINCOMPLIANCE\",\r\n\t\t\t\t        \"taxId\": \"21062106\"\r\n\t\t\t\t    },\r\n\t\t\t\t\t\"header\": {\r\n\t\t\t\t\t\t\"date\": \"2017-06-06\",\r\n\t\t\t\t\t\t\"filingId\": 789,\r\n\t\t\t\t\t\t\"name\": \"changeOfDirectors\",\r\n\t\t\t\t\t\t\"status\": \"PENDING\"\r\n\t\t\t\t\t}\r\n\t\t\t\t}\r\n\t\t\t},\r\n\t\t\t\"order\": 1,\r\n\t\t\t\"enabled\": true\r\n\t\t}\r\n\t]\r\n}"
+						},
+						{
+							"name": "get-business-tasks - CP1000004",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{url}}/api/v1/businesses/:id/tasks",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"businesses",
+										":id",
+										"tasks"
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "CP1000004"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "X-Application-Context",
+									"value": "application:prod",
+									"description": "",
+									"type": "text"
+								},
+								{
+									"key": "Access-Control-Allow-Origin",
+									"value": "*",
+									"description": "",
+									"type": "text"
+								},
+								{
+									"key": "API",
+									"value": "legal_api/0.1.0a0.dev",
+									"description": "",
+									"type": "text"
+								},
+								{
+									"key": "Server",
+									"value": "Werkzeug/0.15.4 Python/3.7.3",
+									"description": "",
+									"type": "text"
+								},
+								{
+									"key": "Access-Control-Allow-Methods",
+									"value": "HEAD, GET, OPTIONS, DELETE, POST, PUT",
+									"description": "",
+									"type": "text"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json",
+									"description": "",
+									"type": "text"
+								}
+							],
+							"cookie": [],
+							"body": "{\r\n\t\"tasks\": [\r\n\t\t{\r\n\t\t\t\"task\": {\r\n\t\t\t\t\"todo\": {\r\n\t\t\t\t\t\"business\": {\r\n\t\t\t\t\t\t\"foundingDate\": \"2019-06-10T00:00:00+00:00\",\r\n\t\t\t\t\t\t\"identifier\": \"CP1000004\",\r\n\t\t\t\t\t\t\"lastModified\": \"2019-06-10T22:35:19.652478+00:00\",\r\n\t\t\t\t\t\t\"lastAnnualGeneralMeetingDate\": \"2018-04-08\",\r\n\t\t\t\t\t\t\"lastAnnualReport\": \"2018-04-08\",\r\n\t\t\t            \"lastPreBobFilingTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n\t\t\t\t\t\t\"legalName\": \"Legal Name CP1000004\",\r\n\t\t\t\t\t\t\"status\": \"PENDINGDISSOLUTION\",\r\n\t\t\t\t\t\t\"taxId\": \"21032103\"\r\n\t\t\t\t\t},\r\n\t\t\t\t\t\"header\": {\r\n\t\t\t\t\t\t\"name\": \"annualReport\",\r\n\t\t\t\t\t\t\"ARFilingYear\": 2019,\r\n\t\t\t\t\t\t\"status\": \"NEW\"\r\n\t\t\t\t\t}\r\n\t\t\t\t}\r\n\t\t\t},\r\n\t\t\t\"order\": 1,\r\n\t\t\t\"enabled\": true\r\n\t\t}\r\n\t]\r\n}"
 						}
 					]
 				}
@@ -2932,75 +2937,6 @@
 							},
 							"response": [
 								{
-									"name": "get-business-tasks - CP1000005",
-									"originalRequest": {
-										"method": "GET",
-										"header": [],
-										"url": {
-											"raw": "{{url}}/api/v1/businesses/:id/tasks",
-											"host": [
-												"{{url}}"
-											],
-											"path": [
-												"api",
-												"v1",
-												"businesses",
-												":id",
-												"tasks"
-											],
-											"variable": [
-												{
-													"key": "id",
-													"value": "CP1000005"
-												}
-											]
-										}
-									},
-									"status": "OK",
-									"code": 200,
-									"_postman_previewlanguage": "json",
-									"header": [
-										{
-											"key": "X-Application-Context",
-											"value": "application:prod",
-											"description": "",
-											"type": "text"
-										},
-										{
-											"key": "Access-Control-Allow-Origin",
-											"value": "*",
-											"description": "",
-											"type": "text"
-										},
-										{
-											"key": "API",
-											"value": "legal_api/0.1.0a0.dev",
-											"description": "",
-											"type": "text"
-										},
-										{
-											"key": "Server",
-											"value": "Werkzeug/0.15.4 Python/3.7.3",
-											"description": "",
-											"type": "text"
-										},
-										{
-											"key": "Access-Control-Allow-Methods",
-											"value": "HEAD, GET, OPTIONS, DELETE, POST, PUT",
-											"description": "",
-											"type": "text"
-										},
-										{
-											"key": "Content-Type",
-											"value": "application/json",
-											"description": "",
-											"type": "text"
-										}
-									],
-									"cookie": [],
-									"body": "{\r\n\t\"tasks\": [\r\n\t\t{\r\n\t\t\t\"task\": {\r\n\t\t\t\t\"filing\": {\r\n\t\t\t\t\t\"changeOfAddress\": {\r\n\t\t\t\t\t\t\"certifiedBy\": \"full2 name2\",\r\n\t\t\t\t\t\t\"email\": \"no_one@never.get\",\r\n\t\t\t\t\t    \"deliveryAddress\": {\r\n\t\t\t\t\t        \"streetAddress\": \"delivery_address - address line one\",\r\n\t\t\t\t\t        \"addressCity\": \"delivery_address city\",\r\n\t\t\t\t\t        \"addressCountry\": \"delivery_address country\",\r\n\t\t\t\t\t        \"postalCode\": \"H0H0H0\",\r\n\t\t\t\t\t        \"addressRegion\": \"BC\",\r\n\t\t\t\t\t        \"actions\": []\r\n\t\t\t\t\t    },\r\n\t\t\t\t\t    \"mailingAddress\": {\r\n\t\t\t\t\t        \"streetAddress\": \"mailing_address - address line one\",\r\n\t\t\t\t\t        \"addressCity\": \"mailing_address city\",\r\n\t\t\t\t\t        \"addressCountry\": \"mailing_address country\",\r\n\t\t\t\t\t        \"postalCode\": \"H0H0H0\",\r\n\t\t\t\t\t        \"addressRegion\": \"BC\",\r\n\t\t\t\t\t        \"actions\": [\"addressChanged\"]\r\n\t\t\t\t\t    }\r\n\t\t\t\t\t},\r\n\t\t\t\t    \"business\": {\r\n\t\t\t\t        \"foundingDate\": \"2019-06-10T00:00:00+00:00\",\r\n\t\t\t\t        \"identifier\": \"CP1000005\",\r\n\t\t\t\t        \"lastModified\": \"2019-06-10T22:35:19.652478+00:00\",\r\n\t\t\t\t        \"lastAnnualGeneralMeetingDate\": \"2019-04-08\",\r\n\t\t\t\t        \"lastAnnualReport\": \"2019-04-08\",\r\n\t\t\t            \"lastPreBobFilingTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n\t\t\t\t        \"legalName\": \"Legal Name CP1000005\",\r\n\t\t\t\t        \"status\": \"NOTINCOMPLIANCE\",\r\n\t\t\t\t        \"taxId\": \"21062106\"\r\n\t\t\t\t    },\r\n\t\t\t\t\t\"header\": {\r\n\t\t\t\t\t\t\"date\": \"2017-06-06\",\r\n\t\t\t\t\t\t\"filingId\": 456,\r\n\t\t\t\t\t\t\"name\": \"changeOfAddress\",\r\n\t\t\t\t\t\t\"status\": \"ERROR\"\r\n\t\t\t\t\t}\r\n\t\t\t\t}\r\n\t\t\t},\r\n\t\t\t\"order\": 2,\r\n\t\t\t\"enabled\": false\r\n\t\t},\r\n\t\t{\r\n\t\t\t\"task\": {\r\n\t\t\t\t\"filing\": {\r\n\t\t\t\t\t\"changeOfDirectors\": {\r\n\t\t\t\t\t\t\"certifiedBy\": \"full3 name3\",\r\n\t\t\t\t\t\t\"email\": \"no_one@never.get\",\r\n\t\t\t            \"directors\": [\r\n\t\t\t                {\r\n\t\t\t                \t\"actions\": [],\r\n\t\t\t                    \"officer\": {\r\n\t\t\t\t                    \"prevFirstName\": \"\",\r\n\t\t\t\t                    \"prevMiddleInitial\": \"\",\r\n\t\t\t\t                    \"prevLastName\": \"\",\r\n\t\t\t                        \"firstName\": \"Peter\",\r\n\t\t\t                        \"middleInitial\": \"G\",\r\n\t\t\t                        \"lastName\": \"Griffin\"\r\n\t\t\t                    },\r\n\t\t\t                    \"deliveryAddress\": {\r\n\t\t\t                        \"streetAddress\": \"2729 Belmont Ave\",\r\n\t\t\t                        \"additionalStreetAddress\": \"Back door\",\r\n\t\t\t                        \"addressCity\": \"Victoria\",\r\n\t\t\t                        \"addressCountry\": \"CA\",\r\n\t\t\t                        \"postalCode\": \"H0H0H0\",\r\n\t\t\t                        \"addressRegion\": \"BC\",\r\n\t\t\t                        \"deliveryInstructions\": \"Send to back\"\r\n\t\t\t                    },\r\n\t\t\t                    \"title\": \"President\",\r\n\t\t\t                    \"appointmentDate\": \"2014-03-30\",\r\n\t\t\t                    \"cessationDate\": null\r\n\t\t\t                },\r\n\t\t\t                {\r\n\t\t\t                \t\"actions\": [\"ceased\"],\r\n\t\t\t                    \"officer\": {\r\n\t\t\t                        \"prevFirstName\": \"\",\r\n\t\t\t                        \"prevMiddleInitial\": \"\",\r\n\t\t\t                        \"prevLastName\": \"\",\r\n\t\t\t                        \"firstName\": \"Joe\",\r\n\t\t\t                        \"middleInitial\": \"P\",\r\n\t\t\t                        \"lastName\": \"Swanson\"\r\n\t\t\t                    },\r\n\t\t\t                    \"deliveryAddress\": {\r\n\t\t\t                        \"streetAddress\": \"1020 Douglas Street\",\r\n\t\t\t                        \"additionalStreetAddress\": \"Kirkintiloch\",\r\n\t\t\t                        \"addressCity\": \"Glasgow\",\r\n\t\t\t                        \"addressCountry\": \"UK\",\r\n\t\t\t                        \"postalCode\": \"H0H 0H0\",\r\n\t\t\t                        \"addressRegion\": \"SC\",\r\n\t\t\t                        \"deliveryInstructions\": \"Please call 250-812-2445.\"\r\n\t\t\t                    },\r\n\t\t\t                    \"title\": \"Treasurer\",\r\n\t\t\t                    \"appointmentDate\": \"2014-03-30\",\r\n\t\t\t                    \"cessationDate\": \"2019-01-01\"\r\n\t\t\t                }\r\n\t\t\t\t\t\t]\r\n\t\t\t\t\t},\r\n\t\t\t\t    \"business\": {\r\n\t\t\t\t        \"foundingDate\": \"2019-06-10T00:00:00+00:00\",\r\n\t\t\t\t        \"identifier\": \"CP1000005\",\r\n\t\t\t\t        \"lastModified\": \"2019-06-10T22:35:19.652478+00:00\",\r\n\t\t\t\t        \"lastAnnualGeneralMeetingDate\": \"2019-04-08\",\r\n\t\t\t\t        \"lastAnnualReport\": \"2019-04-08\",\r\n\t\t\t            \"lastPreBobFilingTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n\t\t\t\t        \"legalName\": \"Legal Name CP1000005\",\r\n\t\t\t\t        \"status\": \"NOTINCOMPLIANCE\",\r\n\t\t\t\t        \"taxId\": \"21062106\"\r\n\t\t\t\t    },\r\n\t\t\t\t\t\"header\": {\r\n\t\t\t\t\t\t\"date\": \"2017-06-06\",\r\n\t\t\t\t\t\t\"filingId\": 789,\r\n\t\t\t\t\t\t\"name\": \"changeOfDirectors\",\r\n\t\t\t\t\t\t\"status\": \"PENDING\"\r\n\t\t\t\t\t}\r\n\t\t\t\t}\r\n\t\t\t},\r\n\t\t\t\"order\": 1,\r\n\t\t\t\"enabled\": true\r\n\t\t}\r\n\t]\r\n}"
-								},
-								{
 									"name": "get-business-tasks - CP1000003",
 									"originalRequest": {
 										"method": "GET",
@@ -3125,6 +3061,75 @@
 									],
 									"cookie": [],
 									"body": "{\r\n\t\"tasks\": [\r\n\t\t{\r\n\t\t\t\"task\": {\r\n\t\t\t\t\"todo\": {\r\n\t\t\t\t\t\"business\": {\r\n\t\t\t\t\t\t\"foundingDate\": \"2019-06-10T00:00:00+00:00\",\r\n\t\t\t\t\t\t\"identifier\": \"CP1000004\",\r\n\t\t\t\t\t\t\"lastModified\": \"2019-06-10T22:35:19.652478+00:00\",\r\n\t\t\t\t\t\t\"lastAnnualGeneralMeetingDate\": \"2018-04-08\",\r\n\t\t\t\t\t\t\"lastAnnualReport\": \"2018-04-08\",\r\n\t\t\t            \"lastPreBobFilingTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n\t\t\t\t\t\t\"legalName\": \"Legal Name CP1000004\",\r\n\t\t\t\t\t\t\"status\": \"PENDINGDISSOLUTION\",\r\n\t\t\t\t\t\t\"taxId\": \"21032103\"\r\n\t\t\t\t\t},\r\n\t\t\t\t\t\"header\": {\r\n\t\t\t\t\t\t\"name\": \"annualReport\",\r\n\t\t\t\t\t\t\"ARFilingYear\": 2019,\r\n\t\t\t\t\t\t\"status\": \"NEW\"\r\n\t\t\t\t\t}\r\n\t\t\t\t}\r\n\t\t\t},\r\n\t\t\t\"order\": 1,\r\n\t\t\t\"enabled\": true\r\n\t\t}\r\n\t]\r\n}"
+								},
+								{
+									"name": "get-business-tasks - CP1000005",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{url}}/api/v1/businesses/:id/tasks",
+											"host": [
+												"{{url}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"businesses",
+												":id",
+												"tasks"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "CP1000005"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "X-Application-Context",
+											"value": "application:prod",
+											"description": "",
+											"type": "text"
+										},
+										{
+											"key": "Access-Control-Allow-Origin",
+											"value": "*",
+											"description": "",
+											"type": "text"
+										},
+										{
+											"key": "API",
+											"value": "legal_api/0.1.0a0.dev",
+											"description": "",
+											"type": "text"
+										},
+										{
+											"key": "Server",
+											"value": "Werkzeug/0.15.4 Python/3.7.3",
+											"description": "",
+											"type": "text"
+										},
+										{
+											"key": "Access-Control-Allow-Methods",
+											"value": "HEAD, GET, OPTIONS, DELETE, POST, PUT",
+											"description": "",
+											"type": "text"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json",
+											"description": "",
+											"type": "text"
+										}
+									],
+									"cookie": [],
+									"body": "{\r\n\t\"tasks\": [\r\n\t\t{\r\n\t\t\t\"task\": {\r\n\t\t\t\t\"filing\": {\r\n\t\t\t\t\t\"changeOfAddress\": {\r\n\t\t\t\t\t\t\"certifiedBy\": \"full2 name2\",\r\n\t\t\t\t\t\t\"email\": \"no_one@never.get\",\r\n\t\t\t\t\t    \"deliveryAddress\": {\r\n\t\t\t\t\t        \"streetAddress\": \"delivery_address - address line one\",\r\n\t\t\t\t\t        \"addressCity\": \"delivery_address city\",\r\n\t\t\t\t\t        \"addressCountry\": \"delivery_address country\",\r\n\t\t\t\t\t        \"postalCode\": \"H0H0H0\",\r\n\t\t\t\t\t        \"addressRegion\": \"BC\",\r\n\t\t\t\t\t        \"actions\": []\r\n\t\t\t\t\t    },\r\n\t\t\t\t\t    \"mailingAddress\": {\r\n\t\t\t\t\t        \"streetAddress\": \"mailing_address - address line one\",\r\n\t\t\t\t\t        \"addressCity\": \"mailing_address city\",\r\n\t\t\t\t\t        \"addressCountry\": \"mailing_address country\",\r\n\t\t\t\t\t        \"postalCode\": \"H0H0H0\",\r\n\t\t\t\t\t        \"addressRegion\": \"BC\",\r\n\t\t\t\t\t        \"actions\": [\"addressChanged\"]\r\n\t\t\t\t\t    }\r\n\t\t\t\t\t},\r\n\t\t\t\t    \"business\": {\r\n\t\t\t\t        \"foundingDate\": \"2019-06-10T00:00:00+00:00\",\r\n\t\t\t\t        \"identifier\": \"CP1000005\",\r\n\t\t\t\t        \"lastModified\": \"2019-06-10T22:35:19.652478+00:00\",\r\n\t\t\t\t        \"lastAnnualGeneralMeetingDate\": \"2019-04-08\",\r\n\t\t\t\t        \"lastAnnualReport\": \"2019-04-08\",\r\n\t\t\t            \"lastPreBobFilingTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n\t\t\t\t        \"legalName\": \"Legal Name CP1000005\",\r\n\t\t\t\t        \"status\": \"NOTINCOMPLIANCE\",\r\n\t\t\t\t        \"taxId\": \"21062106\"\r\n\t\t\t\t    },\r\n\t\t\t\t\t\"header\": {\r\n\t\t\t\t\t\t\"date\": \"2017-06-06\",\r\n\t\t\t\t\t\t\"filingId\": 456,\r\n\t\t\t\t\t\t\"name\": \"changeOfAddress\",\r\n\t\t\t\t\t\t\"status\": \"ERROR\"\r\n\t\t\t\t\t}\r\n\t\t\t\t}\r\n\t\t\t},\r\n\t\t\t\"order\": 2,\r\n\t\t\t\"enabled\": false\r\n\t\t},\r\n\t\t{\r\n\t\t\t\"task\": {\r\n\t\t\t\t\"filing\": {\r\n\t\t\t\t\t\"changeOfDirectors\": {\r\n\t\t\t\t\t\t\"certifiedBy\": \"full3 name3\",\r\n\t\t\t\t\t\t\"email\": \"no_one@never.get\",\r\n\t\t\t            \"directors\": [\r\n\t\t\t                {\r\n\t\t\t                \t\"actions\": [],\r\n\t\t\t                    \"officer\": {\r\n\t\t\t\t                    \"prevFirstName\": \"\",\r\n\t\t\t\t                    \"prevMiddleInitial\": \"\",\r\n\t\t\t\t                    \"prevLastName\": \"\",\r\n\t\t\t                        \"firstName\": \"Peter\",\r\n\t\t\t                        \"middleInitial\": \"G\",\r\n\t\t\t                        \"lastName\": \"Griffin\"\r\n\t\t\t                    },\r\n\t\t\t                    \"deliveryAddress\": {\r\n\t\t\t                        \"streetAddress\": \"2729 Belmont Ave\",\r\n\t\t\t                        \"additionalStreetAddress\": \"Back door\",\r\n\t\t\t                        \"addressCity\": \"Victoria\",\r\n\t\t\t                        \"addressCountry\": \"CA\",\r\n\t\t\t                        \"postalCode\": \"H0H0H0\",\r\n\t\t\t                        \"addressRegion\": \"BC\",\r\n\t\t\t                        \"deliveryInstructions\": \"Send to back\"\r\n\t\t\t                    },\r\n\t\t\t                    \"title\": \"President\",\r\n\t\t\t                    \"appointmentDate\": \"2014-03-30\",\r\n\t\t\t                    \"cessationDate\": null\r\n\t\t\t                },\r\n\t\t\t                {\r\n\t\t\t                \t\"actions\": [\"ceased\"],\r\n\t\t\t                    \"officer\": {\r\n\t\t\t                        \"prevFirstName\": \"\",\r\n\t\t\t                        \"prevMiddleInitial\": \"\",\r\n\t\t\t                        \"prevLastName\": \"\",\r\n\t\t\t                        \"firstName\": \"Joe\",\r\n\t\t\t                        \"middleInitial\": \"P\",\r\n\t\t\t                        \"lastName\": \"Swanson\"\r\n\t\t\t                    },\r\n\t\t\t                    \"deliveryAddress\": {\r\n\t\t\t                        \"streetAddress\": \"1020 Douglas Street\",\r\n\t\t\t                        \"additionalStreetAddress\": \"Kirkintiloch\",\r\n\t\t\t                        \"addressCity\": \"Glasgow\",\r\n\t\t\t                        \"addressCountry\": \"UK\",\r\n\t\t\t                        \"postalCode\": \"H0H 0H0\",\r\n\t\t\t                        \"addressRegion\": \"SC\",\r\n\t\t\t                        \"deliveryInstructions\": \"Please call 250-812-2445.\"\r\n\t\t\t                    },\r\n\t\t\t                    \"title\": \"Treasurer\",\r\n\t\t\t                    \"appointmentDate\": \"2014-03-30\",\r\n\t\t\t                    \"cessationDate\": \"2019-01-01\"\r\n\t\t\t                }\r\n\t\t\t\t\t\t]\r\n\t\t\t\t\t},\r\n\t\t\t\t    \"business\": {\r\n\t\t\t\t        \"foundingDate\": \"2019-06-10T00:00:00+00:00\",\r\n\t\t\t\t        \"identifier\": \"CP1000005\",\r\n\t\t\t\t        \"lastModified\": \"2019-06-10T22:35:19.652478+00:00\",\r\n\t\t\t\t        \"lastAnnualGeneralMeetingDate\": \"2019-04-08\",\r\n\t\t\t\t        \"lastAnnualReport\": \"2019-04-08\",\r\n\t\t\t            \"lastPreBobFilingTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n\t\t\t\t        \"legalName\": \"Legal Name CP1000005\",\r\n\t\t\t\t        \"status\": \"NOTINCOMPLIANCE\",\r\n\t\t\t\t        \"taxId\": \"21062106\"\r\n\t\t\t\t    },\r\n\t\t\t\t\t\"header\": {\r\n\t\t\t\t\t\t\"date\": \"2017-06-06\",\r\n\t\t\t\t\t\t\"filingId\": 789,\r\n\t\t\t\t\t\t\"name\": \"changeOfDirectors\",\r\n\t\t\t\t\t\t\"status\": \"PENDING\"\r\n\t\t\t\t\t}\r\n\t\t\t\t}\r\n\t\t\t},\r\n\t\t\t\"order\": 1,\r\n\t\t\t\"enabled\": true\r\n\t\t}\r\n\t]\r\n}"
 								}
 							]
 						},
@@ -3791,6 +3796,63 @@
 									"body": "{\r\n\t\"tasks\": [\r\n\t\t{\r\n\t\t\t\"task\": {\r\n\t\t\t\t\"filing\": {\r\n\t\t\t\t\t\"changeOfAddress\": {\r\n\t\t\t\t\t\t\"certifiedBy\": \"full2 name2\",\r\n\t\t\t\t\t\t\"email\": \"no_one@never.get\",\r\n\t\t\t\t\t    \"deliveryAddress\": {\r\n\t\t\t\t\t        \"streetAddress\": \"delivery_address - address line one\",\r\n\t\t\t\t\t        \"addressCity\": \"delivery_address city\",\r\n\t\t\t\t\t        \"addressCountry\": \"delivery_address country\",\r\n\t\t\t\t\t        \"postalCode\": \"H0H0H0\",\r\n\t\t\t\t\t        \"addressRegion\": \"BC\",\r\n\t\t\t\t\t        \"actions\": []\r\n\t\t\t\t\t    },\r\n\t\t\t\t\t    \"mailingAddress\": {\r\n\t\t\t\t\t        \"streetAddress\": \"mailing_address - address line one\",\r\n\t\t\t\t\t        \"addressCity\": \"mailing_address city\",\r\n\t\t\t\t\t        \"addressCountry\": \"mailing_address country\",\r\n\t\t\t\t\t        \"postalCode\": \"H0H0H0\",\r\n\t\t\t\t\t        \"addressRegion\": \"BC\",\r\n\t\t\t\t\t        \"actions\": [\"addressChanged\"]\r\n\t\t\t\t\t    }\r\n\t\t\t\t\t},\r\n\t\t\t\t    \"business\": {\r\n\t\t\t\t        \"foundingDate\": \"2019-06-10T00:00:00+00:00\",\r\n\t\t\t\t        \"identifier\": \"CP1000005\",\r\n\t\t\t\t        \"lastModified\": \"2019-06-10T22:35:19.652478+00:00\",\r\n\t\t\t\t        \"lastAnnualGeneralMeetingDate\": \"2019-04-08\",\r\n\t\t\t\t        \"lastAnnualReport\": \"2019-04-08\",\r\n\t\t\t            \"lastPreBobFilingTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n\t\t\t\t        \"legalName\": \"Legal Name CP1000005\",\r\n\t\t\t\t        \"status\": \"NOTINCOMPLIANCE\",\r\n\t\t\t\t        \"taxId\": \"21062106\"\r\n\t\t\t\t    },\r\n\t\t\t\t\t\"header\": {\r\n\t\t\t\t\t\t\"date\": \"2017-06-06\",\r\n\t\t\t\t\t\t\"filingId\": 456,\r\n\t\t\t\t\t\t\"name\": \"changeOfAddress\",\r\n\t\t\t\t\t\t\"status\": \"ERROR\"\r\n\t\t\t\t\t}\r\n\t\t\t\t}\r\n\t\t\t},\r\n\t\t\t\"order\": 2,\r\n\t\t\t\"enabled\": false\r\n\t\t},\r\n\t\t{\r\n\t\t\t\"task\": {\r\n\t\t\t\t\"filing\": {\r\n\t\t\t\t\t\"changeOfDirectors\": {\r\n\t\t\t\t\t\t\"certifiedBy\": \"full3 name3\",\r\n\t\t\t\t\t\t\"email\": \"no_one@never.get\",\r\n\t\t\t            \"directors\": [\r\n\t\t\t                {\r\n\t\t\t                \t\"actions\": [],\r\n\t\t\t                    \"officer\": {\r\n\t\t\t\t                    \"prevFirstName\": \"\",\r\n\t\t\t\t                    \"prevMiddleInitial\": \"\",\r\n\t\t\t\t                    \"prevLastName\": \"\",\r\n\t\t\t                        \"firstName\": \"Peter\",\r\n\t\t\t                        \"middleInitial\": \"G\",\r\n\t\t\t                        \"lastName\": \"Griffin\"\r\n\t\t\t                    },\r\n\t\t\t                    \"deliveryAddress\": {\r\n\t\t\t                        \"streetAddress\": \"2729 Belmont Ave\",\r\n\t\t\t                        \"additionalStreetAddress\": \"Back door\",\r\n\t\t\t                        \"addressCity\": \"Victoria\",\r\n\t\t\t                        \"addressCountry\": \"CA\",\r\n\t\t\t                        \"postalCode\": \"H0H0H0\",\r\n\t\t\t                        \"addressRegion\": \"BC\",\r\n\t\t\t                        \"deliveryInstructions\": \"Send to back\"\r\n\t\t\t                    },\r\n\t\t\t                    \"title\": \"President\",\r\n\t\t\t                    \"appointmentDate\": \"2014-03-30\",\r\n\t\t\t                    \"cessationDate\": null\r\n\t\t\t                },\r\n\t\t\t                {\r\n\t\t\t                \t\"actions\": [\"ceased\"],\r\n\t\t\t                    \"officer\": {\r\n\t\t\t                        \"prevFirstName\": \"\",\r\n\t\t\t                        \"prevMiddleInitial\": \"\",\r\n\t\t\t                        \"prevLastName\": \"\",\r\n\t\t\t                        \"firstName\": \"Joe\",\r\n\t\t\t                        \"middleInitial\": \"P\",\r\n\t\t\t                        \"lastName\": \"Swanson\"\r\n\t\t\t                    },\r\n\t\t\t                    \"deliveryAddress\": {\r\n\t\t\t                        \"streetAddress\": \"1020 Douglas Street\",\r\n\t\t\t                        \"additionalStreetAddress\": \"Kirkintiloch\",\r\n\t\t\t                        \"addressCity\": \"Glasgow\",\r\n\t\t\t                        \"addressCountry\": \"UK\",\r\n\t\t\t                        \"postalCode\": \"H0H 0H0\",\r\n\t\t\t                        \"addressRegion\": \"SC\",\r\n\t\t\t                        \"deliveryInstructions\": \"Please call 250-812-2445.\"\r\n\t\t\t                    },\r\n\t\t\t                    \"title\": \"Treasurer\",\r\n\t\t\t                    \"appointmentDate\": \"2014-03-30\",\r\n\t\t\t                    \"cessationDate\": \"2019-01-01\"\r\n\t\t\t                }\r\n\t\t\t\t\t\t]\r\n\t\t\t\t\t},\r\n\t\t\t\t    \"business\": {\r\n\t\t\t\t        \"foundingDate\": \"2019-06-10T00:00:00+00:00\",\r\n\t\t\t\t        \"identifier\": \"CP1000005\",\r\n\t\t\t\t        \"lastModified\": \"2019-06-10T22:35:19.652478+00:00\",\r\n\t\t\t\t        \"lastAnnualGeneralMeetingDate\": \"2019-04-08\",\r\n\t\t\t\t        \"lastAnnualReport\": \"2019-04-08\",\r\n\t\t\t            \"lastPreBobFilingTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n\t\t\t\t        \"legalName\": \"Legal Name CP1000005\",\r\n\t\t\t\t        \"status\": \"NOTINCOMPLIANCE\",\r\n\t\t\t\t        \"taxId\": \"21062106\"\r\n\t\t\t\t    },\r\n\t\t\t\t\t\"header\": {\r\n\t\t\t\t\t\t\"date\": \"2017-06-06\",\r\n\t\t\t\t\t\t\"filingId\": 789,\r\n\t\t\t\t\t\t\"name\": \"changeOfDirectors\",\r\n\t\t\t\t\t\t\"status\": \"PENDING\"\r\n\t\t\t\t\t}\r\n\t\t\t\t}\r\n\t\t\t},\r\n\t\t\t\"order\": 1,\r\n\t\t\t\"enabled\": true\r\n\t\t}\r\n\t]\r\n}"
 								},
 								{
+									"name": "get-business-tasks - CP1000003",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{url}}/api/v1/businesses/:id/tasks",
+											"host": [
+												"{{url}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"businesses",
+												":id",
+												"tasks"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "CP1000003"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "X-Application-Context",
+											"value": "application:prod"
+										},
+										{
+											"key": "Access-Control-Allow-Origin",
+											"value": "*"
+										},
+										{
+											"key": "API",
+											"value": "legal_api/0.1.0a0.dev"
+										},
+										{
+											"key": "Server",
+											"value": "Werkzeug/0.15.4 Python/3.7.3"
+										},
+										{
+											"key": "Access-Control-Allow-Methods",
+											"value": "HEAD, GET, OPTIONS, DELETE, POST, PUT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\r\n  \"tasks\": [\r\n    {\r\n      \"task\": {\r\n        \"todo\": {\r\n          \"business\": {\r\n            \"cacheId\": 1,\r\n            \"foundingDate\": \"2007-04-08\",\r\n            \"identifier\": \"CP1000003\",\r\n            \"lastLedgerTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n\t\t\t\"lastPreBobFilingTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n            \"legalName\": \"Legal Name CP1000003\"\r\n          },\r\n          \"header\": {\r\n            \"name\": \"annualReport\",\r\n            \"ARFilingYear\": 2019,\r\n            \"status\": \"NEW\"\r\n          }\r\n        }\r\n      },\r\n      \"order\": 2,\r\n      \"enabled\": false\r\n    },\r\n    {\r\n      \"task\": {\r\n        \"filing\": {\r\n          \"annualReport\": {\r\n            \"annualGeneralMeetingDate\": \"2018-07-15\",\r\n            \"certifiedBy\": \"full1 name1\",\r\n            \"email\": \"no_one@never.get\",\r\n\t\t    \"directors\": [\r\n\t\t        {\r\n\t\t            \"officer\": {\r\n                        \"prevFirstName\": \"\",\r\n                        \"prevMiddleInitial\": \"\",\r\n                        \"prevLastName\": \"\",\r\n\t\t                \"firstName\": \"Scott2\",\r\n\t\t                \"lastName\": \"Johnson2\"\r\n\t\t            },\r\n\t\t            \"deliveryAddress\": {\r\n\t\t                \"streetAddress\": \"3950A Helen Road\",\r\n\t\t                \"addressCity\": \"Edmonton\",\r\n\t\t                \"addressCountry\": \"CA\",\r\n\t\t                \"postalCode\": \"V5Z 8C8\",\r\n\t\t                \"addressRegion\": \"AB\"\r\n\t\t            },\r\n\t\t            \"appointmentDate\": \"2015-10-12\",\r\n\t\t            \"cessationDate\": null\r\n\t\t        }\r\n\t\t    ],\r\n\t\t    \"mailingAddress\": {\r\n\t\t        \"addressCity\": \"Victoria\",\r\n\t\t        \"addressCountry\": \"CANADA\",\r\n\t\t        \"addressRegion\": \"BC\",\r\n\t\t        \"addressType\": \"mailing\",\r\n\t\t        \"deliveryInstructions\": \"draft filing\",\r\n\t\t        \"postalCode\": \"T3S3T3\",\r\n\t\t        \"streetAddress\": \"2098 North Street\",\r\n\t\t        \"streetAddressAdditional\": \"apt 2098\"\r\n\t\t    },\r\n\t\t    \"deliveryAddress\": {\r\n\t\t        \"addressCity\": \"Victoria\",\r\n\t\t        \"addressCountry\": \"CANADA\",\r\n\t\t        \"addressRegion\": \"BC\",\r\n\t\t        \"addressType\": \"mailing\",\r\n\t\t        \"deliveryInstructions\": \"draft filing\",\r\n\t\t        \"postalCode\": \"T3S3T3\",\r\n\t\t        \"streetAddress\": \"2098 West Avenue\",\r\n\t\t        \"streetAddressAdditional\": \"suite 2098\"\r\n\t\t    }\r\n          },\r\n          \"changeOfAddress\": {\r\n            \"certifiedBy\": \"full2 name2\",\r\n            \"email\": \"no_one@never.get\",\r\n\t\t    \"mailingAddress\": {\r\n\t            \"actions\": [\"addressChanged\"],\r\n\t\t        \"addressCity\": \"Victoria\",\r\n\t\t        \"addressCountry\": \"CANADA\",\r\n\t\t        \"addressRegion\": \"BC\",\r\n\t\t        \"addressType\": \"mailing\",\r\n\t\t        \"deliveryInstructions\": \"draft filing\",\r\n\t\t        \"postalCode\": \"T3S3T3\",\r\n\t\t        \"streetAddress\": \"2098 North Street\",\r\n\t\t        \"streetAddressAdditional\": \"apt 2098\"\r\n\t\t    },\r\n\t\t    \"deliveryAddress\": {\r\n\t            \"actions\": [],\r\n\t\t        \"addressCity\": \"Victoria\",\r\n\t\t        \"addressCountry\": \"CANADA\",\r\n\t\t        \"addressRegion\": \"BC\",\r\n\t\t        \"addressType\": \"mailing\",\r\n\t\t        \"deliveryInstructions\": \"draft filing\",\r\n\t\t        \"postalCode\": \"T3S3T3\",\r\n\t\t        \"streetAddress\": \"2098 West Avenue\",\r\n\t\t        \"streetAddressAdditional\": \"suite 2098\"\r\n\t\t    }\r\n          },\r\n          \"changeOfDirectors\": {\r\n            \"certifiedBy\": \"full3 name3\",\r\n            \"email\": \"no_one@never.get\",\r\n\t\t    \"directors\": [\r\n\t\t        {\r\n\t\t            \"actions\": [\"appointed\"],\r\n\t\t            \"officer\": {\r\n                        \"prevFirstName\": \"\",\r\n                        \"prevMiddleInitial\": \"\",\r\n                        \"prevLastName\": \"\",\r\n\t\t                \"firstName\": \"Scott2\",\r\n\t\t                \"lastName\": \"Johnson2\"\r\n\t\t            },\r\n\t\t            \"deliveryAddress\": {\r\n\t\t                \"streetAddress\": \"3950A Helen Road\",\r\n\t\t                \"addressCity\": \"Edmonton\",\r\n\t\t                \"addressCountry\": \"CA\",\r\n\t\t                \"postalCode\": \"V5Z 8C8\",\r\n\t\t                \"addressRegion\": \"AB\"\r\n\t\t            },\r\n\t\t            \"appointmentDate\": \"2015-10-12\",\r\n\t\t            \"cessationDate\": null\r\n\t\t        }\r\n\t\t    ]\r\n          },\r\n          \"business\": {\r\n            \"cacheId\": 1,\r\n            \"foundingDate\": \"2007-04-08\",\r\n            \"identifier\": \"CP1000003\",\r\n            \"lastLedgerTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n\t\t\t\"lastPreBobFilingTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n            \"legalName\": \"Legal Name CP1000003\"\r\n          },\r\n          \"header\": {\r\n            \"date\": \"2017-06-06\",\r\n            \"filingId\": 4,\r\n            \"name\": \"annualReport\",\r\n            \"status\": \"DRAFT\"\r\n          }\r\n        }\r\n      },\r\n      \"order\": 1,\r\n      \"enabled\": true\r\n    }\r\n  ]\r\n}"
+								},
+								{
 									"name": "get-business-tasks - CP1000004",
 									"originalRequest": {
 										"method": "GET",
@@ -3858,63 +3920,6 @@
 									],
 									"cookie": [],
 									"body": "{\r\n\t\"tasks\": [\r\n\t\t{\r\n\t\t\t\"task\": {\r\n\t\t\t\t\"todo\": {\r\n\t\t\t\t\t\"business\": {\r\n\t\t\t\t\t\t\"foundingDate\": \"2019-06-10T00:00:00+00:00\",\r\n\t\t\t\t\t\t\"identifier\": \"CP1000004\",\r\n\t\t\t\t\t\t\"lastModified\": \"2019-06-10T22:35:19.652478+00:00\",\r\n\t\t\t\t\t\t\"lastAnnualGeneralMeetingDate\": \"2018-04-08\",\r\n\t\t\t\t\t\t\"lastAnnualReport\": \"2018-04-08\",\r\n\t\t\t            \"lastPreBobFilingTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n\t\t\t\t\t\t\"legalName\": \"Legal Name CP1000004\",\r\n\t\t\t\t\t\t\"status\": \"PENDINGDISSOLUTION\",\r\n\t\t\t\t\t\t\"taxId\": \"21032103\"\r\n\t\t\t\t\t},\r\n\t\t\t\t\t\"header\": {\r\n\t\t\t\t\t\t\"name\": \"annualReport\",\r\n\t\t\t\t\t\t\"ARFilingYear\": 2019,\r\n\t\t\t\t\t\t\"status\": \"NEW\"\r\n\t\t\t\t\t}\r\n\t\t\t\t}\r\n\t\t\t},\r\n\t\t\t\"order\": 1,\r\n\t\t\t\"enabled\": true\r\n\t\t}\r\n\t]\r\n}"
-								},
-								{
-									"name": "get-business-tasks - CP1000003",
-									"originalRequest": {
-										"method": "GET",
-										"header": [],
-										"url": {
-											"raw": "{{url}}/api/v1/businesses/:id/tasks",
-											"host": [
-												"{{url}}"
-											],
-											"path": [
-												"api",
-												"v1",
-												"businesses",
-												":id",
-												"tasks"
-											],
-											"variable": [
-												{
-													"key": "id",
-													"value": "CP1000003"
-												}
-											]
-										}
-									},
-									"status": "OK",
-									"code": 200,
-									"_postman_previewlanguage": "json",
-									"header": [
-										{
-											"key": "X-Application-Context",
-											"value": "application:prod"
-										},
-										{
-											"key": "Access-Control-Allow-Origin",
-											"value": "*"
-										},
-										{
-											"key": "API",
-											"value": "legal_api/0.1.0a0.dev"
-										},
-										{
-											"key": "Server",
-											"value": "Werkzeug/0.15.4 Python/3.7.3"
-										},
-										{
-											"key": "Access-Control-Allow-Methods",
-											"value": "HEAD, GET, OPTIONS, DELETE, POST, PUT"
-										},
-										{
-											"key": "Content-Type",
-											"value": "application/json"
-										}
-									],
-									"cookie": [],
-									"body": "{\r\n  \"tasks\": [\r\n    {\r\n      \"task\": {\r\n        \"todo\": {\r\n          \"business\": {\r\n            \"cacheId\": 1,\r\n            \"foundingDate\": \"2007-04-08\",\r\n            \"identifier\": \"CP1000003\",\r\n            \"lastLedgerTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n\t\t\t\"lastPreBobFilingTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n            \"legalName\": \"Legal Name CP1000003\"\r\n          },\r\n          \"header\": {\r\n            \"name\": \"annualReport\",\r\n            \"ARFilingYear\": 2019,\r\n            \"status\": \"NEW\"\r\n          }\r\n        }\r\n      },\r\n      \"order\": 2,\r\n      \"enabled\": false\r\n    },\r\n    {\r\n      \"task\": {\r\n        \"filing\": {\r\n          \"annualReport\": {\r\n            \"annualGeneralMeetingDate\": \"2018-07-15\",\r\n            \"certifiedBy\": \"full1 name1\",\r\n            \"email\": \"no_one@never.get\",\r\n\t\t    \"directors\": [\r\n\t\t        {\r\n\t\t            \"officer\": {\r\n                        \"prevFirstName\": \"\",\r\n                        \"prevMiddleInitial\": \"\",\r\n                        \"prevLastName\": \"\",\r\n\t\t                \"firstName\": \"Scott2\",\r\n\t\t                \"lastName\": \"Johnson2\"\r\n\t\t            },\r\n\t\t            \"deliveryAddress\": {\r\n\t\t                \"streetAddress\": \"3950A Helen Road\",\r\n\t\t                \"addressCity\": \"Edmonton\",\r\n\t\t                \"addressCountry\": \"CA\",\r\n\t\t                \"postalCode\": \"V5Z 8C8\",\r\n\t\t                \"addressRegion\": \"AB\"\r\n\t\t            },\r\n\t\t            \"appointmentDate\": \"2015-10-12\",\r\n\t\t            \"cessationDate\": null\r\n\t\t        }\r\n\t\t    ],\r\n\t\t    \"mailingAddress\": {\r\n\t\t        \"addressCity\": \"Victoria\",\r\n\t\t        \"addressCountry\": \"CANADA\",\r\n\t\t        \"addressRegion\": \"BC\",\r\n\t\t        \"addressType\": \"mailing\",\r\n\t\t        \"deliveryInstructions\": \"draft filing\",\r\n\t\t        \"postalCode\": \"T3S3T3\",\r\n\t\t        \"streetAddress\": \"2098 North Street\",\r\n\t\t        \"streetAddressAdditional\": \"apt 2098\"\r\n\t\t    },\r\n\t\t    \"deliveryAddress\": {\r\n\t\t        \"addressCity\": \"Victoria\",\r\n\t\t        \"addressCountry\": \"CANADA\",\r\n\t\t        \"addressRegion\": \"BC\",\r\n\t\t        \"addressType\": \"mailing\",\r\n\t\t        \"deliveryInstructions\": \"draft filing\",\r\n\t\t        \"postalCode\": \"T3S3T3\",\r\n\t\t        \"streetAddress\": \"2098 West Avenue\",\r\n\t\t        \"streetAddressAdditional\": \"suite 2098\"\r\n\t\t    }\r\n          },\r\n          \"changeOfAddress\": {\r\n            \"certifiedBy\": \"full2 name2\",\r\n            \"email\": \"no_one@never.get\",\r\n\t\t    \"mailingAddress\": {\r\n\t            \"actions\": [\"addressChanged\"],\r\n\t\t        \"addressCity\": \"Victoria\",\r\n\t\t        \"addressCountry\": \"CANADA\",\r\n\t\t        \"addressRegion\": \"BC\",\r\n\t\t        \"addressType\": \"mailing\",\r\n\t\t        \"deliveryInstructions\": \"draft filing\",\r\n\t\t        \"postalCode\": \"T3S3T3\",\r\n\t\t        \"streetAddress\": \"2098 North Street\",\r\n\t\t        \"streetAddressAdditional\": \"apt 2098\"\r\n\t\t    },\r\n\t\t    \"deliveryAddress\": {\r\n\t            \"actions\": [],\r\n\t\t        \"addressCity\": \"Victoria\",\r\n\t\t        \"addressCountry\": \"CANADA\",\r\n\t\t        \"addressRegion\": \"BC\",\r\n\t\t        \"addressType\": \"mailing\",\r\n\t\t        \"deliveryInstructions\": \"draft filing\",\r\n\t\t        \"postalCode\": \"T3S3T3\",\r\n\t\t        \"streetAddress\": \"2098 West Avenue\",\r\n\t\t        \"streetAddressAdditional\": \"suite 2098\"\r\n\t\t    }\r\n          },\r\n          \"changeOfDirectors\": {\r\n            \"certifiedBy\": \"full3 name3\",\r\n            \"email\": \"no_one@never.get\",\r\n\t\t    \"directors\": [\r\n\t\t        {\r\n\t\t            \"actions\": [\"appointed\"],\r\n\t\t            \"officer\": {\r\n                        \"prevFirstName\": \"\",\r\n                        \"prevMiddleInitial\": \"\",\r\n                        \"prevLastName\": \"\",\r\n\t\t                \"firstName\": \"Scott2\",\r\n\t\t                \"lastName\": \"Johnson2\"\r\n\t\t            },\r\n\t\t            \"deliveryAddress\": {\r\n\t\t                \"streetAddress\": \"3950A Helen Road\",\r\n\t\t                \"addressCity\": \"Edmonton\",\r\n\t\t                \"addressCountry\": \"CA\",\r\n\t\t                \"postalCode\": \"V5Z 8C8\",\r\n\t\t                \"addressRegion\": \"AB\"\r\n\t\t            },\r\n\t\t            \"appointmentDate\": \"2015-10-12\",\r\n\t\t            \"cessationDate\": null\r\n\t\t        }\r\n\t\t    ]\r\n          },\r\n          \"business\": {\r\n            \"cacheId\": 1,\r\n            \"foundingDate\": \"2007-04-08\",\r\n            \"identifier\": \"CP1000003\",\r\n            \"lastLedgerTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n\t\t\t\"lastPreBobFilingTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n            \"legalName\": \"Legal Name CP1000003\"\r\n          },\r\n          \"header\": {\r\n            \"date\": \"2017-06-06\",\r\n            \"filingId\": 4,\r\n            \"name\": \"annualReport\",\r\n            \"status\": \"DRAFT\"\r\n          }\r\n        }\r\n      },\r\n      \"order\": 1,\r\n      \"enabled\": true\r\n    }\r\n  ]\r\n}"
 								}
 							]
 						},
@@ -4149,6 +4154,63 @@
 							},
 							"response": [
 								{
+									"name": "get-business-tasks - CP1000003",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{url}}/api/v1/businesses/:id/tasks",
+											"host": [
+												"{{url}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"businesses",
+												":id",
+												"tasks"
+											],
+											"variable": [
+												{
+													"key": "id",
+													"value": "CP1000003"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "X-Application-Context",
+											"value": "application:prod"
+										},
+										{
+											"key": "Access-Control-Allow-Origin",
+											"value": "*"
+										},
+										{
+											"key": "API",
+											"value": "legal_api/0.1.0a0.dev"
+										},
+										{
+											"key": "Server",
+											"value": "Werkzeug/0.15.4 Python/3.7.3"
+										},
+										{
+											"key": "Access-Control-Allow-Methods",
+											"value": "HEAD, GET, OPTIONS, DELETE, POST, PUT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\r\n  \"tasks\": [\r\n    {\r\n      \"task\": {\r\n        \"todo\": {\r\n          \"business\": {\r\n            \"cacheId\": 1,\r\n            \"foundingDate\": \"2007-04-08\",\r\n            \"identifier\": \"CP1000003\",\r\n            \"lastLedgerTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n\t\t\t\"lastPreBobFilingTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n            \"legalName\": \"Legal Name CP1000003\"\r\n          },\r\n          \"header\": {\r\n            \"name\": \"annualReport\",\r\n            \"ARFilingYear\": 2019,\r\n            \"status\": \"NEW\"\r\n          }\r\n        }\r\n      },\r\n      \"order\": 2,\r\n      \"enabled\": false\r\n    },\r\n    {\r\n      \"task\": {\r\n        \"filing\": {\r\n          \"annualReport\": {\r\n            \"annualGeneralMeetingDate\": \"2018-07-15\",\r\n            \"certifiedBy\": \"full1 name1\",\r\n            \"email\": \"no_one@never.get\",\r\n\t\t    \"directors\": [\r\n\t\t        {\r\n\t\t            \"officer\": {\r\n                        \"prevFirstName\": \"\",\r\n                        \"prevMiddleInitial\": \"\",\r\n                        \"prevLastName\": \"\",\r\n\t\t                \"firstName\": \"Scott2\",\r\n\t\t                \"lastName\": \"Johnson2\"\r\n\t\t            },\r\n\t\t            \"deliveryAddress\": {\r\n\t\t                \"streetAddress\": \"3950A Helen Road\",\r\n\t\t                \"addressCity\": \"Edmonton\",\r\n\t\t                \"addressCountry\": \"CA\",\r\n\t\t                \"postalCode\": \"V5Z 8C8\",\r\n\t\t                \"addressRegion\": \"AB\"\r\n\t\t            },\r\n\t\t            \"appointmentDate\": \"2015-10-12\",\r\n\t\t            \"cessationDate\": null\r\n\t\t        }\r\n\t\t    ],\r\n\t\t    \"mailingAddress\": {\r\n\t\t        \"addressCity\": \"Victoria\",\r\n\t\t        \"addressCountry\": \"CANADA\",\r\n\t\t        \"addressRegion\": \"BC\",\r\n\t\t        \"addressType\": \"mailing\",\r\n\t\t        \"deliveryInstructions\": \"draft filing\",\r\n\t\t        \"postalCode\": \"T3S3T3\",\r\n\t\t        \"streetAddress\": \"2098 North Street\",\r\n\t\t        \"streetAddressAdditional\": \"apt 2098\"\r\n\t\t    },\r\n\t\t    \"deliveryAddress\": {\r\n\t\t        \"addressCity\": \"Victoria\",\r\n\t\t        \"addressCountry\": \"CANADA\",\r\n\t\t        \"addressRegion\": \"BC\",\r\n\t\t        \"addressType\": \"mailing\",\r\n\t\t        \"deliveryInstructions\": \"draft filing\",\r\n\t\t        \"postalCode\": \"T3S3T3\",\r\n\t\t        \"streetAddress\": \"2098 West Avenue\",\r\n\t\t        \"streetAddressAdditional\": \"suite 2098\"\r\n\t\t    }\r\n          },\r\n          \"changeOfAddress\": {\r\n            \"certifiedBy\": \"full2 name2\",\r\n            \"email\": \"no_one@never.get\",\r\n\t\t    \"mailingAddress\": {\r\n\t            \"actions\": [\"addressChanged\"],\r\n\t\t        \"addressCity\": \"Victoria\",\r\n\t\t        \"addressCountry\": \"CANADA\",\r\n\t\t        \"addressRegion\": \"BC\",\r\n\t\t        \"addressType\": \"mailing\",\r\n\t\t        \"deliveryInstructions\": \"draft filing\",\r\n\t\t        \"postalCode\": \"T3S3T3\",\r\n\t\t        \"streetAddress\": \"2098 North Street\",\r\n\t\t        \"streetAddressAdditional\": \"apt 2098\"\r\n\t\t    },\r\n\t\t    \"deliveryAddress\": {\r\n\t            \"actions\": [],\r\n\t\t        \"addressCity\": \"Victoria\",\r\n\t\t        \"addressCountry\": \"CANADA\",\r\n\t\t        \"addressRegion\": \"BC\",\r\n\t\t        \"addressType\": \"mailing\",\r\n\t\t        \"deliveryInstructions\": \"draft filing\",\r\n\t\t        \"postalCode\": \"T3S3T3\",\r\n\t\t        \"streetAddress\": \"2098 West Avenue\",\r\n\t\t        \"streetAddressAdditional\": \"suite 2098\"\r\n\t\t    }\r\n          },\r\n          \"changeOfDirectors\": {\r\n            \"certifiedBy\": \"full3 name3\",\r\n            \"email\": \"no_one@never.get\",\r\n\t\t    \"directors\": [\r\n\t\t        {\r\n\t\t            \"actions\": [\"appointed\"],\r\n\t\t            \"officer\": {\r\n                        \"prevFirstName\": \"\",\r\n                        \"prevMiddleInitial\": \"\",\r\n                        \"prevLastName\": \"\",\r\n\t\t                \"firstName\": \"Scott2\",\r\n\t\t                \"lastName\": \"Johnson2\"\r\n\t\t            },\r\n\t\t            \"deliveryAddress\": {\r\n\t\t                \"streetAddress\": \"3950A Helen Road\",\r\n\t\t                \"addressCity\": \"Edmonton\",\r\n\t\t                \"addressCountry\": \"CA\",\r\n\t\t                \"postalCode\": \"V5Z 8C8\",\r\n\t\t                \"addressRegion\": \"AB\"\r\n\t\t            },\r\n\t\t            \"appointmentDate\": \"2015-10-12\",\r\n\t\t            \"cessationDate\": null\r\n\t\t        }\r\n\t\t    ]\r\n          },\r\n          \"business\": {\r\n            \"cacheId\": 1,\r\n            \"foundingDate\": \"2007-04-08\",\r\n            \"identifier\": \"CP1000003\",\r\n            \"lastLedgerTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n\t\t\t\"lastPreBobFilingTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n            \"legalName\": \"Legal Name CP1000003\"\r\n          },\r\n          \"header\": {\r\n            \"date\": \"2017-06-06\",\r\n            \"filingId\": 4,\r\n            \"name\": \"annualReport\",\r\n            \"status\": \"DRAFT\"\r\n          }\r\n        }\r\n      },\r\n      \"order\": 1,\r\n      \"enabled\": true\r\n    }\r\n  ]\r\n}"
+								},
+								{
 									"name": "get-business-tasks - CP1000004",
 									"originalRequest": {
 										"method": "GET",
@@ -4285,63 +4347,6 @@
 									],
 									"cookie": [],
 									"body": "{\r\n\t\"tasks\": [\r\n\t\t{\r\n\t\t\t\"task\": {\r\n\t\t\t\t\"filing\": {\r\n\t\t\t\t\t\"changeOfAddress\": {\r\n\t\t\t\t\t\t\"certifiedBy\": \"full2 name2\",\r\n\t\t\t\t\t\t\"email\": \"no_one@never.get\",\r\n\t\t\t\t\t    \"deliveryAddress\": {\r\n\t\t\t\t\t        \"streetAddress\": \"delivery_address - address line one\",\r\n\t\t\t\t\t        \"addressCity\": \"delivery_address city\",\r\n\t\t\t\t\t        \"addressCountry\": \"delivery_address country\",\r\n\t\t\t\t\t        \"postalCode\": \"H0H0H0\",\r\n\t\t\t\t\t        \"addressRegion\": \"BC\",\r\n\t\t\t\t\t        \"actions\": []\r\n\t\t\t\t\t    },\r\n\t\t\t\t\t    \"mailingAddress\": {\r\n\t\t\t\t\t        \"streetAddress\": \"mailing_address - address line one\",\r\n\t\t\t\t\t        \"addressCity\": \"mailing_address city\",\r\n\t\t\t\t\t        \"addressCountry\": \"mailing_address country\",\r\n\t\t\t\t\t        \"postalCode\": \"H0H0H0\",\r\n\t\t\t\t\t        \"addressRegion\": \"BC\",\r\n\t\t\t\t\t        \"actions\": [\"addressChanged\"]\r\n\t\t\t\t\t    }\r\n\t\t\t\t\t},\r\n\t\t\t\t    \"business\": {\r\n\t\t\t\t        \"foundingDate\": \"2019-06-10T00:00:00+00:00\",\r\n\t\t\t\t        \"identifier\": \"CP1000005\",\r\n\t\t\t\t        \"lastModified\": \"2019-06-10T22:35:19.652478+00:00\",\r\n\t\t\t\t        \"lastAnnualGeneralMeetingDate\": \"2019-04-08\",\r\n\t\t\t\t        \"lastAnnualReport\": \"2019-04-08\",\r\n\t\t\t            \"lastPreBobFilingTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n\t\t\t\t        \"legalName\": \"Legal Name CP1000005\",\r\n\t\t\t\t        \"status\": \"NOTINCOMPLIANCE\",\r\n\t\t\t\t        \"taxId\": \"21062106\"\r\n\t\t\t\t    },\r\n\t\t\t\t\t\"header\": {\r\n\t\t\t\t\t\t\"date\": \"2017-06-06\",\r\n\t\t\t\t\t\t\"filingId\": 456,\r\n\t\t\t\t\t\t\"name\": \"changeOfAddress\",\r\n\t\t\t\t\t\t\"status\": \"ERROR\"\r\n\t\t\t\t\t}\r\n\t\t\t\t}\r\n\t\t\t},\r\n\t\t\t\"order\": 2,\r\n\t\t\t\"enabled\": false\r\n\t\t},\r\n\t\t{\r\n\t\t\t\"task\": {\r\n\t\t\t\t\"filing\": {\r\n\t\t\t\t\t\"changeOfDirectors\": {\r\n\t\t\t\t\t\t\"certifiedBy\": \"full3 name3\",\r\n\t\t\t\t\t\t\"email\": \"no_one@never.get\",\r\n\t\t\t            \"directors\": [\r\n\t\t\t                {\r\n\t\t\t                \t\"actions\": [],\r\n\t\t\t                    \"officer\": {\r\n\t\t\t\t                    \"prevFirstName\": \"\",\r\n\t\t\t\t                    \"prevMiddleInitial\": \"\",\r\n\t\t\t\t                    \"prevLastName\": \"\",\r\n\t\t\t                        \"firstName\": \"Peter\",\r\n\t\t\t                        \"middleInitial\": \"G\",\r\n\t\t\t                        \"lastName\": \"Griffin\"\r\n\t\t\t                    },\r\n\t\t\t                    \"deliveryAddress\": {\r\n\t\t\t                        \"streetAddress\": \"2729 Belmont Ave\",\r\n\t\t\t                        \"additionalStreetAddress\": \"Back door\",\r\n\t\t\t                        \"addressCity\": \"Victoria\",\r\n\t\t\t                        \"addressCountry\": \"CA\",\r\n\t\t\t                        \"postalCode\": \"H0H0H0\",\r\n\t\t\t                        \"addressRegion\": \"BC\",\r\n\t\t\t                        \"deliveryInstructions\": \"Send to back\"\r\n\t\t\t                    },\r\n\t\t\t                    \"title\": \"President\",\r\n\t\t\t                    \"appointmentDate\": \"2014-03-30\",\r\n\t\t\t                    \"cessationDate\": null\r\n\t\t\t                },\r\n\t\t\t                {\r\n\t\t\t                \t\"actions\": [\"ceased\"],\r\n\t\t\t                    \"officer\": {\r\n\t\t\t                        \"prevFirstName\": \"\",\r\n\t\t\t                        \"prevMiddleInitial\": \"\",\r\n\t\t\t                        \"prevLastName\": \"\",\r\n\t\t\t                        \"firstName\": \"Joe\",\r\n\t\t\t                        \"middleInitial\": \"P\",\r\n\t\t\t                        \"lastName\": \"Swanson\"\r\n\t\t\t                    },\r\n\t\t\t                    \"deliveryAddress\": {\r\n\t\t\t                        \"streetAddress\": \"1020 Douglas Street\",\r\n\t\t\t                        \"additionalStreetAddress\": \"Kirkintiloch\",\r\n\t\t\t                        \"addressCity\": \"Glasgow\",\r\n\t\t\t                        \"addressCountry\": \"UK\",\r\n\t\t\t                        \"postalCode\": \"H0H 0H0\",\r\n\t\t\t                        \"addressRegion\": \"SC\",\r\n\t\t\t                        \"deliveryInstructions\": \"Please call 250-812-2445.\"\r\n\t\t\t                    },\r\n\t\t\t                    \"title\": \"Treasurer\",\r\n\t\t\t                    \"appointmentDate\": \"2014-03-30\",\r\n\t\t\t                    \"cessationDate\": \"2019-01-01\"\r\n\t\t\t                }\r\n\t\t\t\t\t\t]\r\n\t\t\t\t\t},\r\n\t\t\t\t    \"business\": {\r\n\t\t\t\t        \"foundingDate\": \"2019-06-10T00:00:00+00:00\",\r\n\t\t\t\t        \"identifier\": \"CP1000005\",\r\n\t\t\t\t        \"lastModified\": \"2019-06-10T22:35:19.652478+00:00\",\r\n\t\t\t\t        \"lastAnnualGeneralMeetingDate\": \"2019-04-08\",\r\n\t\t\t\t        \"lastAnnualReport\": \"2019-04-08\",\r\n\t\t\t            \"lastPreBobFilingTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n\t\t\t\t        \"legalName\": \"Legal Name CP1000005\",\r\n\t\t\t\t        \"status\": \"NOTINCOMPLIANCE\",\r\n\t\t\t\t        \"taxId\": \"21062106\"\r\n\t\t\t\t    },\r\n\t\t\t\t\t\"header\": {\r\n\t\t\t\t\t\t\"date\": \"2017-06-06\",\r\n\t\t\t\t\t\t\"filingId\": 789,\r\n\t\t\t\t\t\t\"name\": \"changeOfDirectors\",\r\n\t\t\t\t\t\t\"status\": \"PENDING\"\r\n\t\t\t\t\t}\r\n\t\t\t\t}\r\n\t\t\t},\r\n\t\t\t\"order\": 1,\r\n\t\t\t\"enabled\": true\r\n\t\t}\r\n\t]\r\n}"
-								},
-								{
-									"name": "get-business-tasks - CP1000003",
-									"originalRequest": {
-										"method": "GET",
-										"header": [],
-										"url": {
-											"raw": "{{url}}/api/v1/businesses/:id/tasks",
-											"host": [
-												"{{url}}"
-											],
-											"path": [
-												"api",
-												"v1",
-												"businesses",
-												":id",
-												"tasks"
-											],
-											"variable": [
-												{
-													"key": "id",
-													"value": "CP1000003"
-												}
-											]
-										}
-									},
-									"status": "OK",
-									"code": 200,
-									"_postman_previewlanguage": "json",
-									"header": [
-										{
-											"key": "X-Application-Context",
-											"value": "application:prod"
-										},
-										{
-											"key": "Access-Control-Allow-Origin",
-											"value": "*"
-										},
-										{
-											"key": "API",
-											"value": "legal_api/0.1.0a0.dev"
-										},
-										{
-											"key": "Server",
-											"value": "Werkzeug/0.15.4 Python/3.7.3"
-										},
-										{
-											"key": "Access-Control-Allow-Methods",
-											"value": "HEAD, GET, OPTIONS, DELETE, POST, PUT"
-										},
-										{
-											"key": "Content-Type",
-											"value": "application/json"
-										}
-									],
-									"cookie": [],
-									"body": "{\r\n  \"tasks\": [\r\n    {\r\n      \"task\": {\r\n        \"todo\": {\r\n          \"business\": {\r\n            \"cacheId\": 1,\r\n            \"foundingDate\": \"2007-04-08\",\r\n            \"identifier\": \"CP1000003\",\r\n            \"lastLedgerTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n\t\t\t\"lastPreBobFilingTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n            \"legalName\": \"Legal Name CP1000003\"\r\n          },\r\n          \"header\": {\r\n            \"name\": \"annualReport\",\r\n            \"ARFilingYear\": 2019,\r\n            \"status\": \"NEW\"\r\n          }\r\n        }\r\n      },\r\n      \"order\": 2,\r\n      \"enabled\": false\r\n    },\r\n    {\r\n      \"task\": {\r\n        \"filing\": {\r\n          \"annualReport\": {\r\n            \"annualGeneralMeetingDate\": \"2018-07-15\",\r\n            \"certifiedBy\": \"full1 name1\",\r\n            \"email\": \"no_one@never.get\",\r\n\t\t    \"directors\": [\r\n\t\t        {\r\n\t\t            \"officer\": {\r\n                        \"prevFirstName\": \"\",\r\n                        \"prevMiddleInitial\": \"\",\r\n                        \"prevLastName\": \"\",\r\n\t\t                \"firstName\": \"Scott2\",\r\n\t\t                \"lastName\": \"Johnson2\"\r\n\t\t            },\r\n\t\t            \"deliveryAddress\": {\r\n\t\t                \"streetAddress\": \"3950A Helen Road\",\r\n\t\t                \"addressCity\": \"Edmonton\",\r\n\t\t                \"addressCountry\": \"CA\",\r\n\t\t                \"postalCode\": \"V5Z 8C8\",\r\n\t\t                \"addressRegion\": \"AB\"\r\n\t\t            },\r\n\t\t            \"appointmentDate\": \"2015-10-12\",\r\n\t\t            \"cessationDate\": null\r\n\t\t        }\r\n\t\t    ],\r\n\t\t    \"mailingAddress\": {\r\n\t\t        \"addressCity\": \"Victoria\",\r\n\t\t        \"addressCountry\": \"CANADA\",\r\n\t\t        \"addressRegion\": \"BC\",\r\n\t\t        \"addressType\": \"mailing\",\r\n\t\t        \"deliveryInstructions\": \"draft filing\",\r\n\t\t        \"postalCode\": \"T3S3T3\",\r\n\t\t        \"streetAddress\": \"2098 North Street\",\r\n\t\t        \"streetAddressAdditional\": \"apt 2098\"\r\n\t\t    },\r\n\t\t    \"deliveryAddress\": {\r\n\t\t        \"addressCity\": \"Victoria\",\r\n\t\t        \"addressCountry\": \"CANADA\",\r\n\t\t        \"addressRegion\": \"BC\",\r\n\t\t        \"addressType\": \"mailing\",\r\n\t\t        \"deliveryInstructions\": \"draft filing\",\r\n\t\t        \"postalCode\": \"T3S3T3\",\r\n\t\t        \"streetAddress\": \"2098 West Avenue\",\r\n\t\t        \"streetAddressAdditional\": \"suite 2098\"\r\n\t\t    }\r\n          },\r\n          \"changeOfAddress\": {\r\n            \"certifiedBy\": \"full2 name2\",\r\n            \"email\": \"no_one@never.get\",\r\n\t\t    \"mailingAddress\": {\r\n\t            \"actions\": [\"addressChanged\"],\r\n\t\t        \"addressCity\": \"Victoria\",\r\n\t\t        \"addressCountry\": \"CANADA\",\r\n\t\t        \"addressRegion\": \"BC\",\r\n\t\t        \"addressType\": \"mailing\",\r\n\t\t        \"deliveryInstructions\": \"draft filing\",\r\n\t\t        \"postalCode\": \"T3S3T3\",\r\n\t\t        \"streetAddress\": \"2098 North Street\",\r\n\t\t        \"streetAddressAdditional\": \"apt 2098\"\r\n\t\t    },\r\n\t\t    \"deliveryAddress\": {\r\n\t            \"actions\": [],\r\n\t\t        \"addressCity\": \"Victoria\",\r\n\t\t        \"addressCountry\": \"CANADA\",\r\n\t\t        \"addressRegion\": \"BC\",\r\n\t\t        \"addressType\": \"mailing\",\r\n\t\t        \"deliveryInstructions\": \"draft filing\",\r\n\t\t        \"postalCode\": \"T3S3T3\",\r\n\t\t        \"streetAddress\": \"2098 West Avenue\",\r\n\t\t        \"streetAddressAdditional\": \"suite 2098\"\r\n\t\t    }\r\n          },\r\n          \"changeOfDirectors\": {\r\n            \"certifiedBy\": \"full3 name3\",\r\n            \"email\": \"no_one@never.get\",\r\n\t\t    \"directors\": [\r\n\t\t        {\r\n\t\t            \"actions\": [\"appointed\"],\r\n\t\t            \"officer\": {\r\n                        \"prevFirstName\": \"\",\r\n                        \"prevMiddleInitial\": \"\",\r\n                        \"prevLastName\": \"\",\r\n\t\t                \"firstName\": \"Scott2\",\r\n\t\t                \"lastName\": \"Johnson2\"\r\n\t\t            },\r\n\t\t            \"deliveryAddress\": {\r\n\t\t                \"streetAddress\": \"3950A Helen Road\",\r\n\t\t                \"addressCity\": \"Edmonton\",\r\n\t\t                \"addressCountry\": \"CA\",\r\n\t\t                \"postalCode\": \"V5Z 8C8\",\r\n\t\t                \"addressRegion\": \"AB\"\r\n\t\t            },\r\n\t\t            \"appointmentDate\": \"2015-10-12\",\r\n\t\t            \"cessationDate\": null\r\n\t\t        }\r\n\t\t    ]\r\n          },\r\n          \"business\": {\r\n            \"cacheId\": 1,\r\n            \"foundingDate\": \"2007-04-08\",\r\n            \"identifier\": \"CP1000003\",\r\n            \"lastLedgerTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n\t\t\t\"lastPreBobFilingTimestamp\": \"2019-04-15T20:05:49.068272+00:00\",\r\n            \"legalName\": \"Legal Name CP1000003\"\r\n          },\r\n          \"header\": {\r\n            \"date\": \"2017-06-06\",\r\n            \"filingId\": 4,\r\n            \"name\": \"annualReport\",\r\n            \"status\": \"DRAFT\"\r\n          }\r\n        }\r\n      },\r\n      \"order\": 1,\r\n      \"enabled\": true\r\n    }\r\n  ]\r\n}"
 								}
 							]
 						}
@@ -7131,6 +7136,113 @@
 			"name": "Incorporation",
 			"item": [
 				{
+					"name": "authenticate as staff",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "c6720c75-f388-4f9a-a157-c4b4b560a99f",
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Response time is less than 10000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(10000);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Returns the access token\", () => {",
+									"    pm.expect(jsonData.access_token).to.exist",
+									"    pm.environment.set(\"token\", jsonData['access_token'])",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"username\":\"{{staff_username}}\", \"password\":\"{{staff_password}}\"}"
+						},
+						"url": {
+							"raw": "{{tokenUrl}}",
+							"host": [
+								"{{tokenUrl}}"
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "authenticate",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\"username\":\"coops-updater-job\", \"password\":\"coops-updater-job\"}"
+								},
+								"url": {
+									"raw": "{{get_token_url}}",
+									"host": [
+										"{{get_token_url}}"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "html",
+							"header": [
+								{
+									"key": "Server",
+									"value": "gunicorn/19.9.0"
+								},
+								{
+									"key": "Date",
+									"value": "Tue, 30 Jul 2019 18:39:41 GMT"
+								},
+								{
+									"key": "Content-Type",
+									"value": "text/html; charset=utf-8"
+								},
+								{
+									"key": "Access-Control-Allow-Origin",
+									"value": "*"
+								},
+								{
+									"key": "Access-Control-Allow-Methods",
+									"value": "POST, OPTIONS"
+								},
+								{
+									"key": "Access-Control-Max-Age",
+									"value": "21600"
+								},
+								{
+									"key": "API",
+									"value": "auth_api/0.1.0a0.dev-462c33674f5ae76b1e8ef2f968e55f41f26d8f95"
+								}
+							],
+							"cookie": [],
+							"body": "{\"access_token\": \"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJUbWdtZUk0MnVsdUZ0N3FQbmUtcTEzdDUwa0JDbjF3bHF6dHN0UGdUM1dFIn0.eyJqdGkiOiI4NmQzMGNhNi04ZmM2LTRiMDctYWFmNS1mYWEzMjg0ODk0NzciLCJleHAiOjE1NjQ1OTgzODEsIm5iZiI6MCwiaWF0IjoxNTY0NTExOTgxLCJpc3MiOiJodHRwczovL3Nzby1kZXYucGF0aGZpbmRlci5nb3YuYmMuY2EvYXV0aC9yZWFsbXMvZmNmMGtwcXIiLCJhdWQiOiJzYmMtYXV0aC13ZWIiLCJzdWIiOiI1MmRjZDNjZi1jMmNmLTQ1NWQtYjY4Zi04NTU4NTcyMjg1OTEiLCJ0eXAiOiJCZWFyZXIiLCJhenAiOiJzYmMtYXV0aC13ZWIiLCJhdXRoX3RpbWUiOjAsInNlc3Npb25fc3RhdGUiOiJkMjQ3YjhlZS1kMGI3LTQxZDgtYTA1Yy0yZGVlY2UyNmMxMTIiLCJhY3IiOiIxIiwiYWxsb3dlZC1vcmlnaW5zIjpbImh0dHA6Ly8xOTIuMTY4LjAuMTM6ODA4MC8iLCIxOTIuMTY4LjAuMTMiLCIqIiwiaHR0cDovLzE5Mi4xNjguMC4xMzo4MDgwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJjb2xpbiIsInVtYV9hdXRob3JpemF0aW9uIiwiam9iIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwicHJlZmVycmVkX3VzZXJuYW1lIjoiY29vcHMtdXBkYXRlci1qb2IiLCJ1c2VybmFtZSI6ImNvb3BzLXVwZGF0ZXItam9iIn0.Bbr9ehKYRfUvFLhjtfR3QfzRx5ItZzTWjdtxevBh1kPLhhSIqH456LBLh96vUOCqA3X2MsWpqFQrKRHdhxe5mkisXFME3J3dQKXcXnGJSsam8yRfDtMyre1DYC6bo3tIujtwr7G6OMwotcz_hGqYKm_8FjsNIKOXcMv9S88NNKohj_o9F6RXgq9JnTTP2fZakpqYn2E4imLmOSIK7ft2ODfCyH74owd35NQBse4U0B7YAvlsFjtyFInzO5wGXCzVUnS99vm4Hv4JMTsQz5R4S_HlTVwM5jAJGn4ZXu_QK6tH8J78t-7MZQn39QEdGHtf-oc4RyRGLIPdqp7wsvwfJw\", \"expires_in\": 86400, \"refresh_expires_in\": 86400, \"refresh_token\": \"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJUbWdtZUk0MnVsdUZ0N3FQbmUtcTEzdDUwa0JDbjF3bHF6dHN0UGdUM1dFIn0.eyJqdGkiOiI2M2UwMGYwMi00MGNjLTQzOTUtYTJlMS00MjliOTViMDQ5ODMiLCJleHAiOjE1NjQ1OTgzODEsIm5iZiI6MCwiaWF0IjoxNTY0NTExOTgxLCJpc3MiOiJodHRwczovL3Nzby1kZXYucGF0aGZpbmRlci5nb3YuYmMuY2EvYXV0aC9yZWFsbXMvZmNmMGtwcXIiLCJhdWQiOiJzYmMtYXV0aC13ZWIiLCJzdWIiOiI1MmRjZDNjZi1jMmNmLTQ1NWQtYjY4Zi04NTU4NTcyMjg1OTEiLCJ0eXAiOiJSZWZyZXNoIiwiYXpwIjoic2JjLWF1dGgtd2ViIiwiYXV0aF90aW1lIjowLCJzZXNzaW9uX3N0YXRlIjoiZDI0N2I4ZWUtZDBiNy00MWQ4LWEwNWMtMmRlZWNlMjZjMTEyIiwicmVhbG1fYWNjZXNzIjp7InJvbGVzIjpbImNvbGluIiwidW1hX2F1dGhvcml6YXRpb24iLCJqb2IiXX0sInJlc291cmNlX2FjY2VzcyI6eyJhY2NvdW50Ijp7InJvbGVzIjpbIm1hbmFnZS1hY2NvdW50IiwibWFuYWdlLWFjY291bnQtbGlua3MiLCJ2aWV3LXByb2ZpbGUiXX19fQ.HYmcM0cM2kVtB81mvqjVe5A3wtDW8ERidoC0M-vkSNVTscb6GuqEvaw_0w2jXZJccAhXlmKdKIb_YLWrSAg_hYJz04rj-Vw3r7TuE_I_tpAMbycsSBEb9XREGV9XNTzYk1SNAGQGsQrCDXOZWqKaAR8_QkISLRlnHmwyLXM-FrgJk8Msh37z4nnmF5dr68d5mavx6AfDJdlxx-c6A7pUaKVaQhPnzSdy80Hdew8zLUUS1oWLCMsUosDNBosv0nnfpDEaScSAxrqimIhjVRWOGZDEa3b9qkXf1pgPDU6We_n17aA77ytgepbMJNqqOLPZkZNEF9gQIJ7l0dPQGCE_vw\", \"token_type\": \"bearer\", \"not-before-policy\": 1562910731, \"session_state\": \"d247b8ee-d0b7-41d8-a05c-2deece26c112\", \"registries-trace-id\": \"f2dfaa910187eccb:f42fb400f9f894ac:f2dfaa910187eccb:1\"}"
+						}
+					]
+				},
+				{
 					"name": "Save draft ",
 					"event": [
 						{
@@ -7195,10 +7307,10 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"filing\": {\r\n        \"header\": {\r\n        \t\"certifiedBy\": \"full name\",\r\n            \"email\": \"no_one@never.get\",\r\n            \"name\": \"incorporationApplication\",\r\n            \"date\": \"{{today}}\"\r\n        },\r\n        \"incorporationApplication\": {\r\n\t        \"nameRequest\": {\r\n\t            \"legalType\": \"BC\",\r\n\t            \"nrNumber\": \"{{nr_num}}\"\r\n\t        },\r\n\t        \"offices\": {\r\n\t            \"registeredOffice\": {\r\n\t                \"deliveryAddress\": {\r\n\t                    \"streetAddress\": \"delivery_address - address line one\",\r\n\t                    \"addressCity\": \"delivery_address city\",\r\n\t                    \"addressCountry\": \"delivery_address country\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                },\r\n\t                \"mailingAddress\": {\r\n\t                    \"streetAddress\": \"mailing_address - address line one\",\r\n\t                    \"addressCity\": \"mailing_address city\",\r\n\t                    \"addressCountry\": \"mailing_address country\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                }\r\n\t            },\r\n\t            \"recordsOffice\": {\r\n\t                \"deliveryAddress\": {\r\n\t                    \"streetAddress\": \"delivery_address - address line one\",\r\n\t                    \"addressCity\": \"delivery_address city\",\r\n\t                    \"addressCountry\": \"delivery_address country\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                },\r\n\t                \"mailingAddress\": {\r\n\t                    \"streetAddress\": \"mailing_address - address line one\",\r\n\t                    \"addressCity\": \"mailing_address city\",\r\n\t                    \"addressCountry\": \"mailing_address country\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                }\r\n\t            }\r\n\t        },\r\n\t        \"contactPoint\": {\r\n\t            \"email\": \"no_one@never.get\",\r\n\t            \"phone\": \"123-456-7890\"\r\n\t        }\r\n    \t}\r\n    }\r\n}"
+							"raw": "{\r\n    \"filing\": {\r\n        \"header\": {\r\n        \t\"certifiedBy\": \"full name\",\r\n            \"email\": \"no_one@never.get\",\r\n            \"name\": \"incorporationApplication\",\r\n            \"date\": \"{{today}}\"\r\n        },\r\n        \"incorporationApplication\": {\r\n\t        \"nameRequest\": {\r\n\t            \"legalType\": \"BC\",\r\n\t            \"nrNumber\": \"{{nr_num}}\"\r\n\t        },\r\n\t        \"offices\": {\r\n\t            \"registeredOffice\": {\r\n\t                \"deliveryAddress\": {\r\n\t                    \"streetAddress\": \"delivery_address - address line one\",\r\n\t                    \"addressCity\": \"delivery_address city\",\r\n\t                    \"addressCountry\": \"CA\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                },\r\n\t                \"mailingAddress\": {\r\n\t                    \"streetAddress\": \"mailing_address - address line one\",\r\n\t                    \"addressCity\": \"mailing_address city\",\r\n\t                    \"addressCountry\": \"CA\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                }\r\n\t            },\r\n\t            \"recordsOffice\": {\r\n\t                \"deliveryAddress\": {\r\n\t                    \"streetAddress\": \"delivery_address - address line one\",\r\n\t                    \"addressCity\": \"delivery_address city\",\r\n\t                    \"addressCountry\": \"CA\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                },\r\n\t                \"mailingAddress\": {\r\n\t                    \"streetAddress\": \"mailing_address - address line one\",\r\n\t                    \"addressCity\": \"mailing_address city\",\r\n\t                    \"addressCountry\": \"CA\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                }\r\n\t            }\r\n\t        },\r\n\t        \"contactPoint\": {\r\n\t            \"email\": \"no_one@never.get\",\r\n\t            \"phone\": \"123-456-7890\"\r\n\t        }\r\n    \t}\r\n    }\r\n}"
 						},
 						"url": {
-							"raw": "{{url}}/api/v1/businesses",
+							"raw": "{{url}}/api/v1/businesses?draft=true",
 							"host": [
 								"{{url}}"
 							],
@@ -7206,6 +7318,12 @@
 								"api",
 								"v1",
 								"businesses"
+							],
+							"query": [
+								{
+									"key": "draft",
+									"value": "true"
+								}
 							]
 						}
 					},
@@ -7269,7 +7387,7 @@
 							"raw": "{\r\n    \"filing\": {\r\n        \"header\": {\r\n        \t\"certifiedBy\": \"full name\",\r\n            \"email\": \"no_one@never.get\",\r\n            \"name\": \"incorporationApplication\",\r\n            \"date\": \"{{today}}\"\r\n        },\r\n        \"incorporationApplication\": {\r\n\t        \"nameRequest\": {\r\n\t            \"legalType\": \"BC\",\r\n\t            \"nrNumber\": \"{{nr_num}}\"\r\n\t        },\r\n\t        \"offices\": {\r\n\t            \"registeredOffice\": {\r\n\t                \"deliveryAddress\": {\r\n\t                    \"streetAddress\": \"delivery_address - address line one\",\r\n\t                    \"addressCity\": \"delivery_address city\",\r\n\t                    \"addressCountry\": \"delivery_address country\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                },\r\n\t                \"mailingAddress\": {\r\n\t                    \"streetAddress\": \"mailing_address - address line one\",\r\n\t                    \"addressCity\": \"mailing_address city\",\r\n\t                    \"addressCountry\": \"mailing_address country\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                }\r\n\t            },\r\n\t            \"recordsOffice\": {\r\n\t                \"deliveryAddress\": {\r\n\t                    \"streetAddress\": \"delivery_address - address line one\",\r\n\t                    \"addressCity\": \"delivery_address city\",\r\n\t                    \"addressCountry\": \"delivery_address country\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                },\r\n\t                \"mailingAddress\": {\r\n\t                    \"streetAddress\": \"mailing_address - address line one\",\r\n\t                    \"addressCity\": \"mailing_address city\",\r\n\t                    \"addressCountry\": \"mailing_address country\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                }\r\n\t            }\r\n\t        },\r\n\t        \"contactPoint\": {\r\n\t            \"email\": \"no_one@never.get\",\r\n\t            \"phone\": \"123-456-7890\"\r\n\t        }\r\n    \t}\r\n    }\r\n}"
 						},
 						"url": {
-							"raw": "{{url}}/api/v1/businesses/:nr_num",
+							"raw": "{{url}}/api/v1/businesses/:nr_num/filings/:filing_id?draft=true",
 							"host": [
 								"{{url}}"
 							],
@@ -7277,12 +7395,24 @@
 								"api",
 								"v1",
 								"businesses",
-								":nr_num"
+								":nr_num",
+								"filings",
+								":filing_id"
+							],
+							"query": [
+								{
+									"key": "draft",
+									"value": "true"
+								}
 							],
 							"variable": [
 								{
 									"key": "nr_num",
 									"value": "{{nr_num}}"
+								},
+								{
+									"key": "filing_id",
+									"value": "{{filing_id}}"
 								}
 							]
 						}
@@ -7329,6 +7459,16 @@
 						}
 					],
 					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
 						"method": "POST",
 						"header": [
 							{
@@ -7339,10 +7479,10 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"filing\": {\r\n        \"header\": {\r\n        \t\"certifiedBy\": \"full name\",\r\n            \"email\": \"no_one@never.get\",\r\n            \"name\": \"incorporationApplication\",\r\n            \"date\": \"{{today}}\"\r\n        },\r\n        \"incorporationApplication\": {\r\n\t        \"nameRequest\": {\r\n\t            \"legalType\": \"BC\",\r\n\t            \"nrNumber\": \"{{nr_num}}\"\r\n\t        },\r\n\t        \"offices\": {\r\n\t            \"registeredOffice\": {\r\n\t                \"deliveryAddress\": {\r\n\t                    \"streetAddress\": \"delivery_address - address line one\",\r\n\t                    \"addressCity\": \"delivery_address city\",\r\n\t                    \"addressCountry\": \"delivery_address country\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                },\r\n\t                \"mailingAddress\": {\r\n\t                    \"streetAddress\": \"mailing_address - address line one\",\r\n\t                    \"addressCity\": \"mailing_address city\",\r\n\t                    \"addressCountry\": \"mailing_address country\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                }\r\n\t            },\r\n\t            \"recordsOffice\": {\r\n\t                \"deliveryAddress\": {\r\n\t                    \"streetAddress\": \"delivery_address - address line one\",\r\n\t                    \"addressCity\": \"delivery_address city\",\r\n\t                    \"addressCountry\": \"delivery_address country\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                },\r\n\t                \"mailingAddress\": {\r\n\t                    \"streetAddress\": \"mailing_address - address line one\",\r\n\t                    \"addressCity\": \"mailing_address city\",\r\n\t                    \"addressCountry\": \"mailing_address country\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                }\r\n\t            }\r\n\t        },\r\n\t        \"contactPoint\": {\r\n\t            \"email\": \"no_one@never.get\",\r\n\t            \"phone\": \"123-456-7890\"\r\n\t        }\r\n    \t}\r\n    }\r\n}"
+							"raw": "{\r\n    \"filing\": {\r\n        \"header\": {\r\n        \t\"certifiedBy\": \"full name\",\r\n            \"email\": \"no_one@never.get\",\r\n            \"name\": \"incorporationApplication\",\r\n            \"date\": \"{{today}}\"\r\n        },\r\n        \"incorporationApplication\": {\r\n\t        \"nameRequest\": {\r\n\t            \"legalType\": \"BC\",\r\n\t            \"nrNumber\": \"{{nr_num}}\"\r\n\t        },\r\n\t        \"offices\": {\r\n\t            \"registeredOffice\": {\r\n\t                \"deliveryAddress\": {\r\n\t                    \"streetAddress\": \"delivery_address - address line one\",\r\n\t                    \"addressCity\": \"delivery_address city\",\r\n\t                    \"addressCountry\": \"CA\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                },\r\n\t                \"mailingAddress\": {\r\n\t                    \"streetAddress\": \"mailing_address - address line one\",\r\n\t                    \"addressCity\": \"mailing_address city\",\r\n\t                    \"addressCountry\": \"CA\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                }\r\n\t            },\r\n\t            \"recordsOffice\": {\r\n\t                \"deliveryAddress\": {\r\n\t                    \"streetAddress\": \"delivery_address - address line one\",\r\n\t                    \"addressCity\": \"delivery_address city\",\r\n\t                    \"addressCountry\": \"CA\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                },\r\n\t                \"mailingAddress\": {\r\n\t                    \"streetAddress\": \"mailing_address - address line one\",\r\n\t                    \"addressCity\": \"mailing_address city\",\r\n\t                    \"addressCountry\": \"CA\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                }\r\n\t            }\r\n\t        },\r\n\t        \"contactPoint\": {\r\n\t            \"email\": \"no_one@never.get\",\r\n\t            \"phone\": \"123-456-7890\"\r\n\t        }\r\n    \t}\r\n    }\r\n}"
 						},
 						"url": {
-							"raw": "{{url}}/api/v1/businesses",
+							"raw": "{{url}}/api/v1/businesses?draft=true",
 							"host": [
 								"{{url}}"
 							],
@@ -7350,6 +7490,12 @@
 								"api",
 								"v1",
 								"businesses"
+							],
+							"query": [
+								{
+									"key": "draft",
+									"value": "true"
+								}
 							]
 						}
 					},
@@ -7375,8 +7521,8 @@
 								"exec": [
 									"var jsonData = pm.response.json()",
 									"",
-									"pm.test(\"Status code is 400\", function () {",
-									"    pm.response.to.have.status(400);",
+									"pm.test(\"Status code is 404/Not Found\", function () {",
+									"    pm.response.to.have.status(404);",
 									"});",
 									"",
 									"pm.test('should return JSON', function () {",
@@ -7385,7 +7531,7 @@
 									"",
 									"pm.test(\"Returns error message\", () => {",
 									"    pm.expect(jsonData.errors).to.exist",
-									"    pm.expect(jsonData.errors[0].message).to.contain('No incorporation filing exists')",
+									"    pm.expect(jsonData.errors[0].message).to.contain(pm.environment.get('nr_num_2') + ' not found')",
 									"});",
 									"",
 									""
@@ -7395,6 +7541,16 @@
 						}
 					],
 					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
 						"method": "PUT",
 						"header": [
 							{
@@ -7408,7 +7564,7 @@
 							"raw": "{\r\n    \"filing\": {\r\n        \"header\": {\r\n        \t\"certifiedBy\": \"full name\",\r\n            \"email\": \"no_one@never.get\",\r\n            \"name\": \"incorporationApplication\",\r\n            \"date\": \"{{today}}\"\r\n        },\r\n        \"incorporationApplication\": {\r\n\t        \"nameRequest\": {\r\n\t            \"legalType\": \"BC\",\r\n\t            \"nrNumber\": \"{{nr_num_2}}\"\r\n\t        },\r\n\t        \"offices\": {\r\n\t            \"registeredOffice\": {\r\n\t                \"deliveryAddress\": {\r\n\t                    \"streetAddress\": \"delivery_address - address line one\",\r\n\t                    \"addressCity\": \"delivery_address city\",\r\n\t                    \"addressCountry\": \"delivery_address country\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                },\r\n\t                \"mailingAddress\": {\r\n\t                    \"streetAddress\": \"mailing_address - address line one\",\r\n\t                    \"addressCity\": \"mailing_address city\",\r\n\t                    \"addressCountry\": \"mailing_address country\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                }\r\n\t            },\r\n\t            \"recordsOffice\": {\r\n\t                \"deliveryAddress\": {\r\n\t                    \"streetAddress\": \"delivery_address - address line one\",\r\n\t                    \"addressCity\": \"delivery_address city\",\r\n\t                    \"addressCountry\": \"delivery_address country\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                },\r\n\t                \"mailingAddress\": {\r\n\t                    \"streetAddress\": \"mailing_address - address line one\",\r\n\t                    \"addressCity\": \"mailing_address city\",\r\n\t                    \"addressCountry\": \"mailing_address country\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                }\r\n\t            }\r\n\t        },\r\n\t        \"contactPoint\": {\r\n\t            \"email\": \"no_one@never.get\",\r\n\t            \"phone\": \"123-456-7890\"\r\n\t        }\r\n    \t}\r\n    }\r\n}"
 						},
 						"url": {
-							"raw": "{{url}}/api/v1/businesses/:nr_num",
+							"raw": "{{url}}/api/v1/businesses/:nr_num/filings/:filing_id?draft=true",
 							"host": [
 								"{{url}}"
 							],
@@ -7416,12 +7572,24 @@
 								"api",
 								"v1",
 								"businesses",
-								":nr_num"
+								":nr_num",
+								"filings",
+								":filing_id"
+							],
+							"query": [
+								{
+									"key": "draft",
+									"value": "true"
+								}
 							],
 							"variable": [
 								{
 									"key": "nr_num",
 									"value": "{{nr_num_2}}"
+								},
+								{
+									"key": "filing_id",
+									"value": "1"
 								}
 							]
 						}
@@ -7436,6 +7604,8 @@
 							"script": {
 								"id": "886af58a-1aff-4c0b-bf8d-fe1520be03d5",
 								"exec": [
+									"// clear filing_id ",
+									"pm.environment.set('filing_id', '')",
 									""
 								],
 								"type": "text/javascript"
@@ -7450,6 +7620,88 @@
 									"",
 									"pm.test(\"Status code is 201/Created\", function () {",
 									"    pm.response.to.have.status(201);",
+									"",
+									"    ",
+									"    // success, so set filing_id",
+									"    pm.environment.set(\"filing_id\", jsonData.filing.header.filingId)",
+									"",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"filing\": {\r\n        \"header\": {\r\n        \t\"certifiedBy\": \"full name\",\r\n            \"email\": \"no_one@never.get\",\r\n            \"name\": \"incorporationApplication\",\r\n            \"date\": \"{{today}}\"\r\n        },\r\n        \"incorporationApplication\": {\r\n\t        \"nameRequest\": {\r\n\t            \"legalType\": \"BC\",\r\n\t            \"nrNumber\": \"{{nr_num_2}}\"\r\n\t        },\r\n\t        \"offices\": {\r\n\t            \"registeredOffice\": {\r\n\t                \"deliveryAddress\": {\r\n\t                    \"streetAddress\": \"delivery_address - address line one\",\r\n\t                    \"addressCity\": \"delivery_address city\",\r\n\t                    \"addressCountry\": \"CA\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                },\r\n\t                \"mailingAddress\": {\r\n\t                    \"streetAddress\": \"mailing_address - address line one\",\r\n\t                    \"addressCity\": \"mailing_address city\",\r\n\t                    \"addressCountry\": \"CA\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                }\r\n\t            },\r\n\t            \"recordsOffice\": {\r\n\t                \"deliveryAddress\": {\r\n\t                    \"streetAddress\": \"delivery_address - address line one\",\r\n\t                    \"addressCity\": \"delivery_address city\",\r\n\t                    \"addressCountry\": \"CA\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                },\r\n\t                \"mailingAddress\": {\r\n\t                    \"streetAddress\": \"mailing_address - address line one\",\r\n\t                    \"addressCity\": \"mailing_address city\",\r\n\t                    \"addressCountry\": \"CA\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                }\r\n\t            }\r\n\t        },\r\n\t        \"contactPoint\": {\r\n\t            \"email\": \"no_one@never.get\",\r\n\t            \"phone\": \"123-456-7890\"\r\n\t        }\r\n    \t}\r\n    }\r\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/businesses?draft=true",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"businesses"
+							],
+							"query": [
+								{
+									"key": "draft",
+									"value": "true"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "Filing Comments/Details",
+			"item": [
+				{
+					"name": "authenticate as staff",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "c6720c75-f388-4f9a-a157-c4b4b560a99f",
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Response time is less than 10000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(10000);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Returns the access token\", () => {",
+									"    pm.expect(jsonData.access_token).to.exist",
+									"    pm.environment.set(\"token\", jsonData['access_token'])",
 									"});",
 									""
 								],
@@ -7462,35 +7714,1065 @@
 						"header": [
 							{
 								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"username\":\"{{staff_username}}\", \"password\":\"{{staff_password}}\"}"
+						},
+						"url": {
+							"raw": "{{tokenUrl}}",
+							"host": [
+								"{{tokenUrl}}"
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "authenticate",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\"username\":\"coops-updater-job\", \"password\":\"coops-updater-job\"}"
+								},
+								"url": {
+									"raw": "{{get_token_url}}",
+									"host": [
+										"{{get_token_url}}"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "html",
+							"header": [
+								{
+									"key": "Server",
+									"value": "gunicorn/19.9.0"
+								},
+								{
+									"key": "Date",
+									"value": "Tue, 30 Jul 2019 18:39:41 GMT"
+								},
+								{
+									"key": "Content-Type",
+									"value": "text/html; charset=utf-8"
+								},
+								{
+									"key": "Access-Control-Allow-Origin",
+									"value": "*"
+								},
+								{
+									"key": "Access-Control-Allow-Methods",
+									"value": "POST, OPTIONS"
+								},
+								{
+									"key": "Access-Control-Max-Age",
+									"value": "21600"
+								},
+								{
+									"key": "API",
+									"value": "auth_api/0.1.0a0.dev-462c33674f5ae76b1e8ef2f968e55f41f26d8f95"
+								}
+							],
+							"cookie": [],
+							"body": "{\"access_token\": \"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJUbWdtZUk0MnVsdUZ0N3FQbmUtcTEzdDUwa0JDbjF3bHF6dHN0UGdUM1dFIn0.eyJqdGkiOiI4NmQzMGNhNi04ZmM2LTRiMDctYWFmNS1mYWEzMjg0ODk0NzciLCJleHAiOjE1NjQ1OTgzODEsIm5iZiI6MCwiaWF0IjoxNTY0NTExOTgxLCJpc3MiOiJodHRwczovL3Nzby1kZXYucGF0aGZpbmRlci5nb3YuYmMuY2EvYXV0aC9yZWFsbXMvZmNmMGtwcXIiLCJhdWQiOiJzYmMtYXV0aC13ZWIiLCJzdWIiOiI1MmRjZDNjZi1jMmNmLTQ1NWQtYjY4Zi04NTU4NTcyMjg1OTEiLCJ0eXAiOiJCZWFyZXIiLCJhenAiOiJzYmMtYXV0aC13ZWIiLCJhdXRoX3RpbWUiOjAsInNlc3Npb25fc3RhdGUiOiJkMjQ3YjhlZS1kMGI3LTQxZDgtYTA1Yy0yZGVlY2UyNmMxMTIiLCJhY3IiOiIxIiwiYWxsb3dlZC1vcmlnaW5zIjpbImh0dHA6Ly8xOTIuMTY4LjAuMTM6ODA4MC8iLCIxOTIuMTY4LjAuMTMiLCIqIiwiaHR0cDovLzE5Mi4xNjguMC4xMzo4MDgwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJjb2xpbiIsInVtYV9hdXRob3JpemF0aW9uIiwiam9iIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwicHJlZmVycmVkX3VzZXJuYW1lIjoiY29vcHMtdXBkYXRlci1qb2IiLCJ1c2VybmFtZSI6ImNvb3BzLXVwZGF0ZXItam9iIn0.Bbr9ehKYRfUvFLhjtfR3QfzRx5ItZzTWjdtxevBh1kPLhhSIqH456LBLh96vUOCqA3X2MsWpqFQrKRHdhxe5mkisXFME3J3dQKXcXnGJSsam8yRfDtMyre1DYC6bo3tIujtwr7G6OMwotcz_hGqYKm_8FjsNIKOXcMv9S88NNKohj_o9F6RXgq9JnTTP2fZakpqYn2E4imLmOSIK7ft2ODfCyH74owd35NQBse4U0B7YAvlsFjtyFInzO5wGXCzVUnS99vm4Hv4JMTsQz5R4S_HlTVwM5jAJGn4ZXu_QK6tH8J78t-7MZQn39QEdGHtf-oc4RyRGLIPdqp7wsvwfJw\", \"expires_in\": 86400, \"refresh_expires_in\": 86400, \"refresh_token\": \"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJUbWdtZUk0MnVsdUZ0N3FQbmUtcTEzdDUwa0JDbjF3bHF6dHN0UGdUM1dFIn0.eyJqdGkiOiI2M2UwMGYwMi00MGNjLTQzOTUtYTJlMS00MjliOTViMDQ5ODMiLCJleHAiOjE1NjQ1OTgzODEsIm5iZiI6MCwiaWF0IjoxNTY0NTExOTgxLCJpc3MiOiJodHRwczovL3Nzby1kZXYucGF0aGZpbmRlci5nb3YuYmMuY2EvYXV0aC9yZWFsbXMvZmNmMGtwcXIiLCJhdWQiOiJzYmMtYXV0aC13ZWIiLCJzdWIiOiI1MmRjZDNjZi1jMmNmLTQ1NWQtYjY4Zi04NTU4NTcyMjg1OTEiLCJ0eXAiOiJSZWZyZXNoIiwiYXpwIjoic2JjLWF1dGgtd2ViIiwiYXV0aF90aW1lIjowLCJzZXNzaW9uX3N0YXRlIjoiZDI0N2I4ZWUtZDBiNy00MWQ4LWEwNWMtMmRlZWNlMjZjMTEyIiwicmVhbG1fYWNjZXNzIjp7InJvbGVzIjpbImNvbGluIiwidW1hX2F1dGhvcml6YXRpb24iLCJqb2IiXX0sInJlc291cmNlX2FjY2VzcyI6eyJhY2NvdW50Ijp7InJvbGVzIjpbIm1hbmFnZS1hY2NvdW50IiwibWFuYWdlLWFjY291bnQtbGlua3MiLCJ2aWV3LXByb2ZpbGUiXX19fQ.HYmcM0cM2kVtB81mvqjVe5A3wtDW8ERidoC0M-vkSNVTscb6GuqEvaw_0w2jXZJccAhXlmKdKIb_YLWrSAg_hYJz04rj-Vw3r7TuE_I_tpAMbycsSBEb9XREGV9XNTzYk1SNAGQGsQrCDXOZWqKaAR8_QkISLRlnHmwyLXM-FrgJk8Msh37z4nnmF5dr68d5mavx6AfDJdlxx-c6A7pUaKVaQhPnzSdy80Hdew8zLUUS1oWLCMsUosDNBosv0nnfpDEaScSAxrqimIhjVRWOGZDEa3b9qkXf1pgPDU6We_n17aA77ytgepbMJNqqOLPZkZNEF9gQIJ7l0dPQGCE_vw\", \"token_type\": \"bearer\", \"not-before-policy\": 1562910731, \"session_state\": \"d247b8ee-d0b7-41d8-a05c-2deece26c112\", \"registries-trace-id\": \"f2dfaa910187eccb:f42fb400f9f894ac:f2dfaa910187eccb:1\"}"
+						}
+					]
+				},
+				{
+					"name": "post - create a comment",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9178a795-5b99-4f0d-87c4-012aeeaef580",
+								"exec": [
+									"var jsonData = pm.response.json()",
+									"",
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"",
+									"    // save comment id",
+									"    comment_id = jsonData.comment.id",
+									"    pm.environment.set('comment_id', comment_id)",
+									"    ",
+									"});",
+									"",
+									"pm.test('should return JSON', function () {",
+									"    pm.response.to.have.header('Content-Type', 'application/json');",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "b93cfbb3-3f85-4112-939d-56f996ff07a6",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
 								"type": "text",
 								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"filing\": {\r\n        \"header\": {\r\n        \t\"certifiedBy\": \"full name\",\r\n            \"email\": \"no_one@never.get\",\r\n            \"name\": \"incorporationApplication\",\r\n            \"date\": \"{{today}}\"\r\n        },\r\n        \"incorporationApplication\": {\r\n\t        \"nameRequest\": {\r\n\t            \"legalType\": \"BC\",\r\n\t            \"nrNumber\": \"{{nr_num_2}}\"\r\n\t        },\r\n\t        \"offices\": {\r\n\t            \"registeredOffice\": {\r\n\t                \"deliveryAddress\": {\r\n\t                    \"streetAddress\": \"delivery_address - address line one\",\r\n\t                    \"addressCity\": \"delivery_address city\",\r\n\t                    \"addressCountry\": \"delivery_address country\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                },\r\n\t                \"mailingAddress\": {\r\n\t                    \"streetAddress\": \"mailing_address - address line one\",\r\n\t                    \"addressCity\": \"mailing_address city\",\r\n\t                    \"addressCountry\": \"mailing_address country\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                }\r\n\t            },\r\n\t            \"recordsOffice\": {\r\n\t                \"deliveryAddress\": {\r\n\t                    \"streetAddress\": \"delivery_address - address line one\",\r\n\t                    \"addressCity\": \"delivery_address city\",\r\n\t                    \"addressCountry\": \"delivery_address country\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                },\r\n\t                \"mailingAddress\": {\r\n\t                    \"streetAddress\": \"mailing_address - address line one\",\r\n\t                    \"addressCity\": \"mailing_address city\",\r\n\t                    \"addressCountry\": \"mailing_address country\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                }\r\n\t            }\r\n\t        },\r\n\t        \"contactPoint\": {\r\n\t            \"email\": \"no_one@never.get\",\r\n\t            \"phone\": \"123-456-7890\"\r\n\t        }\r\n    \t}\r\n    }\r\n}"
+							"raw": "{\n    \"comment\": {\n    \t\"comment\": \"this is a test from postman\",\n    \t\"filingId\": {{comment_filing_id}}\n    }\n}"
 						},
 						"url": {
-							"raw": "{{url}}/api/v1/businesses",
+							"raw": "{{url}}/api/v1/businesses/:id/filings/:filing_id/comments",
 							"host": [
 								"{{url}}"
 							],
 							"path": [
 								"api",
 								"v1",
-								"businesses"
+								"businesses",
+								":id",
+								"filings",
+								":filing_id",
+								"comments"
+							],
+							"query": [
+								{
+									"key": "only_validate",
+									"value": "true",
+									"disabled": true
+								}
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "CP1000001"
+								},
+								{
+									"key": "filing_id",
+									"value": "{{comment_filing_id}}"
+								}
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "post - annual report - Save Draft",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"filing\": {\n        \"header\": {\n        \t\"certifiedBy\": \"full name\",\n            \"email\": \"no_one@never.get\",\n            \"name\": \"annualReport\",\n            \"date\": \"{{today}}\"\n        },\n        \"business\": {\n\t        \"fiscalYearEndDate\": \"2019-08-28\",\n\t        \"foundingDate\": \"1982-06-08T00:00:00+00:00\",\n\t        \"identifier\": \"CP1000001\",\n\t        \"lastAnnualGeneralMeetingDate\": \"2018-08-11\",\n\t        \"lastAnnualReport\": \"2018-08-11\",\n\t        \"lastLedgerTimestamp\": \"2018-08-29T00:00:00+00:00\",\n\t        \"lastModified\": \"2019-08-28T18:12:08.102010+00:00\",\n\t        \"legalName\": \"MERIDIAN GARDENS COOPERATIVE ASSOCIATION\"\n\t    },\n        \"annualReport\": {\n            \"annualGeneralMeetingDate\": \"2019-04-08\",\n            \"annualReportDate\": \"2019{{ar_date_info}}\",\n        \t\"directors\": [\n\t\t        {\n\t\t            \"appointmentDate\": \"2017-10-23\",\n\t\t            \"cessationDate\": null,\n\t\t            \"deliveryAddress\": {\n\t\t                \"addressCity\": \"PARKSVILLE\",\n\t\t                \"addressCountry\": \"CA\",\n\t\t                \"addressRegion\": \"BC\",\n\t\t                \"deliveryInstructions\": \"\",\n\t\t                \"postalCode\": \"V8N 4R7\",\n\t\t                \"streetAddress\": \"UNIT I 394 CRAIG ST.\",\n\t\t                \"streetAddressAdditional\": \"\"\n\t\t            },\n\t\t            \"officer\": {\n\t\t                \"firstName\": \"WENDY\",\n\t\t                \"lastName\": \"HAMPTON\"\n\t\t            }\n\t\t        },\n\t\t        {\n\t\t            \"appointmentDate\": \"2017-10-23\",\n\t\t            \"cessationDate\": null,\n\t\t            \"deliveryAddress\": {\n\t\t                \"addressCity\": \"PARKSVILLE\",\n\t\t                \"addressCountry\": \"CA\",\n\t\t                \"addressRegion\": \"BC\",\n\t\t                \"deliveryInstructions\": \"\",\n\t\t                \"postalCode\": \"V8N 4R7\",\n\t\t                \"streetAddress\": \"UNIT K 394 CRAIG ST.\",\n\t\t                \"streetAddressAdditional\": \"\"\n\t\t            },\n\t\t            \"officer\": {\n\t\t                \"firstName\": \"ANN\",\n\t\t                \"lastName\": \"MOORE\"\n\t\t            }\n\t\t        },\n\t\t        {\n\t\t            \"appointmentDate\": \"2018-08-29\",\n\t\t            \"cessationDate\": null,\n\t\t            \"deliveryAddress\": {\n\t\t                \"addressCity\": \"PARKSVILLE\",\n\t\t                \"addressCountry\": \"CA\",\n\t\t                \"addressRegion\": \"BC\",\n\t\t                \"deliveryInstructions\": \"\",\n\t\t                \"postalCode\": \"V8N 4R7\",\n\t\t                \"streetAddress\": \"B - 394 CRAIG STREET\",\n\t\t                \"streetAddressAdditional\": \"\"\n\t\t            },\n\t\t            \"officer\": {\n\t\t                \"firstName\": \"INA\",\n\t\t                \"lastName\": \"BOTHMA\"\n\t\t            }\n\t\t        },\n\t\t        {\n\t\t            \"appointmentDate\": \"2018-08-29\",\n\t\t            \"cessationDate\": null,\n\t\t            \"deliveryAddress\": {\n\t\t                \"addressCity\": \"PARKSVILLE\",\n\t\t                \"addressCountry\": \"CA\",\n\t\t                \"addressRegion\": \"BC\",\n\t\t                \"deliveryInstructions\": \"\",\n\t\t                \"postalCode\": \"V8N 4R7\",\n\t\t                \"streetAddress\": \"H - 394 CRAIG STREET\",\n\t\t                \"streetAddressAdditional\": \"\"\n\t\t            },\n\t\t            \"officer\": {\n\t\t                \"firstName\": \"E. MARY\",\n\t\t                \"lastName\": \"SURTEL\"\n\t\t            }\n\t\t        }\n\t\t    ],\n\t\t\t\"deliveryAddress\": {\n\t\t        \"addressCity\": \"PARKSVILLE\",\n\t\t        \"addressCountry\": \"CA\",\n\t\t        \"addressRegion\": \"BC\",\n\t\t        \"addressType\": \"delivery\",\n\t\t        \"deliveryInstructions\": \"\",\n\t\t        \"postalCode\": \"V8N 4R7\",\n\t\t        \"streetAddress\": \"118 MCMILLAN STREET\",\n\t\t        \"streetAddressAdditional\": \"\"\n\t\t    },\n\t\t    \"mailingAddress\": {\n\t\t        \"addressCity\": \"PARKSVILLE\",\n\t\t        \"addressCountry\": \"CA\",\n\t\t        \"addressRegion\": \"BC\",\n\t\t        \"addressType\": \"mailing\",\n\t\t        \"deliveryInstructions\": \"\",\n\t\t        \"postalCode\": \"V8N 4R7\",\n\t\t        \"streetAddress\": \"PO BOX 580\",\n\t\t        \"streetAddressAdditional\": \"\"\n\t\t    }\n        }\n    }\n}"
+								},
+								"url": {
+									"raw": "{{url}}/api/v1/businesses/:id/filings?draft=true",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"businesses",
+										":id",
+										"filings"
+									],
+									"query": [
+										{
+											"key": "draft",
+											"value": "true"
+										},
+										{
+											"key": "only_validate",
+											"value": "true",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "CP1000001"
+										}
+									]
+								}
+							},
+							"status": "CREATED",
+							"code": 201,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Server",
+									"value": "gunicorn/19.9.0"
+								},
+								{
+									"key": "Date",
+									"value": "Thu, 29 Aug 2019 15:59:14 GMT"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Access-Control-Allow-Origin",
+									"value": "*"
+								},
+								{
+									"key": "Access-Control-Allow-Methods",
+									"value": "DELETE, HEAD, PUT, POST, GET, OPTIONS"
+								},
+								{
+									"key": "Access-Control-Max-Age",
+									"value": "21600"
+								},
+								{
+									"key": "API",
+									"value": "legal_api/1.0.0-e1641cb346253fa39582358ee8904abfd5c821bc"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"errors\": [\n        null\n    ],\n    \"filing\": {\n        \"annualReport\": {\n            \"annualGeneralMeetingDate\": \"2019-04-08\",\n            \"annualReportDate\": \"2019-08-29\",\n            \"deliveryAddress\": {\n                \"addressCity\": \"PARKSVILLE\",\n                \"addressCountry\": \"CA\",\n                \"addressRegion\": \"BC\",\n                \"addressType\": \"delivery\",\n                \"deliveryInstructions\": \"\",\n                \"postalCode\": \"V8N 4R7\",\n                \"streetAddress\": \"118 MCMILLAN STREET\",\n                \"streetAddressAdditional\": \"\"\n            },\n            \"directors\": [\n                {\n                    \"appointmentDate\": \"2017-10-23\",\n                    \"cessationDate\": null,\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"PARKSVILLE\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"deliveryInstructions\": \"\",\n                        \"postalCode\": \"V8N 4R7\",\n                        \"streetAddress\": \"UNIT I 394 CRAIG ST.\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"WENDY\",\n                        \"lastName\": \"HAMPTON\"\n                    }\n                },\n                {\n                    \"appointmentDate\": \"2017-10-23\",\n                    \"cessationDate\": null,\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"PARKSVILLE\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"deliveryInstructions\": \"\",\n                        \"postalCode\": \"V8N 4R7\",\n                        \"streetAddress\": \"UNIT K 394 CRAIG ST.\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"ANN\",\n                        \"lastName\": \"MOORE\"\n                    }\n                },\n                {\n                    \"appointmentDate\": \"2018-08-29\",\n                    \"cessationDate\": null,\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"PARKSVILLE\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"deliveryInstructions\": \"\",\n                        \"postalCode\": \"V8N 4R7\",\n                        \"streetAddress\": \"B - 394 CRAIG STREET\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"INA\",\n                        \"lastName\": \"BOTHMA\"\n                    }\n                },\n                {\n                    \"appointmentDate\": \"2018-08-29\",\n                    \"cessationDate\": null,\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"PARKSVILLE\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"deliveryInstructions\": \"\",\n                        \"postalCode\": \"V8N 4R7\",\n                        \"streetAddress\": \"H - 394 CRAIG STREET\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"E. MARY\",\n                        \"lastName\": \"SURTEL\"\n                    }\n                }\n            ],\n            \"mailingAddress\": {\n                \"addressCity\": \"PARKSVILLE\",\n                \"addressCountry\": \"CA\",\n                \"addressRegion\": \"BC\",\n                \"addressType\": \"mailing\",\n                \"deliveryInstructions\": \"\",\n                \"postalCode\": \"V8N 4R7\",\n                \"streetAddress\": \"PO BOX 580\",\n                \"streetAddressAdditional\": \"\"\n            }\n        },\n        \"business\": {\n            \"fiscalYearEndDate\": \"2019-08-28\",\n            \"foundingDate\": \"1982-06-08T00:00:00+00:00\",\n            \"identifier\": \"CP1000001\",\n            \"lastAnnualGeneralMeetingDate\": \"2018-08-11\",\n            \"lastAnnualReport\": \"2018-08-11\",\n            \"lastLedgerTimestamp\": \"2018-08-29T00:00:00+00:00\",\n            \"lastModified\": \"2019-08-28T18:12:08.102010+00:00\",\n            \"legalName\": \"MERIDIAN GARDENS COOPERATIVE ASSOCIATION\"\n        },\n        \"header\": {\n            \"certifiedBy\": \"full name\",\n            \"colinId\": null,\n            \"date\": \"2019-08-29\",\n            \"email\": \"no_one@never.get\",\n            \"filingId\": 77,\n            \"name\": \"annualReport\",\n            \"status\": \"DRAFT\",\n            \"submitter\": \"CP1000001\"\n        }\n    }\n}"
+						}
+					]
+				},
+				{
+					"name": "get comments",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "effee34c-2213-4369-b93b-09b323d1ae69",
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test('should return JSON', function () {",
+									"    pm.response.to.have.header('Content-Type', 'application/json');",
+									"});",
+									"",
+									"pm.test(\"Returns comments.\", () => {",
+									"    pm.expect(jsonData.comments).to.exist",
+									"    pm.expect(jsonData.comments.length).to.be.at.least(1)",
+									"    pm.expect(jsonData.comments[0].comment.comment).to.eql('this is a test from postman')",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{url}}/api/v1/businesses/:id/filings/:filing_id/comments",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"businesses",
+								":id",
+								"filings",
+								":filing_id",
+								"comments"
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "CP1000001"
+								},
+								{
+									"key": "filing_id",
+									"value": "{{comment_filing_id}}"
+								}
 							]
 						}
 					},
 					"response": []
 				},
 				{
-					"name": "Save draft  - fail, identifier mismatch",
+					"name": "get filing, check for comments",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "effee34c-2213-4369-b93b-09b323d1ae69",
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test('should return JSON', function () {",
+									"    pm.response.to.have.header('Content-Type', 'application/json');",
+									"});",
+									"",
+									"pm.test(\"Returns comments in filing header.\", () => {",
+									"    pm.expect(jsonData.filing.header.comments).to.exist",
+									"    pm.expect(jsonData.filing.header.comments.length).to.be.at.least(1)",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{url}}/api/v1/businesses/:id/filings/:filing_id",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"businesses",
+								":id",
+								"filings",
+								":filing_id"
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "CP1000001"
+								},
+								{
+									"key": "filing_id",
+									"value": "{{comment_filing_id}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "get a single comment",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "effee34c-2213-4369-b93b-09b323d1ae69",
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test('should return JSON', function () {",
+									"    pm.response.to.have.header('Content-Type', 'application/json');",
+									"});",
+									"",
+									"pm.test(\"Returns a single comment.\", () => {",
+									"    pm.expect(jsonData.comment).to.exist",
+									"    pm.expect(jsonData.comment.comment).to.eql('this is a test from postman')",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{url}}/api/v1/businesses/:id/filings/:filing_id/comments/:comment_id",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"businesses",
+								":id",
+								"filings",
+								":filing_id",
+								"comments",
+								":comment_id"
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "CP1000001"
+								},
+								{
+									"key": "filing_id",
+									"value": "{{comment_filing_id}}"
+								},
+								{
+									"key": "comment_id",
+									"value": "{{comment_id}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "get comments - fail - business/filing mismatch",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "effee34c-2213-4369-b93b-09b323d1ae69",
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Status code is 500\", function () {",
+									"    pm.response.to.have.status(500);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{url}}/api/v1/businesses/:id/filings/:filing_id/comments",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"businesses",
+								":id",
+								"filings",
+								":filing_id",
+								"comments"
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "CP1000002"
+								},
+								{
+									"key": "filing_id",
+									"value": "{{comment_filing_id}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "post - fail - invalid filing",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9178a795-5b99-4f0d-87c4-012aeeaef580",
+								"exec": [
+									"var jsonData = pm.response.json()",
+									"",
+									"pm.test(\"Status code is 404\", function () {",
+									"    pm.response.to.have.status(404);",
+									"",
+									"});",
+									"",
+									"pm.test('should return JSON', function () {",
+									"    pm.response.to.have.header('Content-Type', 'application/json');",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "b93cfbb3-3f85-4112-939d-56f996ff07a6",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"comment\": {\n    \t\"comment\": \"this is a test from postman\",\n    \t\"filingId\": 2\n    }\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/businesses/:id/filings/:filing_id/comments",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"businesses",
+								":id",
+								"filings",
+								":filing_id",
+								"comments"
+							],
+							"query": [
+								{
+									"key": "only_validate",
+									"value": "true",
+									"disabled": true
+								}
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "CP1000001"
+								},
+								{
+									"key": "filing_id",
+									"value": "2"
+								}
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "post - annual report - Save Draft",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"filing\": {\n        \"header\": {\n        \t\"certifiedBy\": \"full name\",\n            \"email\": \"no_one@never.get\",\n            \"name\": \"annualReport\",\n            \"date\": \"{{today}}\"\n        },\n        \"business\": {\n\t        \"fiscalYearEndDate\": \"2019-08-28\",\n\t        \"foundingDate\": \"1982-06-08T00:00:00+00:00\",\n\t        \"identifier\": \"CP1000001\",\n\t        \"lastAnnualGeneralMeetingDate\": \"2018-08-11\",\n\t        \"lastAnnualReport\": \"2018-08-11\",\n\t        \"lastLedgerTimestamp\": \"2018-08-29T00:00:00+00:00\",\n\t        \"lastModified\": \"2019-08-28T18:12:08.102010+00:00\",\n\t        \"legalName\": \"MERIDIAN GARDENS COOPERATIVE ASSOCIATION\"\n\t    },\n        \"annualReport\": {\n            \"annualGeneralMeetingDate\": \"2019-04-08\",\n            \"annualReportDate\": \"2019{{ar_date_info}}\",\n        \t\"directors\": [\n\t\t        {\n\t\t            \"appointmentDate\": \"2017-10-23\",\n\t\t            \"cessationDate\": null,\n\t\t            \"deliveryAddress\": {\n\t\t                \"addressCity\": \"PARKSVILLE\",\n\t\t                \"addressCountry\": \"CA\",\n\t\t                \"addressRegion\": \"BC\",\n\t\t                \"deliveryInstructions\": \"\",\n\t\t                \"postalCode\": \"V8N 4R7\",\n\t\t                \"streetAddress\": \"UNIT I 394 CRAIG ST.\",\n\t\t                \"streetAddressAdditional\": \"\"\n\t\t            },\n\t\t            \"officer\": {\n\t\t                \"firstName\": \"WENDY\",\n\t\t                \"lastName\": \"HAMPTON\"\n\t\t            }\n\t\t        },\n\t\t        {\n\t\t            \"appointmentDate\": \"2017-10-23\",\n\t\t            \"cessationDate\": null,\n\t\t            \"deliveryAddress\": {\n\t\t                \"addressCity\": \"PARKSVILLE\",\n\t\t                \"addressCountry\": \"CA\",\n\t\t                \"addressRegion\": \"BC\",\n\t\t                \"deliveryInstructions\": \"\",\n\t\t                \"postalCode\": \"V8N 4R7\",\n\t\t                \"streetAddress\": \"UNIT K 394 CRAIG ST.\",\n\t\t                \"streetAddressAdditional\": \"\"\n\t\t            },\n\t\t            \"officer\": {\n\t\t                \"firstName\": \"ANN\",\n\t\t                \"lastName\": \"MOORE\"\n\t\t            }\n\t\t        },\n\t\t        {\n\t\t            \"appointmentDate\": \"2018-08-29\",\n\t\t            \"cessationDate\": null,\n\t\t            \"deliveryAddress\": {\n\t\t                \"addressCity\": \"PARKSVILLE\",\n\t\t                \"addressCountry\": \"CA\",\n\t\t                \"addressRegion\": \"BC\",\n\t\t                \"deliveryInstructions\": \"\",\n\t\t                \"postalCode\": \"V8N 4R7\",\n\t\t                \"streetAddress\": \"B - 394 CRAIG STREET\",\n\t\t                \"streetAddressAdditional\": \"\"\n\t\t            },\n\t\t            \"officer\": {\n\t\t                \"firstName\": \"INA\",\n\t\t                \"lastName\": \"BOTHMA\"\n\t\t            }\n\t\t        },\n\t\t        {\n\t\t            \"appointmentDate\": \"2018-08-29\",\n\t\t            \"cessationDate\": null,\n\t\t            \"deliveryAddress\": {\n\t\t                \"addressCity\": \"PARKSVILLE\",\n\t\t                \"addressCountry\": \"CA\",\n\t\t                \"addressRegion\": \"BC\",\n\t\t                \"deliveryInstructions\": \"\",\n\t\t                \"postalCode\": \"V8N 4R7\",\n\t\t                \"streetAddress\": \"H - 394 CRAIG STREET\",\n\t\t                \"streetAddressAdditional\": \"\"\n\t\t            },\n\t\t            \"officer\": {\n\t\t                \"firstName\": \"E. MARY\",\n\t\t                \"lastName\": \"SURTEL\"\n\t\t            }\n\t\t        }\n\t\t    ],\n\t\t\t\"deliveryAddress\": {\n\t\t        \"addressCity\": \"PARKSVILLE\",\n\t\t        \"addressCountry\": \"CA\",\n\t\t        \"addressRegion\": \"BC\",\n\t\t        \"addressType\": \"delivery\",\n\t\t        \"deliveryInstructions\": \"\",\n\t\t        \"postalCode\": \"V8N 4R7\",\n\t\t        \"streetAddress\": \"118 MCMILLAN STREET\",\n\t\t        \"streetAddressAdditional\": \"\"\n\t\t    },\n\t\t    \"mailingAddress\": {\n\t\t        \"addressCity\": \"PARKSVILLE\",\n\t\t        \"addressCountry\": \"CA\",\n\t\t        \"addressRegion\": \"BC\",\n\t\t        \"addressType\": \"mailing\",\n\t\t        \"deliveryInstructions\": \"\",\n\t\t        \"postalCode\": \"V8N 4R7\",\n\t\t        \"streetAddress\": \"PO BOX 580\",\n\t\t        \"streetAddressAdditional\": \"\"\n\t\t    }\n        }\n    }\n}"
+								},
+								"url": {
+									"raw": "{{url}}/api/v1/businesses/:id/filings?draft=true",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"businesses",
+										":id",
+										"filings"
+									],
+									"query": [
+										{
+											"key": "draft",
+											"value": "true"
+										},
+										{
+											"key": "only_validate",
+											"value": "true",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "CP1000001"
+										}
+									]
+								}
+							},
+							"status": "CREATED",
+							"code": 201,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Server",
+									"value": "gunicorn/19.9.0"
+								},
+								{
+									"key": "Date",
+									"value": "Thu, 29 Aug 2019 15:59:14 GMT"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Access-Control-Allow-Origin",
+									"value": "*"
+								},
+								{
+									"key": "Access-Control-Allow-Methods",
+									"value": "DELETE, HEAD, PUT, POST, GET, OPTIONS"
+								},
+								{
+									"key": "Access-Control-Max-Age",
+									"value": "21600"
+								},
+								{
+									"key": "API",
+									"value": "legal_api/1.0.0-e1641cb346253fa39582358ee8904abfd5c821bc"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"errors\": [\n        null\n    ],\n    \"filing\": {\n        \"annualReport\": {\n            \"annualGeneralMeetingDate\": \"2019-04-08\",\n            \"annualReportDate\": \"2019-08-29\",\n            \"deliveryAddress\": {\n                \"addressCity\": \"PARKSVILLE\",\n                \"addressCountry\": \"CA\",\n                \"addressRegion\": \"BC\",\n                \"addressType\": \"delivery\",\n                \"deliveryInstructions\": \"\",\n                \"postalCode\": \"V8N 4R7\",\n                \"streetAddress\": \"118 MCMILLAN STREET\",\n                \"streetAddressAdditional\": \"\"\n            },\n            \"directors\": [\n                {\n                    \"appointmentDate\": \"2017-10-23\",\n                    \"cessationDate\": null,\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"PARKSVILLE\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"deliveryInstructions\": \"\",\n                        \"postalCode\": \"V8N 4R7\",\n                        \"streetAddress\": \"UNIT I 394 CRAIG ST.\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"WENDY\",\n                        \"lastName\": \"HAMPTON\"\n                    }\n                },\n                {\n                    \"appointmentDate\": \"2017-10-23\",\n                    \"cessationDate\": null,\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"PARKSVILLE\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"deliveryInstructions\": \"\",\n                        \"postalCode\": \"V8N 4R7\",\n                        \"streetAddress\": \"UNIT K 394 CRAIG ST.\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"ANN\",\n                        \"lastName\": \"MOORE\"\n                    }\n                },\n                {\n                    \"appointmentDate\": \"2018-08-29\",\n                    \"cessationDate\": null,\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"PARKSVILLE\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"deliveryInstructions\": \"\",\n                        \"postalCode\": \"V8N 4R7\",\n                        \"streetAddress\": \"B - 394 CRAIG STREET\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"INA\",\n                        \"lastName\": \"BOTHMA\"\n                    }\n                },\n                {\n                    \"appointmentDate\": \"2018-08-29\",\n                    \"cessationDate\": null,\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"PARKSVILLE\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"deliveryInstructions\": \"\",\n                        \"postalCode\": \"V8N 4R7\",\n                        \"streetAddress\": \"H - 394 CRAIG STREET\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"E. MARY\",\n                        \"lastName\": \"SURTEL\"\n                    }\n                }\n            ],\n            \"mailingAddress\": {\n                \"addressCity\": \"PARKSVILLE\",\n                \"addressCountry\": \"CA\",\n                \"addressRegion\": \"BC\",\n                \"addressType\": \"mailing\",\n                \"deliveryInstructions\": \"\",\n                \"postalCode\": \"V8N 4R7\",\n                \"streetAddress\": \"PO BOX 580\",\n                \"streetAddressAdditional\": \"\"\n            }\n        },\n        \"business\": {\n            \"fiscalYearEndDate\": \"2019-08-28\",\n            \"foundingDate\": \"1982-06-08T00:00:00+00:00\",\n            \"identifier\": \"CP1000001\",\n            \"lastAnnualGeneralMeetingDate\": \"2018-08-11\",\n            \"lastAnnualReport\": \"2018-08-11\",\n            \"lastLedgerTimestamp\": \"2018-08-29T00:00:00+00:00\",\n            \"lastModified\": \"2019-08-28T18:12:08.102010+00:00\",\n            \"legalName\": \"MERIDIAN GARDENS COOPERATIVE ASSOCIATION\"\n        },\n        \"header\": {\n            \"certifiedBy\": \"full name\",\n            \"colinId\": null,\n            \"date\": \"2019-08-29\",\n            \"email\": \"no_one@never.get\",\n            \"filingId\": 77,\n            \"name\": \"annualReport\",\n            \"status\": \"DRAFT\",\n            \"submitter\": \"CP1000001\"\n        }\n    }\n}"
+						}
+					]
+				},
+				{
+					"name": "post - fail - mismatch filing in json",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9178a795-5b99-4f0d-87c4-012aeeaef580",
+								"exec": [
+									"var jsonData = pm.response.json()",
+									"",
+									"pm.test(\"Status code is 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"",
+									"});",
+									"",
+									"pm.test('should return JSON', function () {",
+									"    pm.response.to.have.header('Content-Type', 'application/json');",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "b93cfbb3-3f85-4112-939d-56f996ff07a6",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"comment\": {\n    \t\"comment\": \"this is a test from postman\",\n    \t\"filingId\": 2\n    }\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/businesses/:id/filings/:filing_id/comments",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"businesses",
+								":id",
+								"filings",
+								":filing_id",
+								"comments"
+							],
+							"query": [
+								{
+									"key": "only_validate",
+									"value": "true",
+									"disabled": true
+								}
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "CP1000001"
+								},
+								{
+									"key": "filing_id",
+									"value": "{{comment_filing_id}}"
+								}
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "post - annual report - Save Draft",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"filing\": {\n        \"header\": {\n        \t\"certifiedBy\": \"full name\",\n            \"email\": \"no_one@never.get\",\n            \"name\": \"annualReport\",\n            \"date\": \"{{today}}\"\n        },\n        \"business\": {\n\t        \"fiscalYearEndDate\": \"2019-08-28\",\n\t        \"foundingDate\": \"1982-06-08T00:00:00+00:00\",\n\t        \"identifier\": \"CP1000001\",\n\t        \"lastAnnualGeneralMeetingDate\": \"2018-08-11\",\n\t        \"lastAnnualReport\": \"2018-08-11\",\n\t        \"lastLedgerTimestamp\": \"2018-08-29T00:00:00+00:00\",\n\t        \"lastModified\": \"2019-08-28T18:12:08.102010+00:00\",\n\t        \"legalName\": \"MERIDIAN GARDENS COOPERATIVE ASSOCIATION\"\n\t    },\n        \"annualReport\": {\n            \"annualGeneralMeetingDate\": \"2019-04-08\",\n            \"annualReportDate\": \"2019{{ar_date_info}}\",\n        \t\"directors\": [\n\t\t        {\n\t\t            \"appointmentDate\": \"2017-10-23\",\n\t\t            \"cessationDate\": null,\n\t\t            \"deliveryAddress\": {\n\t\t                \"addressCity\": \"PARKSVILLE\",\n\t\t                \"addressCountry\": \"CA\",\n\t\t                \"addressRegion\": \"BC\",\n\t\t                \"deliveryInstructions\": \"\",\n\t\t                \"postalCode\": \"V8N 4R7\",\n\t\t                \"streetAddress\": \"UNIT I 394 CRAIG ST.\",\n\t\t                \"streetAddressAdditional\": \"\"\n\t\t            },\n\t\t            \"officer\": {\n\t\t                \"firstName\": \"WENDY\",\n\t\t                \"lastName\": \"HAMPTON\"\n\t\t            }\n\t\t        },\n\t\t        {\n\t\t            \"appointmentDate\": \"2017-10-23\",\n\t\t            \"cessationDate\": null,\n\t\t            \"deliveryAddress\": {\n\t\t                \"addressCity\": \"PARKSVILLE\",\n\t\t                \"addressCountry\": \"CA\",\n\t\t                \"addressRegion\": \"BC\",\n\t\t                \"deliveryInstructions\": \"\",\n\t\t                \"postalCode\": \"V8N 4R7\",\n\t\t                \"streetAddress\": \"UNIT K 394 CRAIG ST.\",\n\t\t                \"streetAddressAdditional\": \"\"\n\t\t            },\n\t\t            \"officer\": {\n\t\t                \"firstName\": \"ANN\",\n\t\t                \"lastName\": \"MOORE\"\n\t\t            }\n\t\t        },\n\t\t        {\n\t\t            \"appointmentDate\": \"2018-08-29\",\n\t\t            \"cessationDate\": null,\n\t\t            \"deliveryAddress\": {\n\t\t                \"addressCity\": \"PARKSVILLE\",\n\t\t                \"addressCountry\": \"CA\",\n\t\t                \"addressRegion\": \"BC\",\n\t\t                \"deliveryInstructions\": \"\",\n\t\t                \"postalCode\": \"V8N 4R7\",\n\t\t                \"streetAddress\": \"B - 394 CRAIG STREET\",\n\t\t                \"streetAddressAdditional\": \"\"\n\t\t            },\n\t\t            \"officer\": {\n\t\t                \"firstName\": \"INA\",\n\t\t                \"lastName\": \"BOTHMA\"\n\t\t            }\n\t\t        },\n\t\t        {\n\t\t            \"appointmentDate\": \"2018-08-29\",\n\t\t            \"cessationDate\": null,\n\t\t            \"deliveryAddress\": {\n\t\t                \"addressCity\": \"PARKSVILLE\",\n\t\t                \"addressCountry\": \"CA\",\n\t\t                \"addressRegion\": \"BC\",\n\t\t                \"deliveryInstructions\": \"\",\n\t\t                \"postalCode\": \"V8N 4R7\",\n\t\t                \"streetAddress\": \"H - 394 CRAIG STREET\",\n\t\t                \"streetAddressAdditional\": \"\"\n\t\t            },\n\t\t            \"officer\": {\n\t\t                \"firstName\": \"E. MARY\",\n\t\t                \"lastName\": \"SURTEL\"\n\t\t            }\n\t\t        }\n\t\t    ],\n\t\t\t\"deliveryAddress\": {\n\t\t        \"addressCity\": \"PARKSVILLE\",\n\t\t        \"addressCountry\": \"CA\",\n\t\t        \"addressRegion\": \"BC\",\n\t\t        \"addressType\": \"delivery\",\n\t\t        \"deliveryInstructions\": \"\",\n\t\t        \"postalCode\": \"V8N 4R7\",\n\t\t        \"streetAddress\": \"118 MCMILLAN STREET\",\n\t\t        \"streetAddressAdditional\": \"\"\n\t\t    },\n\t\t    \"mailingAddress\": {\n\t\t        \"addressCity\": \"PARKSVILLE\",\n\t\t        \"addressCountry\": \"CA\",\n\t\t        \"addressRegion\": \"BC\",\n\t\t        \"addressType\": \"mailing\",\n\t\t        \"deliveryInstructions\": \"\",\n\t\t        \"postalCode\": \"V8N 4R7\",\n\t\t        \"streetAddress\": \"PO BOX 580\",\n\t\t        \"streetAddressAdditional\": \"\"\n\t\t    }\n        }\n    }\n}"
+								},
+								"url": {
+									"raw": "{{url}}/api/v1/businesses/:id/filings?draft=true",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"businesses",
+										":id",
+										"filings"
+									],
+									"query": [
+										{
+											"key": "draft",
+											"value": "true"
+										},
+										{
+											"key": "only_validate",
+											"value": "true",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "CP1000001"
+										}
+									]
+								}
+							},
+							"status": "CREATED",
+							"code": 201,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Server",
+									"value": "gunicorn/19.9.0"
+								},
+								{
+									"key": "Date",
+									"value": "Thu, 29 Aug 2019 15:59:14 GMT"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Access-Control-Allow-Origin",
+									"value": "*"
+								},
+								{
+									"key": "Access-Control-Allow-Methods",
+									"value": "DELETE, HEAD, PUT, POST, GET, OPTIONS"
+								},
+								{
+									"key": "Access-Control-Max-Age",
+									"value": "21600"
+								},
+								{
+									"key": "API",
+									"value": "legal_api/1.0.0-e1641cb346253fa39582358ee8904abfd5c821bc"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"errors\": [\n        null\n    ],\n    \"filing\": {\n        \"annualReport\": {\n            \"annualGeneralMeetingDate\": \"2019-04-08\",\n            \"annualReportDate\": \"2019-08-29\",\n            \"deliveryAddress\": {\n                \"addressCity\": \"PARKSVILLE\",\n                \"addressCountry\": \"CA\",\n                \"addressRegion\": \"BC\",\n                \"addressType\": \"delivery\",\n                \"deliveryInstructions\": \"\",\n                \"postalCode\": \"V8N 4R7\",\n                \"streetAddress\": \"118 MCMILLAN STREET\",\n                \"streetAddressAdditional\": \"\"\n            },\n            \"directors\": [\n                {\n                    \"appointmentDate\": \"2017-10-23\",\n                    \"cessationDate\": null,\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"PARKSVILLE\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"deliveryInstructions\": \"\",\n                        \"postalCode\": \"V8N 4R7\",\n                        \"streetAddress\": \"UNIT I 394 CRAIG ST.\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"WENDY\",\n                        \"lastName\": \"HAMPTON\"\n                    }\n                },\n                {\n                    \"appointmentDate\": \"2017-10-23\",\n                    \"cessationDate\": null,\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"PARKSVILLE\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"deliveryInstructions\": \"\",\n                        \"postalCode\": \"V8N 4R7\",\n                        \"streetAddress\": \"UNIT K 394 CRAIG ST.\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"ANN\",\n                        \"lastName\": \"MOORE\"\n                    }\n                },\n                {\n                    \"appointmentDate\": \"2018-08-29\",\n                    \"cessationDate\": null,\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"PARKSVILLE\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"deliveryInstructions\": \"\",\n                        \"postalCode\": \"V8N 4R7\",\n                        \"streetAddress\": \"B - 394 CRAIG STREET\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"INA\",\n                        \"lastName\": \"BOTHMA\"\n                    }\n                },\n                {\n                    \"appointmentDate\": \"2018-08-29\",\n                    \"cessationDate\": null,\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"PARKSVILLE\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"deliveryInstructions\": \"\",\n                        \"postalCode\": \"V8N 4R7\",\n                        \"streetAddress\": \"H - 394 CRAIG STREET\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"E. MARY\",\n                        \"lastName\": \"SURTEL\"\n                    }\n                }\n            ],\n            \"mailingAddress\": {\n                \"addressCity\": \"PARKSVILLE\",\n                \"addressCountry\": \"CA\",\n                \"addressRegion\": \"BC\",\n                \"addressType\": \"mailing\",\n                \"deliveryInstructions\": \"\",\n                \"postalCode\": \"V8N 4R7\",\n                \"streetAddress\": \"PO BOX 580\",\n                \"streetAddressAdditional\": \"\"\n            }\n        },\n        \"business\": {\n            \"fiscalYearEndDate\": \"2019-08-28\",\n            \"foundingDate\": \"1982-06-08T00:00:00+00:00\",\n            \"identifier\": \"CP1000001\",\n            \"lastAnnualGeneralMeetingDate\": \"2018-08-11\",\n            \"lastAnnualReport\": \"2018-08-11\",\n            \"lastLedgerTimestamp\": \"2018-08-29T00:00:00+00:00\",\n            \"lastModified\": \"2019-08-28T18:12:08.102010+00:00\",\n            \"legalName\": \"MERIDIAN GARDENS COOPERATIVE ASSOCIATION\"\n        },\n        \"header\": {\n            \"certifiedBy\": \"full name\",\n            \"colinId\": null,\n            \"date\": \"2019-08-29\",\n            \"email\": \"no_one@never.get\",\n            \"filingId\": 77,\n            \"name\": \"annualReport\",\n            \"status\": \"DRAFT\",\n            \"submitter\": \"CP1000001\"\n        }\n    }\n}"
+						}
+					]
+				},
+				{
+					"name": "put - fail, not allowed",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9178a795-5b99-4f0d-87c4-012aeeaef580",
+								"exec": [
+									"var jsonData = pm.response.json()",
+									"",
+									"pm.test(\"Status code is 405/Method Not Allowed\", function () {",
+									"    pm.response.to.have.status(405);",
+									"});",
+									"",
+									"pm.test('should return JSON', function () {",
+									"    pm.response.to.have.header('Content-Type', 'application/json');",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "b93cfbb3-3f85-4112-939d-56f996ff07a6",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"comment\": {\n    \t\"comment\": \"this is a test from postman\",\n    \t\"filingId\": {{comment_filing_id}}\n    }\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/businesses/:id/filings/:filing_id/comments/:comment_id",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"businesses",
+								":id",
+								"filings",
+								":filing_id",
+								"comments",
+								":comment_id"
+							],
+							"query": [
+								{
+									"key": "only_validate",
+									"value": "true",
+									"disabled": true
+								}
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "CP1000001"
+								},
+								{
+									"key": "filing_id",
+									"value": "{{comment_filing_id}}"
+								},
+								{
+									"key": "comment_id",
+									"value": "{{comment_id}}"
+								}
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "post - annual report - Save Draft",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"filing\": {\n        \"header\": {\n        \t\"certifiedBy\": \"full name\",\n            \"email\": \"no_one@never.get\",\n            \"name\": \"annualReport\",\n            \"date\": \"{{today}}\"\n        },\n        \"business\": {\n\t        \"fiscalYearEndDate\": \"2019-08-28\",\n\t        \"foundingDate\": \"1982-06-08T00:00:00+00:00\",\n\t        \"identifier\": \"CP1000001\",\n\t        \"lastAnnualGeneralMeetingDate\": \"2018-08-11\",\n\t        \"lastAnnualReport\": \"2018-08-11\",\n\t        \"lastLedgerTimestamp\": \"2018-08-29T00:00:00+00:00\",\n\t        \"lastModified\": \"2019-08-28T18:12:08.102010+00:00\",\n\t        \"legalName\": \"MERIDIAN GARDENS COOPERATIVE ASSOCIATION\"\n\t    },\n        \"annualReport\": {\n            \"annualGeneralMeetingDate\": \"2019-04-08\",\n            \"annualReportDate\": \"2019{{ar_date_info}}\",\n        \t\"directors\": [\n\t\t        {\n\t\t            \"appointmentDate\": \"2017-10-23\",\n\t\t            \"cessationDate\": null,\n\t\t            \"deliveryAddress\": {\n\t\t                \"addressCity\": \"PARKSVILLE\",\n\t\t                \"addressCountry\": \"CA\",\n\t\t                \"addressRegion\": \"BC\",\n\t\t                \"deliveryInstructions\": \"\",\n\t\t                \"postalCode\": \"V8N 4R7\",\n\t\t                \"streetAddress\": \"UNIT I 394 CRAIG ST.\",\n\t\t                \"streetAddressAdditional\": \"\"\n\t\t            },\n\t\t            \"officer\": {\n\t\t                \"firstName\": \"WENDY\",\n\t\t                \"lastName\": \"HAMPTON\"\n\t\t            }\n\t\t        },\n\t\t        {\n\t\t            \"appointmentDate\": \"2017-10-23\",\n\t\t            \"cessationDate\": null,\n\t\t            \"deliveryAddress\": {\n\t\t                \"addressCity\": \"PARKSVILLE\",\n\t\t                \"addressCountry\": \"CA\",\n\t\t                \"addressRegion\": \"BC\",\n\t\t                \"deliveryInstructions\": \"\",\n\t\t                \"postalCode\": \"V8N 4R7\",\n\t\t                \"streetAddress\": \"UNIT K 394 CRAIG ST.\",\n\t\t                \"streetAddressAdditional\": \"\"\n\t\t            },\n\t\t            \"officer\": {\n\t\t                \"firstName\": \"ANN\",\n\t\t                \"lastName\": \"MOORE\"\n\t\t            }\n\t\t        },\n\t\t        {\n\t\t            \"appointmentDate\": \"2018-08-29\",\n\t\t            \"cessationDate\": null,\n\t\t            \"deliveryAddress\": {\n\t\t                \"addressCity\": \"PARKSVILLE\",\n\t\t                \"addressCountry\": \"CA\",\n\t\t                \"addressRegion\": \"BC\",\n\t\t                \"deliveryInstructions\": \"\",\n\t\t                \"postalCode\": \"V8N 4R7\",\n\t\t                \"streetAddress\": \"B - 394 CRAIG STREET\",\n\t\t                \"streetAddressAdditional\": \"\"\n\t\t            },\n\t\t            \"officer\": {\n\t\t                \"firstName\": \"INA\",\n\t\t                \"lastName\": \"BOTHMA\"\n\t\t            }\n\t\t        },\n\t\t        {\n\t\t            \"appointmentDate\": \"2018-08-29\",\n\t\t            \"cessationDate\": null,\n\t\t            \"deliveryAddress\": {\n\t\t                \"addressCity\": \"PARKSVILLE\",\n\t\t                \"addressCountry\": \"CA\",\n\t\t                \"addressRegion\": \"BC\",\n\t\t                \"deliveryInstructions\": \"\",\n\t\t                \"postalCode\": \"V8N 4R7\",\n\t\t                \"streetAddress\": \"H - 394 CRAIG STREET\",\n\t\t                \"streetAddressAdditional\": \"\"\n\t\t            },\n\t\t            \"officer\": {\n\t\t                \"firstName\": \"E. MARY\",\n\t\t                \"lastName\": \"SURTEL\"\n\t\t            }\n\t\t        }\n\t\t    ],\n\t\t\t\"deliveryAddress\": {\n\t\t        \"addressCity\": \"PARKSVILLE\",\n\t\t        \"addressCountry\": \"CA\",\n\t\t        \"addressRegion\": \"BC\",\n\t\t        \"addressType\": \"delivery\",\n\t\t        \"deliveryInstructions\": \"\",\n\t\t        \"postalCode\": \"V8N 4R7\",\n\t\t        \"streetAddress\": \"118 MCMILLAN STREET\",\n\t\t        \"streetAddressAdditional\": \"\"\n\t\t    },\n\t\t    \"mailingAddress\": {\n\t\t        \"addressCity\": \"PARKSVILLE\",\n\t\t        \"addressCountry\": \"CA\",\n\t\t        \"addressRegion\": \"BC\",\n\t\t        \"addressType\": \"mailing\",\n\t\t        \"deliveryInstructions\": \"\",\n\t\t        \"postalCode\": \"V8N 4R7\",\n\t\t        \"streetAddress\": \"PO BOX 580\",\n\t\t        \"streetAddressAdditional\": \"\"\n\t\t    }\n        }\n    }\n}"
+								},
+								"url": {
+									"raw": "{{url}}/api/v1/businesses/:id/filings?draft=true",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"businesses",
+										":id",
+										"filings"
+									],
+									"query": [
+										{
+											"key": "draft",
+											"value": "true"
+										},
+										{
+											"key": "only_validate",
+											"value": "true",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "CP1000001"
+										}
+									]
+								}
+							},
+							"status": "CREATED",
+							"code": 201,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Server",
+									"value": "gunicorn/19.9.0"
+								},
+								{
+									"key": "Date",
+									"value": "Thu, 29 Aug 2019 15:59:14 GMT"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Access-Control-Allow-Origin",
+									"value": "*"
+								},
+								{
+									"key": "Access-Control-Allow-Methods",
+									"value": "DELETE, HEAD, PUT, POST, GET, OPTIONS"
+								},
+								{
+									"key": "Access-Control-Max-Age",
+									"value": "21600"
+								},
+								{
+									"key": "API",
+									"value": "legal_api/1.0.0-e1641cb346253fa39582358ee8904abfd5c821bc"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"errors\": [\n        null\n    ],\n    \"filing\": {\n        \"annualReport\": {\n            \"annualGeneralMeetingDate\": \"2019-04-08\",\n            \"annualReportDate\": \"2019-08-29\",\n            \"deliveryAddress\": {\n                \"addressCity\": \"PARKSVILLE\",\n                \"addressCountry\": \"CA\",\n                \"addressRegion\": \"BC\",\n                \"addressType\": \"delivery\",\n                \"deliveryInstructions\": \"\",\n                \"postalCode\": \"V8N 4R7\",\n                \"streetAddress\": \"118 MCMILLAN STREET\",\n                \"streetAddressAdditional\": \"\"\n            },\n            \"directors\": [\n                {\n                    \"appointmentDate\": \"2017-10-23\",\n                    \"cessationDate\": null,\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"PARKSVILLE\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"deliveryInstructions\": \"\",\n                        \"postalCode\": \"V8N 4R7\",\n                        \"streetAddress\": \"UNIT I 394 CRAIG ST.\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"WENDY\",\n                        \"lastName\": \"HAMPTON\"\n                    }\n                },\n                {\n                    \"appointmentDate\": \"2017-10-23\",\n                    \"cessationDate\": null,\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"PARKSVILLE\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"deliveryInstructions\": \"\",\n                        \"postalCode\": \"V8N 4R7\",\n                        \"streetAddress\": \"UNIT K 394 CRAIG ST.\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"ANN\",\n                        \"lastName\": \"MOORE\"\n                    }\n                },\n                {\n                    \"appointmentDate\": \"2018-08-29\",\n                    \"cessationDate\": null,\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"PARKSVILLE\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"deliveryInstructions\": \"\",\n                        \"postalCode\": \"V8N 4R7\",\n                        \"streetAddress\": \"B - 394 CRAIG STREET\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"INA\",\n                        \"lastName\": \"BOTHMA\"\n                    }\n                },\n                {\n                    \"appointmentDate\": \"2018-08-29\",\n                    \"cessationDate\": null,\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"PARKSVILLE\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"deliveryInstructions\": \"\",\n                        \"postalCode\": \"V8N 4R7\",\n                        \"streetAddress\": \"H - 394 CRAIG STREET\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"E. MARY\",\n                        \"lastName\": \"SURTEL\"\n                    }\n                }\n            ],\n            \"mailingAddress\": {\n                \"addressCity\": \"PARKSVILLE\",\n                \"addressCountry\": \"CA\",\n                \"addressRegion\": \"BC\",\n                \"addressType\": \"mailing\",\n                \"deliveryInstructions\": \"\",\n                \"postalCode\": \"V8N 4R7\",\n                \"streetAddress\": \"PO BOX 580\",\n                \"streetAddressAdditional\": \"\"\n            }\n        },\n        \"business\": {\n            \"fiscalYearEndDate\": \"2019-08-28\",\n            \"foundingDate\": \"1982-06-08T00:00:00+00:00\",\n            \"identifier\": \"CP1000001\",\n            \"lastAnnualGeneralMeetingDate\": \"2018-08-11\",\n            \"lastAnnualReport\": \"2018-08-11\",\n            \"lastLedgerTimestamp\": \"2018-08-29T00:00:00+00:00\",\n            \"lastModified\": \"2019-08-28T18:12:08.102010+00:00\",\n            \"legalName\": \"MERIDIAN GARDENS COOPERATIVE ASSOCIATION\"\n        },\n        \"header\": {\n            \"certifiedBy\": \"full name\",\n            \"colinId\": null,\n            \"date\": \"2019-08-29\",\n            \"email\": \"no_one@never.get\",\n            \"filingId\": 77,\n            \"name\": \"annualReport\",\n            \"status\": \"DRAFT\",\n            \"submitter\": \"CP1000001\"\n        }\n    }\n}"
+						}
+					]
+				},
+				{
+					"name": "delete - fail, not allowed",
 					"event": [
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "886af58a-1aff-4c0b-bf8d-fe1520be03d5",
+								"id": "6bd93be1-2196-4ce2-9801-23744f170a2f",
 								"exec": [
 									""
 								],
@@ -7500,23 +8782,17 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "548ebc4a-ad15-49b2-a4ee-8264a08a27cf",
+								"id": "623a4af1-3c48-478e-b8c4-dc02e62b2e73",
 								"exec": [
 									"var jsonData = pm.response.json()",
 									"",
-									"pm.test(\"Status code is 400\", function () {",
-									"    pm.response.to.have.status(400);",
+									"pm.test(\"Status code is 405/Method Not Allowed\", function () {",
+									"    pm.response.to.have.status(405);",
 									"});",
 									"",
 									"pm.test('should return JSON', function () {",
 									"    pm.response.to.have.header('Content-Type', 'application/json');",
 									"});",
-									"",
-									"pm.test(\"Returns error message\", () => {",
-									"    pm.expect(jsonData.errors).to.exist",
-									"    pm.expect(jsonData.errors[0].error).to.contain('does not match the identifier')",
-									"});",
-									"",
 									""
 								],
 								"type": "text/javascript"
@@ -7524,20 +8800,36 @@
 						}
 					],
 					"request": {
-						"method": "PUT",
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
 						"header": [
 							{
 								"key": "Content-Type",
+								"name": "Content-Type",
 								"type": "text",
 								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"type": "text",
+								"value": "Bearer {{token}}"
 							}
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"filing\": {\r\n        \"header\": {\r\n        \t\"certifiedBy\": \"full name\",\r\n            \"email\": \"no_one@never.get\",\r\n            \"name\": \"incorporationApplication\",\r\n            \"date\": \"{{today}}\"\r\n        },\r\n        \"incorporationApplication\": {\r\n\t        \"nameRequest\": {\r\n\t            \"legalType\": \"BC\",\r\n\t            \"nrNumber\": \"{{nr_num}}\"\r\n\t        },\r\n\t        \"offices\": {\r\n\t            \"registeredOffice\": {\r\n\t                \"deliveryAddress\": {\r\n\t                    \"streetAddress\": \"delivery_address - address line one\",\r\n\t                    \"addressCity\": \"delivery_address city\",\r\n\t                    \"addressCountry\": \"delivery_address country\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                },\r\n\t                \"mailingAddress\": {\r\n\t                    \"streetAddress\": \"mailing_address - address line one\",\r\n\t                    \"addressCity\": \"mailing_address city\",\r\n\t                    \"addressCountry\": \"mailing_address country\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                }\r\n\t            },\r\n\t            \"recordsOffice\": {\r\n\t                \"deliveryAddress\": {\r\n\t                    \"streetAddress\": \"delivery_address - address line one\",\r\n\t                    \"addressCity\": \"delivery_address city\",\r\n\t                    \"addressCountry\": \"delivery_address country\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                },\r\n\t                \"mailingAddress\": {\r\n\t                    \"streetAddress\": \"mailing_address - address line one\",\r\n\t                    \"addressCity\": \"mailing_address city\",\r\n\t                    \"addressCountry\": \"mailing_address country\",\r\n\t                    \"postalCode\": \"H0H0H0\",\r\n\t                    \"addressRegion\": \"BC\"\r\n\t                }\r\n\t            }\r\n\t        },\r\n\t        \"contactPoint\": {\r\n\t            \"email\": \"no_one@never.get\",\r\n\t            \"phone\": \"123-456-7890\"\r\n\t        }\r\n    \t}\r\n    }\r\n}"
+							"raw": ""
 						},
 						"url": {
-							"raw": "{{url}}/api/v1/businesses/:nr_num",
+							"raw": "{{url}}/api/v1/businesses/:id/filings/:filing_id/comments/:comment_id",
 							"host": [
 								"{{url}}"
 							],
@@ -7545,17 +8837,413 @@
 								"api",
 								"v1",
 								"businesses",
-								":nr_num"
+								":id",
+								"filings",
+								":filing_id",
+								"comments",
+								":comment_id"
 							],
 							"variable": [
 								{
-									"key": "nr_num",
-									"value": "{{nr_num_2}}"
+									"key": "id",
+									"value": "CP1000001"
+								},
+								{
+									"key": "filing_id",
+									"value": "{{comment_filing_id}}"
+								},
+								{
+									"key": "comment_id",
+									"value": "{{comment_id}}"
 								}
 							]
 						}
 					},
-					"response": []
+					"response": [
+						{
+							"name": "put - annual report CP1000001",
+							"originalRequest": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"type": "text",
+										"value": "Bearer {{token}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"filing\": {\n        \"header\": {\n        \t\"certifiedBy\": \"full name\",\n            \"email\": \"no_one@never.get\",\n            \"name\": \"annualReport\",\n            \"date\": \"{{today}}\"\n        },\n        \"business\": {\n\t        \"fiscalYearEndDate\": \"2019-08-28\",\n\t        \"foundingDate\": \"1982-06-08T00:00:00+00:00\",\n\t        \"identifier\": \"CP1000001\",\n\t        \"lastAnnualGeneralMeetingDate\": \"2018-08-11\",\n\t        \"lastAnnualReport\": \"2018-08-11\",\n\t        \"lastLedgerTimestamp\": \"2018-08-29T00:00:00+00:00\",\n\t        \"lastModified\": \"2019-08-28T18:12:08.102010+00:00\",\n\t        \"legalName\": \"MERIDIAN GARDENS COOPERATIVE ASSOCIATION\"\n\t    },\n        \"annualReport\": {\n            \"annualGeneralMeetingDate\": \"2019-04-08\",\n            \"annualReportDate\": \"2019{{ar_date_info}}\",\n        \t\"directors\": [\n\t\t        {\n\t\t            \"appointmentDate\": \"2017-10-23\",\n\t\t            \"cessationDate\": null,\n\t\t            \"deliveryAddress\": {\n\t\t                \"addressCity\": \"PARKSVILLE\",\n\t\t                \"addressCountry\": \"CA\",\n\t\t                \"addressRegion\": \"BC\",\n\t\t                \"deliveryInstructions\": \"\",\n\t\t                \"postalCode\": \"V8N 4R7\",\n\t\t                \"streetAddress\": \"UNIT I 394 CRAIG ST.\",\n\t\t                \"streetAddressAdditional\": \"\"\n\t\t            },\n\t\t            \"officer\": {\n\t\t                \"firstName\": \"WENDY\",\n\t\t                \"lastName\": \"HAMPTON\"\n\t\t            }\n\t\t        },\n\t\t        {\n\t\t            \"appointmentDate\": \"2017-10-23\",\n\t\t            \"cessationDate\": null,\n\t\t            \"deliveryAddress\": {\n\t\t                \"addressCity\": \"PARKSVILLE\",\n\t\t                \"addressCountry\": \"CA\",\n\t\t                \"addressRegion\": \"BC\",\n\t\t                \"deliveryInstructions\": \"\",\n\t\t                \"postalCode\": \"V8N 4R7\",\n\t\t                \"streetAddress\": \"UNIT K 394 CRAIG ST.\",\n\t\t                \"streetAddressAdditional\": \"\"\n\t\t            },\n\t\t            \"officer\": {\n\t\t                \"firstName\": \"ANN\",\n\t\t                \"lastName\": \"MOORE\"\n\t\t            }\n\t\t        },\n\t\t        {\n\t\t            \"appointmentDate\": \"2018-08-29\",\n\t\t            \"cessationDate\": null,\n\t\t            \"deliveryAddress\": {\n\t\t                \"addressCity\": \"PARKSVILLE\",\n\t\t                \"addressCountry\": \"CA\",\n\t\t                \"addressRegion\": \"BC\",\n\t\t                \"deliveryInstructions\": \"\",\n\t\t                \"postalCode\": \"V8N 4R7\",\n\t\t                \"streetAddress\": \"B - 394 CRAIG STREET\",\n\t\t                \"streetAddressAdditional\": \"\"\n\t\t            },\n\t\t            \"officer\": {\n\t\t                \"firstName\": \"INA\",\n\t\t                \"lastName\": \"BOTHMA\"\n\t\t            }\n\t\t        },\n\t\t        {\n\t\t            \"appointmentDate\": \"2018-08-29\",\n\t\t            \"cessationDate\": null,\n\t\t            \"deliveryAddress\": {\n\t\t                \"addressCity\": \"PARKSVILLE\",\n\t\t                \"addressCountry\": \"CA\",\n\t\t                \"addressRegion\": \"BC\",\n\t\t                \"deliveryInstructions\": \"\",\n\t\t                \"postalCode\": \"V8N 4R7\",\n\t\t                \"streetAddress\": \"H - 394 CRAIG STREET\",\n\t\t                \"streetAddressAdditional\": \"\"\n\t\t            },\n\t\t            \"officer\": {\n\t\t                \"firstName\": \"E. MARY\",\n\t\t                \"lastName\": \"SURTEL\"\n\t\t            }\n\t\t        }\n\t\t    ],\n\t\t\t\"deliveryAddress\": {\n\t\t        \"addressCity\": \"PARKSVILLE\",\n\t\t        \"addressCountry\": \"CA\",\n\t\t        \"addressRegion\": \"BC\",\n\t\t        \"addressType\": \"delivery\",\n\t\t        \"deliveryInstructions\": \"\",\n\t\t        \"postalCode\": \"V8N 4R7\",\n\t\t        \"streetAddress\": \"118 MCMILLAN STREET\",\n\t\t        \"streetAddressAdditional\": \"\"\n\t\t    },\n\t\t    \"mailingAddress\": {\n\t\t        \"addressCity\": \"PARKSVILLE\",\n\t\t        \"addressCountry\": \"CA\",\n\t\t        \"addressRegion\": \"BC\",\n\t\t        \"addressType\": \"mailing\",\n\t\t        \"deliveryInstructions\": \"\",\n\t\t        \"postalCode\": \"V8N 4R7\",\n\t\t        \"streetAddress\": \"PO BOX 580\",\n\t\t        \"streetAddressAdditional\": \"\"\n\t\t    }\n        }\n    }\n}"
+								},
+								"url": {
+									"raw": "{{url}}/api/v1/businesses/:id/filings/:filing_id",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"businesses",
+										":id",
+										"filings",
+										":filing_id"
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "CP1000001"
+										},
+										{
+											"key": "filing_id",
+											"value": "{{filing_id}}"
+										}
+									]
+								}
+							},
+							"status": "ACCEPTED",
+							"code": 202,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Server",
+									"value": "gunicorn/19.9.0"
+								},
+								{
+									"key": "Date",
+									"value": "Thu, 29 Aug 2019 16:04:00 GMT"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Access-Control-Allow-Origin",
+									"value": "*"
+								},
+								{
+									"key": "Access-Control-Allow-Methods",
+									"value": "DELETE, HEAD, PUT, POST, GET, OPTIONS"
+								},
+								{
+									"key": "Access-Control-Max-Age",
+									"value": "21600"
+								},
+								{
+									"key": "API",
+									"value": "legal_api/1.0.0-e1641cb346253fa39582358ee8904abfd5c821bc"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"filing\": {\n        \"annualReport\": {\n            \"annualGeneralMeetingDate\": \"2019-04-08\",\n            \"annualReportDate\": \"2019-08-29\",\n            \"deliveryAddress\": {\n                \"addressCity\": \"PARKSVILLE\",\n                \"addressCountry\": \"CA\",\n                \"addressRegion\": \"BC\",\n                \"addressType\": \"delivery\",\n                \"deliveryInstructions\": \"\",\n                \"postalCode\": \"V8N 4R7\",\n                \"streetAddress\": \"118 MCMILLAN STREET\",\n                \"streetAddressAdditional\": \"\"\n            },\n            \"directors\": [\n                {\n                    \"appointmentDate\": \"2017-10-23\",\n                    \"cessationDate\": null,\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"PARKSVILLE\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"deliveryInstructions\": \"\",\n                        \"postalCode\": \"V8N 4R7\",\n                        \"streetAddress\": \"UNIT I 394 CRAIG ST.\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"WENDY\",\n                        \"lastName\": \"HAMPTON\"\n                    }\n                },\n                {\n                    \"appointmentDate\": \"2017-10-23\",\n                    \"cessationDate\": null,\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"PARKSVILLE\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"deliveryInstructions\": \"\",\n                        \"postalCode\": \"V8N 4R7\",\n                        \"streetAddress\": \"UNIT K 394 CRAIG ST.\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"ANN\",\n                        \"lastName\": \"MOORE\"\n                    }\n                },\n                {\n                    \"appointmentDate\": \"2018-08-29\",\n                    \"cessationDate\": null,\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"PARKSVILLE\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"deliveryInstructions\": \"\",\n                        \"postalCode\": \"V8N 4R7\",\n                        \"streetAddress\": \"B - 394 CRAIG STREET\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"INA\",\n                        \"lastName\": \"BOTHMA\"\n                    }\n                },\n                {\n                    \"appointmentDate\": \"2018-08-29\",\n                    \"cessationDate\": null,\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"PARKSVILLE\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"deliveryInstructions\": \"\",\n                        \"postalCode\": \"V8N 4R7\",\n                        \"streetAddress\": \"H - 394 CRAIG STREET\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"E. MARY\",\n                        \"lastName\": \"SURTEL\"\n                    }\n                }\n            ],\n            \"mailingAddress\": {\n                \"addressCity\": \"PARKSVILLE\",\n                \"addressCountry\": \"CA\",\n                \"addressRegion\": \"BC\",\n                \"addressType\": \"mailing\",\n                \"deliveryInstructions\": \"\",\n                \"postalCode\": \"V8N 4R7\",\n                \"streetAddress\": \"PO BOX 580\",\n                \"streetAddressAdditional\": \"\"\n            }\n        },\n        \"business\": {\n            \"fiscalYearEndDate\": \"2019-08-28\",\n            \"foundingDate\": \"1982-06-08T00:00:00+00:00\",\n            \"identifier\": \"CP1000001\",\n            \"lastAnnualGeneralMeetingDate\": \"2018-08-11\",\n            \"lastAnnualReport\": \"2018-08-11\",\n            \"lastLedgerTimestamp\": \"2018-08-29T00:00:00+00:00\",\n            \"lastModified\": \"2019-08-28T18:12:08.102010+00:00\",\n            \"legalName\": \"MERIDIAN GARDENS COOPERATIVE ASSOCIATION\"\n        },\n        \"header\": {\n            \"certifiedBy\": \"full name\",\n            \"colinId\": null,\n            \"date\": \"2019-08-29\",\n            \"email\": \"no_one@never.get\",\n            \"filingId\": 77,\n            \"name\": \"annualReport\",\n            \"paymentToken\": \"33\",\n            \"status\": \"PENDING\",\n            \"submitter\": \"CP1000001\"\n        }\n    }\n}"
+						}
+					]
+				},
+				{
+					"name": "authenticate as customer",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "c6720c75-f388-4f9a-a157-c4b4b560a99f",
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Response time is less than 10000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(10000);",
+									"});",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Returns the access token\", () => {",
+									"    pm.expect(jsonData.access_token).to.exist",
+									"    pm.environment.set(\"token\", jsonData['access_token'])",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"username\":\"CP1000001\", \"password\":\"{{password}}\"}"
+						},
+						"url": {
+							"raw": "{{tokenUrl}}",
+							"host": [
+								"{{tokenUrl}}"
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "authenticate",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\"username\":\"coops-updater-job\", \"password\":\"coops-updater-job\"}"
+								},
+								"url": {
+									"raw": "{{get_token_url}}",
+									"host": [
+										"{{get_token_url}}"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "html",
+							"header": [
+								{
+									"key": "Server",
+									"value": "gunicorn/19.9.0"
+								},
+								{
+									"key": "Date",
+									"value": "Tue, 30 Jul 2019 18:39:41 GMT"
+								},
+								{
+									"key": "Content-Type",
+									"value": "text/html; charset=utf-8"
+								},
+								{
+									"key": "Access-Control-Allow-Origin",
+									"value": "*"
+								},
+								{
+									"key": "Access-Control-Allow-Methods",
+									"value": "POST, OPTIONS"
+								},
+								{
+									"key": "Access-Control-Max-Age",
+									"value": "21600"
+								},
+								{
+									"key": "API",
+									"value": "auth_api/0.1.0a0.dev-462c33674f5ae76b1e8ef2f968e55f41f26d8f95"
+								}
+							],
+							"cookie": [],
+							"body": "{\"access_token\": \"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJUbWdtZUk0MnVsdUZ0N3FQbmUtcTEzdDUwa0JDbjF3bHF6dHN0UGdUM1dFIn0.eyJqdGkiOiI4NmQzMGNhNi04ZmM2LTRiMDctYWFmNS1mYWEzMjg0ODk0NzciLCJleHAiOjE1NjQ1OTgzODEsIm5iZiI6MCwiaWF0IjoxNTY0NTExOTgxLCJpc3MiOiJodHRwczovL3Nzby1kZXYucGF0aGZpbmRlci5nb3YuYmMuY2EvYXV0aC9yZWFsbXMvZmNmMGtwcXIiLCJhdWQiOiJzYmMtYXV0aC13ZWIiLCJzdWIiOiI1MmRjZDNjZi1jMmNmLTQ1NWQtYjY4Zi04NTU4NTcyMjg1OTEiLCJ0eXAiOiJCZWFyZXIiLCJhenAiOiJzYmMtYXV0aC13ZWIiLCJhdXRoX3RpbWUiOjAsInNlc3Npb25fc3RhdGUiOiJkMjQ3YjhlZS1kMGI3LTQxZDgtYTA1Yy0yZGVlY2UyNmMxMTIiLCJhY3IiOiIxIiwiYWxsb3dlZC1vcmlnaW5zIjpbImh0dHA6Ly8xOTIuMTY4LjAuMTM6ODA4MC8iLCIxOTIuMTY4LjAuMTMiLCIqIiwiaHR0cDovLzE5Mi4xNjguMC4xMzo4MDgwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJjb2xpbiIsInVtYV9hdXRob3JpemF0aW9uIiwiam9iIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwicHJlZmVycmVkX3VzZXJuYW1lIjoiY29vcHMtdXBkYXRlci1qb2IiLCJ1c2VybmFtZSI6ImNvb3BzLXVwZGF0ZXItam9iIn0.Bbr9ehKYRfUvFLhjtfR3QfzRx5ItZzTWjdtxevBh1kPLhhSIqH456LBLh96vUOCqA3X2MsWpqFQrKRHdhxe5mkisXFME3J3dQKXcXnGJSsam8yRfDtMyre1DYC6bo3tIujtwr7G6OMwotcz_hGqYKm_8FjsNIKOXcMv9S88NNKohj_o9F6RXgq9JnTTP2fZakpqYn2E4imLmOSIK7ft2ODfCyH74owd35NQBse4U0B7YAvlsFjtyFInzO5wGXCzVUnS99vm4Hv4JMTsQz5R4S_HlTVwM5jAJGn4ZXu_QK6tH8J78t-7MZQn39QEdGHtf-oc4RyRGLIPdqp7wsvwfJw\", \"expires_in\": 86400, \"refresh_expires_in\": 86400, \"refresh_token\": \"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJUbWdtZUk0MnVsdUZ0N3FQbmUtcTEzdDUwa0JDbjF3bHF6dHN0UGdUM1dFIn0.eyJqdGkiOiI2M2UwMGYwMi00MGNjLTQzOTUtYTJlMS00MjliOTViMDQ5ODMiLCJleHAiOjE1NjQ1OTgzODEsIm5iZiI6MCwiaWF0IjoxNTY0NTExOTgxLCJpc3MiOiJodHRwczovL3Nzby1kZXYucGF0aGZpbmRlci5nb3YuYmMuY2EvYXV0aC9yZWFsbXMvZmNmMGtwcXIiLCJhdWQiOiJzYmMtYXV0aC13ZWIiLCJzdWIiOiI1MmRjZDNjZi1jMmNmLTQ1NWQtYjY4Zi04NTU4NTcyMjg1OTEiLCJ0eXAiOiJSZWZyZXNoIiwiYXpwIjoic2JjLWF1dGgtd2ViIiwiYXV0aF90aW1lIjowLCJzZXNzaW9uX3N0YXRlIjoiZDI0N2I4ZWUtZDBiNy00MWQ4LWEwNWMtMmRlZWNlMjZjMTEyIiwicmVhbG1fYWNjZXNzIjp7InJvbGVzIjpbImNvbGluIiwidW1hX2F1dGhvcml6YXRpb24iLCJqb2IiXX0sInJlc291cmNlX2FjY2VzcyI6eyJhY2NvdW50Ijp7InJvbGVzIjpbIm1hbmFnZS1hY2NvdW50IiwibWFuYWdlLWFjY291bnQtbGlua3MiLCJ2aWV3LXByb2ZpbGUiXX19fQ.HYmcM0cM2kVtB81mvqjVe5A3wtDW8ERidoC0M-vkSNVTscb6GuqEvaw_0w2jXZJccAhXlmKdKIb_YLWrSAg_hYJz04rj-Vw3r7TuE_I_tpAMbycsSBEb9XREGV9XNTzYk1SNAGQGsQrCDXOZWqKaAR8_QkISLRlnHmwyLXM-FrgJk8Msh37z4nnmF5dr68d5mavx6AfDJdlxx-c6A7pUaKVaQhPnzSdy80Hdew8zLUUS1oWLCMsUosDNBosv0nnfpDEaScSAxrqimIhjVRWOGZDEa3b9qkXf1pgPDU6We_n17aA77ytgepbMJNqqOLPZkZNEF9gQIJ7l0dPQGCE_vw\", \"token_type\": \"bearer\", \"not-before-policy\": 1562910731, \"session_state\": \"d247b8ee-d0b7-41d8-a05c-2deece26c112\", \"registries-trace-id\": \"f2dfaa910187eccb:f42fb400f9f894ac:f2dfaa910187eccb:1\"}"
+						}
+					]
+				},
+				{
+					"name": "post - fail, not authorized as customer",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9178a795-5b99-4f0d-87c4-012aeeaef580",
+								"exec": [
+									"var jsonData = pm.response.json()",
+									"",
+									"pm.test(\"Status code is 401/Unauthorized\", function () {",
+									"    pm.response.to.have.status(401);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "b93cfbb3-3f85-4112-939d-56f996ff07a6",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"comment\": {\n    \t\"comment\": \"this is a test from postman as a customer\",\n    \t\"filingId\": {{comment_filing_id}}\n    }\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/businesses/:id/filings/:filing_id/comments",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"businesses",
+								":id",
+								"filings",
+								":filing_id",
+								"comments"
+							],
+							"query": [
+								{
+									"key": "only_validate",
+									"value": "true",
+									"disabled": true
+								}
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "CP1000001"
+								},
+								{
+									"key": "filing_id",
+									"value": "{{comment_filing_id}}"
+								}
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "post - annual report - Save Draft",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"filing\": {\n        \"header\": {\n        \t\"certifiedBy\": \"full name\",\n            \"email\": \"no_one@never.get\",\n            \"name\": \"annualReport\",\n            \"date\": \"{{today}}\"\n        },\n        \"business\": {\n\t        \"fiscalYearEndDate\": \"2019-08-28\",\n\t        \"foundingDate\": \"1982-06-08T00:00:00+00:00\",\n\t        \"identifier\": \"CP1000001\",\n\t        \"lastAnnualGeneralMeetingDate\": \"2018-08-11\",\n\t        \"lastAnnualReport\": \"2018-08-11\",\n\t        \"lastLedgerTimestamp\": \"2018-08-29T00:00:00+00:00\",\n\t        \"lastModified\": \"2019-08-28T18:12:08.102010+00:00\",\n\t        \"legalName\": \"MERIDIAN GARDENS COOPERATIVE ASSOCIATION\"\n\t    },\n        \"annualReport\": {\n            \"annualGeneralMeetingDate\": \"2019-04-08\",\n            \"annualReportDate\": \"2019{{ar_date_info}}\",\n        \t\"directors\": [\n\t\t        {\n\t\t            \"appointmentDate\": \"2017-10-23\",\n\t\t            \"cessationDate\": null,\n\t\t            \"deliveryAddress\": {\n\t\t                \"addressCity\": \"PARKSVILLE\",\n\t\t                \"addressCountry\": \"CA\",\n\t\t                \"addressRegion\": \"BC\",\n\t\t                \"deliveryInstructions\": \"\",\n\t\t                \"postalCode\": \"V8N 4R7\",\n\t\t                \"streetAddress\": \"UNIT I 394 CRAIG ST.\",\n\t\t                \"streetAddressAdditional\": \"\"\n\t\t            },\n\t\t            \"officer\": {\n\t\t                \"firstName\": \"WENDY\",\n\t\t                \"lastName\": \"HAMPTON\"\n\t\t            }\n\t\t        },\n\t\t        {\n\t\t            \"appointmentDate\": \"2017-10-23\",\n\t\t            \"cessationDate\": null,\n\t\t            \"deliveryAddress\": {\n\t\t                \"addressCity\": \"PARKSVILLE\",\n\t\t                \"addressCountry\": \"CA\",\n\t\t                \"addressRegion\": \"BC\",\n\t\t                \"deliveryInstructions\": \"\",\n\t\t                \"postalCode\": \"V8N 4R7\",\n\t\t                \"streetAddress\": \"UNIT K 394 CRAIG ST.\",\n\t\t                \"streetAddressAdditional\": \"\"\n\t\t            },\n\t\t            \"officer\": {\n\t\t                \"firstName\": \"ANN\",\n\t\t                \"lastName\": \"MOORE\"\n\t\t            }\n\t\t        },\n\t\t        {\n\t\t            \"appointmentDate\": \"2018-08-29\",\n\t\t            \"cessationDate\": null,\n\t\t            \"deliveryAddress\": {\n\t\t                \"addressCity\": \"PARKSVILLE\",\n\t\t                \"addressCountry\": \"CA\",\n\t\t                \"addressRegion\": \"BC\",\n\t\t                \"deliveryInstructions\": \"\",\n\t\t                \"postalCode\": \"V8N 4R7\",\n\t\t                \"streetAddress\": \"B - 394 CRAIG STREET\",\n\t\t                \"streetAddressAdditional\": \"\"\n\t\t            },\n\t\t            \"officer\": {\n\t\t                \"firstName\": \"INA\",\n\t\t                \"lastName\": \"BOTHMA\"\n\t\t            }\n\t\t        },\n\t\t        {\n\t\t            \"appointmentDate\": \"2018-08-29\",\n\t\t            \"cessationDate\": null,\n\t\t            \"deliveryAddress\": {\n\t\t                \"addressCity\": \"PARKSVILLE\",\n\t\t                \"addressCountry\": \"CA\",\n\t\t                \"addressRegion\": \"BC\",\n\t\t                \"deliveryInstructions\": \"\",\n\t\t                \"postalCode\": \"V8N 4R7\",\n\t\t                \"streetAddress\": \"H - 394 CRAIG STREET\",\n\t\t                \"streetAddressAdditional\": \"\"\n\t\t            },\n\t\t            \"officer\": {\n\t\t                \"firstName\": \"E. MARY\",\n\t\t                \"lastName\": \"SURTEL\"\n\t\t            }\n\t\t        }\n\t\t    ],\n\t\t\t\"deliveryAddress\": {\n\t\t        \"addressCity\": \"PARKSVILLE\",\n\t\t        \"addressCountry\": \"CA\",\n\t\t        \"addressRegion\": \"BC\",\n\t\t        \"addressType\": \"delivery\",\n\t\t        \"deliveryInstructions\": \"\",\n\t\t        \"postalCode\": \"V8N 4R7\",\n\t\t        \"streetAddress\": \"118 MCMILLAN STREET\",\n\t\t        \"streetAddressAdditional\": \"\"\n\t\t    },\n\t\t    \"mailingAddress\": {\n\t\t        \"addressCity\": \"PARKSVILLE\",\n\t\t        \"addressCountry\": \"CA\",\n\t\t        \"addressRegion\": \"BC\",\n\t\t        \"addressType\": \"mailing\",\n\t\t        \"deliveryInstructions\": \"\",\n\t\t        \"postalCode\": \"V8N 4R7\",\n\t\t        \"streetAddress\": \"PO BOX 580\",\n\t\t        \"streetAddressAdditional\": \"\"\n\t\t    }\n        }\n    }\n}"
+								},
+								"url": {
+									"raw": "{{url}}/api/v1/businesses/:id/filings?draft=true",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"businesses",
+										":id",
+										"filings"
+									],
+									"query": [
+										{
+											"key": "draft",
+											"value": "true"
+										},
+										{
+											"key": "only_validate",
+											"value": "true",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "CP1000001"
+										}
+									]
+								}
+							},
+							"status": "CREATED",
+							"code": 201,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Server",
+									"value": "gunicorn/19.9.0"
+								},
+								{
+									"key": "Date",
+									"value": "Thu, 29 Aug 2019 15:59:14 GMT"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Access-Control-Allow-Origin",
+									"value": "*"
+								},
+								{
+									"key": "Access-Control-Allow-Methods",
+									"value": "DELETE, HEAD, PUT, POST, GET, OPTIONS"
+								},
+								{
+									"key": "Access-Control-Max-Age",
+									"value": "21600"
+								},
+								{
+									"key": "API",
+									"value": "legal_api/1.0.0-e1641cb346253fa39582358ee8904abfd5c821bc"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"errors\": [\n        null\n    ],\n    \"filing\": {\n        \"annualReport\": {\n            \"annualGeneralMeetingDate\": \"2019-04-08\",\n            \"annualReportDate\": \"2019-08-29\",\n            \"deliveryAddress\": {\n                \"addressCity\": \"PARKSVILLE\",\n                \"addressCountry\": \"CA\",\n                \"addressRegion\": \"BC\",\n                \"addressType\": \"delivery\",\n                \"deliveryInstructions\": \"\",\n                \"postalCode\": \"V8N 4R7\",\n                \"streetAddress\": \"118 MCMILLAN STREET\",\n                \"streetAddressAdditional\": \"\"\n            },\n            \"directors\": [\n                {\n                    \"appointmentDate\": \"2017-10-23\",\n                    \"cessationDate\": null,\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"PARKSVILLE\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"deliveryInstructions\": \"\",\n                        \"postalCode\": \"V8N 4R7\",\n                        \"streetAddress\": \"UNIT I 394 CRAIG ST.\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"WENDY\",\n                        \"lastName\": \"HAMPTON\"\n                    }\n                },\n                {\n                    \"appointmentDate\": \"2017-10-23\",\n                    \"cessationDate\": null,\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"PARKSVILLE\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"deliveryInstructions\": \"\",\n                        \"postalCode\": \"V8N 4R7\",\n                        \"streetAddress\": \"UNIT K 394 CRAIG ST.\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"ANN\",\n                        \"lastName\": \"MOORE\"\n                    }\n                },\n                {\n                    \"appointmentDate\": \"2018-08-29\",\n                    \"cessationDate\": null,\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"PARKSVILLE\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"deliveryInstructions\": \"\",\n                        \"postalCode\": \"V8N 4R7\",\n                        \"streetAddress\": \"B - 394 CRAIG STREET\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"INA\",\n                        \"lastName\": \"BOTHMA\"\n                    }\n                },\n                {\n                    \"appointmentDate\": \"2018-08-29\",\n                    \"cessationDate\": null,\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"PARKSVILLE\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"deliveryInstructions\": \"\",\n                        \"postalCode\": \"V8N 4R7\",\n                        \"streetAddress\": \"H - 394 CRAIG STREET\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"E. MARY\",\n                        \"lastName\": \"SURTEL\"\n                    }\n                }\n            ],\n            \"mailingAddress\": {\n                \"addressCity\": \"PARKSVILLE\",\n                \"addressCountry\": \"CA\",\n                \"addressRegion\": \"BC\",\n                \"addressType\": \"mailing\",\n                \"deliveryInstructions\": \"\",\n                \"postalCode\": \"V8N 4R7\",\n                \"streetAddress\": \"PO BOX 580\",\n                \"streetAddressAdditional\": \"\"\n            }\n        },\n        \"business\": {\n            \"fiscalYearEndDate\": \"2019-08-28\",\n            \"foundingDate\": \"1982-06-08T00:00:00+00:00\",\n            \"identifier\": \"CP1000001\",\n            \"lastAnnualGeneralMeetingDate\": \"2018-08-11\",\n            \"lastAnnualReport\": \"2018-08-11\",\n            \"lastLedgerTimestamp\": \"2018-08-29T00:00:00+00:00\",\n            \"lastModified\": \"2019-08-28T18:12:08.102010+00:00\",\n            \"legalName\": \"MERIDIAN GARDENS COOPERATIVE ASSOCIATION\"\n        },\n        \"header\": {\n            \"certifiedBy\": \"full name\",\n            \"colinId\": null,\n            \"date\": \"2019-08-29\",\n            \"email\": \"no_one@never.get\",\n            \"filingId\": 77,\n            \"name\": \"annualReport\",\n            \"status\": \"DRAFT\",\n            \"submitter\": \"CP1000001\"\n        }\n    }\n}"
+						}
+					]
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "2f85958e-ee75-4d74-be26-8a02442d093f",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"id": "ffe130c0-b843-4819-adc8-98b45499f1ee",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
 				}
 			],
 			"protocolProfileBehavior": {}


### PR DESCRIPTION
*Issue #:* n/a

*Description of changes:*
Added comments and updated incorp postman tests.

NOTE 1 - when completing this today (Tuesday) they didn't pass *I think* because openshift is shifty.
NOTE 2 - comments cannot be deleted currently by the legal API (existing business rules) so that's not part of data loader. However that means when entities are reset, comments are orphaned. So dev db is going to be messy. Not functionally wrong, just messy.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
