### PR TITLE
fixes to data-reset tool and edits to migration script to handle peop…

### DIFF
--- a/data-reset-tool/src/data_reset_tool/converter/ExcelConverter.py
+++ b/data-reset-tool/src/data_reset_tool/converter/ExcelConverter.py
@@ -3,9 +3,10 @@
 import xlrd
 from flask import json
 from legal_api import db
-from legal_api.models.business import Address, Business, Filing, Party, PartyRole
+from legal_api.models.business import Address, Business, Filing, PartyRole
 from legal_api.models.colin_event_id import ColinEventId
 from legal_api.models.office import Office, OfficeType
+from legal_api.models.party_role import Party
 from sqlalchemy_continuum import versioning_manager
 
 from data_reset_tool.converter.utils import SheetName
@@ -123,7 +124,7 @@ class ExcelConverter:
                     party=party
                 )
 
-                business.party_role.append(party_role)
+                business.party_roles.append(party_role)
 
         db.session.add(business)
         business.save()

--- a/data-reset-tool/src/data_reset_tool/converter/ExcelWriter.py
+++ b/data-reset-tool/src/data_reset_tool/converter/ExcelWriter.py
@@ -155,7 +155,7 @@ class ExcelWriter:  # pylint: disable=too-few-public-methods
 
         self.__business_sheet_row_index += 1
 
-        directors = business.directors.all()
+        directors = business.party_roles.all()
         for director in directors:
             self.__write_director_to_excel(business.identifier, director)
 
@@ -173,24 +173,24 @@ class ExcelWriter:  # pylint: disable=too-few-public-methods
         self.__director_sheet.write(
             self.__director_sheet_row_index, 0, format_non_date(business_identifier))
         self.__director_sheet.write(
-            self.__director_sheet_row_index, 1, format_non_date(director.first_name))
+            self.__director_sheet_row_index, 1, format_non_date(director.party.first_name))
         self.__director_sheet.write(
-            self.__director_sheet_row_index, 2, format_non_date(director.middle_initial))
+            self.__director_sheet_row_index, 2, format_non_date(director.party.middle_initial))
         self.__director_sheet.write(
-            self.__director_sheet_row_index, 3, format_non_date(director.last_name))
+            self.__director_sheet_row_index, 3, format_non_date(director.party.last_name))
         self.__director_sheet.write(
-            self.__director_sheet_row_index, 4, format_non_date(director.title))
+            self.__director_sheet_row_index, 4, format_non_date(director.party.title))
         self.__director_sheet.write(
             self.__director_sheet_row_index, 5, format_date(director.appointment_date))
         self.__director_sheet.write(
             self.__director_sheet_row_index, 6, format_date(director.cessation_date))
 
-        delivery_address = director.delivery_address
+        delivery_address = director.party.delivery_address
         if delivery_address:
             self.__write_director_address_to_excel(
                 business_identifier, director, delivery_address, self.__director_sheet_row_index)
 
-        mailing_address = director.mailing_address
+        mailing_address = director.party.mailing_address
         if mailing_address:
             self.__write_director_address_to_excel(
                 business_identifier, director, mailing_address, self.__director_sheet_row_index)
@@ -202,9 +202,9 @@ class ExcelWriter:  # pylint: disable=too-few-public-methods
         self.__director_address_sheet.write(
             self.__director_address_sheet_row_index, 0, format_non_date(business_identifier))
         self.__director_address_sheet.write(
-            self.__director_address_sheet_row_index, 1, format_non_date(director.first_name))
+            self.__director_address_sheet_row_index, 1, format_non_date(director.party.first_name))
         self.__director_address_sheet.write(
-            self.__director_address_sheet_row_index, 2, format_non_date(director.last_name))
+            self.__director_address_sheet_row_index, 2, format_non_date(director.party.last_name))
         self.__director_address_sheet.write(
             self.__director_address_sheet_row_index, 3, format_non_date(director_address.address_type))
         self.__director_address_sheet.write(

--- a/data-reset-tool/src/data_reset_tool/converter/JsonConverter.py
+++ b/data-reset-tool/src/data_reset_tool/converter/JsonConverter.py
@@ -1,7 +1,7 @@
 # pylint: disable=invalid-name
 """Util class to convert to json."""
 from flask import jsonify
-from legal_api.models.business import Address
+from legal_api.models.business import Address, PartyRole
 from legal_api.models.office import OfficeType
 
 from data_reset_tool.converter.utils import format_boolean, format_date, format_non_date
@@ -42,7 +42,7 @@ class JsonConverter:  # pylint: disable=too-few-public-methods
             'lastLedgerTimestamp': format_date(business.last_ledger_timestamp),
             'submitterUserId': format_non_date(business.submitter_userid),
             'lastModified': format_date(business.last_modified),
-            'directors': self.__json_directors(business.directors),
+            'directors': self.__json_directors(PartyRole.get_parties_by_role(business.id, PartyRole.RoleTypes.DIRECTOR.value)),
             'registeredOffice': registered_office,
             OfficeType.REGISTERED: format_non_date(registered_office),
             OfficeType.RECORDS: format_non_date(records_office),
@@ -56,14 +56,14 @@ class JsonConverter:  # pylint: disable=too-few-public-methods
 
         for director in directors:
             d = {
-                'firstName': format_non_date(director.first_name),
-                'middleInitial': format_non_date(director.middle_initial),
-                'lastName': format_non_date(director.last_name),
-                'title': format_non_date(director.title),
+                'firstName': format_non_date(director.party.first_name),
+                'middleInitial': format_non_date(director.party.middle_initial),
+                'lastName': format_non_date(director.party.last_name),
+                'title': format_non_date(director.party.title),
                 'appointmentDate': format_date(director.appointment_date),
                 'cessationDate': format_date(director.cessation_date),
-                'deliveryAddress': self.__format_address(director.delivery_address),
-                'mailingAddress': self.__format_address(director.mailing_address)
+                'deliveryAddress': self.__format_address(director.party.delivery_address),
+                'mailingAddress': self.__format_address(director.party.mailing_address)
             }
             directors_json_list.append(d)
 


### PR DESCRIPTION
…le being a director for multiple coops

Signed-off-by: Kial Jinnah <kialj876@gmail.com>

*Issue #:* /bcgov/entity#2820

*Description of changes:*
- several missed fixes for the data-reset tool (wasn't running it properly before)
- edited migration script (ran over test env already) now handles people who are directors for more than one company (exists in test and prod)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
