### PR TITLE
set default encoding for oracle connections to UTF-8

### DIFF
--- a/colin-api/src/colin_api/resources/db.py
+++ b/colin-api/src/colin_api/resources/db.py
@@ -70,7 +70,9 @@ class OracleDB:
                                      getmode=cx_Oracle.SPOOL_ATTRVAL_NOWAIT,  # pylint:disable=c-extension-no-member
                                      waitTimeout=1500,
                                      timeout=3600,
-                                     sessionCallback=init_session)
+                                     sessionCallback=init_session,
+                                     encoding='UTF-8',
+                                     nencoding='UTF-8')
 
     @property
     def connection(self):  # pylint: disable=inconsistent-return-statements


### PR DESCRIPTION
*Issue #:* /bcgov/entity#3025

*Description of changes:*
COLIN itself does not have any issues with Unicode characters (I was able to locate many records with french characters for example), the issue is that the default encoding for cx_Oracle is ascii. Switching this to utf-8 seems to fix the issue for all operations. Lots of digging for a small fix

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
