### PR TITLE
3102 - Incorporate NR todo item

### DIFF
--- a/legal-api/src/legal_api/resources/business/business_filings.py
+++ b/legal-api/src/legal_api/resources/business/business_filings.py
@@ -57,7 +57,7 @@ class ListFilingResource(Resource):
         business = Business.find_by_identifier(identifier)
 
         if not business:
-            return jsonify({'message': f'{identifier} not found'}), HTTPStatus.NOT_FOUND
+            return jsonify(filings=[]), HTTPStatus.OK
 
         if filing_id:
             rv = db.session.query(Business, Filing). \

--- a/legal-api/src/legal_api/services/__init__.py
+++ b/legal-api/src/legal_api/services/__init__.py
@@ -14,9 +14,12 @@
 """This module wraps the calls to external services used by the API."""
 from .authz import BASIC_USER, COLIN_SVC_ROLE, STAFF_ROLE, authorized
 from .flags import Flags
+from .namex import NameXService
 from .queue import QueueService
 
 
 flags = Flags()  # pylint: disable=invalid-name; shared variables are lower case by Flask convention.
 
 queue = QueueService()  # pylint: disable=invalid-name; shared variables are lower case by Flask convention.
+
+namex = NameXService()  # pylint: disable=invalid-name; shared variables are lower case by Flask convention.

--- a/legal-api/src/legal_api/services/namex.py
+++ b/legal-api/src/legal_api/services/namex.py
@@ -1,0 +1,116 @@
+# Copyright © 2020 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This provides the service for namex-api calls."""
+from datetime import datetime
+from enum import Enum
+
+import requests
+from flask import current_app
+
+
+class NameXService():
+    """Provides services to use the namex-api."""
+
+    class State(Enum):
+        """Name request states."""
+
+        APPROVED = 'APPROVED'
+        CANCELLED = 'CANCELLED'
+        COMPLETED = 'COMPLETED'
+        CONDITIONAL = 'CONDITIONAL'
+        DRAFT = 'DRAFT'
+        EXPIRED = 'EXPIRED'
+        HISTORICAL = 'HISTORICAL'
+        HOLD = 'HOLD'
+        INPROGRESS = 'INPROGRESS'
+        REJECTED = 'REJECTED'
+        NRO_UPDATING = 'NRO_UPDATING'
+
+    @staticmethod
+    def query_nr_number(identifier: str):
+        """Return a JSON object with name request information."""
+        auth_url = current_app.config.get('NAMEX_AUTH_SVC_URL')
+        username = current_app.config.get('NAMEX_SERVICE_CLIENT_USERNAME')
+        secret = current_app.config.get('NAMEX_SERVICE_CLIENT_SECRET')
+        namex_url = current_app.config.get('NAMEX_SVC_URL')
+
+        # Get access token for namex-api in a different keycloak realm
+        auth = requests.post(auth_url, auth=(username, secret), headers={
+            'Content-Type': 'application/x-www-form-urlencoded'}, data={'grant_type': 'client_credentials'})
+
+        # Return the auth response if an error occurs
+        if auth.status_code != 200:
+            return auth.json()
+
+        token = dict(auth.json())['access_token']
+
+        # Perform proxy call using the inputted identifier (e.g. NR 1234567)
+        nr_response = requests.get(namex_url + 'requests/' + identifier, headers={
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer ' + token
+            })
+
+        return nr_response
+
+    @staticmethod
+    def validate_nr(nr_json):
+        """Provide validation info based on a name request response payload."""
+        # Initial validation result state
+        is_consumable = False
+        is_approved = False
+        is_expired = False
+        consent_required = None
+        consent_received = None
+        nr_state = nr_json['state']
+
+        if nr_json['expirationDate']:
+            expiration_date = datetime.strptime(nr_json['expirationDate'], '%a, %d %b %Y %H:%M:%S %Z')
+            if expiration_date < datetime.today():
+                is_expired = True
+
+        # Not consumable and not approved
+        if nr_state not in (NameXService.State.APPROVED.value, NameXService.State.CONDITIONAL.value):
+            is_consumable = False
+            is_approved = False
+
+        # Is approved
+        elif nr_state == NameXService.State.APPROVED.value:
+            is_approved = True
+            consumed = False
+            # Approved, but check if it has been consumed
+            for name in nr_json['names']:
+                # Already consumed
+                if name['consumptionDate']:
+                    consumed = True
+            if not consumed:
+                is_consumable = True
+
+        # Is conditionally approved
+        elif nr_state == NameXService.State.CONDITIONAL.value:
+            is_approved = True
+            consent_required = True
+            consent_received = False
+            # Check if consent received
+            if nr_json['consentFlag'] == 'R':
+                consent_received = True
+                is_consumable = True
+
+        return {
+            'is_consumable': is_consumable,
+            'is_approved': is_approved,
+            'is_expired': is_expired,
+            'consent_required': consent_required,
+            'consent_received': consent_received
+            }

--- a/legal-api/tests/unit/api/test_business_filings.py
+++ b/legal-api/tests/unit/api/test_business_filings.py
@@ -111,7 +111,7 @@ def test_get_404_when_business_invalid_filing_id(session, client, jwt):
     assert rv.json == {'message': f'{identifier} no filings found'}
 
 
-def test_get_404_filing_with_invalid_business(session, client, jwt):
+def test_get_empty_filings_with_invalid_business(session, client, jwt):
     """Assert that a filing cannot be created against non-existent business."""
     identifier = 'CP7654321'
     filings_id = 1
@@ -119,8 +119,8 @@ def test_get_404_filing_with_invalid_business(session, client, jwt):
     rv = client.get(f'/api/v1/businesses/{identifier}/filings/{filings_id}',
                     headers=create_header(jwt, [STAFF_ROLE], identifier))
 
-    assert rv.status_code == HTTPStatus.NOT_FOUND
-    assert rv.json == {'message': f'{identifier} not found'}
+    assert rv.status_code == HTTPStatus.OK
+    assert rv.json == {'filings': []}
 
 
 def test_post_fail_if_given_filing_id(session, client, jwt):

--- a/legal-api/tests/unit/api/test_business_tasks.py
+++ b/legal-api/tests/unit/api/test_business_tasks.py
@@ -186,14 +186,15 @@ def test_bcorp_get_tasks_prev_year_incomplete_filing_exists(session, client):
     # assert len(rv.json.get('tasks')) == 2  # Previous year filing and a disabled to-do for current year.
 
 
-def test_get_404_filing_with_invalid_business(session, client):
-    """Assert that error is returned when business does not exist."""
+def test_get_empty_filings_with_invalid_business(session, client):
+    """Assert that an empty filings array is returned when business does not exist."""
     identifier = 'CP7654321'
 
     rv = client.get(f'/api/v1/businesses/{identifier}/tasks')
 
-    assert rv.status_code == HTTPStatus.NOT_FOUND
-    assert rv.json == {'message': f'{identifier} not found'}
+    assert rv.status_code == HTTPStatus.OK
+    print('rv json', rv.json)
+    assert rv.json == {'tasks': []}
 
 
 def test_get_tasks_error_filings(session, client, jwt):

--- a/legal-api/tests/unit/api/test_business_tasks.py
+++ b/legal-api/tests/unit/api/test_business_tasks.py
@@ -186,7 +186,7 @@ def test_bcorp_get_tasks_prev_year_incomplete_filing_exists(session, client):
     # assert len(rv.json.get('tasks')) == 2  # Previous year filing and a disabled to-do for current year.
 
 
-def test_get_empty_filings_with_invalid_business(session, client):
+def test_get_empty_tasks_with_invalid_business(session, client):
     """Assert that an empty filings array is returned when business does not exist."""
     identifier = 'CP7654321'
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#3102

*Description of changes:*
- Implemented namex service for re-usable code when querying for NR data
- Updated name request proxy endpoint to use namex service
- Added function and logic to validate NR data
- Updated filings endpoint to return empty filings array when business not found
- Updated tasks endpoint to return empty tasks array when business not found
- Added in NR number check for tasks endpoint and return todo item if no draft filing exists
- Added in error handling when NR is invalid to return 403
- Added in a function for specifically creating a todo item for incorporating NR
- Added unit tests to cover the different NR data validations

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
