### PR TITLE
Effective date change

### DIFF
--- a/legal-api/src/legal_api/resources/business/business_filings.py
+++ b/legal-api/src/legal_api/resources/business/business_filings.py
@@ -349,9 +349,9 @@ class ListFilingResource(Resource):
                 filing.filing_date = datetime.datetime.utcnow()
 
             # for any legal type, set effective date as set in json; otherwise leave as default
-            if filing.filing_json['filing']['header'].get('effectiveDate', None):
-                filing.effective_date = \
-                    datetime.datetime.fromisoformat(filing.filing_json['filing']['header']['effectiveDate'])
+            filing.effective_date = \
+                datetime.datetime.fromisoformat(filing.filing_json['filing']['header']['effectiveDate']) \
+                if filing.filing_json['filing']['header'].get('effectiveDate', None) else None
 
             filing.save()
         except BusinessException as err:


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*
Set the effective date as null if it is not present of if the value is null.  

Currently if the incorporation filing is saved as draft with a future effective date and after resuming if it is changed to immediately effective, the value of the effective date is not cleared from the db. This will result in the immediately effective filing to be treated as a future effective one

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
