### PR TITLE
1891 handle multiple names

### DIFF
--- a/lear-db/test_data/process_for_parties_fix.md
+++ b/lear-db/test_data/process_for_parties_fix.md
@@ -1,0 +1,15 @@
+## Parties Table Data Fix
+
+### Getting the Parties that might need to be fixed / added
+SQL for setup
+- Get the counts for the parties connected to party roles `select count(*) as b, party_id from party_roles group by (party_id);`
+- Select the counts that are only above 1 (these are the only possible parties that might need a change) `select party_id from (select count(*) as b, party_id from party_roles group by (party_id)) as a where b > 1 order by b desc;`
+- Select the party_id, party_role_id, business_id from the above list (this will give all the necessary info we need to change things if necessary)
+`select id, party_id, business_id from party_roles where party_id in (select party_id from (select count(*) as b, party_id from party_roles group by (party_id)) as a where b > 1 order by b desc) order by party_id;`
+
+### Verify / add new parties
+Verify the party info for each party that spans more than 1 business_id. You can accomplish this by comparing `select * from parties where id=<party_id you are verifying>` with the get current directors call in postman for the colin-api.
+- ensure there is a different entry in the party table (for the party being verified) for the party roles of each business (the party can be the same for the party_roles within each business). To add a new entry into the parties table: 
+    - `insert into addresses (address_type, street, city, region, country, postal_code) values (<values for each one>)` 
+    - `insert into parties (party_type, first_name, middle_initial, last_name, delivery_address_id) values (<values for each, address_id should be from above>)`
+    - `update party_roles set party_id=<id from above insert> where id=<party_role_id you are updating>`

--- a/legal-api/src/legal_api/models/party.py
+++ b/legal-api/src/legal_api/models/party.py
@@ -100,11 +100,6 @@ class Party(db.Model):  # pylint: disable=too-many-instance-attributes
     @property
     def name(self) -> str:
         """Return the full name of the party for comparison."""
-        print(self.first_name)
-        print(self.middle_initial)
-        print(self.last_name)
-        print(self.organization_name)
-        print(self.party_type)
         if self.party_type == Party.PartyTypes.PERSON.value:
             if self.middle_initial:
                 return ' '.join((self.first_name, self.middle_initial, self.last_name)).strip().upper()

--- a/legal-api/src/legal_api/models/party.py
+++ b/legal-api/src/legal_api/models/party.py
@@ -98,6 +98,20 @@ class Party(db.Model):  # pylint: disable=too-many-instance-attributes
         return member
 
     @property
+    def name(self) -> str:
+        """Return the full name of the party for comparison."""
+        print(self.first_name)
+        print(self.middle_initial)
+        print(self.last_name)
+        print(self.organization_name)
+        print(self.party_type)
+        if self.party_type == Party.PartyTypes.PERSON.value:
+            if self.middle_initial:
+                return ' '.join((self.first_name, self.middle_initial, self.last_name)).strip().upper()
+            return ' '.join((self.first_name, self.last_name)).strip().upper()
+        return self.organization_name.strip().upper()
+
+    @property
     def valid_party_type_data(self) -> bool:
         """Validate the model based on the party type (person/organization)."""
         if self.party_type == Party.PartyTypes.ORGANIZATION.value:
@@ -108,16 +122,6 @@ class Party(db.Model):  # pylint: disable=too-many-instance-attributes
             if self.organization_name or not (self.first_name or self.middle_initial or self.last_name):
                 return False
         return True
-
-    @classmethod
-    def find_by_name(cls, first_name: str, last_name: str, organization_name: str) -> Party:
-        """Return a Party by the name given."""
-        party = None
-        if organization_name:
-            party = cls.query.filter_by(organization_name=organization_name).one_or_none()
-        else:
-            party = cls.query.filter_by(first_name=first_name, last_name=last_name).one_or_none()
-        return party
 
 
 @event.listens_for(Party, 'before_insert')

--- a/legal-api/src/legal_api/models/party_role.py
+++ b/legal-api/src/legal_api/models/party_role.py
@@ -74,6 +74,30 @@ class PartyRole(db.Model):
             party_role = cls.query.filter_by(id=internal_id).one_or_none()
         return party_role
 
+    @classmethod
+    def find_party_by_name(cls, business_id: int, first_name: str,  # pylint: disable=too-many-arguments; one too many
+                           last_name: str, middle_initial: str, org_name: str) -> Party:
+        """Return a Party connected to the given business_id by the given name."""
+        party_roles = cls.query.filter_by(business_id=business_id).all()
+        party = None
+        # the given name to find
+        search_name = ''
+        if org_name:
+            search_name = org_name
+        elif middle_initial:
+            search_name = ' '.join((first_name.strip(), middle_initial.strip(), last_name.strip()))
+        else:
+            search_name = ' '.join((first_name.strip(), last_name.strip()))
+
+        for role in party_roles:
+            # the name of the party for each role
+            name = role.party.name
+            if name and name.strip().upper() == search_name.strip().upper():
+                party = role.party
+                break
+
+        return party
+
     @staticmethod
     def get_parties_by_role(business_id: int, role: str) -> list:
         """Return all people/oraganizations with the given role for this business (ceased + current)."""

--- a/queue_services/entity-filer/requirements/dev.txt
+++ b/queue_services/entity-filer/requirements/dev.txt
@@ -22,7 +22,7 @@ flake8-quotes
 pep8-naming
 autopep8
 coverage
-pylint
+pylint<=2.3.1
 pylint-flask
 
 # docker

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/__init__.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/__init__.py
@@ -73,12 +73,14 @@ def create_office(business, office_type, addresses) -> Office:
     return office
 
 
-def create_party(party_info: dict) -> Party:
+def create_party(business_id: int, party_info: dict) -> Party:
     """Create a new party or get them if they already exist."""
-    party = Party.find_by_name(
+    party = PartyRole.find_party_by_name(
+        business_id=business_id,
         first_name=party_info['officer'].get('firstName', '').upper(),
         last_name=party_info['officer'].get('lastName', '').upper(),
-        organization_name=party_info.get('orgName', '').upper()
+        middle_initial=party_info['officer'].get('middle_initial', '').upper(),
+        org_name=party_info.get('orgName', '').upper()
     )
     if not party:
         party = Party(

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/change_of_directors.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/change_of_directors.py
@@ -57,7 +57,7 @@ def process(business: Business, filing: Dict):  # pylint: disable=too-many-branc
         if 'appointed' in new_director['actions']:
 
             # add new diretor party role to the business
-            party = create_party(party_info=new_director)
+            party = create_party(business_id=business.id, party_info=new_director)
             role = {
                 'roleType': 'Director',
                 'appointmentDate': new_director.get('appointmentDate'),

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/incorporation_filing.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/incorporation_filing.py
@@ -72,7 +72,7 @@ def process(business: Business, filing: Dict, app: Flask = None):  # pylint: dis
 
                 if parties:
                     for party_info in parties:
-                        party = create_party(party_info=party_info)
+                        party = create_party(business_id=business.id, party_info=party_info)
                         for role_type in party_info.get('roles'):
                             role = {
                                 'roleType': role_type.get('roleType'),

--- a/queue_services/entity-filer/tests/unit/test_worker.py
+++ b/queue_services/entity-filer/tests/unit/test_worker.py
@@ -134,7 +134,7 @@ def test_process_ar_filing(app, session):
 
 
 def test_process_ar_filing_no_agm(app, session):
-    """Assert that an AR filling can be applied to the model correctly."""
+    """Assert that a no agm AR filling can be applied to the model correctly."""
     # vars
     payment_id = str(random.SystemRandom().getrandbits(0x58))
     identifier = 'CP1234567'
@@ -170,7 +170,7 @@ def test_process_ar_filing_no_agm(app, session):
 
 
 def test_process_coa_filing(app, session):
-    """Assert that an AR filling can be applied to the model correctly."""
+    """Assert that a COD filling can be applied to the model correctly."""
     # vars
     payment_id = str(random.SystemRandom().getrandbits(0x58))
     identifier = 'CP1234567'
@@ -208,11 +208,12 @@ def test_process_cod_filing(app, session):
     # vars
     payment_id = str(random.SystemRandom().getrandbits(0x58))
     identifier = 'CP1234567'
+    business = create_business(identifier)
     end_date = datetime.datetime.utcnow().date()
     # prep director for no change
     filing_data = copy.deepcopy(COD_FILING)
     directors = filing_data['filing']['changeOfDirectors']['directors']
-    director_party1 = create_party(directors[0])
+    director_party1 = create_party(business.id, directors[0])
     role1 = {
         'roleType': 'Director',
         'appointmentDate': directors[0].get('appointmentDate'),
@@ -224,7 +225,7 @@ def test_process_cod_filing(app, session):
     director_party2_dict['officer']['firstName'] = director_party2_dict['officer']['prevFirstName']
     director_party2_dict['officer']['middleInitial'] = director_party2_dict['officer']['prevMiddleInitial']
     director_party2_dict['officer']['lastName'] = director_party2_dict['officer']['prevLastName']
-    director_party2 = create_party(director_party2_dict)
+    director_party2 = create_party(business.id, director_party2_dict)
     role2 = {
         'roleType': 'Director',
         'appointmentDate': director_party2_dict.get('appointmentDate'),
@@ -232,7 +233,7 @@ def test_process_cod_filing(app, session):
     }
     director2 = create_role(party=director_party2, role_info=role2)
     # prep director for cease
-    director_party3 = create_party(directors[2])
+    director_party3 = create_party(business.id, directors[2])
     role3 = {
         'roleType': 'Director',
         'appointmentDate': directors[3].get('appointmentDate'),
@@ -242,7 +243,7 @@ def test_process_cod_filing(app, session):
     # prep director for address change
     director_party4_dict = directors[3]
     director_party4_dict['deliveryAddress']['streetAddress'] = 'should get changed'
-    director_party4 = create_party(director_party4_dict)
+    director_party4 = create_party(business.id, director_party4_dict)
     role4 = {
         'roleType': 'Director',
         'appointmentDate': director_party4_dict.get('appointmentDate'),
@@ -254,7 +255,6 @@ def test_process_cod_filing(app, session):
     ceased_directors, active_directors = active_ceased_lists(COD_FILING)
 
     # setup
-    business = create_business(identifier)
     business.party_roles.append(director1)
     business.party_roles.append(director2)
     business.party_roles.append(director3)
@@ -286,7 +286,7 @@ def test_process_cod_filing(app, session):
 
 
 def test_process_cod_mailing_address(app, session):
-    """Assert that an AR filling can be applied to the model correctly."""
+    """Assert that a COD address change filling can be applied to the model correctly."""
     # vars
     payment_id = str(random.SystemRandom().getrandbits(0x58))
     identifier = 'CP1234567'
@@ -364,6 +364,7 @@ def test_process_combined_filing(app, session):
     # vars
     payment_id = str(random.SystemRandom().getrandbits(0x58))
     identifier = 'CP1234567'
+    business = create_business(identifier)
     agm_date = datetime.date.fromisoformat(COMBINED_FILING['filing']['annualReport'].get('annualGeneralMeetingDate'))
     ar_date = datetime.date.fromisoformat(COMBINED_FILING['filing']['annualReport'].get('annualReportDate'))
     new_delivery_address = COMBINED_FILING['filing']['changeOfAddress']['offices']['registeredOffice']['deliveryAddress']  # noqa: E501; line too long by 1 char
@@ -372,7 +373,7 @@ def test_process_combined_filing(app, session):
     # prep director for no change
     filing_data = copy.deepcopy(COMBINED_FILING)
     directors = filing_data['filing']['changeOfDirectors']['directors']
-    director_party1 = create_party(directors[0])
+    director_party1 = create_party(business.id, directors[0])
     role1 = {
         'roleType': 'Director',
         'appointmentDate': directors[0].get('appointmentDate'),
@@ -384,7 +385,7 @@ def test_process_combined_filing(app, session):
     director_party2_dict['officer']['firstName'] = director_party2_dict['officer']['prevFirstName']
     director_party2_dict['officer']['middleInitial'] = director_party2_dict['officer']['prevMiddleInitial']
     director_party2_dict['officer']['lastName'] = director_party2_dict['officer']['prevLastName']
-    director_party2 = create_party(director_party2_dict)
+    director_party2 = create_party(business.id, director_party2_dict)
     role2 = {
         'roleType': 'Director',
         'appointmentDate': director_party2_dict.get('appointmentDate'),
@@ -392,7 +393,7 @@ def test_process_combined_filing(app, session):
     }
     director2 = create_role(party=director_party2, role_info=role2)
     # prep director for cease
-    director_party3 = create_party(directors[2])
+    director_party3 = create_party(business.id, directors[2])
     role3 = {
         'roleType': 'Director',
         'appointmentDate': directors[3].get('appointmentDate'),
@@ -402,7 +403,7 @@ def test_process_combined_filing(app, session):
     # prep director for address change
     director_party4_dict = directors[3]
     director_party4_dict['deliveryAddress']['streetAddress'] = 'should get changed'
-    director_party4 = create_party(director_party4_dict)
+    director_party4 = create_party(business.id, director_party4_dict)
     role4 = {
         'roleType': 'Director',
         'appointmentDate': director_party4_dict.get('appointmentDate'),
@@ -414,7 +415,6 @@ def test_process_combined_filing(app, session):
     ceased_directors, active_directors = active_ceased_lists(COMBINED_FILING)
 
     # setup
-    business = create_business(identifier)
     business.party_roles.append(director1)
     business.party_roles.append(director2)
     business.party_roles.append(director3)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#1891

*Description of changes:*
- added changes for allowing multiple parties with the same exact name across different corps
- tests added to secure this
- added md file to explain the process for data fixing the parties that were possibly copied over incorrectly (as result of them having the exact same names) when the directors table was deleted

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
