### PR TITLE
Update the business record founding date , legal name and legal type

### DIFF
--- a/queue_services/entity-filer/src/entity_filer/worker.py
+++ b/queue_services/entity-filer/src/entity_filer/worker.py
@@ -138,7 +138,7 @@ def process_filing(filing_msg: Dict, flask_app: Flask):  # pylint: disable=too-m
                     voluntary_dissolution.process(business, filing)
 
                 elif filing.get('incorporationApplication'):
-                    incorporation_filing.process(business, filing, flask_app)
+                    incorporation_filing.process(business, filing, filing_submission, flask_app)
 
                 elif filing.get('correction'):
                     correction.process(filing_submission, filing)


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

The only business attribute that filer updates is the identifier. Some fields like legal name and legal type are empty and the value of the founding date is the default date at the time of initial business record creation

*Description of changes:*
Changes to update business attributes

Open questions
The value of fiscal year end date and last ledger time stamp are also default values. If they have to be updated, what is the value?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
