### PR TITLE
3536 - BCOL Payment error messages

### DIFF
--- a/legal-api/migrations/versions/54a3fc54a2cf_.py
+++ b/legal-api/migrations/versions/54a3fc54a2cf_.py
@@ -1,0 +1,24 @@
+"""empty message
+
+Revision ID: 54a3fc54a2cf
+Revises: 442829649a2a
+Create Date: 2020-05-05 07:49:31.147648
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '54a3fc54a2cf'
+down_revision = '442829649a2a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('filings', sa.Column('payment_error_type', sa.String(length=50), nullable=True))
+
+
+def downgrade():
+    op.drop_column('filings', 'payment_error_type')


### PR DESCRIPTION
*Issue #:* /bcgov/entity#3536

*Description of changes:*
- added payment_error_type column to filings to capture the the type of payment error used to query error details from pay-api
- added logic to return payment error type on the header so dashboard can fetch the error and display as needed
- added logic to clear out payment error type on successful payment


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
