### PR TITLE
3639 - added in legislation datetime utility with helper functions dealing with legislation timezone (future effective dating)

### DIFF
--- a/legal-api/src/legal_api/config.py
+++ b/legal-api/src/legal_api/config.py
@@ -123,6 +123,9 @@ class _Config():  # pylint: disable=too-few-public-methods
     ACCOUNT_SVC_CLIENT_SECRET = os.getenv('ACCOUNT_SVC_CLIENT_SECRET')
     ACCOUNT_SVC_TIMEOUT = os.getenv('ACCOUNT_SVC_TIMEOUT')
 
+    # legislative timezone for future effective dating
+    LEGISLATIVE_TIMEZONE = os.getenv('LEGISLATIVE_TIMEZONE', 'America/Vancouver')
+
     TESTING = False
     DEBUG = False
 

--- a/legal-api/src/legal_api/utils/legislation_datetime.py
+++ b/legal-api/src/legal_api/utils/legislation_datetime.py
@@ -1,0 +1,42 @@
+# Copyright © 2020 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Legislation Date time utilities."""
+import datetime
+
+import datedelta
+import pytz
+from flask import current_app
+
+
+class LegislationDatetime():
+    """Date utility using legislation timezone for reporting and future effective dates."""
+
+    @staticmethod
+    def now():
+        """Construct a datetime using the legislation timezone."""
+        return datetime.datetime.now().astimezone(pytz.timezone(current_app.config.get('LEGISLATIVE_TIMEZONE')))
+
+    @staticmethod
+    def tomorrow_midnight():
+        """Construct a datetime tomorrow midnight using the legislation timezone."""
+        date = datetime.datetime.now().astimezone(pytz.timezone(current_app.config.get('LEGISLATIVE_TIMEZONE')))
+        date += datedelta.datedelta(days=1)
+        date = date.replace(hour=0, minute=0, second=0, microsecond=0)
+
+        return date
+
+    @staticmethod
+    def as_legislation_timezone(date_time: datetime):
+        """Return a datetime adjusted to the legislation timezone."""
+        return date_time.astimezone(pytz.timezone(current_app.config.get('LEGISLATIVE_TIMEZONE')))


### PR DESCRIPTION
*Issue #:* /bcgov/entity#3639

*Description of changes:*
- added in legislation datetime utility with helper functions dealing with legislation timezone (future effective dating) to allow for COA to future effective to tomorrow midnight for the legislation timezone
- added in config for LEGISLATION_TIMEZONE (can be overridden through config map params, but I think we can just default to America/Vancouver)
- Fixed COA unit test
- Fixed Payment failed test (Due to BCOL error message changes)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
