### PR TITLE
changed corpType to TMP, placed NR# in name if present, updated error handling now that deletes are now available

### DIFF
--- a/legal-api/src/legal_api/models/registration_bootstrap.py
+++ b/legal-api/src/legal_api/models/registration_bootstrap.py
@@ -71,6 +71,11 @@ class RegistrationBootstrap(db.Model):  # pylint: disable=too-many-instance-attr
         db.session.add(self)
         db.session.commit()
 
+    def delete(self):
+        """Render a Business to the local cache."""
+        db.session.delete(self)
+        db.session.commit()
+
     def json(self):
         """Return the Business as a json object."""
         return {

--- a/legal-api/tests/unit/services/test_registraion_bootstrap_service.py
+++ b/legal-api/tests/unit/services/test_registraion_bootstrap_service.py
@@ -38,7 +38,7 @@ def test_create_account_affiliation(app_ctx):
                                           business_registration=(f'XA{_id}')[:10],
                                           business_name='')
 
-    assert not r
+    assert r == HTTPStatus.OK
 
 
 @integration_affiliation


### PR DESCRIPTION
*Issue #:* /bcgov/entity#3779

*Description of changes:*
- change corpType on affiliation to TMP, until we have lookups for all filing types
- add NR# to the name field, if an NR is provided
- add error handling for failed affiliations

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
