### PR TITLE
fix formatting in get_next_corp_num()

### DIFF
--- a/queue_services/entity-filer/requirements/dev.txt
+++ b/queue_services/entity-filer/requirements/dev.txt
@@ -8,6 +8,7 @@ pytest-aiohttp
 pytest-asyncio
 pytest-mock
 requests
+requests_mock
 pyhamcrest
 dpath
 

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/incorporation_filing.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/incorporation_filing.py
@@ -36,9 +36,9 @@ def get_next_corp_num(business_type: str):
 
     if resp.status_code == 200:
         new_corpnum = resp.json()['corpNum'][0]
-        if new_corpnum:
+        if new_corpnum and new_corpnum <= 9999999:
             # TODO: Fix endpoint
-            return business_type + str(new_corpnum)
+            return f'{business_type}{new_corpnum:07d}'
     return None
 
 


### PR DESCRIPTION
*Issue #:* n/a

*Description of changes:*
fix the formatting of the corp_num returned by get_next_corp_num()

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
