### PR TITLE
strip out incorrect address type coming from front end

### DIFF
--- a/queue_services/entity-filer/src/entity_filer/filing_processors/__init__.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/__init__.py
@@ -34,6 +34,14 @@ def create_address(address_info: Dict, address_type: str) -> Address:
     """Create an address."""
     if not address_info:
         return Address()
+
+    db_address_type = address_type
+
+    if db_address_type == 'mailingAddress':
+        db_address_type == 'mailing'
+    elif db_address_type == 'deliveryAddress':
+        db_address_type = 'delivery'
+
     address = Address(street=address_info.get('streetAddress'),
                       street_additional=address_info.get('streetAddressAdditional'),
                       city=address_info.get('addressCity'),
@@ -41,7 +49,7 @@ def create_address(address_info: Dict, address_type: str) -> Address:
                       country=pycountry.countries.search_fuzzy(address_info.get('addressCountry'))[0].alpha_2,
                       postal_code=address_info.get('postalCode'),
                       delivery_instructions=address_info.get('deliveryInstructions'),
-                      address_type=address_type.replace('Address', '')
+                      address_type=db_address_type
                       )
     return address
 

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/__init__.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/__init__.py
@@ -41,7 +41,7 @@ def create_address(address_info: Dict, address_type: str) -> Address:
                       country=pycountry.countries.search_fuzzy(address_info.get('addressCountry'))[0].alpha_2,
                       postal_code=address_info.get('postalCode'),
                       delivery_instructions=address_info.get('deliveryInstructions'),
-                      address_type=address_type
+                      address_type=address_type.replace('Address', '')
                       )
     return address
 

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/__init__.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/__init__.py
@@ -38,7 +38,7 @@ def create_address(address_info: Dict, address_type: str) -> Address:
     db_address_type = address_type
 
     if db_address_type == 'mailingAddress':
-        db_address_type == 'mailing'
+        db_address_type = 'mailing'
     elif db_address_type == 'deliveryAddress':
         db_address_type = 'delivery'
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#4016

*Description of changes:*
remove the word 'Address' in the address key if it exists. It comes from the front end into the filing JSON for formatting reasons, but it is not a valid address type. This is the simplest way to sanitise it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
