### PR TITLE
fixed paragraph whitespace for MRAS initiative notice

### DIFF
--- a/queue_services/entity-emailer/src/entity_emailer/email_templates/BC-BN.html
+++ b/queue_services/entity-emailer/src/entity_emailer/email_templates/BC-BN.html
@@ -21,6 +21,7 @@
               Canada Revenue Agency has provided a Business Number for the company {{business.legalName}},
               Incorporation Number {{business.identifier}}.
             </p>
+
             [[whitespace-16px.html]]
             <table class="business-info-table" cellspacing="10" role="presentation">
               <tr>
@@ -28,6 +29,7 @@
                 <td class="value">{{business.taxId}}</td>
               </tr>
             </table>
+
             [[whitespace-16px.html]]
             [[footer.html]]
           </div>

--- a/queue_services/entity-emailer/src/entity_emailer/email_templates/common/initiative-notice.html
+++ b/queue_services/entity-emailer/src/entity_emailer/email_templates/common/initiative-notice.html
@@ -6,7 +6,9 @@
   </p>
 
   <!-- whitespace -->
-  <p style="margin-top: 16px !important;">
+  <p style="margin-top: 16px !important;">&nbsp;</p>
+
+  <p>
     The initiative will facilitate the updating of information to new or existing
     extra provincial registrations of your BC company with one or more of the
     partner jurisdictions. Select the jurisdictions you wish to be redirected
@@ -15,7 +17,9 @@
   </p>
 
   <!-- whitespace -->
-  <p style="margin-top: 16px !important;">Our Partners:</p>
+  <p style="margin-top: 16px !important;">&nbsp;</p>
+
+  <p>Our Partners:</p>
   <ul>
     <li><a href="http://www.servicealberta.gov.ab.ca/Provincial-trade-agreement.cfm">Alberta</a></li>
     <li><a href="https://companiesoffice.gov.mb.ca">Manitoba</a></li>
@@ -24,7 +28,9 @@
   </ul>
 
   <!-- whitespace -->
-  <p style="margin-top: 16px !important;">
+  <p style="margin-top: 16px !important;">&nbsp;</p>
+
+  <p>
     If your jurisdiction is not listed as one of BC's extraprovincial partners, you
     must contact the jurisdiction you wish to register in directly in order to submit
     a name request or complete an extraprovincial registration.


### PR DESCRIPTION
*Issue #:* N/A

*Description of changes:*
I added extra "whitespace paragraphs" to the MRAS initiative notice, as is done in the other email templates, to fix the issue of margins not working as expected in Outlook.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).