### PR TITLE
fixed Name Translations classname

### DIFF
--- a/legal-api/report-templates/incorporationApplication.html
+++ b/legal-api/report-templates/incorporationApplication.html
@@ -92,7 +92,7 @@
                </p>
                {% if listOfTranslations|length > 0 %}
                <p>
-                  <div class="title">Translation(s) of Company Name:</div>
+                  <div class="section-sub-title">Translation(s) of Company Name:</div>
                   {% for translation in listOfTranslations %}
                   <div>{{translation}}</div>
                   {% endfor %}


### PR DESCRIPTION
*Issue #:* /bcgov/entity#4104

*Description of changes:*
- fixed classname used for Name Translation in IA/NOA output
- the broken unit test is not due to this code change

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).