### PR TITLE
Translations, Resolutions and Restriction Indicator in NOA

### DIFF
--- a/legal-api/report-templates/noticeOfArticles.html
+++ b/legal-api/report-templates/noticeOfArticles.html
@@ -52,6 +52,8 @@
          <div class="separator"></div>
          [[notice-of-articles/directors.html]]
          <div class="separator"></div>
+         [[notice-of-articles/restrictions.html]]
+         [[notice-of-articles/resolutionDates.html]]
          {% if shareClasses|length > 0 %}
             [[common/shareStructure.html]]
          {% endif %}

--- a/legal-api/report-templates/template-parts/common/style.html
+++ b/legal-api/report-templates/template-parts/common/style.html
@@ -419,7 +419,19 @@
 		font-family: 'BCSans-Italic', sans-serif !important;
 	}
 
-	.name-translation-container {
+	.name-translation-container,section-container {
         padding-bottom: 0.5rem;
+     }
+
+     .resolution-date-list {
+        list-style-type: disc
+     }
+
+     .resolution-date-list-item {
+        margin-left: 0.3rem;
+     }
+
+     .section-description{
+        margin-bottom: 0.5rem;
      }
 </style>

--- a/legal-api/report-templates/template-parts/common/style.html
+++ b/legal-api/report-templates/template-parts/common/style.html
@@ -419,7 +419,7 @@
 		font-family: 'BCSans-Italic', sans-serif !important;
 	}
 
-	.name-translation-container,section-container {
+	.name-translation-container, .section-container {
         padding-bottom: 0.5rem;
      }
 

--- a/legal-api/report-templates/template-parts/notice-of-articles/resolutionDates.html
+++ b/legal-api/report-templates/template-parts/notice-of-articles/resolutionDates.html
@@ -1,0 +1,15 @@
+{% if resolutions|length > 0 %}
+    <div class="section-container no-page-break">
+          <div class="section-title">Resolution or Court Order Dates</div>
+           <div class="section-data section-description">
+               Date(s) of Resolution(s) or Court Order(s) attaching or altering Special Rights
+               and Restrictions attached to a class or a series of shares:
+           </div>
+            <ul class="resolution-date-list">
+              {% for resolution in resolutions %}
+                <li class="section-data resolution-date-list-item">{{resolution.date}}</li>
+              {% endfor %}
+            </ul>
+    </div>
+    <div class="separator"></div>
+{% endif %}

--- a/legal-api/report-templates/template-parts/notice-of-articles/restrictions.html
+++ b/legal-api/report-templates/template-parts/notice-of-articles/restrictions.html
@@ -1,0 +1,9 @@
+{% if business.hasRestrictions %}
+    <div class="section-container no-page-break">
+      <div class="section-title">Pre-existing Company Provisions</div>
+       <div class="section-data section-description">
+           The Pre-existing Company Provisions apply to this company.
+       </div>
+    </div>
+    <div class="separator"></div>
+{% endif %}

--- a/legal-api/src/legal_api/models/share_series.py
+++ b/legal-api/src/legal_api/models/share_series.py
@@ -70,7 +70,7 @@ def receive_before_change(mapper, connection, target):  # pylint: disable=unused
                 status_code=HTTPStatus.BAD_REQUEST
             )
         if share_series.share_class.max_share_flag:
-            if share_series.max_shares > share_series.share_class.max_shares:
+            if int(share_series.max_shares) > int(share_series.share_class.max_shares):
                 raise BusinessException(
                     error=f'The max share quantity of {share_series.name} must be <= that of share class quantity.',
                     status_code=HTTPStatus.BAD_REQUEST

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -177,7 +177,7 @@ class Report:  # pylint: disable=too-few-public-methods
         filing['effective_date'] = effective_date.strftime('%B %d, %Y')
         # Recognition Date
         recognition_datetime = LegislationDatetime.as_legislation_timezone(self._business.founding_date)
-        recognition_hour = recognition_datetime.strftime('%I')
+        recognition_hour = recognition_datetime.strftime('%I').lstrip('0')
         filing['recognition_date_time'] = \
             recognition_datetime.strftime(f'%B %-d, %Y at {recognition_hour}:%M %p Pacific Time')
         # For Annual Report - Set AGM date as the effective date

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -119,6 +119,8 @@ class Report:  # pylint: disable=too-few-public-methods
             'notice-of-articles/nameTranslations',
             'notice-of-articles/headerDetails',
             'notice-of-articles/directors',
+            'notice-of-articles/resolutionDates',
+            'notice-of-articles/restrictions',
             'bc-director-change/directorChangeDetails',
             'bc-director-change/directors'
         ]

--- a/legal-api/src/legal_api/services/business_details_version.py
+++ b/legal-api/src/legal_api/services/business_details_version.py
@@ -47,7 +47,7 @@ class VersionedBusinessDetailsService:
 
     @staticmethod
     def get_business_revision(transaction_id, business) -> dict:
-        """Gets the business info as of a particular transaction."""
+        """Consolidates the business info as of a particular transaction."""
         business_version = version_class(Business)
         business_revision = db.session.query(business_version) \
             .filter(business_version.transaction_id <= transaction_id) \
@@ -271,13 +271,14 @@ class VersionedBusinessDetailsService:
         """Return the resolution revision as a json object."""
         resolution = {
             'id': resolution_revision.id,
-            'date': resolution_revision.resolution_date.strftime(f'%B %-d, %Y'),
+            'date': resolution_revision.resolution_date.strftime('%B %-d, %Y'),
             'type': resolution_revision.resolution_type
         }
         return resolution
 
     @staticmethod
     def business_revision_json(business_revision, business_json):
+        """Return the business revision as a json object."""
         business_json['hasRestrictions'] = business_revision.restriction_ind
         if business_revision.dissolution_date:
             business_json['dissolutionDate'] = datetime.date(business_revision.dissolution_date).isoformat()


### PR DESCRIPTION
*Issue #:* /bcgov/entity#4108

*Description of changes:*
Modified versioned business service to include name translations, resolutions and restriction indicator
Added new template parts for the above
Added a cast to integer for share structure number of shares as the UI is currently passing it as string and "500">"1000" returns true
Minor formatting  fixes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
