### PR TITLE
4753 event message in Cloud Events format with values needed by payments

### DIFF
--- a/queue_services/entity-filer/src/entity_filer/config.py
+++ b/queue_services/entity-filer/src/entity_filer/config.py
@@ -117,6 +117,7 @@ class _Config():  # pylint: disable=too-few-public-methods
     # BCRegistry Services
     ACCOUNT_SVC_ENTITY_URL = os.getenv('ACCOUNT_SVC_ENTITY_URL')
     ACCOUNT_SVC_AFFILIATE_URL = os.getenv('ACCOUNT_SVC_AFFILIATE_URL')
+    LEGAL_API_URL = os.getenv('LEGAL_API_URL')
     NAMEX_API = os.getenv('NAMEX_API')
 
     # legislative timezone for future effective dating


### PR DESCRIPTION
*Issue #:* /bcgov/entity#4753

*Description of changes:*
- changed event message to Cloud Events format
- added fields needed by payments for receipts

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
