### PR TITLE
Fixing the free filing  fee code for Benefit company

### DIFF
--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -90,6 +90,12 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
             'codes': {
                 'CP': 'OTCDR',
                 'BEN': 'BCCDR'
+            },
+            'free': {
+                'codes': {
+                    'CP': 'OTFDR',
+                    'BEN': 'BCFDR'
+                }
             }
         },
         'changeOfName': {'name': 'changeOfName', 'title': 'Change of Name Filing'},

--- a/legal-api/src/legal_api/resources/business/business_filings.py
+++ b/legal-api/src/legal_api/resources/business/business_filings.py
@@ -508,7 +508,8 @@ class ListFilingResource(Resource):
                     if not all(change in free_changes for change in director.get('actions', [])):
                         free = False
                         break
-                filing_type_code = 'OTFDR' if free else Filing.FILINGS[k].get('codes', {}).get(legal_type)
+                filing_type_code = Filing.FILINGS[k].get('free', {}).get('codes', {}).get(legal_type)\
+                    if free else Filing.FILINGS[k].get('codes', {}).get(legal_type)
 
             # check if priority handled in parent filing
             if k in ['changeOfDirectors', 'changeOfAddress']:

--- a/legal-api/tests/unit/api/test_business_filings/test_filings.py
+++ b/legal-api/tests/unit/api/test_business_filings/test_filings.py
@@ -783,6 +783,7 @@ def test_calc_annual_report_date(session, client, jwt):
         ('BC1234569', ANNUAL_REPORT, 'annualReport', Business.LegalTypes.BCOMP.value, None, False),
         ('BC1234569', FILING_HEADER, 'changeOfAddress', Business.LegalTypes.BCOMP.value, None, False),
         ('BC1234569', FILING_HEADER, 'changeOfDirectors', Business.LegalTypes.BCOMP.value, None, False),
+        ('BC1234569', FILING_HEADER, 'changeOfDirectors', Business.LegalTypes.BCOMP.value, None, True),
         ('CP1234567', ANNUAL_REPORT, 'annualReport', Business.LegalTypes.COOP.value, None, False),
         ('CP1234567', FILING_HEADER, 'changeOfAddress', Business.LegalTypes.COOP.value, None, False),
         ('CP1234567', FILING_HEADER, 'changeOfDirectors', Business.LegalTypes.COOP.value, None, False),
@@ -795,7 +796,7 @@ def test_get_correct_fee_codes(session, identifier, base_filing, filing_name, or
     """Assert fee codes are properly assigned to filings before sending to payment."""
     # setup
     if free:
-        expected_fee_code = 'OTFDR'
+        expected_fee_code = Filing.FILINGS[filing_name].get('free', {}).get('codes', {}).get(orig_legal_type)
     else:
         expected_fee_code = Filing.FILINGS[filing_name].get('codes', {}).get(orig_legal_type)
     if not identifier.startswith('T'):


### PR DESCRIPTION
*Issue #:* /bcgov/entity#5126

*Description of changes:*
OT* codes are no longer valid for Benefit Companies on the Payment side.
Updated the code to BCFDR for Benefit Company free filing
Updated tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
