### PR TITLE
Fix - Default value of corp type if legal type is not present in filing

### DIFF
--- a/legal-api/src/legal_api/resources/business/business_filings.py
+++ b/legal-api/src/legal_api/resources/business/business_filings.py
@@ -556,7 +556,7 @@ class ListFilingResource(Resource):
 
         else:
             mailing_address = business.mailing_address.one_or_none()
-            corp_type = filing.json['filing']['business'].get('legalType', business.identifier[:-7])
+            corp_type = filing.json['filing']['business'].get('legalType', business.legal_type)
 
         payload = {
             'businessInfo': {

--- a/legal-api/src/legal_api/resources/business/business_filings.py
+++ b/legal-api/src/legal_api/resources/business/business_filings.py
@@ -556,7 +556,8 @@ class ListFilingResource(Resource):
 
         else:
             mailing_address = business.mailing_address.one_or_none()
-            corp_type = filing.json['filing']['business'].get('legalType', business.legal_type)
+            corp_type = business.legal_type if business.legal_type else \
+                filing.json['filing']['business'].get('legalType')
 
         payload = {
             'businessInfo': {


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*
We should not be looking at the business identifier prefix to identify the corp type in case the legal type is not
present in the business json. We should take that value from the business model.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
