### PR TITLE
Fix for corrections adding fee for sub filing type

### DIFF
--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -103,7 +103,8 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
             'name': 'correction',
             'title': 'Correction',
             'codes': {
-                'BEN': 'CRCTN'
+                'BEN': 'CRCTN',
+                'CP': 'CRCTN'
             }
         },
         'incorporationApplication': {

--- a/legal-api/tests/unit/api/test_business_filings/test_filings.py
+++ b/legal-api/tests/unit/api/test_business_filings/test_filings.py
@@ -29,6 +29,8 @@ from registry_schemas.example_data import (
     ANNUAL_REPORT,
     CHANGE_OF_ADDRESS,
     CHANGE_OF_DIRECTORS,
+    CORRECTION_AR,
+    CORRECTION_INCORPORATION,
     FILING_HEADER,
     INCORPORATION_FILING_TEMPLATE,
 )
@@ -784,9 +786,11 @@ def test_calc_annual_report_date(session, client, jwt):
         ('BC1234569', FILING_HEADER, 'changeOfAddress', Business.LegalTypes.BCOMP.value, None, False),
         ('BC1234569', FILING_HEADER, 'changeOfDirectors', Business.LegalTypes.BCOMP.value, None, False),
         ('BC1234569', FILING_HEADER, 'changeOfDirectors', Business.LegalTypes.BCOMP.value, None, True),
+        ('BC1234569', CORRECTION_INCORPORATION, 'correction', Business.LegalTypes.BCOMP.value, None, False),
         ('CP1234567', ANNUAL_REPORT, 'annualReport', Business.LegalTypes.COOP.value, None, False),
         ('CP1234567', FILING_HEADER, 'changeOfAddress', Business.LegalTypes.COOP.value, None, False),
         ('CP1234567', FILING_HEADER, 'changeOfDirectors', Business.LegalTypes.COOP.value, None, False),
+        ('CP1234567', CORRECTION_AR, 'correction', Business.LegalTypes.COOP.value, None, False),
         ('CP1234567', FILING_HEADER, 'changeOfDirectors', Business.LegalTypes.COOP.value, None, True),
         ('T1234567', INCORPORATION_FILING_TEMPLATE, 'incorporationApplication',
          Business.LegalTypes.BCOMP.value, None, False)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#4642

*Description of changes:*
Currently if it is a correction filing it adds the fee for the sub filing types under it. If it is a correction it has a defined fee for each entity type and it should not consider the sub filing types.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
