### PR TITLE
Multiple Fixes in document list generation for corrections

### DIFF
--- a/legal-api/report-templates/template-parts/notice-of-articles/benefitCompanyStmt.html
+++ b/legal-api/report-templates/template-parts/notice-of-articles/benefitCompanyStmt.html
@@ -1,9 +1,11 @@
 <div class="no-page-break">
+  {% if business.legalType == 'BEN' %}
     <div class="section-title mt-4">Benefit Company Statement</div>
     <div class="section-data mt-4">
         This company is a benefit company and, as such, has purposes that include conducting its
         business in a responsible and sustainable manner and promoting one or more public benefits.
     </div>
+  {% endif %}
 </div>
 
 <div class="no-page-break">

--- a/legal-api/src/legal_api/resources/business/business_filings.py
+++ b/legal-api/src/legal_api/resources/business/business_filings.py
@@ -98,8 +98,6 @@ class ListFilingResource(Resource):
 
             if str(request.accept_mimetypes) == 'application/pdf':
                 report_type = request.args.get('type', None)
-                if rv[1].filing_type == 'incorporationApplication':
-                    ListFilingResource._populate_business_info_to_filing(rv[1], business)
                 return legal_api.reports.get_pdf(rv[1], report_type)
             return jsonify(rv[1].json)
 
@@ -655,17 +653,6 @@ class ListFilingResource(Resource):
         if effective_date:
             is_future_effective = effective_date > datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
         return is_future_effective
-
-    @staticmethod
-    def _populate_business_info_to_filing(filing: Filing, business: Business):
-        founding_datetime = LegislationDatetime.as_legislation_timezone(business.founding_date)
-        hour = founding_datetime.strftime('%I')
-        business_json = business.json()
-        business_json['formatted_founding_date_time'] = \
-            founding_datetime.strftime(f'%B %-d, %Y at {hour}:%M %p Pacific Time')
-        business_json['formatted_founding_date'] = founding_datetime.strftime('%B %-d, %Y')
-        filing.filing_json['filing']['business'] = business_json
-        filing.filing_json['filing']['header']['filingId'] = filing.id
 
 
 @cors_preflight('GET, POST, PUT, PATCH, DELETE')

--- a/legal-api/src/legal_api/services/business_details_version.py
+++ b/legal-api/src/legal_api/services/business_details_version.py
@@ -345,4 +345,6 @@ class VersionedBusinessDetailsService:
             business_json['dissolutionDate'] = None
         if business_revision.tax_id:
             business_json['taxId'] = business_revision.tax_id
+        business_json['legalName'] = business_revision.legal_name
+        business_json['legalType'] = business_revision.legal_type
         return business_json

--- a/legal-api/src/legal_api/services/document_meta.py
+++ b/legal-api/src/legal_api/services/document_meta.py
@@ -207,10 +207,6 @@ class DocumentMetaService():
 
     def get_corrected_ia_reports(self, filing: dict):
         """Return corrected incorporation application meta object(s)."""
-        # safety check - for now, IA only applies to BCOMPs
-        if not self.is_bcomp():
-            return []
-
         reports = []
 
         reports.append(self.create_report_object(
@@ -251,10 +247,6 @@ class DocumentMetaService():
 
     def get_incorporation_application_reports(self, filing: dict):
         """Return incorporation application meta object(s)."""
-        # safety check - for now, IA only applies to BCOMPs
-        if not self.is_bcomp():
-            return []
-
         is_fed = LegislationDatetime.is_future(filing['filing']['header']['effectiveDate'])
 
         # return FED instead of PAID or COMPLETED
@@ -276,9 +268,9 @@ class DocumentMetaService():
 
         filing_data = Filing.find_by_id(filing['filing']['header']['filingId'])
         has_corrected = filing_data.parent_filing_id is not None  # Identify whether it is corrected
-        label_original = ' (Original)'
-        if not has_corrected:
-            label_original = ''
+        label_original = ' (Original)' if has_corrected else ''
+        label_certificate_original = ' (Original)' if has_corrected and NameXService.\
+            has_correction_changed_name(Filing.find_by_id(filing_data.parent_filing_id).json) else ''
 
         # else status is COMPLETED
         return [
@@ -293,8 +285,8 @@ class DocumentMetaService():
             ),
 
             self.create_report_object(
-                f'Certificate{label_original}',
-                self.get_general_filename(f'Certificate{label_original}'),
+                f'Certificate{label_certificate_original}',
+                self.get_general_filename(f'Certificate{label_certificate_original}'),
                 DocumentMetaService.ReportType.CERTIFICATE.value
             )
         ]

--- a/legal-api/src/legal_api/services/namex.py
+++ b/legal-api/src/legal_api/services/namex.py
@@ -197,7 +197,9 @@ class NameXService():
         """Has correction changed the legal name."""
         corrected_filing = Filing.find_by_id(filing['filing']['correction']['correctedFilingId'])
         nr_path = '/filing/incorporationApplication/nameRequest/nrNumber'
+        legal_name_path = '/filing/incorporationApplication/nameRequest/legalName'
         old_nr_number = get_str(corrected_filing.json, nr_path)
         new_nr_number = get_str(filing, nr_path)
-
-        return new_nr_number and old_nr_number != new_nr_number
+        old_legal_name = get_str(corrected_filing.json, legal_name_path)
+        new_legal_name = get_str(filing, legal_name_path)
+        return old_nr_number != new_nr_number or old_legal_name != new_legal_name


### PR DESCRIPTION
Fix for original certificate not retaining its old name

*Issue #:* /bcgov/entity#5284,/bcgov/entity#5310

*Description of changes:*
Fix for following issues:

- Corrected certificate not present in the documents list for the scenarios
     Named to Numbered Company correction
     Name correction without an NR
- IA and correction documents not getting listed if there is a company type alteration
- Original certificate not retaining the old business name after correction
- Original label getting appended to the certificate even if there is no name correction
- Check for legal type around benefit company statement in NOA
- Added more tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
