### PR TITLE
Fix to use the versioned business info only if transaction id is present

### DIFF
--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -283,7 +283,10 @@ class Report:  # pylint: disable=too-few-public-methods
     def _populate_business_info_to_filing(filing: Filing, business: Business):
         founding_datetime = LegislationDatetime.as_legislation_timezone(business.founding_date)
         hour = founding_datetime.strftime('%I')
-        business_json = VersionedBusinessDetailsService.get_business_revision(filing.transaction_id, business)
+        if filing.transaction_id:
+            business_json = VersionedBusinessDetailsService.get_business_revision(filing.transaction_id, business)
+        else:
+            business_json = business.json()
         business_json['formatted_founding_date_time'] = \
             founding_datetime.strftime(f'%B %-d, %Y at {hour}:%M %p Pacific Time')
         business_json['formatted_founding_date'] = founding_datetime.strftime('%B %-d, %Y')


### PR DESCRIPTION
*Issue #:* /bcgov/entity#N/A

*Description of changes:*
The versioned business detail depends on the transaction id and is available only after a filing is complete. For a future effective
filing or immediately after the payment is done, transaction id will not be present in the filing and this causes issue while trying to download the report of a filing in paid status

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
