### PR TITLE
Fix for not sending the email to completing party for an IA correction

### DIFF
--- a/queue_services/entity-emailer/src/entity_emailer/email_processors/__init__.py
+++ b/queue_services/entity-emailer/src/entity_emailer/email_processors/__init__.py
@@ -50,7 +50,8 @@ def get_recipients(option: str, filing_json: dict, token: str = None) -> str:
     recipients = ''
     if filing_json['filing'].get('incorporationApplication'):
         recipients = filing_json['filing']['incorporationApplication']['contactPoint']['email']
-        if option in [Filing.Status.PAID.value, 'bn']:
+        if option in [Filing.Status.PAID.value, 'bn'] and \
+                filing_json['filing']['header']['name'] == 'incorporationApplication':
             parties = filing_json['filing']['incorporationApplication'].get('parties')
             comp_party_email = None
             for party in parties:


### PR DESCRIPTION
*Issue #:* /bcgov/entity#4606

*Description of changes:*
Fix for not sending the email to completing party for an IA correction

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
