### PR TITLE
fixed coop AR wrong filing year in output

### DIFF
--- a/legal-api/report-templates/annualReport.html
+++ b/legal-api/report-templates/annualReport.html
@@ -19,7 +19,7 @@
     <div class="column-report">
       <div class="column-report-headspace"></div>
       <div class="header-blue">
-        {{ annualReport.annualReportDate[:4] }} BC COOPERATIVE ANNUAL REPORT
+        {{ header.ARFilingYear }} BC COOPERATIVE ANNUAL REPORT
       </div>
       <div class="header-gold">
         BC Cooperative &bull; Cooperative Association Act


### PR DESCRIPTION
*Issue #:* /bcgov/entity#6443

*Description of changes:*

The AR output needs to use the "AR Filing Year" instead of the AR date, now that AGMs can be held in the year after.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).