### PR TITLE
NR name change bug and validator update

### DIFF
--- a/legal-api/src/legal_api/services/filings/validations/alteration.py
+++ b/legal-api/src/legal_api/services/filings/validations/alteration.py
@@ -71,7 +71,7 @@ def company_name_validation(filing):
         nr_response = namex.query_nr_number(nr_number)
         validation_result = namex.validate_nr(nr_response)
 
-        if not nr_response['requestTypeCd'] in ('CCP', 'BEC'):
+        if not nr_response['requestTypeCd'] in ('CCR', 'CCP', 'BEC'):
             msg.append({'error': babel('Alteration only available for Change of Name Name requests.'), 'path': nr_path})
 
         if not validation_result['is_approved']:

--- a/legal-api/src/legal_api/services/namex.py
+++ b/legal-api/src/legal_api/services/namex.py
@@ -69,7 +69,7 @@ class NameXService():
             'Authorization': 'Bearer ' + token
         })
 
-        return nr_response
+        return nr_response.json()
 
     @staticmethod
     def update_nr(nr_json):

--- a/legal-api/tests/unit/services/filings/validations/test_alteration.py
+++ b/legal-api/tests/unit/services/filings/validations/test_alteration.py
@@ -29,6 +29,7 @@ ALTERATION_FILING = copy.deepcopy(ALTERATION_FILING_TEMPLATE)
 TEST_DATA = [
     (False, '', '', '', True),
     (True, 'legal_name-BC1234567_Changed', 'BEN', 'BEC', True),
+    (True, 'legal_name-BC1234567_Changed', 'BC', 'CCR', True),
     (True, 'legal_name-BC1234568', 'CP', 'XCLP', False)
 ]
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#6902

*Description of changes:*

* Updates `query_nr_number` method to return the response in json.

* Updates the validator to allow Bc company name changes. We will need these for Limited Companies coming into our system.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
