### PR TITLE
7038 - Saving an alteration as staff resulting in 500 error (court order related)

### DIFF
--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -107,17 +107,14 @@ def validate_court_order(court_order_path, court_order):
             msg.append({'error': 'Length of court order file number must be from 5 to 20 characters.',
                         'path': err_path})
 
-    if 'effectOfOrder' not in court_order and (len(court_order['effectOfOrder']) < 5 or
-                                               len(court_order['effectOfOrder']) > 500):
+    if 'effectOfOrder' in court_order and (len(court_order['effectOfOrder']) < 5 or
+                                           len(court_order['effectOfOrder']) > 500):
         err_path = court_order_path + '/effectOfOrder'
         msg.append({'error': 'Length of court order effect of order must be from 5 to 500 characters.',
                     'path': err_path})
 
     court_order_date_path = court_order_path + '/orderDate'
-    if 'orderDate'not in court_order:
-        err_path = court_order_date_path
-        msg.append({'error': 'Court order date is required.', 'path': err_path})
-    else:
+    if 'orderDate' in court_order:
         try:
             court_order_date = dt.fromisoformat(court_order['orderDate'])
             if court_order_date.timestamp() > datetime.utcnow().timestamp():

--- a/legal-api/tests/unit/services/filings/validations/alteration/__init__.py
+++ b/legal-api/tests/unit/services/filings/validations/alteration/__init__.py
@@ -1,0 +1,14 @@
+# Copyright © 2021 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test Suite for Alteration validations."""

--- a/legal-api/tests/unit/services/filings/validations/alteration/test_court_order.py
+++ b/legal-api/tests/unit/services/filings/validations/alteration/test_court_order.py
@@ -1,0 +1,63 @@
+# Copyright © 2021 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests to assure the Court Order is validated properly."""
+import pytest
+
+from legal_api.services.filings.validations.common_validations import validate_court_order
+
+
+@pytest.mark.parametrize('invalid_court_order', [
+    {
+        'fileNumber': '123456789012345678901',  # long fileNumber
+        'orderDate': '2021-01-30T09:56:01+01:00',
+        'effectOfOrder': 'Valid effect of order'
+    },
+    {
+        'orderDate': '2021-01-30T09:56:01+01:00',
+        'effectOfOrder': 'Valid effect of order'
+    },
+    {
+        'fileNumber': 'Valid file number',
+        'orderDate': 'a2021-01-30T09:56:01',  # Invalid date
+        'effectOfOrder': 'Valid effect of order'
+    },
+    {
+        'fileNumber': 'Valid File Number',
+        'orderDate': '2021-01-30T09:56:01+01:00',
+        'effectOfOrder': ('a' * 501)  # long effectOfOrder
+    }
+])
+def test_validate_invalid_court_orders(session, invalid_court_order):
+    """Assert not valid court orders."""
+    msg = validate_court_order('/filing/alteration/courtOrder', invalid_court_order)
+
+    assert msg
+    assert len(msg) > 0
+
+
+@pytest.mark.parametrize('valid_court_order', [
+    {
+        'fileNumber': '12345678901234567890'
+    },
+    {
+        'fileNumber': 'Valid file number',
+        'orderDate': '2021-01-30T09:56:01+01:00',
+        'effectOfOrder': 'Valid effect of order'
+    }
+])
+def test_validate_valid_court_orders(session, valid_court_order):
+    """Assert valid court orders."""
+    msg = validate_court_order('/filing/alteration/courtOrder', valid_court_order)
+
+    assert not msg


### PR DESCRIPTION
*Issue #:* /bcgov/entity#7038

*Description of changes:*

- Fixed validator bug and added tests for the validator

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
