### PR TITLE
Fixed logic to display Name Translations in Alteration Notice

### DIFF
--- a/legal-api/report-templates/template-parts/common/nameTranslation.html
+++ b/legal-api/report-templates/template-parts/common/nameTranslation.html
@@ -1,5 +1,5 @@
 <div class="no-page-break">
-    {% if listOfTranslations|length == 0 %}
+    {% if listOfTranslations|length or nameTranslations|length %}
         <div class="separator mt-4"></div>
         <div class="section-title mt-4">Company Name Translation(s)</div>
         <div class="section-data mt-3">

--- a/legal-api/report-templates/template-parts/common/nameTranslation.html
+++ b/legal-api/report-templates/template-parts/common/nameTranslation.html
@@ -1,10 +1,10 @@
 <div class="no-page-break">
-    {% if listOfTranslations|length or nameTranslations|length %}
+    {% if listOfTranslations|length or previousNameTranslations|length %}
         <div class="separator mt-4"></div>
         <div class="section-title mt-4">Company Name Translation(s)</div>
         <div class="section-data mt-3">
             <table class="section-translation-table" role="presentation">
-                {% if listOfTranslations|length == 0 and nameTranslations| length %}
+                {% if listOfTranslations|length == 0 and previousNameTranslations|length %}
                     <div class="mt-2">NONE</div>
                 {% else %}
                     {% for translation in listOfTranslations %}

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -350,7 +350,7 @@ class Report:  # pylint: disable=too-few-public-methods
         if 'nameTranslations' in filing['alteration']:
             filing['listOfTranslations'] = filing['alteration'].get('nameTranslations', [])
             # Get previous translations for deleted translations. No record created in aliases version for deletions
-            filing['nameTranslations'] = VersionedBusinessDetailsService.get_name_translations_before_revision(
+            filing['previousNameTranslations'] = VersionedBusinessDetailsService.get_name_translations_before_revision(
                 self._filing.transaction_id, self._business.id)
         if filing['alteration'].get('shareStructure', None):
             filing['shareClasses'] = filing['alteration']['shareStructure']['shareClasses']

--- a/legal-api/tests/unit/reports/templates/__init__.py
+++ b/legal-api/tests/unit/reports/templates/__init__.py
@@ -1,0 +1,14 @@
+# Copyright © 2021 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Templates tests."""

--- a/legal-api/tests/unit/reports/templates/test_name_translations.py
+++ b/legal-api/tests/unit/reports/templates/test_name_translations.py
@@ -1,0 +1,50 @@
+# Copyright © 2021 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Name Translation template tests."""
+
+
+from pathlib import Path
+
+from flask import current_app
+from jinja2 import Template
+
+
+def test_no_rendering(session):
+    """Test Company Name Translation(s) section should not rendered when no current translation nor previous ones."""
+    template_path = current_app.config.get('REPORT_TEMPLATE_PATH')
+    template_code = Path(f'{template_path}/template-parts/common/nameTranslation.html').read_text()
+    template = Template(template_code)
+    rendered = template.render(listOfTranslations=[], previousNameTranslations=[])
+    assert 'Company Name Translation(s)' not in rendered
+
+
+def test_render_none(session):
+    """Test Company Name Translation(s) should render none when no current translation and there were previous ones."""
+    template_path = current_app.config.get('REPORT_TEMPLATE_PATH')
+    template_code = Path(f'{template_path}/template-parts/common/nameTranslation.html').read_text()
+    template = Template(template_code)
+    rendered = template.render(listOfTranslations=[], previousNameTranslations=['Une Grande Enterprise'])
+    assert 'Company Name Translation(s)' in rendered
+    assert 'Une Grande Enterprise' not in rendered
+    assert 'NONE' in rendered
+
+
+def test_render_translations(session):
+    """Test Company Name Translation(s) should render when there are current translations."""
+    template_path = current_app.config.get('REPORT_TEMPLATE_PATH')
+    template_code = Path(f'{template_path}/template-parts/common/nameTranslation.html').read_text()
+    template = Template(template_code)
+    rendered = template.render(listOfTranslations=['Ma Enterprise'], previousNameTranslations=[])
+    assert 'Company Name Translation(s)' in rendered
+    assert 'Ma Enterprise' in rendered

--- a/legal-api/tests/unit/reports/templates/test_name_translations.py
+++ b/legal-api/tests/unit/reports/templates/test_name_translations.py
@@ -13,38 +13,44 @@
 # limitations under the License.
 """Name Translation template tests."""
 
-
+from typing import Final
 from pathlib import Path
 
 from flask import current_app
 from jinja2 import Template
 
 
-def test_no_rendering(session):
-    """Test Company Name Translation(s) section should not rendered when no current translation nor previous ones."""
+title: Final = 'Company Name Translation(s)'
+
+
+def get_template():
+    """Returns the template."""
     template_path = current_app.config.get('REPORT_TEMPLATE_PATH')
     template_code = Path(f'{template_path}/template-parts/common/nameTranslation.html').read_text()
-    template = Template(template_code)
+    return Template(template_code)
+
+
+def test_no_rendering(session):
+    """Test Company Name Translation(s) section should not rendered when no current translation nor previous ones."""
+    template = get_template()
     rendered = template.render(listOfTranslations=[], previousNameTranslations=[])
-    assert 'Company Name Translation(s)' not in rendered
+    assert title not in rendered
 
 
 def test_render_none(session):
     """Test Company Name Translation(s) should render none when no current translation and there were previous ones."""
-    template_path = current_app.config.get('REPORT_TEMPLATE_PATH')
-    template_code = Path(f'{template_path}/template-parts/common/nameTranslation.html').read_text()
-    template = Template(template_code)
-    rendered = template.render(listOfTranslations=[], previousNameTranslations=['Une Grande Enterprise'])
-    assert 'Company Name Translation(s)' in rendered
+    template = get_template()
+    name_translation = {'name': 'Une Grande Enterprise'}
+    rendered = template.render(listOfTranslations=[], previousNameTranslations=[name_translation])
+    assert title in rendered
     assert 'Une Grande Enterprise' not in rendered
     assert 'NONE' in rendered
 
 
 def test_render_translations(session):
     """Test Company Name Translation(s) should render when there are current translations."""
-    template_path = current_app.config.get('REPORT_TEMPLATE_PATH')
-    template_code = Path(f'{template_path}/template-parts/common/nameTranslation.html').read_text()
-    template = Template(template_code)
-    rendered = template.render(listOfTranslations=['Ma Enterprise'], previousNameTranslations=[])
-    assert 'Company Name Translation(s)' in rendered
+    template = get_template()
+    name_translation = {'name': 'Ma Enterprise'}
+    rendered = template.render(listOfTranslations=[name_translation], previousNameTranslations=[])
+    assert title in rendered
     assert 'Ma Enterprise' in rendered

--- a/legal-api/tests/unit/reports/templates/test_name_translations.py
+++ b/legal-api/tests/unit/reports/templates/test_name_translations.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 """Name Translation template tests."""
 
-from typing import Final
 from pathlib import Path
+from typing import Final
 
+import pytest
 from flask import current_app
 from jinja2 import Template
 
@@ -30,27 +31,22 @@ def get_template():
     return Template(template_code)
 
 
-def test_no_rendering(session):
-    """Test Company Name Translation(s) section should not rendered when no current translation nor previous ones."""
+@pytest.mark.parametrize('list_of_translations,previous_translations', [
+    ([{'name': 'Ma Enterprise'}], []),
+    ([], [{'name': 'Ma Enterprise'}]),
+    ([], [])])
+def test_render_translations(session, list_of_translations, previous_translations):
+    """Test Company Name Translation(s) rendering."""
     template = get_template()
-    rendered = template.render(listOfTranslations=[], previousNameTranslations=[])
-    assert title not in rendered
-
-
-def test_render_none(session):
-    """Test Company Name Translation(s) should render none when no current translation and there were previous ones."""
-    template = get_template()
-    name_translation = {'name': 'Une Grande Enterprise'}
-    rendered = template.render(listOfTranslations=[], previousNameTranslations=[name_translation])
-    assert title in rendered
-    assert 'Une Grande Enterprise' not in rendered
-    assert 'NONE' in rendered
-
-
-def test_render_translations(session):
-    """Test Company Name Translation(s) should render when there are current translations."""
-    template = get_template()
-    name_translation = {'name': 'Ma Enterprise'}
-    rendered = template.render(listOfTranslations=[name_translation], previousNameTranslations=[])
-    assert title in rendered
-    assert 'Ma Enterprise' in rendered
+    rendered = template.render(listOfTranslations=list_of_translations,
+                               previousNameTranslations=previous_translations)
+    if len(list_of_translations):
+        assert title in rendered
+        assert list_of_translations[0]['name'] in rendered
+        assert 'NONE' not in rendered
+    elif len(previous_translations):
+        assert title in rendered
+        assert previous_translations[0]['name'] not in rendered
+        assert 'NONE' in rendered
+    else:
+        assert title not in rendered


### PR DESCRIPTION
*Issue #:* /bcgov/entity#7006

*Description of changes:*

- Fixed logic to display Name Translations in Alteration Notice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
