### PR TITLE
Remove watch rollout step for cronjob CD flows.

### DIFF
--- a/.github/workflows/filings-notebook-report-cd.yml
+++ b/.github/workflows/filings-notebook-report-cd.yml
@@ -54,11 +54,6 @@ jobs:
         run: |
           make cd
 
-      - name: Watch new rollout (trigger by image change in Openshift)
-        shell: bash
-        run: |
-          oc rollout status dc/${{ env.APP_NAME }}-${{ env.TAG_NAME }} -n ${{ secrets.OPENSHIFT4_REPOSITORY_DEPLOYMENT }}-${{ env.TAG_NAME }} -w
-
       - name: Rocket.Chat Notification
         uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@master
         if: failure()

--- a/.github/workflows/future-effective-filings-cd.yml
+++ b/.github/workflows/future-effective-filings-cd.yml
@@ -54,11 +54,6 @@ jobs:
         run: |
           make cd
 
-      - name: Watch new rollout (trigger by image change in Openshift)
-        shell: bash
-        run: |
-          oc rollout status dc/${{ env.APP_NAME }}-${{ env.TAG_NAME }} -n ${{ secrets.OPENSHIFT4_REPOSITORY_DEPLOYMENT }}-${{ env.TAG_NAME }} -w
-
       - name: Rocket.Chat Notification
         uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@master
         if: failure()

--- a/.github/workflows/update-colin-filings-cd.yml
+++ b/.github/workflows/update-colin-filings-cd.yml
@@ -54,11 +54,6 @@ jobs:
         run: |
           make cd
 
-      - name: Watch new rollout (trigger by image change in Openshift)
-        shell: bash
-        run: |
-          oc rollout status dc/${{ env.APP_NAME }}-${{ env.TAG_NAME }} -n ${{ secrets.OPENSHIFT4_REPOSITORY_DEPLOYMENT }}-${{ env.TAG_NAME }} -w
-
       - name: Rocket.Chat Notification
         uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@master
         if: failure()

--- a/.github/workflows/update-legal-filings-cd.yml
+++ b/.github/workflows/update-legal-filings-cd.yml
@@ -54,11 +54,6 @@ jobs:
         run: |
           make cd
 
-      - name: Watch new rollout (trigger by image change in Openshift)
-        shell: bash
-        run: |
-          oc rollout status dc/${{ env.APP_NAME }}-${{ env.TAG_NAME }} -n ${{ secrets.OPENSHIFT4_REPOSITORY_DEPLOYMENT }}-${{ env.TAG_NAME }} -w
-
       - name: Rocket.Chat Notification
         uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@master
         if: failure()


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*
Remove watch rollout step for the Jobs CD.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
