### PR TITLE
Fixed service_utils imports

### DIFF
--- a/queue_services/common/src/entity_queue_common/service_utils/__init__.py
+++ b/queue_services/common/src/entity_queue_common/service_utils/__init__.py
@@ -14,7 +14,8 @@
 """Callbacks and utility functions used to support the service loop."""
 from typing import Callable
 
-import stan
+from stan.aio.client import Client as StanClient
+from stan.aio.client import Msg as StanMessage
 
 from .exceptions import EmailException, FilingException, QueueException
 from .handlers import error_cb, signal_handler
@@ -22,11 +23,11 @@ from .run_version import get_run_version
 from .service_logger import logger
 
 
-async def subscribe_to_queue(stan_client: stan.aio.client.Client,
+async def subscribe_to_queue(stan_client: StanClient,
                              subject: str,
                              queue: str,
                              durable_name: str,
-                             call_back: Callable[[stan.aio.client.Msg], None]) \
+                             call_back: Callable[[StanMessage], None]) \
         -> str:
     """Subscribe to the Queue using the environment setup.
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#4923

*Description of changes:*

- Fixed some imports because of issue with updated libs

The reason of this fix is an issue with entity-emailer:

```
Traceback (most recent call last):
  File "q_cli.py", line 34, in <module>
    from entity_queue_common.service_utils import error_cb, logger, signal_handler
  File "/usr/local/lib/python3.8/site-packages/entity_queue_common/service_utils/__init__.py", line 25, in <module>
    async def subscribe_to_queue(stan_client: stan.aio.client.Client,
AttributeError: module 'stan' has no attribute 'aio'
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
