### PR TITLE
4711 colin api updates for data loader

### DIFF
--- a/colin-api/requirements.txt
+++ b/colin-api/requirements.txt
@@ -12,7 +12,7 @@ click==7.1.2
 cx-Oracle==8.1.0
 ecdsa==0.14.1
 flask-jwt-oidc==0.1.5
-flask-restx==0.2.0
+flask-restx==0.3.0
 gunicorn==20.0.4
 itsdangerous==1.1.0
 jsonschema==3.2.0

--- a/colin-api/src/colin_api/models/business.py
+++ b/colin-api/src/colin_api/models/business.py
@@ -45,6 +45,7 @@ class Business:  # pylint: disable=too-many-instance-attributes
         BCOMP = 'BEN'
         BC_COMP = 'BC'
         ULC_COMP = 'ULC'
+        CCC_COMP = 'CC'
 
     class CorpFrozenTypes(Enum):
         """Render an Enum of the Corporation Frozen Type Codes.
@@ -70,7 +71,8 @@ class Business:  # pylint: disable=too-many-instance-attributes
         LearBusinessTypes.BC_COMP.value: [
             TypeCodes.BCOMP.value,
             TypeCodes.BC_COMP.value,
-            TypeCodes.ULC_COMP.value
+            TypeCodes.ULC_COMP.value,
+            TypeCodes.CCC_COMP.value
         ]
     }
 

--- a/colin-api/src/colin_api/models/filing.py
+++ b/colin-api/src/colin_api/models/filing.py
@@ -53,27 +53,48 @@ class Filing:
         'annualReport': {
             'type_code_list': ['OTANN', 'ANNBC'],
             Business.TypeCodes.COOP.value: 'OTANN',
-            Business.TypeCodes.BCOMP.value: 'ANNBC'
+            Business.TypeCodes.BCOMP.value: 'ANNBC',
+            Business.TypeCodes.BC_COMP.value: 'ANNBC',
+            Business.TypeCodes.ULC_COMP.value: 'ANNBC',
+            Business.TypeCodes.CCC_COMP.value: 'ANNBC',
         },
         'changeOfDirectors': {
             'type_code_list': ['OTCDR', 'NOCDR'],
             Business.TypeCodes.COOP.value: 'OTCDR',
-            Business.TypeCodes.BCOMP.value: 'NOCDR'
+            Business.TypeCodes.BCOMP.value: 'NOCDR',
+            Business.TypeCodes.BC_COMP.value: 'NOCDR',
+            Business.TypeCodes.ULC_COMP.value: 'NOCDR',
+            Business.TypeCodes.CCC_COMP.value: 'NOCDR'
         },
         'changeOfAddress': {
             'type_code_list': ['OTADD', 'NOCAD'],
             Business.TypeCodes.COOP.value: 'OTADD',
-            Business.TypeCodes.BCOMP.value: 'NOCAD'
+            Business.TypeCodes.BCOMP.value: 'NOCAD',
+            Business.TypeCodes.BC_COMP.value: 'NOCAD',
+            Business.TypeCodes.ULC_COMP.value: 'NOCAD',
+            Business.TypeCodes.CCC_COMP.value: 'NOCAD',
+
         },
         'incorporationApplication': {
-            'type_code_list': ['OTINC', 'BEINC'],
+            'type_code_list': ['OTINC', 'BEINC', 'ICORP', 'ICORU', 'ICORC'],
             Business.TypeCodes.COOP.value: 'OTINC',
-            Business.TypeCodes.BCOMP.value: 'BEINC'
+            Business.TypeCodes.BCOMP.value: 'BEINC',
+            Business.TypeCodes.BC_COMP.value: 'ICORP',
+            Business.TypeCodes.ULC_COMP.value: 'ICORU',
+            Business.TypeCodes.CCC_COMP.value: 'ICORC',
+        },
+        'conversion': {
+            'type_code_list': ['CONVL'],
+            Business.TypeCodes.BC_COMP.value: 'CONVL',
+            Business.TypeCodes.ULC_COMP.value: 'CONVL',
+            Business.TypeCodes.CCC_COMP.value: 'CONVL'
         },
         'alteration': {
-            'type_code_list': ['NOALE', 'NOALR'],
+            'type_code_list': ['NOALA', 'NOALR'],
             Business.TypeCodes.BCOMP.value: 'NOALR',
-            Business.TypeCodes.BC_COMP.value: 'NOALE'
+            Business.TypeCodes.BC_COMP.value: 'NOALA',
+            Business.TypeCodes.ULC_COMP.value: 'NOALA',
+            Business.TypeCodes.CCC_COMP.value: 'NOALA'
         },
         'correction': {
             'type_code_list': ['CRBIN'],


### PR DESCRIPTION
*Issue #:* /bcgov/entity#4711

*Description of changes:*
 

* Addition of endpoint to retrieve all events specific to a business.  This was specifically created for the data loader so is able to retrieve the event associated with an incorporation application or conversion ledger
* Updated event `/event/<string:corp_type>/<string:event_id>` endpoint to support other corp types.  The way it was implemented previously did not really allow query events for any companies where the corp num did not have an alphabetical prefix
* `FILING_TYPES` in `colin-api/src/colin_api/models/filing.py` was updated to include type codes for Colin specific filing type codes.  This is used by data loader to determine the generic application filing type.  e.g. `incorporationApplication` or `conversion`
* Addition of type codes and values for ULC and CCC
* Updated flask-restx to 0.3.0 to resolve dependency conflict

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
