### PR TITLE
4711 legal api updates for data loader

### DIFF
--- a/legal-api/requirements.txt
+++ b/legal-api/requirements.txt
@@ -27,7 +27,7 @@ dpath==2.0.1
 ecdsa==0.14.1
 expiringdict==1.1.4
 flask-jwt-oidc==0.3.0
-flask-restx==0.2.0
+flask-restx==0.3.0
 gunicorn==20.1.0
 idna==2.10
 itsdangerous==1.1.0

--- a/legal-api/src/legal_api/constants.py
+++ b/legal-api/src/legal_api/constants.py
@@ -1,0 +1,16 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Constants for legal api."""
+
+BOB_DATE = '2019-03-08'


### PR DESCRIPTION
*Issue #:* /bcgov/entity#4711

*Description of changes:*

* Added `conversion` to `FILINGS` which is used by other lear components.  Specifically entity filer was updated to use `conversion`
* Updated filings save logic such that historical colin filings are not validated before saving
* Updated filings save logic such for colin filngs so that the filing is pushed to the entity filer queue in the following two scenarios:
  * business has epoch lear filing and the currently colin filing being saved is after the epoch lear filing date
  * business has no epoch lear filing 
* Updated flask-restx dependency conflict

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
