### PR TITLE
6833 Update court order validation logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ coverage.xml
 .pytest_cache/
 *.postman_environment.json
 coverage/
+http-client.*
 
 # Translations
 *.mo

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -110,22 +110,6 @@ def validate_court_order(court_order_path, court_order):
     """Validate the courtOrder data of the filing."""
     msg = []
 
-    # TODO remove it when the issue with schema validation is fixed
-    if 'fileNumber' not in court_order:
-        err_path = court_order_path + '/fileNumber'
-        msg.append({'error': 'Court order file number is required.', 'path': err_path})
-    else:
-        if len(court_order['fileNumber']) < 5 or len(court_order['fileNumber']) > 20:
-            err_path = court_order_path + '/fileNumber'
-            msg.append({'error': 'Length of court order file number must be from 5 to 20 characters.',
-                        'path': err_path})
-
-    if 'effectOfOrder' in court_order and (len(court_order['effectOfOrder']) < 5 or
-                                           len(court_order['effectOfOrder']) > 500):
-        err_path = court_order_path + '/effectOfOrder'
-        msg.append({'error': 'Length of court order effect of order must be from 5 to 500 characters.',
-                    'path': err_path})
-
     court_order_date_path = court_order_path + '/orderDate'
     if 'orderDate' in court_order:
         try:

--- a/legal-api/src/legal_api/utils/datetime.py
+++ b/legal-api/src/legal_api/utils/datetime.py
@@ -14,7 +14,8 @@
 """Date time utilities."""
 # from datetime import datetime, timezone
 import time as _time
-from datetime import date, datetime as _datetime, timezone  # pylint: disable=unused-import # noqa: F401, I001, I005
+from datetime import date, datetime as _datetime, timezone, \
+    timedelta  # pylint: disable=unused-import # noqa: F401, I001, I005
 # noqa: I003,I005
 
 

--- a/legal-api/tests/unit/services/filings/validations/alteration/test_court_order.py
+++ b/legal-api/tests/unit/services/filings/validations/alteration/test_court_order.py
@@ -14,29 +14,14 @@
 """Tests to assure the Court Order is validated properly."""
 import pytest
 
+from legal_api.utils.datetime import datetime, timedelta
 from legal_api.services.filings.validations.common_validations import validate_court_order
 
 
 @pytest.mark.parametrize('invalid_court_order', [
-    {
-        'fileNumber': '123456789012345678901',  # long fileNumber
-        'orderDate': '2021-01-30T09:56:01+01:00',
-        'effectOfOrder': 'Valid effect of order'
-    },
-    {
-        'orderDate': '2021-01-30T09:56:01+01:00',
-        'effectOfOrder': 'Valid effect of order'
-    },
-    {
-        'fileNumber': 'Valid file number',
-        'orderDate': 'a2021-01-30T09:56:01',  # Invalid date
-        'effectOfOrder': 'Valid effect of order'
-    },
-    {
-        'fileNumber': 'Valid File Number',
-        'orderDate': '2021-01-30T09:56:01+01:00',
-        'effectOfOrder': ('a' * 501)  # long effectOfOrder
-    }
+    {'orderDate': (datetime.today() + timedelta(days=1)).isoformat()}, #invalid date - tommorow
+    {'orderDate': (datetime.today() + timedelta(days=30)).isoformat()}, #invalid date - 30 days later
+    {'orderDate': (datetime.today() + timedelta(days=366)).isoformat()} #invalid date - 366 days later
 ])
 def test_validate_invalid_court_orders(session, invalid_court_order):
     """Assert not valid court orders."""
@@ -45,16 +30,11 @@ def test_validate_invalid_court_orders(session, invalid_court_order):
     assert msg
     assert len(msg) > 0
 
-
 @pytest.mark.parametrize('valid_court_order', [
-    {
-        'fileNumber': '12345678901234567890'
-    },
-    {
-        'fileNumber': 'Valid file number',
-        'orderDate': '2021-01-30T09:56:01+01:00',
-        'effectOfOrder': 'Valid effect of order'
-    }
+    {'orderDate': datetime.today().isoformat()}, #valid date - today
+    {'orderDate': (datetime.today() + timedelta(days=-1)).isoformat()}, #valid date - yesterday
+    {'orderDate': (datetime.today() + timedelta(days=-30)).isoformat()}, #valid date - 30 days ago
+    {'orderDate': (datetime.today() + timedelta(days=-366)).isoformat()}  #valid date - 366 days ago
 ])
 def test_validate_valid_court_orders(session, valid_court_order):
     """Assert valid court orders."""


### PR DESCRIPTION
*Issue #:* /bcgov/entity#6833

Note: dependent on business-schemas PR https://github.com/bcgov/business-schemas/pull/58

*Description of changes:*

* Remove temporary court order validation logic to work around issue of alteration filing schema not being triggered properly in filings endpoint previously
* Updated `test_validate_invalid_court_orders` and `test_validate_valid_court_orders ` tests to only test the `orderDate` field in the `courtOrder` object as that is now the only field that the legal api filings endpoint validates against.  The other fields are validated via the filings schema.
* Added http-client file types to gitignore

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
