### PR TITLE
4711 Add conversion filing to FILINGS dictionary in filing model

### DIFF
--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -112,6 +112,10 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
                 'BEN': 'BCINC'
             }
         },
+        'conversion': {
+            'name': 'conversion',
+            'title': 'Conversion Ledger'
+        },
         'specialResolution': {'name': 'specialResolution', 'title': 'Special Resolution',
                               'codes': {
                                   'CP': 'RES'}},


### PR DESCRIPTION
*Issue #:* /bcgov/entity#4711

*Description of changes:*

* Add `conversion` filing to FILINGS dictionary in `legal-api/src/legal_api/models/filing.py`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
