### PR TITLE
4711 bug fix filings endpoint for NOALA filing type

### DIFF
--- a/colin-api/src/colin_api/models/filing.py
+++ b/colin-api/src/colin_api/models/filing.py
@@ -683,6 +683,8 @@ class Filing:
                     filing.body['business']['legalType'] = Business.TypeCodes.BC_COMP.value
                 elif filing_event_info['filing_type_code'] == 'NOALE':
                     filing.body['business']['legalType'] = Business.TypeCodes.BCOMP.value
+                elif filing_event_info['filing_type_code'] == 'NOALA':
+                    filing.body['business']['legalType'] = filing.business.corp_type
                 else:
                     raise InvalidFilingTypeException(filing_type=filing_event_info['filing_type_code'])
                 filing.body['business']['identifier'] = f'BC{filing.business.corp_num}'


### PR DESCRIPTION
*Issue #:* /bcgov/entity#4711

*Description of changes:

* Added support for `NOALA` filing type code for a GET on filings endpoint.  This was preventing the legal updater job from pulling over this type of filing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
