### PR TITLE
make setup fix for local and colin-api fix for null email

### DIFF
--- a/colin-api/requirements/dev.txt
+++ b/colin-api/requirements/dev.txt
@@ -1,5 +1,4 @@
-# Everything the developer needs in addition to the production requirements
--r prod.txt
+# Everything the developer needs in outside of the production requirements
 
 # Testing
 pytest

--- a/colin-api/src/colin_api/models/filing.py
+++ b/colin-api/src/colin_api/models/filing.py
@@ -742,6 +742,8 @@ class Filing:
                 'name': filing.filing_type,
                 'source': cls.LearSource.COLIN.value
             }
+            if not filing.header['email']:
+                del filing.header['email']
 
             return filing
 

--- a/data-reset-tool/requirements/dev.txt
+++ b/data-reset-tool/requirements/dev.txt
@@ -1,5 +1,4 @@
-# Everything the developer needs in addition to the production requirements
--r prod.txt
+# Everything the developer needs outside of the production requirements
 
 # Testing
 attrs<=19.1.0

--- a/jobs/filings-notebook-report/requirements/dev.txt
+++ b/jobs/filings-notebook-report/requirements/dev.txt
@@ -1,5 +1,4 @@
-# Everything the developer needs in addition to the production requirements
--r prod.txt
+# Everything the developer needs outside of the production requirements
 
 # Testing
 pytest

--- a/jobs/future-effective-filings/requirements/dev.txt
+++ b/jobs/future-effective-filings/requirements/dev.txt
@@ -1,5 +1,4 @@
-# Everything the developer needs in addition to the production requirements
--r prod.txt
+# Everything the developer needs outside of the production requirements
 
 # Testing
 pytest<4.1

--- a/jobs/update-colin-filings/requirements/dev.txt
+++ b/jobs/update-colin-filings/requirements/dev.txt
@@ -1,5 +1,4 @@
-# Everything the developer needs in addition to the production requirements
--r prod.txt
+# Everything the developer needs outside of the production requirements
 
 # Testing
 pytest<5.1

--- a/jobs/update-legal-filings/requirements/dev.txt
+++ b/jobs/update-legal-filings/requirements/dev.txt
@@ -1,5 +1,4 @@
-# Everything the developer needs in addition to the production requirements
--r prod.txt
+# Everything the developer needs outside of the production requirements
 
 # Testing
 pytest

--- a/lear-db/test_data/requirements/dev.txt
+++ b/lear-db/test_data/requirements/dev.txt
@@ -1,5 +1,4 @@
-# Everything the developer needs in addition to the production requirements
--r prod.txt
+# Everything the developer needs outside of the production requirements
 
 # Lint and code style
 flake8

--- a/legal-api/src/legal_api/services/filings/validations/annual_report.py
+++ b/legal-api/src/legal_api/services/filings/validations/annual_report.py
@@ -97,10 +97,10 @@ def validate_ar_year(*, business: Business, current_annual_report: Dict) -> Erro
     start_date = (business.last_ar_date if business.last_ar_date else business.founding_date).date()
     ar_min_date, ar_max_date = get_ar_dates(business, start_date, next_ar_year)
 
-    # if ar_date < ar_min_date:
-    #     return Error(HTTPStatus.BAD_REQUEST,
-    #                  [{'error': _('Annual Report Date cannot be before a previous Annual Report or the Founding Date.'),
-    #                    'path': 'filing/annualReport/annualReportDate'}])
+    if ar_date < ar_min_date:
+        return Error(HTTPStatus.BAD_REQUEST,
+                     [{'error': _('Annual Report Date cannot be before a previous Annual Report or the Founding Date.'),
+                       'path': 'filing/annualReport/annualReportDate'}])
 
     # AR Date must be the next contiguous year, from either the last AR or foundingDate
     if ar_date > ar_max_date:

--- a/legal-api/src/legal_api/services/filings/validations/annual_report.py
+++ b/legal-api/src/legal_api/services/filings/validations/annual_report.py
@@ -97,10 +97,10 @@ def validate_ar_year(*, business: Business, current_annual_report: Dict) -> Erro
     start_date = (business.last_ar_date if business.last_ar_date else business.founding_date).date()
     ar_min_date, ar_max_date = get_ar_dates(business, start_date, next_ar_year)
 
-    if ar_date < ar_min_date:
-        return Error(HTTPStatus.BAD_REQUEST,
-                     [{'error': _('Annual Report Date cannot be before a previous Annual Report or the Founding Date.'),
-                       'path': 'filing/annualReport/annualReportDate'}])
+    # if ar_date < ar_min_date:
+    #     return Error(HTTPStatus.BAD_REQUEST,
+    #                  [{'error': _('Annual Report Date cannot be before a previous Annual Report or the Founding Date.'),
+    #                    'path': 'filing/annualReport/annualReportDate'}])
 
     # AR Date must be the next contiguous year, from either the last AR or foundingDate
     if ar_date > ar_max_date:

--- a/queue_services/common/requirements/dev.txt
+++ b/queue_services/common/requirements/dev.txt
@@ -1,5 +1,4 @@
-# Everything the developer needs in addition to the production requirements
--r prod.txt
+# Everything the developer needs outside of the production requirements
 
 # Testing
 pytest<=5.0.1

--- a/queue_services/entity-emailer/requirements/dev.txt
+++ b/queue_services/entity-emailer/requirements/dev.txt
@@ -1,5 +1,4 @@
-# Everything the developer needs in addition to the production requirements
--r prod.txt
+# Everything the developer needs outside of the production requirements
 
 # Testing
 freezegun

--- a/queue_services/entity-pay/requirements/dev.txt
+++ b/queue_services/entity-pay/requirements/dev.txt
@@ -1,5 +1,4 @@
-# Everything the developer needs in addition to the production requirements
--r prod.txt
+# Everything the developer needs outside of the production requirements
 
 # Testing
 pytest<=5.0.1


### PR DESCRIPTION
Signed-off-by: Kial Jinnah <kialj876@gmail.com>

*Issue #:* /bcgov/entity###

*Description of changes:*
- removed the prod.txt install within the dev.txt (causes make setup to install most current versions of everything instead of getting the versions from requirements.txt)
- added one liner to remove email from header if email is empty (was causing a validation error when filings were grabbed from colin-api and then posted to legal-api)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
