### PR TITLE
4391 Update colin api to support registrar's notation, registrar's order and court order filings

### DIFF
--- a/colin-api/src/colin_api/resources/filing.py
+++ b/colin-api/src/colin_api/resources/filing.py
@@ -123,7 +123,10 @@ class FilingInfo(Resource):
                     'annualReport': json_data.get('annualReport', None),
                     'incorporationApplication': json_data.get('incorporationApplication', None),
                     'alteration': json_data.get('alteration', None),
-                    'transition': json_data.get('transition', None)
+                    'transition': json_data.get('transition', None),
+                    'registrarsNotation': json_data.get('registrarsNotation', None),
+                    'registrarsOrder': json_data.get('registrarsOrder', None),
+                    'courtOrder': json_data.get('courtOrder', None)
                 }
 
             # Filter out null-values in the filing_list dictionary


### PR DESCRIPTION
*Issue #:* /bcgov/entity#4391

*Description of changes:*

* Updated Colin API such that completed registrar's notation, registrar's order and court order filings in Lear db not yet in Colin db can be pushed to Colin via Colin updater


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
