### PR TITLE
paper and colin flags should be derived from the Filings entity, not submitted json

### DIFF
--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -385,14 +385,10 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
             json_submission['filing']['header']['name'] = self.filing_type
             json_submission['filing']['header']['status'] = self.status
 
-            # if availableOnPaper is not defined in filing json, use the flag on the filing record
-            if json_submission['filing']['header'].get('availableOnPaperOnly', None) is None:
+            if self.paper_only:
                 json_submission['filing']['header']['availableOnPaperOnly'] = self.paper_only
-
-            # if in Colin only is not defined in filing json, use the flag on the filing record
-            if json_submission['filing']['header'].get('inColinOnly', None) is None:
+            if self.colin_only:
                 json_submission['filing']['header']['inColinOnly'] = self.colin_only
-
             if self.effective_date:
                 json_submission['filing']['header']['effectiveDate'] = self.effective_date.isoformat()
             if self._payment_status_code:


### PR DESCRIPTION
*Issue #:* based on OPs efforts

*Description of changes:*
set the colin & paper_only flags in the header, based on the Filing settings

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
