### PR TITLE
7728 fix GET filings endpoint error

### DIFF
--- a/legal-api/src/legal_api/services/document_meta.py
+++ b/legal-api/src/legal_api/services/document_meta.py
@@ -62,8 +62,8 @@ class DocumentMetaService():
             self._legal_type = business.legal_type
 
         self._filing_status = filing['filing']['header']['status']
-        is_paper_only = filing['filing']['header']['availableOnPaperOnly']
-        is_colin_only = filing['filing']['header']['inColinOnly']
+        is_paper_only = filing['filing']['header'].get('availableOnPaperOnly', False)
+        is_colin_only = filing['filing']['header'].get('inColinOnly', False)
 
         if self._filing_status not in (Filing.Status.COMPLETED.value, Filing.Status.PAID.value) \
                 or is_paper_only or is_colin_only:


### PR DESCRIPTION
*Issue #:* /bcgov/entity#7728

*Description of changes:*

* Update `DocumentMetaService.get_documents` such that when filing dict contains no value for `availableOnPaperOnly` and `inColinOnly`, default value is `False`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
