### PR TITLE
7677 Fix issue with orderDetails being added to comments table

### DIFF
--- a/legal-api/migrations/versions/1fcdb213657d_add_order_details_column.py
+++ b/legal-api/migrations/versions/1fcdb213657d_add_order_details_column.py
@@ -1,0 +1,24 @@
+"""add order_details column
+
+Revision ID: 1fcdb213657d
+Revises: 78ddb7f6f8b5
+Create Date: 2021-05-27 13:29:27.893982
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '1fcdb213657d'
+down_revision = '78ddb7f6f8b5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('filings', sa.Column('order_details', sa.String(length=2000), nullable=True))
+
+
+def downgrade():
+    op.drop_column('filings', 'order_details')

--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -159,6 +159,7 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
             'court_order_date',
             'court_order_effect_of_order',
             'court_order_file_number',
+            'order_details',
             'effective_date',
             'paper_only',
             'colin_only',
@@ -190,6 +191,7 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
     court_order_file_number = db.Column('court_order_file_number', db.String(20))
     court_order_date = db.Column('court_order_date', db.DateTime(timezone=True), default=None)
     court_order_effect_of_order = db.Column('court_order_effect_of_order', db.String(500))
+    order_details = db.Column(db.String(2000))
     deletion_locked = db.Column('deletion_locked', db.Boolean, unique=False, default=False)
 
     # # relationships

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/court_order.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/court_order.py
@@ -16,21 +16,14 @@ from contextlib import suppress
 from datetime import datetime
 from typing import Dict
 
-from legal_api.models import Comment, Filing
+from legal_api.models import Filing
 
 
 def process(court_order_filing: Filing, filing: Dict):
     """Render the court order filing into the business model objects."""
     court_order_filing.court_order_file_number = filing['courtOrder'].get('fileNumber')
     court_order_filing.court_order_effect_of_order = filing['courtOrder'].get('effectOfOrder')
+    court_order_filing.order_details = filing['courtOrder']['orderDetails']
 
     with suppress(IndexError, KeyError, TypeError, ValueError):
         court_order_filing.court_order_date = datetime.fromisoformat(filing['courtOrder'].get('orderDate'))
-
-    # add comment to the court order filing
-    court_order_filing.comments.append(
-        Comment(
-            comment=filing['courtOrder']['orderDetails'],
-            staff_id=court_order_filing.submitter_id
-        )
-    )

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/registrars_notation.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/registrars_notation.py
@@ -16,22 +16,15 @@ from contextlib import suppress
 from datetime import datetime
 from typing import Dict
 
-from legal_api.models import Comment, Filing
+from legal_api.models import Filing
 
 
 def process(registrars_notation_filing: Filing, filing: Dict):
     """Render the registrars notation filing into the business model objects."""
     registrars_notation_filing.court_order_file_number = filing['registrarsNotation'].get('fileNumber')
     registrars_notation_filing.court_order_effect_of_order = filing['registrarsNotation'].get('effectOfOrder')
+    registrars_notation_filing.order_details = filing['registrarsNotation']['orderDetails']
 
     with suppress(IndexError, KeyError, TypeError, ValueError):
         registrars_notation_filing.court_order_date = datetime.fromisoformat(
             filing['registrarsNotation'].get('orderDate'))
-
-    # add comment to the registrars notation filing
-    registrars_notation_filing.comments.append(
-        Comment(
-            comment=filing['registrarsNotation']['orderDetails'],
-            staff_id=registrars_notation_filing.submitter_id
-        )
-    )

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/registrars_order.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/registrars_order.py
@@ -16,22 +16,15 @@ from contextlib import suppress
 from datetime import datetime
 from typing import Dict
 
-from legal_api.models import Comment, Filing
+from legal_api.models import Filing
 
 
 def process(registrars_order_filing: Filing, filing: Dict):
     """Render the registrars order filing into the business model objects."""
     registrars_order_filing.court_order_file_number = filing['registrarsOrder'].get('fileNumber')
     registrars_order_filing.court_order_effect_of_order = filing['registrarsOrder'].get('effectOfOrder')
+    registrars_order_filing.order_details = filing['registrarsOrder']['orderDetails']
 
     with suppress(IndexError, KeyError, TypeError, ValueError):
         registrars_order_filing.court_order_date = datetime.fromisoformat(
             filing['registrarsOrder'].get('orderDate'))
-
-    # add comment to the registrars order filing
-    registrars_order_filing.comments.append(
-        Comment(
-            comment=filing['registrarsOrder']['orderDetails'],
-            staff_id=registrars_order_filing.submitter_id
-        )
-    )

--- a/queue_services/entity-filer/tests/unit/filing_processors/test_court_order.py
+++ b/queue_services/entity-filer/tests/unit/filing_processors/test_court_order.py
@@ -42,4 +42,4 @@ async def test_worker_court_order(app, session):
     final_filing = Filing.find_by_id(filing_id)
     assert filing['filing']['courtOrder']['fileNumber'] == final_filing.court_order_file_number
     assert filing['filing']['courtOrder']['effectOfOrder'] == final_filing.court_order_effect_of_order
-    assert filing['filing']['courtOrder']['orderDetails'] == final_filing.comments.first().comment
+    assert filing['filing']['courtOrder']['orderDetails'] == final_filing.order_details

--- a/queue_services/entity-filer/tests/unit/filing_processors/test_registrars_notation.py
+++ b/queue_services/entity-filer/tests/unit/filing_processors/test_registrars_notation.py
@@ -42,4 +42,4 @@ async def test_worker_registrars_notation(app, session):
     final_filing = Filing.find_by_id(filing_id)
     assert filing['filing']['registrarsNotation']['fileNumber'] == final_filing.court_order_file_number
     assert filing['filing']['registrarsNotation']['effectOfOrder'] == final_filing.court_order_effect_of_order
-    assert filing['filing']['registrarsNotation']['orderDetails'] == final_filing.comments.first().comment
+    assert filing['filing']['registrarsNotation']['orderDetails'] == final_filing.order_details

--- a/queue_services/entity-filer/tests/unit/filing_processors/test_registrars_order.py
+++ b/queue_services/entity-filer/tests/unit/filing_processors/test_registrars_order.py
@@ -42,4 +42,4 @@ async def test_worker_registrars_order(app, session):
     final_filing = Filing.find_by_id(filing_id)
     assert filing['filing']['registrarsOrder']['fileNumber'] == final_filing.court_order_file_number
     assert filing['filing']['registrarsOrder']['effectOfOrder'] == final_filing.court_order_effect_of_order
-    assert filing['filing']['registrarsOrder']['orderDetails'] == final_filing.comments.first().comment
+    assert filing['filing']['registrarsOrder']['orderDetails'] == final_filing.order_details


### PR DESCRIPTION
*Issue #:* /bcgov/entity#7677

*Description of changes:* 

* Add `order_details` column to `filings` table
* Added `order_details` to `filings` model
* Update entity filer for registrar's notation, registrar's order and court order filing such that orderDetails value is now saved to new `filings.order_details` column when filing is processed. 
* Removed code saving orderDetails value to `comment` table for the 3 filing types
* Update entity filer processor unit tests

![image](https://user-images.githubusercontent.com/6685223/120032591-43a4fc00-bfaf-11eb-8b64-4ca501edf36f.png)

sample payload of what is returned by GET `/api/v1/businesses/BC0870342/filings`

```
{
  "filings": [
    {
      "filing": {
        "business": {
          "foundingDate": "2021-02-10T19:51:18.758421+00:00",
          "identifier": "BC0870342",
          "legalName": "1230084 B.C. LTD.",
          "legalType": "BEN"
        },
        "courtOrder": {
          "effectOfOrder": "planOfArrangement",
          "fileNumber": "23234324",
          "orderDetails": "A note about court order"
        },
        ...
        "header": {
          "affectedFilings": [
          ],
          "certifiedBy": "jane doe",
          "colinIds": [],
          "comments": [],
          "date": "2021-05-28T16:17:53.029400+00:00",
          "effectiveDate": "2021-05-28T16:17:53.029454+00:00",
          "filingId": 112177,
          ...
          "name": "courtOrder",
          "status": "COMPLETED",
          "submitter": "archiu@idir"
        }
      }
    }
  ]
}
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
