### PR TITLE
always include flag availableOnPaperOnly

### DIFF
--- a/legal-api/Makefile
+++ b/legal-api/Makefile
@@ -89,6 +89,7 @@ cd: build update-env tag ## CD flow
 
 build: ## Build the docker container
 	docker build . -t $(DOCKER_NAME) \
+		--platform linux/amd64 \
 		--build-arg VCS_REF=$(shell git rev-parse --short HEAD) \
 		--build-arg BUILD_DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ") \
 

--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -384,14 +384,8 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
             json_submission['filing']['header']['filingId'] = self.id
             json_submission['filing']['header']['name'] = self.filing_type
             json_submission['filing']['header']['status'] = self.status
-
-            # if availableOnPaper is not defined in filing json, use the flag on the filing record
-            if self.paper_only:
-                json_submission['filing']['header']['availableOnPaperOnly'] = self.paper_only
-
-            # if in Colin only is not defined in filing json, use the flag on the filing record
-            if self.colin_only:
-                json_submission['filing']['header']['inColinOnly'] = self.colin_only
+            json_submission['filing']['header']['availableOnPaperOnly'] = self.paper_only
+            json_submission['filing']['header']['inColinOnly'] = self.colin_only
 
             if self.effective_date:
                 json_submission['filing']['header']['effectiveDate'] = self.effective_date.isoformat()

--- a/legal-api/src/legal_api/resources/business/business_filings.py
+++ b/legal-api/src/legal_api/resources/business/business_filings.py
@@ -395,8 +395,9 @@ class ListFilingResource(Resource):
 
     @staticmethod
     def _is_historical_colin_filing(filing_json: str):
-        if filing_json['filing']['header'].get('source', None) == 'COLIN' \
-                and filing_json['filing']['header']['date'] < BOB_DATE:
+        if (filing_header := filing_json.get('filing', {}).get('header')) \
+            and filing_header.get('source', None) == 'COLIN' \
+                and filing_header.get('date') < BOB_DATE:
             return True
 
         return False

--- a/legal-api/src/legal_api/utils/run_version.py
+++ b/legal-api/src/legal_api/utils/run_version.py
@@ -18,7 +18,7 @@ from legal_api.version import __version__
 
 
 def _get_build_openshift_commit_hash():
-    return os.getenv('OPENSHIFT_BUILD_COMMIT', None)
+    return os.getenv('OPENSHIFT_BUILD_COMMIT', None) or os.getenv('VCS_REF', None)
 
 
 def get_run_version():


### PR DESCRIPTION
*Issue #:* ops

*Description of changes:*
- always include flag availableOnPaperOnly,
- allow missing elements in __is_historical_colin_filing_, 
- add back the hash to version header

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
