### PR TITLE
7516 - Fixed NOA director's middle name

### DIFF
--- a/legal-api/report-templates/template-parts/notice-of-articles/directors.html
+++ b/legal-api/report-templates/template-parts/notice-of-articles/directors.html
@@ -10,8 +10,8 @@
           <div class="section-sub-title">
             <span class="capitalize-text">{{ party.officer.lastName }}</span>,
             <span class="capitalize-text">{{ party.officer.firstName }}</span>
-            {% if party.officer.middleName %}
-              <span class="capitalize-text">{{ party.officer.middleName }}</span>
+            {% if party.officer.middleInitial %}
+              <span class="capitalize-text">{{ party.officer.middleInitial }}</span>
             {% endif %}
           </div>
         </td>


### PR DESCRIPTION
*Issue #:* /bcgov/entity#7516

*Description of changes:*

- Changed NOA report to display party.officer.middleInitial instead of party.officer.middleName

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
