### PR TITLE
4711 updates to get corp type for NOALA filing

### DIFF
--- a/colin-api/src/colin_api/exceptions/__init__.py
+++ b/colin-api/src/colin_api/exceptions/__init__.py
@@ -114,3 +114,16 @@ class InvalidFilingTypeException(GenericException):
         else:
             self.error = 'Filing type invalid'
         self.status_code = 400
+
+
+class UnableToDetermineCorpTypeException(GenericException):
+    """Exception with defined error code and messaging."""
+
+    def __init__(self, *args, filing_type=None, **kwargs):
+        """Return a valid InvalidFilingTypeException."""
+        super(UnableToDetermineCorpTypeException, self).__init__(None, None, *args, **kwargs)
+        if filing_type:
+            self.error = f'Unable to determine corp type for {filing_type} filing type'
+        else:
+            self.error = 'Unable to determine corp type for filing type'
+        self.status_code = 400

--- a/colin-api/src/colin_api/models/__init__.py
+++ b/colin-api/src/colin_api/models/__init__.py
@@ -3,5 +3,6 @@ from .address import Address
 from .business import Business
 from .corp_name import CorpName
 from .corp_party import Party
+from .filing_type import FilingType
 from .office import Office
 from .shares import ShareObject

--- a/colin-api/src/colin_api/models/filing_type.py
+++ b/colin-api/src/colin_api/models/filing_type.py
@@ -1,0 +1,94 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Meta information about the service.
+
+Currently this only provides API versioning information
+"""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from flask import current_app
+
+from colin_api.resources.db import DB
+from colin_api.utils import stringify_list
+
+
+# pylint: disable=too-few-public-methods
+class FilingType:
+    """Filing Type object."""
+
+    FILING_TYPE_QUERY = (
+        """
+            select ft.filing_typ_cd, ft.short_desc, ft.full_desc
+            from filing_type ft
+        """
+    )
+
+    filing_typ_cd = None
+    short_desc = None
+    full_desc = None
+
+    def __init__(self):
+        """Initialize with all values None."""
+
+    @classmethod
+    def _create_filing_type_objs(cls, cursor) -> List:
+        """Return a Filing Type obj by parsing cursor."""
+        filing_types = cursor.fetchall()
+
+        filing_type_objs = []
+        for filing_type_info in filing_types:
+            filing_type_info = dict(zip([x[0].lower() for x in cursor.description], filing_type_info))
+            filing_type_obj = FilingType()
+            filing_type_obj.filing_typ_cd = filing_type_info['filing_typ_cd']
+            filing_type_obj.short_desc = filing_type_info['short_desc']
+            filing_type_obj.full_desc = filing_type_info['full_desc']
+            filing_type_objs.append(filing_type_obj)
+
+        return filing_type_objs
+
+    @classmethod
+    def get_most_recent_match_before_event(cls,
+                                           cursor,
+                                           corp_num: str,
+                                           event_id: str,
+                                           matching_filing_types: List) -> Optional[FilingType]:
+        """Get most recent match of any one of filing types provided before a given event id for a specific corp num."""
+        try:
+            if not cursor:
+                cursor = DB.connection.cursor()
+
+            condition = f"""
+                JOIN FILING f ON (ft.FILING_TYP_CD = f.FILING_TYP_CD)
+                JOIN EVENT e ON (f.EVENT_ID = e.EVENT_ID)
+                WHERE e.CORP_NUM = :corp_num
+                  AND e.EVENT_TYP_CD = 'FILE'
+                  AND e.EVENT_ID < :event_id
+                  AND f.FILING_TYP_CD in ({stringify_list(matching_filing_types)})
+                  and rownum = 1
+                order by f.EVENT_ID asc
+            """
+
+            querystring = cls.FILING_TYPE_QUERY + condition
+            cursor.execute(querystring, corp_num=corp_num, event_id=event_id)
+
+            results = cls._create_filing_type_objs(cursor=cursor)
+            num_results = len(results)
+            result = results[0] if num_results and num_results > 0 else None
+            return result
+
+        except Exception as err:
+            current_app.logger.error(f'error getting filing type for {corp_num} by event {event_id}')
+            raise err


### PR DESCRIPTION
*Issue #:* /bcgov/entity#4711

Note: this PR was recreated from https://github.com/bcgov/lear/pull/1165 after the `main` branch was created for this repo.  For original review comments, please refer to the initial PR.

*Description of changes:*

* Added support for NOALA filing type code for a GET on filings endpoint. This was preventing the legal updater job from pulling over this type of filing
* Added code to determine corp type of a business at the time of a NOALA filing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
