### PR TITLE
7537 version number updates for release 2.23.0

### DIFF
--- a/colin-api/src/colin_api/version.py
+++ b/colin-api/src/colin_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.22.0'  # pylint: disable=invalid-name
+__version__ = '2.23.0'  # pylint: disable=invalid-name

--- a/legal-api/src/legal_api/version.py
+++ b/legal-api/src/legal_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.22.0'  # pylint: disable=invalid-name
+__version__ = '2.23.0'  # pylint: disable=invalid-name

--- a/queue_services/entity-filer/src/entity_filer/version.py
+++ b/queue_services/entity-filer/src/entity_filer/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.22.0'  # pylint: disable=invalid-name
+__version__ = '2.23.0'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:* /bcgov/entity#7537

*Description of changes:*

* update legal-api, colin-api and entity-filer version number to 2.23.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
