### PR TITLE
7338 fix issue where event_timestmp was not being inserted as utc for event table

### DIFF
--- a/colin-api/src/colin_api/models/filing.py
+++ b/colin-api/src/colin_api/models/filing.py
@@ -289,7 +289,7 @@ class Filing:
             cursor.execute(
                 """
                 INSERT INTO event (event_id, corp_num, event_typ_cd, event_timestmp, trigger_dts)
-                VALUES (:event_id, :corp_num, :event_type, sysdate, NULL)
+                VALUES (:event_id, :corp_num, :event_type, current_timestamp at time zone dbtimezone, NULL)
                 """,
                 event_id=event_id,
                 corp_num=corp_num,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#7338

*Description of changes:*

* Update insert statement for event table such that event_timestmp is inserted with utc as opposed to pacific time(sysdate)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
