### PR TITLE
8036 duplicate message tracking tests for entity emailer

### DIFF
--- a/queue_services/entity-emailer/tests/conftest.py
+++ b/queue_services/entity-emailer/tests/conftest.py
@@ -22,6 +22,10 @@ from contextlib import contextmanager
 import pytest
 from flask import Flask
 from flask_migrate import Migrate, upgrade
+from entity_emailer.config import get_named_config  # noqa: I001
+from tracker.config import get_named_config as get_tracker_named_config  # noqa: I001
+from tracker.models import db as tracker_db  # noqa: I001
+from entity_emailer import worker  # noqa: I001
 from legal_api import db as _db
 from legal_api import jwt as _jwt
 from nats.aio.client import Client as Nats
@@ -29,7 +33,6 @@ from sqlalchemy import event, text
 from sqlalchemy.schema import DropConstraint, MetaData
 from stan.aio.client import Client as Stan
 
-from entity_emailer.config import get_named_config
 
 from . import FROZEN_DATETIME
 
@@ -68,6 +71,18 @@ def app():
     return _app
 
 
+@pytest.fixture(scope='session')
+def tracker_app():
+    """Return a session-wide tracker app instance configured in TEST mode.
+
+    This is used only to reset the tracker test db.
+    """
+    _tracker_app = Flask(__name__)
+    _tracker_app.config.from_object(get_tracker_named_config('testing'))
+    tracker_db.init_app(_tracker_app)
+    return _tracker_app
+
+
 @pytest.fixture
 def config(app):
     """Return the application config."""
@@ -102,11 +117,44 @@ def client_id():
 
 
 @pytest.fixture(scope='session')
-def db(app):  # pylint: disable=redefined-outer-name, invalid-name
+def db(app, tracker_app):  # pylint: disable=redefined-outer-name, invalid-name
     """Return a session-wide initialised database.
 
     Drops all existing tables - Meta follows Postgres FKs
     """
+    with tracker_app.app_context():
+        # Clear out any existing tables
+        metadata = MetaData(tracker_db.engine)
+        metadata.reflect()
+        for table in metadata.tables.values():
+            for fk in table.foreign_keys:  # pylint: disable=invalid-name
+                tracker_db.engine.execute(DropConstraint(fk.constraint))
+        metadata.drop_all()
+        tracker_db.drop_all()
+
+        sequence_sql = """SELECT sequence_name FROM information_schema.sequences
+                          WHERE sequence_schema='public'
+                       """
+
+        sess = tracker_db.session()
+        for seq in [name for (name,) in sess.execute(text(sequence_sql))]:
+            try:
+                sess.execute(text('DROP SEQUENCE public.%s ;' % seq))
+                print('DROP SEQUENCE public.%s ' % seq)
+            except Exception as err:  # pylint: disable=broad-except # noqa: B902
+                print(f'Error: {err}')
+        sess.commit()
+
+        # ############################################
+        # There are 2 approaches, an empty database, or the same one that the app will use
+        #     create the tables
+        #     _db.create_all()
+        # or
+        # Use Alembic to load all of the DB revisions including supporting lookup data
+        # even though this isn't referenced directly, it sets up the internal configs that upgrade needs
+        Migrate(tracker_app, tracker_db)
+        upgrade()
+
     with app.app_context():
         # Clear out any existing tables
         metadata = MetaData(_db.engine)
@@ -259,3 +307,10 @@ def create_mock_coro(mocker, monkeypatch):
         return mock, _coro
 
     return _create_mock_patch_coro
+
+
+@pytest.fixture(autouse=True)
+def mock_settings_env_vars(app, db, monkeypatch):
+    """Mock FLASK_APP and db to use test instances for worker.py."""
+    monkeypatch.setattr(worker, 'FLASK_APP', app)
+    monkeypatch.setattr(worker, 'db', db)

--- a/queue_services/entity-emailer/tests/unit/__init__.py
+++ b/queue_services/entity-emailer/tests/unit/__init__.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 """The Unit Tests and the helper routines."""
 import copy
+import json
+from random import randrange
+from unittest.mock import Mock
 
 from legal_api.models import Business, Filing
 from registry_schemas.example_data import (
@@ -137,3 +140,26 @@ def prep_incorporation_correction_filing(session, business, original_filing_id, 
         filing.transaction_id = transaction.id
         filing.save()
     return filing
+
+
+class Obj:
+    """Make a custom object hook used by dict_to_obj."""
+
+    def __init__(self, dict1):
+        """Create instance of obj."""
+        self.__dict__.update(dict1)
+
+
+def dict_to_obj(dict1):
+    """Convert dict to an object."""
+    return json.loads(json.dumps(dict1), object_hook=Obj)
+
+
+def create_mock_message(message_payload: dict):
+    """Return a mock message that can be processed by the queue listener."""
+    mock_msg = Mock()
+    mock_msg.sequence = randrange(1000)
+    mock_msg.data = dict_to_obj(message_payload)
+    json_msg_payload = json.dumps(message_payload)
+    mock_msg.data.decode = Mock(return_value=json_msg_payload)
+    return mock_msg

--- a/queue_services/entity-emailer/tests/unit/test_tracker.py
+++ b/queue_services/entity-emailer/tests/unit/test_tracker.py
@@ -1,0 +1,273 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test Suite to ensure message tracking is working as expected."""
+from unittest.mock import patch
+
+import pytest
+
+from entity_emailer import worker
+from entity_queue_common.service_utils import EmailException, QueueException  # noqa: I001
+from tracker.models import MessageProcessing
+from . import create_mock_message  # noqa: I003
+
+
+@pytest.mark.parametrize(
+    ['expected_msg_id', 'message_payload'],
+    [
+        ('16fd2706-8baf-433b-82eb-8c7fada847aa',
+         {
+            'specversion': '1.x-wip',
+            'type': 'bc.registry.names.request',
+            'source': 'nr_pay',
+            'id': '16fd2706-8baf-433b-82eb-8c7fada847aa',
+            'time': '',
+            'datacontenttype': 'application/json',
+            'identifier': '781020202',
+            'data': {
+                'header': {'nrNum': '781020202'},
+                'paymentToken': '234234234324asjdkfhjsdhf23949239423',
+                'statusCode': 'PAID'
+            }
+         }),
+        ('bc.registry.affiliation_1',
+         {
+             'type': 'bc.registry.affiliation',
+             'identifier': 'BC1234567',
+             'data': {
+                 'filing': {
+                     'header': {
+                         'filingId': 1,
+                     },
+                 }
+             }
+          }
+         ),
+        ('businessNumber_BC1234567',
+         {'email': {
+             'type': 'businessNumber',
+             'option': None,
+             'filingId': '',
+             'identifier': 'BC1234567'
+         }
+         }),
+        ('incorporationApplication_mras_8238434',
+         {
+             'email': {
+                 'type': 'incorporationApplication',
+                 'option': 'mras',
+                 'filingId': '8238434'
+             }
+         }),
+        ('annualReport_2323432432',
+         {
+             'email': {
+                 'type': 'annualReport',
+                 'option': 'COMPLETED',
+                 'filingId': '2323432432'
+             }
+         }),
+        ('annualReport_reminder_2021_33339999',
+         {
+             'email': {
+                 'type': 'annualReport',
+                 'option': 'reminder',
+                 'businessId': '33339999',
+                 'arFee': '100',
+                 'arYear': 2021
+             }
+         }),
+        ('alteration_1112223333',
+         {
+             'email': {
+                 'type': 'alteration',
+                 'option': None,
+                 'filingId': '1112223333'
+             }
+         })
+    ]
+)
+async def test_should_successfully_process_valid_messages_for_all_supported_message_types(
+        app,
+        db,
+        session,
+        expected_msg_id,
+        message_payload):
+    """Assert that all valid messages for all supported message types are processed successfully."""
+    mock_msg = create_mock_message(message_payload)
+
+    # mock out process_email function to return true to simulate successful email processing
+    with patch.object(worker, 'process_email', return_value=True):
+        await worker.cb_subscription_handler(mock_msg)
+        result = MessageProcessing.find_message_by_message_id(message_id=expected_msg_id)
+        assert result
+        assert result.message_id == expected_msg_id
+        assert result.status == 'COMPLETE'
+
+
+async def test_should_not_reprocess_completed_message(app, db, session):
+    """Assert that processed(status=COMPLETE) messages are not re-processed."""
+    message_id = '16fd2111-8baf-433b-82eb-8c7fada847aa'
+    message_payload = {
+        'specversion': '1.x-wip',
+        'type': 'bc.registry.names.request',
+        'source': 'nr_pay',
+        'id': message_id,
+        'time': '',
+        'datacontenttype': 'application/json',
+        'identifier': '781020202',
+        'data': {
+            'header': {'nrNum': '781020202'},
+            'paymentToken': '234234234324asjdkfhjsdhf23949239423',
+            'statusCode': 'PAID'
+        }
+    }
+    mock_msg = create_mock_message(message_payload)
+
+    # mock out process_email function to return true to simulate successful email processing
+    with patch.object(worker, 'process_email', return_value=True):
+        await worker.cb_subscription_handler(mock_msg)
+        result_1st_time = MessageProcessing.find_message_by_message_id(message_id=message_id)
+        assert result_1st_time.message_seen_count == 1
+
+        await worker.cb_subscription_handler(mock_msg)
+        result_2nd_time = MessageProcessing.find_message_by_message_id(message_id=message_id)
+        assert result_2nd_time.message_seen_count == 1
+        assert result_2nd_time.last_update == result_1st_time.last_update
+        assert result_2nd_time.status == 'COMPLETE'
+
+
+async def test_should_mark_message_as_failed_on_queue_exception(app, db, session):
+    """Assert that message is marked as failed on queue exception."""
+    message_id = '16fd2111-8baf-433b-82eb-8c7fada84bbb'
+    message_payload = {
+        'specversion': '1.x-wip',
+        'type': 'bc.registry.names.request',
+        'source': 'nr_pay',
+        'id': message_id,
+        'time': '',
+        'datacontenttype': 'application/json',
+        'identifier': '781020202',
+        'data': {
+            'header': {'nrNum': '781020202'},
+            'paymentToken': '234234234324asjdkfhjsdhf23949239423',
+            'statusCode': 'PAID'
+        }
+    }
+    mock_msg = create_mock_message(message_payload)
+
+    # mock out process_email function to throw queue exception to simulate failed scenario
+    with patch.object(worker, 'process_email', side_effect=QueueException('Queue Error.')):
+        await worker.cb_subscription_handler(mock_msg)
+        result = MessageProcessing.find_message_by_message_id(message_id=message_id)
+        assert result
+        assert result.status == 'FAILED'
+        assert result.message_seen_count == 1
+        assert result.last_error == 'QueueException, Exception - Queue Error.'
+
+
+async def test_should_mark_message_as_failed_on_email_exception(app, db, session):
+    """Assert that message is marked as failed on email exception."""
+    message_id = '16fd2111-8baf-433b-82eb-8c7fada84ccc'
+    message_payload = {
+        'specversion': '1.x-wip',
+        'type': 'bc.registry.names.request',
+        'source': 'nr_pay',
+        'id': message_id,
+        'time': '',
+        'datacontenttype': 'application/json',
+        'identifier': '781020202',
+        'data': {
+            'header': {'nrNum': '781020202'},
+            'paymentToken': '234234234324asjdkfhjsdhf23949239423',
+            'statusCode': 'PAID'
+        }
+    }
+    mock_msg = create_mock_message(message_payload)
+
+    # mock out process_email function to throw EmailException to simulate failed scenario
+    with patch.object(worker, 'process_email', side_effect=EmailException('Unsuccessful response when sending email.')):
+        # check that EmailException raised
+        with pytest.raises(EmailException):
+            await worker.cb_subscription_handler(mock_msg)
+
+        result = MessageProcessing.find_message_by_message_id(message_id=message_id)
+        assert result
+        assert result.status == 'FAILED'
+        assert result.message_seen_count == 1
+        assert result.last_error == 'EmailException - Unsuccessful response when sending email.'
+
+
+async def test_should_process_previously_failed_message_successfully(app, db, session):
+    """Assert that message that failed processing previously can be processed successfully."""
+    message_id = '16fd2111-8baf-433b-82eb-8c7fada84ddd'
+    message_payload = {
+        'specversion': '1.x-wip',
+        'type': 'bc.registry.names.request',
+        'source': 'nr_pay',
+        'id': message_id,
+        'time': '',
+        'datacontenttype': 'application/json',
+        'identifier': '781020202',
+        'data': {
+            'header': {'nrNum': '781020202'},
+            'paymentToken': '234234234324asjdkfhjsdhf23949239423',
+            'statusCode': 'PAID'
+        }
+    }
+    mock_msg = create_mock_message(message_payload)
+
+    # mock out process_email function to throw email exception to simulate failed scenario
+    with patch.object(worker, 'process_email', side_effect=EmailException('Unsuccessful response when sending email.')):
+        with pytest.raises(EmailException):
+            await worker.cb_subscription_handler(mock_msg)
+
+    # mock out process_email function to simulate success scenario
+    with patch.object(worker, 'process_email', return_value=True):
+        await worker.cb_subscription_handler(mock_msg)
+        result = MessageProcessing.find_message_by_message_id(message_id=message_id)
+        assert result
+        assert result.status == 'COMPLETE'
+        assert result.message_seen_count == 2
+        assert result.last_error == 'EmailException - Unsuccessful response when sending email.'
+
+
+async def test_should_correctly_track_retries_for_failed_processing(app, db, session):
+    """Assert that message processing retries are properly tracked."""
+    message_id = '16fd2111-8baf-433b-82eb-8c7fada84eee'
+    message_payload = {
+        'specversion': '1.x-wip',
+        'type': 'bc.registry.names.request',
+        'source': 'nr_pay',
+        'id': message_id,
+        'time': '',
+        'datacontenttype': 'application/json',
+        'identifier': '781020202',
+        'data': {
+            'header': {'nrNum': '781020202'},
+            'paymentToken': '234234234324asjdkfhjsdhf23949239423',
+            'statusCode': 'PAID'
+        }
+    }
+    mock_msg = create_mock_message(message_payload)
+
+    # mock out process_email function to throw exception to simulate failed scenario
+    with patch.object(worker, 'process_email', side_effect=QueueException('Queue Error.')):
+        for x in range(5):
+            await worker.cb_subscription_handler(mock_msg)
+
+    result = MessageProcessing.find_message_by_message_id(message_id=message_id)
+    assert result
+    assert result.status == 'FAILED'
+    assert result.message_seen_count == 5
+    assert result.last_error == 'QueueException, Exception - Queue Error.'

--- a/queue_services/entity-emailer/tests/unit/test_tracker.py
+++ b/queue_services/entity-emailer/tests/unit/test_tracker.py
@@ -98,8 +98,8 @@ from . import create_mock_message  # noqa: I003
     ]
 )
 async def test_should_successfully_process_valid_messages_for_all_supported_message_types(
-        app,
-        db,
+        tracker_app,
+        tracker_db,
         session,
         expected_msg_id,
         message_payload):
@@ -115,7 +115,7 @@ async def test_should_successfully_process_valid_messages_for_all_supported_mess
         assert result.status == 'COMPLETE'
 
 
-async def test_should_not_reprocess_completed_message(app, db, session):
+async def test_should_not_reprocess_completed_message(tracker_app, tracker_db, session):
     """Assert that processed(status=COMPLETE) messages are not re-processed."""
     message_id = '16fd2111-8baf-433b-82eb-8c7fada847aa'
     message_payload = {
@@ -147,7 +147,7 @@ async def test_should_not_reprocess_completed_message(app, db, session):
         assert result_2nd_time.status == 'COMPLETE'
 
 
-async def test_should_mark_message_as_failed_on_queue_exception(app, db, session):
+async def test_should_mark_message_as_failed_on_queue_exception(tracker_app, tracker_db, session):
     """Assert that message is marked as failed on queue exception."""
     message_id = '16fd2111-8baf-433b-82eb-8c7fada84bbb'
     message_payload = {
@@ -176,7 +176,7 @@ async def test_should_mark_message_as_failed_on_queue_exception(app, db, session
         assert result.last_error == 'QueueException, Exception - Queue Error.'
 
 
-async def test_should_mark_message_as_failed_on_email_exception(app, db, session):
+async def test_should_mark_message_as_failed_on_email_exception(tracker_app, tracker_db, session):
     """Assert that message is marked as failed on email exception."""
     message_id = '16fd2111-8baf-433b-82eb-8c7fada84ccc'
     message_payload = {
@@ -208,7 +208,7 @@ async def test_should_mark_message_as_failed_on_email_exception(app, db, session
         assert result.last_error == 'EmailException - Unsuccessful response when sending email.'
 
 
-async def test_should_process_previously_failed_message_successfully(app, db, session):
+async def test_should_process_previously_failed_message_successfully(tracker_app, tracker_db, session):
     """Assert that message that failed processing previously can be processed successfully."""
     message_id = '16fd2111-8baf-433b-82eb-8c7fada84ddd'
     message_payload = {
@@ -242,7 +242,7 @@ async def test_should_process_previously_failed_message_successfully(app, db, se
         assert result.last_error == 'EmailException - Unsuccessful response when sending email.'
 
 
-async def test_should_correctly_track_retries_for_failed_processing(app, db, session):
+async def test_should_correctly_track_retries_for_failed_processing(tracker_app, tracker_db, session):
     """Assert that message processing retries are properly tracked."""
     message_id = '16fd2111-8baf-433b-82eb-8c7fada84eee'
     message_payload = {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#8036

*Description of changes:*

* Added tests to verify message tracking works for following test scenarios:
  * successfully track processed message
  * does not try to re-process processed message
  * successfully track failure when exception thrown
  * failed message will succeed on retry if original error was a send email exception and email exception no longer thrown
  * retry count is properly tracked

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
