### PR TITLE
7882 duplicate message tracking bug fixes

### DIFF
--- a/queue_services/entity-emailer/src/entity_emailer/message_tracker/tracker.py
+++ b/queue_services/entity-emailer/src/entity_emailer/message_tracker/tracker.py
@@ -45,14 +45,11 @@ def get_message_context_properties(queue_msg: nats.aio.client.Msg):  # pylint: d
             return create_message_context_properties(etype, message_id, source, identifier, True)
 
         if etype == 'bc.registry.affiliation' \
-                and (identifier := email_msg.get('data', {})
-                     .get('filing', {})
-                     .get('business', {})
-                     .get('identifier', None)):
-            filing_id = email_msg.get('data', {}) \
-                                    .get('filing', {}) \
-                                    .get('header', {}) \
-                                    .get('filingId', None)
+            and (filing_id := email_msg.get('data', {})
+                 .get('filing', {})
+                 .get('header', {})
+                 .get('filingId', None)):
+            identifier = email_msg.get('identifier', None)
             message_id = f'{etype}_{filing_id}'
             return create_message_context_properties(etype, message_id, None, identifier, False)
     else:
@@ -85,12 +82,8 @@ def get_message_context_properties(queue_msg: nats.aio.client.Msg):  # pylint: d
 
         if etype in filing_notification.FILING_TYPE_CONVERTER.keys() \
                 and (filing_id := email.get('filingId', None)):
-            identifier = \
-                    email.get('filing', {}) \
-                         .get('business', {}) \
-                         .get('identifier', None)
             message_id = f'{etype}_{filing_id}'
-            return create_message_context_properties(etype, message_id, None, identifier, False)
+            return create_message_context_properties(etype, message_id, None, None, False)
 
     return message_context_properties
 

--- a/queue_services/entity-emailer/tracker/services/message_processing_service.py
+++ b/queue_services/entity-emailer/tracker/services/message_processing_service.py
@@ -42,6 +42,8 @@ class MessageProcessingService:  # pylint: disable=too-many-public-methods
         msg.message_type = message_type
         msg.status = status.value
         msg.message_json = message_json
+        msg.message_seen_count = seen_count
+        msg.last_error = last_error
         msg.create_date = dt_now
         msg.last_update = dt_now
         msg.save()

--- a/tracker-db/tracker_db.sql
+++ b/tracker-db/tracker_db.sql
@@ -55,7 +55,7 @@ ALTER TABLE public.alembic_version OWNER TO "userA7C";
 CREATE TABLE public.message_processing (
                                            id integer NOT NULL,
                                            source character varying(36),
-                                           message_id character varying(36) NOT NULL,
+                                           message_id character varying(60) NOT NULL,
                                            identifier character varying(36),
                                            message_type character varying(35) NOT NULL,
                                            status character varying(10) NOT NULL,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#7882

*Description of changes:*
 
* Update `message_id` field to 60 in `tracker_db.sql`.  Was already updated in alembic migration file but forgot to update `tracker_db.sql`
* Fix message context retrieval logic issues
* Include missed fields that were passed in create message function args but never used

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
