### PR TITLE
Fixed issue with nextAnnualReport datetime offset

### DIFF
--- a/legal-api/src/legal_api/models/business.py
+++ b/legal-api/src/legal_api/models/business.py
@@ -179,14 +179,17 @@ class Business(db.Model):  # pylint: disable=too-many-instance-attributes
             # is required. We need more discussion to understand different scenario's which can come across in future.
             if next_ar_year == 2020:
                 # For year 2020, set the max date as October 31th next year (COVID extension).
-                ar_max_date = datetime(next_ar_year, 10, 31).date()
+                ar_max_date = datetime(next_ar_year + 1, 10, 31).date()
             else:
                 # If this is a CO-OP, set the max date as April 30th next year.
-                ar_max_date = datetime(next_ar_year, 4, 30).date()
+                ar_max_date = datetime(next_ar_year + 1, 4, 30).date()
         elif self.legal_type == self.LegalTypes.BCOMP.value:
             # For BCOMP min date is next anniversary date.
-            ar_min_date = datetime(next_ar_year, self.next_anniversary.month, self.next_anniversary.day).date()
+            ar_min_date = datetime(next_ar_year, self.founding_date.month, self.founding_date.day).date()
             ar_max_date = ar_min_date + datedelta.datedelta(days=60)
+
+        if ar_max_date > datetime.utcnow().date():
+            ar_max_date = datetime.utcnow().date()
 
         return ar_min_date, ar_max_date
 

--- a/legal-api/src/legal_api/utils/datetime.py
+++ b/legal-api/src/legal_api/utils/datetime.py
@@ -16,8 +16,11 @@
 import time as _time
 from datetime import date, datetime as _datetime, timezone, \
     timedelta  # pylint: disable=unused-import # noqa: F401, I001, I005
+from dateutil.tz import gettz
 # noqa: I003,I005
 
+
+PACIFIC_TZ = gettz('America/Vancouver')
 
 class datetime(_datetime):  # pylint: disable=invalid-name; # noqa: N801; ha datetime is invalid??
     """Alternative to the built-in datetime that has a timezone on the UTC call."""
@@ -30,5 +33,5 @@ class datetime(_datetime):  # pylint: disable=invalid-name; # noqa: N801; ha dat
 
     @classmethod
     def from_date(cls, date_obj):
-        """Get a datetime object from a date object."""
-        return datetime(date_obj.year, date_obj.month, date_obj.day)
+        """Get a datetime object from a date object and localize it to Pacific time."""
+        return datetime(date_obj.year, date_obj.month, date_obj.day, tzinfo=PACIFIC_TZ)

--- a/legal-api/src/legal_api/utils/datetime.py
+++ b/legal-api/src/legal_api/utils/datetime.py
@@ -16,11 +16,12 @@
 import time as _time
 from datetime import date, datetime as _datetime, timezone, \
     timedelta  # pylint: disable=unused-import # noqa: F401, I001, I005
-from dateutil.tz import gettz
 # noqa: I003,I005
+from dateutil.tz import gettz
 
 
 PACIFIC_TZ = gettz('America/Vancouver')
+
 
 class datetime(_datetime):  # pylint: disable=invalid-name; # noqa: N801; ha datetime is invalid??
     """Alternative to the built-in datetime that has a timezone on the UTC call."""

--- a/legal-api/tests/__init__.py
+++ b/legal-api/tests/__init__.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """The Test Suites to ensure that the service is built and operating correctly."""
 import datetime
-import time
 from collections import MutableMapping, MutableSequence
 from typing import Dict, List
 
@@ -33,7 +32,6 @@ from .pytest_marks import (
 EPOCH_DATETIME = datetime.datetime.utcfromtimestamp(0).replace(tzinfo=datetime.timezone.utc)
 FROZEN_DATETIME = datetime.datetime(2001, 8, 5, 7, 7, 58, 272362).replace(tzinfo=datetime.timezone.utc)
 FROZEN_2018_DATETIME = datetime.datetime(2018, 12, 25, 0, 0, 50, 0).replace(tzinfo=datetime.timezone.utc)
-TIMEZONE_OFFSET=time.timezone/60/60 if time.timezone else 0
 
 
 def add_years(d, years):

--- a/legal-api/tests/unit/api/test_business_tasks.py
+++ b/legal-api/tests/unit/api/test_business_tasks.py
@@ -266,3 +266,7 @@ def test_construct_task_list(session, client, jwt, test_name, identifier, foundi
         identifier, founding_date, previous_ar_datetime, legal_type)
     tasks = TaskListResource.construct_task_list(business)
     assert len(tasks) == tasks_length
+
+    # nextAnnualReport should be in UTC and have the time should have the offset: 7 or 8 hours late
+    if tasks_length:
+        assert tasks[0]['task']['todo']['business']['nextAnnualReport'][-14:] != '00:00:00+00:00'

--- a/legal-api/tests/unit/models/test_business.py
+++ b/legal-api/tests/unit/models/test_business.py
@@ -23,7 +23,7 @@ import pytest
 
 from legal_api.exceptions import BusinessException
 from legal_api.models import Business
-from tests import EPOCH_DATETIME, TIMEZONE_OFFSET
+from tests import EPOCH_DATETIME
 
 
 def factory_business(designation: str = '001'):
@@ -249,7 +249,7 @@ def test_business_json(session):
         'lastModified': EPOCH_DATETIME.isoformat(),
         'lastAnnualReport': datetime.date(EPOCH_DATETIME).isoformat(),
         'lastAnnualGeneralMeetingDate': datetime.date(EPOCH_DATETIME).isoformat(),
-        'nextAnnualReport': (EPOCH_DATETIME + datedelta.YEAR + timedelta(hours=TIMEZONE_OFFSET)).isoformat(),
+        'nextAnnualReport': '1971-01-01T08:00:00+00:00',
         'hasRestrictions': True,
         'goodStanding': False,  # good standing will be false because the epoch is 1970
         'arMinDate': '1971-01-01',

--- a/legal-api/tests/unit/models/test_business.py
+++ b/legal-api/tests/unit/models/test_business.py
@@ -253,7 +253,7 @@ def test_business_json(session):
         'hasRestrictions': True,
         'goodStanding': False,  # good standing will be false because the epoch is 1970
         'arMinDate': '1971-01-01',
-        'arMaxDate': '1971-04-30'
+        'arMaxDate': '1972-04-30'
     }
 
     assert business.json() == d


### PR DESCRIPTION
*Issue #:* /bcgov/entity#7776

*Description of changes:*

- Fixed the nextAnnualReport date. 
- Added test

**I found a difference between my machine that was working in PDT and DEV that works in UTC. I tested with my machine running in UTC and add more tests to assure the offset in running in any TZ.**

**I was supposed to merge to release branch but we won't be able to to it before the release so I will rebase it and merge to main when the release is merged**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
