### PR TITLE
Lear Alteration Validators: Allow Ben Conversion Nr's

### DIFF
--- a/legal-api/src/legal_api/services/filings/validations/alteration.py
+++ b/legal-api/src/legal_api/services/filings/validations/alteration.py
@@ -75,7 +75,7 @@ def company_name_validation(filing):
         nr_response = namex.query_nr_number(nr_number).json()
         validation_result = namex.validate_nr(nr_response)
 
-        if not nr_response['requestTypeCd'] in ('CCR', 'CCP', 'BEC'):
+        if not nr_response['requestTypeCd'] in ('CCR', 'CCP', 'BEC', 'BECV'):
             msg.append({'error': babel('Alteration only available for Change of Name Name requests.'), 'path': nr_path})
 
         if not validation_result['is_approved']:

--- a/legal-api/tests/unit/services/filings/validations/test_alteration.py
+++ b/legal-api/tests/unit/services/filings/validations/test_alteration.py
@@ -30,7 +30,8 @@ TEST_DATA = [
     (False, '', 'BEN', '', True, 0),
     (True, 'legal_name-BC1234567_Changed', 'BEN', 'BEC', True, 0),
     (True, 'legal_name-BC1234567_Changed', 'BC', 'CCR', False, 1),
-    (True, 'legal_name-BC1234568', 'CP', 'XCLP', False, 2)
+    (True, 'legal_name-BC1234568', 'CP', 'XCLP', False, 2),
+    (True, 'legal_name-BC1234567_Changed', 'BEN', 'BECV', True, 0)
 ]
 
 class MockResponse:


### PR DESCRIPTION
*Issue #:* /bcgov/entity#8984

*Description of changes:*
* Added the Ben Conversion code to the allowable NR types for filing a conversion.
* Updated tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
