### PR TITLE
remove mandatory AGM date for AR

### DIFF
--- a/legal-api/requirements.txt
+++ b/legal-api/requirements.txt
@@ -52,4 +52,4 @@ six==1.15.0
 strict-rfc3339==0.7
 urllib3==1.26.4
 minio==7.0.2
-git+https://github.com/bcgov/business-schemas.git@2.15.3#egg=registry_schemas
+git+https://github.com/bcgov/business-schemas.git@2.15.4#egg=registry_schemas


### PR DESCRIPTION
changed to use business-schema-2.15.4 which removes the mandatory AGM date

*Issue #:* /bcgov/entity###

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
