### PR TITLE
8915 Update postman tests to test voluntary dissolution statement validation

### DIFF
--- a/legal-api/tests/postman/legal-api.postman_collection.json
+++ b/legal-api/tests/postman/legal-api.postman_collection.json
@@ -10039,10 +10039,10 @@
 			]
 		},
 		{
-			"name": "Dissolution",
+			"name": "Voluntary Dissolution",
 			"item": [
 				{
-					"name": "post - dissolution - CP1000006",
+					"name": "post - valid statement type - CP3490248",
 					"event": [
 						{
 							"listen": "test",
@@ -10067,7 +10067,6 @@
 									"    pm.expect(jsonData.filing.business).to.exist",
 									"    pm.expect(jsonData.filing.dissolution).to.exist",
 									"    pm.expect(jsonData.filing.header).to.exist",
-									"    pm.expect(jsonData.filing.header.status).to.eql('PENDING')",
 									"});",
 									"",
 									""
@@ -10108,7 +10107,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"filing\": {\n      \"header\": {\n        \"name\": \"dissolution\",\n        \"date\": \"{{today}}\",\n        \"certifiedBy\": \"full name\",\n        \"email\": \"no_one@never.get\",\n        \"effectiveDate\": \"{{today}}T00:00:00+00:00\"\n      },\n      \"business\": {\n        \"identifier\": \"CP0000848\",\n        \"legalType\": \"CP\"\n      },\n      \"dissolution\": {\n        \"dissolutionDate\": \"{{today}}\",\n        \"dissolutionType\": \"voluntary\",\n        \"dissolutionStatementType\": \"197NoAssetsProvisionsLiabilities\",\n        \"hasLiabilities\": false,\n        \"parties\": [\n          {\n            \"officer\": {\n              \"firstName\": \"Completing\",\n              \"lastName\": \"Party\",\n              \"middleName\": \"P\",\n              \"email\": \"cp@example.com\",\n              \"orgName\": \"\",\n              \"partyType\": \"person\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Completing Party\",\n                \"appointmentDate\": \"2021-08-05\"\n\n              }\n            ]\n          },\n          {\n            \"officer\": {\n              \"firstName\": \"\",\n              \"lastName\": \"\",\n              \"middleName\": \"\",\n              \"orgName\": \"Xyz Inc.\",\n              \"partyType\": \"org\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Custodian\",\n                \"appointmentDate\": \"2021-08-05\"\n              }\n            ]\n          }\n        ],\n        \"custodialOffice\": {\n          \"deliveryAddress\": {\n            \"streetAddress\": \"records - delivery_address\",\n            \"addressCity\": \"delivery_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          },\n          \"mailingAddress\": {\n            \"streetAddress\": \"records - mailing_address\",\n            \"addressCity\": \"mailing_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          }\n        }\n      }\n    }\n}"
+							"raw": "{\n    \"filing\": {\n      \"header\": {\n        \"name\": \"dissolution\",\n        \"date\": \"{{today}}\",\n        \"certifiedBy\": \"full name\",\n        \"email\": \"no_one@never.get\",\n        \"effectiveDate\": \"{{today}}T00:00:00+00:00\"\n      },\n      \"business\": {\n        \"identifier\": \"CP3490248\",\n        \"legalType\": \"CP\"\n      },\n      \"dissolution\": {\n        \"dissolutionDate\": \"{{today}}\",\n        \"dissolutionType\": \"voluntary\",\n        \"dissolutionStatementType\": \"197NoAssetsNoLiabilities\",\n        \"hasLiabilities\": false,\n        \"parties\": [\n          {\n            \"officer\": {\n              \"firstName\": \"Completing\",\n              \"lastName\": \"Party\",\n              \"middleName\": \"P\",\n              \"email\": \"cp@example.com\",\n              \"orgName\": \"\",\n              \"partyType\": \"person\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Completing Party\",\n                \"appointmentDate\": \"2021-08-05\"\n\n              }\n            ]\n          },\n          {\n            \"officer\": {\n              \"firstName\": \"\",\n              \"lastName\": \"\",\n              \"middleName\": \"\",\n              \"orgName\": \"Xyz Inc.\",\n              \"partyType\": \"org\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Custodian\",\n                \"appointmentDate\": \"2021-08-05\"\n              }\n            ]\n          }\n        ],\n        \"custodialOffice\": {\n          \"deliveryAddress\": {\n            \"streetAddress\": \"records - delivery_address\",\n            \"addressCity\": \"delivery_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          },\n          \"mailingAddress\": {\n            \"streetAddress\": \"records - mailing_address\",\n            \"addressCity\": \"mailing_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          }\n        }\n      }\n    }\n}"
 						},
 						"url": {
 							"raw": "{{url}}/api/v1/businesses/:id/filings",
@@ -10125,14 +10124,108 @@
 							"variable": [
 								{
 									"key": "id",
-									"value": "CP0000848"
+									"value": "CP3490248"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "post - fail, missing statement type - CP3490248",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json()",
+									"pm.environment.set(\"filing_id\", jsonData.filing.header.filingId)",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Status code is 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"});",
+									"",
+									"pm.test('should return JSON', function () {",
+									"    pm.response.to.have.header('Content-Type', 'application/json');",
+									"});",
+									"",
+									"",
+									"pm.test(\"Returns dissolution filing.\", () => {",
+									"    pm.expect(jsonData.filing).to.exist",
+									"    pm.expect(jsonData.filing.business).to.exist",
+									"    pm.expect(jsonData.filing.dissolution).to.exist",
+									"    pm.expect(jsonData.filing.header).to.exist",
+									"    pm.expect(jsonData.errors).to.exist",
+									"    pm.expect(jsonData.errors.length).to.eq(1)",
+									"    pm.expect(jsonData.errors[0].error).to.eq('Dissolution statement type must be provided.')",
+									"    pm.expect(jsonData.errors[0].path).to.eq('/filing/dissolution/dissolutionStatementType')",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"var today = new Date()",
+									"pm.environment.set(\"today\", today.getFullYear()+'-'+('0'+(today.getMonth()+1)).slice(-2)+'-'+('0'+today.getDate()).slice(-2))"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"filing\": {\n      \"header\": {\n        \"name\": \"dissolution\",\n        \"date\": \"{{today}}\",\n        \"certifiedBy\": \"full name\",\n        \"email\": \"no_one@never.get\",\n        \"effectiveDate\": \"{{today}}T00:00:00+00:00\"\n      },\n      \"business\": {\n        \"identifier\": \"CP3490248\",\n        \"legalType\": \"CP\"\n      },\n      \"dissolution\": {\n        \"dissolutionDate\": \"{{today}}\",\n        \"dissolutionType\": \"voluntary\",\n        \"dissolutionStatementType\": \"\",\n        \"hasLiabilities\": false,\n        \"parties\": [\n          {\n            \"officer\": {\n              \"firstName\": \"Completing\",\n              \"lastName\": \"Party\",\n              \"middleName\": \"P\",\n              \"email\": \"cp@example.com\",\n              \"orgName\": \"\",\n              \"partyType\": \"person\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Completing Party\",\n                \"appointmentDate\": \"2021-08-05\"\n\n              }\n            ]\n          },\n          {\n            \"officer\": {\n              \"firstName\": \"\",\n              \"lastName\": \"\",\n              \"middleName\": \"\",\n              \"orgName\": \"Xyz Inc.\",\n              \"partyType\": \"org\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Custodian\",\n                \"appointmentDate\": \"2021-08-05\"\n              }\n            ]\n          }\n        ],\n        \"custodialOffice\": {\n          \"deliveryAddress\": {\n            \"streetAddress\": \"records - delivery_address\",\n            \"addressCity\": \"delivery_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          },\n          \"mailingAddress\": {\n            \"streetAddress\": \"records - mailing_address\",\n            \"addressCity\": \"mailing_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          }\n        }\n      }\n    }\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/businesses/:id/filings",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"businesses",
+								":id",
+								"filings"
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "CP3490248"
 								}
 							]
 						}
 					},
 					"response": [
 						{
-							"name": "post - dissolution - CP1000006",
+							"name": "post - fail, missing statement type - CP3490248",
 							"originalRequest": {
 								"method": "POST",
 								"header": [
@@ -10145,7 +10238,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"filing\": {\n      \"header\": {\n        \"name\": \"dissolution\",\n        \"date\": \"{{today}}\",\n        \"certifiedBy\": \"full name\",\n        \"email\": \"no_one@never.get\",\n        \"effectiveDate\": \"{{today}}T00:00:00+00:00\"\n      },\n      \"business\": {\n        \"identifier\": \"CP0000848\",\n        \"legalType\": \"CP\"\n      },\n      \"dissolution\": {\n        \"dissolutionDate\": \"{{today}}\",\n        \"dissolutionType\": \"voluntary\",\n        \"dissolutionStatementType\": \"197NoAssetsProvisionsLiabilities\",\n        \"hasLiabilities\": false,\n        \"parties\": [\n          {\n            \"officer\": {\n              \"firstName\": \"Completing\",\n              \"lastName\": \"Party\",\n              \"middleName\": \"P\",\n              \"email\": \"cp@example.com\",\n              \"orgName\": \"\",\n              \"partyType\": \"person\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Completing Party\",\n                \"appointmentDate\": \"2021-08-05\"\n\n              }\n            ]\n          },\n          {\n            \"officer\": {\n              \"firstName\": \"\",\n              \"lastName\": \"\",\n              \"middleName\": \"\",\n              \"orgName\": \"Xyz Inc.\",\n              \"partyType\": \"org\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Custodian\",\n                \"appointmentDate\": \"2021-08-05\"\n              }\n            ]\n          }\n        ],\n        \"custodialOffice\": {\n          \"deliveryAddress\": {\n            \"streetAddress\": \"records - delivery_address\",\n            \"addressCity\": \"delivery_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          },\n          \"mailingAddress\": {\n            \"streetAddress\": \"records - mailing_address\",\n            \"addressCity\": \"mailing_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          }\n        }\n      }\n    }\n}"
+									"raw": "{\n    \"filing\": {\n      \"header\": {\n        \"name\": \"dissolution\",\n        \"date\": \"{{today}}\",\n        \"certifiedBy\": \"full name\",\n        \"email\": \"no_one@never.get\",\n        \"effectiveDate\": \"{{today}}T00:00:00+00:00\"\n      },\n      \"business\": {\n        \"identifier\": \"CP3490248\",\n        \"legalType\": \"CP\"\n      },\n      \"dissolution\": {\n        \"dissolutionDate\": \"{{today}}\",\n        \"dissolutionType\": \"voluntary\",\n        \"dissolutionStatementType\": \"\",\n        \"hasLiabilities\": false,\n        \"parties\": [\n          {\n            \"officer\": {\n              \"firstName\": \"Completing\",\n              \"lastName\": \"Party\",\n              \"middleName\": \"P\",\n              \"email\": \"cp@example.com\",\n              \"orgName\": \"\",\n              \"partyType\": \"person\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Completing Party\",\n                \"appointmentDate\": \"2021-08-05\"\n\n              }\n            ]\n          },\n          {\n            \"officer\": {\n              \"firstName\": \"\",\n              \"lastName\": \"\",\n              \"middleName\": \"\",\n              \"orgName\": \"Xyz Inc.\",\n              \"partyType\": \"org\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Custodian\",\n                \"appointmentDate\": \"2021-08-05\"\n              }\n            ]\n          }\n        ],\n        \"custodialOffice\": {\n          \"deliveryAddress\": {\n            \"streetAddress\": \"records - delivery_address\",\n            \"addressCity\": \"delivery_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          },\n          \"mailingAddress\": {\n            \"streetAddress\": \"records - mailing_address\",\n            \"addressCity\": \"mailing_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          }\n        }\n      }\n    }\n}"
 								},
 								"url": {
 									"raw": "{{url}}/api/v1/businesses/:id/filings",
@@ -10162,22 +10255,30 @@
 									"variable": [
 										{
 											"key": "id",
-											"value": "CP0000848"
+											"value": "CP3490248"
 										}
 									]
 								}
 							},
-							"status": "Created",
-							"code": 201,
+							"status": "BAD REQUEST",
+							"code": 400,
 							"_postman_previewlanguage": "json",
 							"header": [
+								{
+									"key": "Server",
+									"value": "gunicorn"
+								},
+								{
+									"key": "Date",
+									"value": "Tue, 28 Sep 2021 18:55:34 GMT"
+								},
 								{
 									"key": "Content-Type",
 									"value": "application/json"
 								},
 								{
 									"key": "Content-Length",
-									"value": "2046"
+									"value": "1817"
 								},
 								{
 									"key": "Access-Control-Allow-Origin",
@@ -10185,7 +10286,7 @@
 								},
 								{
 									"key": "Access-Control-Allow-Methods",
-									"value": "DELETE, PUT, HEAD, GET, POST, OPTIONS"
+									"value": "DELETE, HEAD, POST, OPTIONS, PUT, GET"
 								},
 								{
 									"key": "Access-Control-Max-Age",
@@ -10193,23 +10294,190 @@
 								},
 								{
 									"key": "API",
-									"value": "legal_api/2.28.0"
+									"value": "legal_api/2.28.0-77c6a70"
 								},
 								{
 									"key": "SCHEMAS",
-									"value": "registry_schemas/2.15.4"
-								},
-								{
-									"key": "Server",
-									"value": "Werkzeug/1.0.1 Python/3.8.8"
-								},
-								{
-									"key": "Date",
-									"value": "Mon, 27 Sep 2021 13:50:48 GMT"
+									"value": "registry_schemas/2.15.5"
 								}
 							],
 							"cookie": [],
-							"body": "{\n    \"filing\": {\n        \"business\": {\n            \"identifier\": \"CP0000848\",\n            \"legalType\": \"CP\"\n        },\n        \"dissolution\": {\n            \"custodialOffice\": {\n                \"deliveryAddress\": {\n                    \"addressCity\": \"delivery_address city\",\n                    \"addressCountry\": \"CA\",\n                    \"addressRegion\": \"BC\",\n                    \"postalCode\": \"H0H0H0\",\n                    \"streetAddress\": \"records - delivery_address\"\n                },\n                \"mailingAddress\": {\n                    \"addressCity\": \"mailing_address city\",\n                    \"addressCountry\": \"CA\",\n                    \"addressRegion\": \"BC\",\n                    \"postalCode\": \"H0H0H0\",\n                    \"streetAddress\": \"records - mailing_address\"\n                }\n            },\n            \"dissolutionDate\": \"2021-09-27\",\n            \"dissolutionStatementType\": \"197NoAssetsProvisionsLiabilities\",\n            \"dissolutionType\": \"voluntary\",\n            \"hasLiabilities\": false,\n            \"parties\": [\n                {\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"delivery_address city\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"postalCode\": \"H0H0H0\",\n                        \"streetAddress\": \"delivery_address - address line one\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"mailingAddress\": {\n                        \"addressCity\": \"mailing_address city\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"postalCode\": \"H0H0H0\",\n                        \"streetAddress\": \"mailing_address - address line one\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"email\": \"cp@example.com\",\n                        \"firstName\": \"Completing\",\n                        \"lastName\": \"Party\",\n                        \"middleName\": \"P\",\n                        \"orgName\": \"\",\n                        \"partyType\": \"person\"\n                    },\n                    \"roles\": [\n                        {\n                            \"appointmentDate\": \"2021-08-05\",\n                            \"roleType\": \"Completing Party\"\n                        }\n                    ]\n                },\n                {\n                    \"mailingAddress\": {\n                        \"addressCity\": \"mailing_address city\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"postalCode\": \"H0H0H0\",\n                        \"streetAddress\": \"mailing_address - address line one\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"\",\n                        \"lastName\": \"\",\n                        \"middleName\": \"\",\n                        \"orgName\": \"Xyz Inc.\",\n                        \"partyType\": \"org\"\n                    },\n                    \"roles\": [\n                        {\n                            \"appointmentDate\": \"2021-08-05\",\n                            \"roleType\": \"Custodian\"\n                        }\n                    ]\n                }\n            ]\n        },\n        \"header\": {\n            \"affectedFilings\": [],\n            \"availableOnPaperOnly\": false,\n            \"certifiedBy\": \"full name\",\n            \"colinIds\": [],\n            \"comments\": [],\n            \"date\": \"2021-09-27T13:50:48.627919+00:00\",\n            \"effectiveDate\": \"2021-09-27T00:00:00+00:00\",\n            \"email\": \"no_one@never.get\",\n            \"filingId\": 112445,\n            \"inColinOnly\": false,\n            \"isCorrected\": false,\n            \"isCorrectionPending\": false,\n            \"name\": \"dissolution\",\n            \"status\": \"DRAFT\",\n            \"submitter\": \"service-account-entity-service-account\"\n        }\n    }\n}"
+							"body": "{\n    \"errors\": [\n        {\n            \"error\": \"Dissolution statement type must be provided.\",\n            \"path\": \"/filing/dissolution/dissolutionStatementType\"\n        }\n    ],\n    \"filing\": {\n        \"business\": {\n            \"identifier\": \"CP3490248\",\n            \"legalType\": \"CP\"\n        },\n        \"dissolution\": {\n            \"custodialOffice\": {\n                \"deliveryAddress\": {\n                    \"addressCity\": \"delivery_address city\",\n                    \"addressCountry\": \"CA\",\n                    \"addressRegion\": \"BC\",\n                    \"postalCode\": \"H0H0H0\",\n                    \"streetAddress\": \"records - delivery_address\"\n                },\n                \"mailingAddress\": {\n                    \"addressCity\": \"mailing_address city\",\n                    \"addressCountry\": \"CA\",\n                    \"addressRegion\": \"BC\",\n                    \"postalCode\": \"H0H0H0\",\n                    \"streetAddress\": \"records - mailing_address\"\n                }\n            },\n            \"dissolutionDate\": \"2021-09-28\",\n            \"dissolutionStatementType\": \"\",\n            \"dissolutionType\": \"voluntary\",\n            \"hasLiabilities\": false,\n            \"parties\": [\n                {\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"delivery_address city\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"postalCode\": \"H0H0H0\",\n                        \"streetAddress\": \"delivery_address - address line one\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"mailingAddress\": {\n                        \"addressCity\": \"mailing_address city\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"postalCode\": \"H0H0H0\",\n                        \"streetAddress\": \"mailing_address - address line one\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"email\": \"cp@example.com\",\n                        \"firstName\": \"Completing\",\n                        \"lastName\": \"Party\",\n                        \"middleName\": \"P\",\n                        \"orgName\": \"\",\n                        \"partyType\": \"person\"\n                    },\n                    \"roles\": [\n                        {\n                            \"appointmentDate\": \"2021-08-05\",\n                            \"roleType\": \"Completing Party\"\n                        }\n                    ]\n                },\n                {\n                    \"mailingAddress\": {\n                        \"addressCity\": \"mailing_address city\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"postalCode\": \"H0H0H0\",\n                        \"streetAddress\": \"mailing_address - address line one\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"\",\n                        \"lastName\": \"\",\n                        \"middleName\": \"\",\n                        \"orgName\": \"Xyz Inc.\",\n                        \"partyType\": \"org\"\n                    },\n                    \"roles\": [\n                        {\n                            \"appointmentDate\": \"2021-08-05\",\n                            \"roleType\": \"Custodian\"\n                        }\n                    ]\n                }\n            ]\n        },\n        \"header\": {\n            \"certifiedBy\": \"full name\",\n            \"date\": \"2021-09-28\",\n            \"effectiveDate\": \"2021-09-28T00:00:00+00:00\",\n            \"email\": \"no_one@never.get\",\n            \"name\": \"dissolution\"\n        }\n    }\n}"
+						}
+					]
+				},
+				{
+					"name": "post - fail, invalid statement type - CP3490248",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json()",
+									"pm.environment.set(\"filing_id\", jsonData.filing.header.filingId)",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Status code is 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"});",
+									"",
+									"pm.test('should return JSON', function () {",
+									"    pm.response.to.have.header('Content-Type', 'application/json');",
+									"});",
+									"",
+									"",
+									"pm.test(\"Returns dissolution filing.\", () => {",
+									"    pm.expect(jsonData.filing).to.exist",
+									"    pm.expect(jsonData.filing.business).to.exist",
+									"    pm.expect(jsonData.filing.dissolution).to.exist",
+									"    pm.expect(jsonData.filing.header).to.exist",
+									"    pm.expect(jsonData.errors).to.exist",
+									"    pm.expect(jsonData.errors.length).to.eq(1)",
+									"    pm.expect(jsonData.errors[0].error).to.eq('Invalid Dissolution statement type.')",
+									"    pm.expect(jsonData.errors[0].path).to.eq('/filing/dissolution/dissolutionStatementType')",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"var today = new Date()",
+									"pm.environment.set(\"today\", today.getFullYear()+'-'+('0'+(today.getMonth()+1)).slice(-2)+'-'+('0'+today.getDate()).slice(-2))"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"filing\": {\n      \"header\": {\n        \"name\": \"dissolution\",\n        \"date\": \"{{today}}\",\n        \"certifiedBy\": \"full name\",\n        \"email\": \"no_one@never.get\",\n        \"effectiveDate\": \"{{today}}T00:00:00+00:00\"\n      },\n      \"business\": {\n        \"identifier\": \"CP3490248\",\n        \"legalType\": \"CP\"\n      },\n      \"dissolution\": {\n        \"dissolutionDate\": \"{{today}}\",\n        \"dissolutionType\": \"voluntary\",\n        \"dissolutionStatementType\": \"sdfsdf\",\n        \"hasLiabilities\": false,\n        \"parties\": [\n          {\n            \"officer\": {\n              \"firstName\": \"Completing\",\n              \"lastName\": \"Party\",\n              \"middleName\": \"P\",\n              \"email\": \"cp@example.com\",\n              \"orgName\": \"\",\n              \"partyType\": \"person\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Completing Party\",\n                \"appointmentDate\": \"2021-08-05\"\n\n              }\n            ]\n          },\n          {\n            \"officer\": {\n              \"firstName\": \"\",\n              \"lastName\": \"\",\n              \"middleName\": \"\",\n              \"orgName\": \"Xyz Inc.\",\n              \"partyType\": \"org\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Custodian\",\n                \"appointmentDate\": \"2021-08-05\"\n              }\n            ]\n          }\n        ],\n        \"custodialOffice\": {\n          \"deliveryAddress\": {\n            \"streetAddress\": \"records - delivery_address\",\n            \"addressCity\": \"delivery_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          },\n          \"mailingAddress\": {\n            \"streetAddress\": \"records - mailing_address\",\n            \"addressCity\": \"mailing_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          }\n        }\n      }\n    }\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/businesses/:id/filings",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"businesses",
+								":id",
+								"filings"
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "CP3490248"
+								}
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "post - fail, invalid statement type - CP3490248",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"filing\": {\n      \"header\": {\n        \"name\": \"dissolution\",\n        \"date\": \"{{today}}\",\n        \"certifiedBy\": \"full name\",\n        \"email\": \"no_one@never.get\",\n        \"effectiveDate\": \"{{today}}T00:00:00+00:00\"\n      },\n      \"business\": {\n        \"identifier\": \"CP3490248\",\n        \"legalType\": \"CP\"\n      },\n      \"dissolution\": {\n        \"dissolutionDate\": \"{{today}}\",\n        \"dissolutionType\": \"voluntary\",\n        \"dissolutionStatementType\": \"sdfsdf\",\n        \"hasLiabilities\": false,\n        \"parties\": [\n          {\n            \"officer\": {\n              \"firstName\": \"Completing\",\n              \"lastName\": \"Party\",\n              \"middleName\": \"P\",\n              \"email\": \"cp@example.com\",\n              \"orgName\": \"\",\n              \"partyType\": \"person\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Completing Party\",\n                \"appointmentDate\": \"2021-08-05\"\n\n              }\n            ]\n          },\n          {\n            \"officer\": {\n              \"firstName\": \"\",\n              \"lastName\": \"\",\n              \"middleName\": \"\",\n              \"orgName\": \"Xyz Inc.\",\n              \"partyType\": \"org\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Custodian\",\n                \"appointmentDate\": \"2021-08-05\"\n              }\n            ]\n          }\n        ],\n        \"custodialOffice\": {\n          \"deliveryAddress\": {\n            \"streetAddress\": \"records - delivery_address\",\n            \"addressCity\": \"delivery_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          },\n          \"mailingAddress\": {\n            \"streetAddress\": \"records - mailing_address\",\n            \"addressCity\": \"mailing_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          }\n        }\n      }\n    }\n}"
+								},
+								"url": {
+									"raw": "{{url}}/api/v1/businesses/:id/filings",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"businesses",
+										":id",
+										"filings"
+									],
+									"variable": [
+										{
+											"key": "id",
+											"value": "CP3490248"
+										}
+									]
+								}
+							},
+							"status": "BAD REQUEST",
+							"code": 400,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Server",
+									"value": "gunicorn"
+								},
+								{
+									"key": "Date",
+									"value": "Tue, 28 Sep 2021 19:16:07 GMT"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Content-Length",
+									"value": "1814"
+								},
+								{
+									"key": "Access-Control-Allow-Origin",
+									"value": "*"
+								},
+								{
+									"key": "Access-Control-Allow-Methods",
+									"value": "DELETE, HEAD, POST, OPTIONS, PUT, GET"
+								},
+								{
+									"key": "Access-Control-Max-Age",
+									"value": "21600"
+								},
+								{
+									"key": "API",
+									"value": "legal_api/2.28.0-77c6a70"
+								},
+								{
+									"key": "SCHEMAS",
+									"value": "registry_schemas/2.15.5"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"errors\": [\n        {\n            \"error\": \"Invalid Dissolution statement type.\",\n            \"path\": \"/filing/dissolution/dissolutionStatementType\"\n        }\n    ],\n    \"filing\": {\n        \"business\": {\n            \"identifier\": \"CP3490248\",\n            \"legalType\": \"CP\"\n        },\n        \"dissolution\": {\n            \"custodialOffice\": {\n                \"deliveryAddress\": {\n                    \"addressCity\": \"delivery_address city\",\n                    \"addressCountry\": \"CA\",\n                    \"addressRegion\": \"BC\",\n                    \"postalCode\": \"H0H0H0\",\n                    \"streetAddress\": \"records - delivery_address\"\n                },\n                \"mailingAddress\": {\n                    \"addressCity\": \"mailing_address city\",\n                    \"addressCountry\": \"CA\",\n                    \"addressRegion\": \"BC\",\n                    \"postalCode\": \"H0H0H0\",\n                    \"streetAddress\": \"records - mailing_address\"\n                }\n            },\n            \"dissolutionDate\": \"2021-09-28\",\n            \"dissolutionStatementType\": \"sdfsdf\",\n            \"dissolutionType\": \"voluntary\",\n            \"hasLiabilities\": false,\n            \"parties\": [\n                {\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"delivery_address city\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"postalCode\": \"H0H0H0\",\n                        \"streetAddress\": \"delivery_address - address line one\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"mailingAddress\": {\n                        \"addressCity\": \"mailing_address city\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"postalCode\": \"H0H0H0\",\n                        \"streetAddress\": \"mailing_address - address line one\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"email\": \"cp@example.com\",\n                        \"firstName\": \"Completing\",\n                        \"lastName\": \"Party\",\n                        \"middleName\": \"P\",\n                        \"orgName\": \"\",\n                        \"partyType\": \"person\"\n                    },\n                    \"roles\": [\n                        {\n                            \"appointmentDate\": \"2021-08-05\",\n                            \"roleType\": \"Completing Party\"\n                        }\n                    ]\n                },\n                {\n                    \"mailingAddress\": {\n                        \"addressCity\": \"mailing_address city\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"postalCode\": \"H0H0H0\",\n                        \"streetAddress\": \"mailing_address - address line one\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"\",\n                        \"lastName\": \"\",\n                        \"middleName\": \"\",\n                        \"orgName\": \"Xyz Inc.\",\n                        \"partyType\": \"org\"\n                    },\n                    \"roles\": [\n                        {\n                            \"appointmentDate\": \"2021-08-05\",\n                            \"roleType\": \"Custodian\"\n                        }\n                    ]\n                }\n            ]\n        },\n        \"header\": {\n            \"certifiedBy\": \"full name\",\n            \"date\": \"2021-09-28\",\n            \"effectiveDate\": \"2021-09-28T00:00:00+00:00\",\n            \"email\": \"no_one@never.get\",\n            \"name\": \"dissolution\"\n        }\n    }\n}"
 						}
 					]
 				}


### PR DESCRIPTION
*Issue #:* /bcgov/entity#8915

*Description of changes:*

* Add postman tests to specifically test scenarios where dissolution statement type is required to confirm required and valid dissolution statement type validation is working

![image](https://user-images.githubusercontent.com/6685223/135154984-b0e67b6c-9df3-4d9e-a72e-a0c54b7879e2.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
