### PR TITLE
8933 Add affidavit/special resolution doc validation to voluntary dissolution filing

### DIFF
--- a/legal-api/requirements.txt
+++ b/legal-api/requirements.txt
@@ -57,5 +57,5 @@ urllib3==1.26.4
 minio==7.0.2
 PyPDF2==1.26.0
 reportlab==3.6.1
-git+https://github.com/bcgov/business-schemas.git@2.15.7#egg=registry_schemas
+git+https://github.com/bcgov/business-schemas.git@2.15.9#egg=registry_schemas
 

--- a/legal-api/requirements/bcregistry-libraries.txt
+++ b/legal-api/requirements/bcregistry-libraries.txt
@@ -1,1 +1,1 @@
-git+https://github.com/bcgov/business-schemas.git@2.15.6#egg=registry_schemas
+git+https://github.com/bcgov/business-schemas.git@2.15.9#egg=registry_schemas

--- a/legal-api/requirements/dev.txt
+++ b/legal-api/requirements/dev.txt
@@ -22,7 +22,7 @@ pydocstyle
 # pydocstyle<4
 pylint
 pylint-flask
-isort
+isort<5
 pytest-cov
 
 # docker

--- a/legal-api/src/legal_api/models/business.py
+++ b/legal-api/src/legal_api/models/business.py
@@ -28,14 +28,14 @@ from legal_api.utils.datetime import datetime, timezone
 from legal_api.utils.legislation_datetime import LegislationDatetime
 
 from .db import db  # noqa: I001
-from .address import Address  # noqa: F401 pylint: disable=unused-import; needed by the SQLAlchemy relationship
+from .address import Address  # noqa: F401,I003 pylint: disable=unused-import; needed by the SQLAlchemy relationship
 from .alias import Alias  # noqa: F401 pylint: disable=unused-import; needed by the SQLAlchemy relationship
 from .filing import Filing  # noqa: F401 pylint: disable=unused-import; needed by the SQLAlchemy backref
 from .office import Office  # noqa: F401 pylint: disable=unused-import; needed by the SQLAlchemy relationship
 from .party_role import PartyRole  # noqa: F401 pylint: disable=unused-import; needed by the SQLAlchemy relationship
 from .resolution import Resolution  # noqa: F401 pylint: disable=unused-import; needed by the SQLAlchemy backref
-from .share_class import ShareClass  # noqa: F401 pylint: disable=unused-import
-from .user import User  # noqa: F401 pylint: disable=unused-import; needed by the SQLAlchemy backref
+from .share_class import ShareClass  # noqa: F401,I001,I003 pylint: disable=unused-import
+from .user import User  # noqa: F401,I003 pylint: disable=unused-import; needed by the SQLAlchemy backref
 
 
 class Business(db.Model):  # pylint: disable=too-many-instance-attributes

--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -29,7 +29,7 @@ from legal_api.models.colin_event_id import ColinEventId
 from legal_api.schemas import rsbc_schemas
 
 from .db import db  # noqa: I001
-from .comment import Comment  # noqa: I001,F401 pylint: disable=unused-import; needed by the SQLAlchemy relationship
+from .comment import Comment  # noqa: I001,F401,I003 pylint: disable=unused-import; needed by SQLAlchemy relationship
 
 
 class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many-public-methods

--- a/legal-api/src/legal_api/models/party.py
+++ b/legal-api/src/legal_api/models/party.py
@@ -22,7 +22,7 @@ from sqlalchemy import event
 from legal_api.exceptions import BusinessException
 
 from .db import db  # noqa: I001
-from .address import Address  # noqa: I001,F401 pylint: disable=unused-import; needed by the SQLAlchemy relationship
+from .address import Address  # noqa: I001,I003,F401 pylint: disable=unused-import; needed by the SQLAlchemy rel
 
 
 class Party(db.Model):  # pylint: disable=too-many-instance-attributes

--- a/legal-api/src/legal_api/models/party_role.py
+++ b/legal-api/src/legal_api/models/party_role.py
@@ -20,7 +20,7 @@ from enum import Enum
 from sqlalchemy import Date, cast, or_
 
 from .db import db  # noqa: I001
-from .party import Party  # noqa: I001,F401 pylint: disable=unused-import; needed by the SQLAlchemy rel
+from .party import Party  # noqa: I001,F401,I003 pylint: disable=unused-import; needed by the SQLAlchemy rel
 
 
 class PartyRole(db.Model):

--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
@@ -25,7 +25,7 @@ from flask_babel import _
 from flask_cors import cross_origin
 from flask_jwt_oidc import JwtManager
 from flask_pydantic import validate as pydantic_validate
-from pydantic import BaseModel  # pylint: disable=E0611; not sure why pylint is unable to scan module
+from pydantic import BaseModel  # noqa: I001; pylint: disable=E0611; not sure why pylint is unable to scan module
 from pydantic.generics import GenericModel
 from werkzeug.local import LocalProxy
 

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -12,10 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Common validations share through the different filings."""
+import io
 from datetime import datetime
 from typing import Optional
 
+import PyPDF2
+from flask_babel import _
+
 from legal_api.errors import Error
+from legal_api.services import MinioService
 from legal_api.utils.datetime import datetime as dt
 
 
@@ -136,6 +141,35 @@ def validate_court_order(court_order_path, court_order):
         except ValueError:
             err_path = court_order_date_path
             msg.append({'error': 'Invalid court order date format.', 'path': err_path})
+
+    if msg:
+        return msg
+
+    return None
+
+
+def validate_pdf(file_key: str, file_key_path: str) -> Optional[list]:
+    """Validate the PDF file."""
+    msg = []
+    try:
+        file = MinioService.get_file(file_key)
+        open_pdf_file = io.BytesIO(file.data)
+        pdf_reader = PyPDF2.PdfFileReader(open_pdf_file)
+        pdf_size_units = pdf_reader.getPage(0).mediaBox
+
+        if pdf_size_units.getWidth() != 612 or pdf_size_units.getHeight() != 792:
+            msg.append({'error': _('Document must be set to fit onto 8.5” x 11” letter-size paper.'),
+                        'path': file_key_path})
+
+        file_info = MinioService.get_file_info(file_key)
+        if file_info.size > 10000000:
+            msg.append({'error': _('File exceeds maximum size.'), 'path': file_key_path})
+
+        if pdf_reader.isEncrypted:
+            msg.append({'error': _('File must be unencrypted.'), 'path': file_key_path})
+
+    except Exception:
+        msg.append({'error': _('Invalid file.'), 'path': file_key_path})
 
     if msg:
         return msg

--- a/legal-api/src/legal_api/services/filings/validations/court_order.py
+++ b/legal-api/src/legal_api/services/filings/validations/court_order.py
@@ -16,7 +16,7 @@ from http import HTTPStatus
 from typing import Dict, Optional
 
 from flask_babel import _ as babel  # noqa: N813, I004, I001; importing camelcase '_' as a name
-
+# noqa: I004
 from legal_api.errors import Error
 from legal_api.models import Business
 

--- a/legal-api/src/legal_api/services/filings/validations/dissolution.py
+++ b/legal-api/src/legal_api/services/filings/validations/dissolution.py
@@ -22,8 +22,9 @@ from flask_babel import _
 from legal_api.errors import Error
 from legal_api.models import Address, Business, PartyRole
 
-from ...utils import get_str
-# noqa: I003; needed as the linter gets confused from the babel override above.
+from .common_validations import validate_pdf
+from ...utils import get_str  # noqa: I003; needed as the linter gets confused from the babel override above.
+
 
 CORP_TYPES: Final = [Business.LegalTypes.COMP.value,
                      Business.LegalTypes.BCOMP.value,
@@ -36,6 +37,18 @@ class DissolutionTypes(str, Enum):
 
     VOLUNTARY = 'voluntary'
     VOLUNTARY_LIQUIDATION = 'voluntaryLiquidation'
+
+
+class DissolutionStatementTypes(str, Enum):
+    """Dissolution statement types."""
+
+    NO_ASSETS_NO_LIABILITIES_197 = '197NoAssetsNoLiabilities'
+    NO_ASSETS_PROVISIONS_LIABILITIES_197 = '197NoAssetsProvisionsLiabilities'
+
+    @classmethod
+    def has_value(cls, value):
+        """Check if enum contains specific value provided via input param."""
+        return value in cls._value2member_map_  # pylint: disable=no-member
 
 
 DISSOLUTION_MAPPING = {
@@ -56,12 +69,15 @@ def validate(business: Business, con: Dict) -> Optional[Error]:
     if err:
         msg.extend(err)
 
-    if legal_type == Business.LegalTypes.COOP.value:
-        err = validate_dissolution_statement_type(con)
-        if err:
-            msg.extend(err)
+    err = validate_dissolution_statement_type(con, legal_type)
+    if err:
+        msg.extend(err)
 
     err = validate_parties_address(con, legal_type)
+    if err:
+        msg.extend(err)
+
+    err = validate_documents(con, legal_type)
     if err:
         msg.extend(err)
 
@@ -88,20 +104,21 @@ def validate_dissolution_type(filing_json, legal_type) -> Optional[list]:
     return None
 
 
-def validate_dissolution_statement_type(filing_json) -> Optional[list]:
+def validate_dissolution_statement_type(filing_json, legal_type) -> Optional[list]:
     """Validate dissolution statement type of the filing."""
     msg = []
     dissolution_stmt_type_path = '/filing/dissolution/dissolutionStatementType'
     dissolution_stmt_type = get_str(filing_json, dissolution_stmt_type_path)
-    if dissolution_stmt_type:
-        if dissolution_stmt_type not in ['197NoAssetsNoLiabilities', '197NoAssetsProvisionsLiabilities']:
+
+    if legal_type == Business.LegalTypes.COOP.value:
+        if not dissolution_stmt_type:
+            msg.append({'error': _('Dissolution statement type must be provided.'),
+                        'path': dissolution_stmt_type_path})
+            return msg
+        if not DissolutionStatementTypes.has_value(dissolution_stmt_type):
             msg.append({'error': _('Invalid Dissolution statement type.'),
                         'path': dissolution_stmt_type_path})
             return msg
-    else:
-        msg.append({'error': _('Dissolution statement type must be provided.'),
-                    'path': dissolution_stmt_type_path})
-        return msg
 
     return None
 
@@ -171,3 +188,45 @@ def _validate_address_location(parties):
         return msg, address_in_bc, address_in_ca
 
     return None, address_in_bc, address_in_ca
+
+
+def validate_documents(filing_json, legal_type) -> Optional[list]:
+    """Validate documents of the filing."""
+    msg = []
+
+    if legal_type == Business.LegalTypes.COOP.value:
+        affidavit_file_key = filing_json['filing']['dissolution'].get('affidavitFileKey', None)
+        affidavit_file_name = filing_json['filing']['dissolution'].get('affidavitFileName', None)
+        special_resolution_file_key = filing_json['filing']['dissolution'].get('specialResolutionFileKey', None)
+        special_resolution_file_name = filing_json['filing']['dissolution'].get('specialResolutionFileName', None)
+
+        # Validate key values exist
+        if not affidavit_file_key:
+            msg.append({'error': _('A valid affidavit key is required.'),
+                        'path': '/filing/dissolution/affidavitFileKey'})
+
+        if not affidavit_file_name:
+            msg.append({'error': _('A valid affidavit file name is required.'),
+                        'path': '/filing/dissolution/affidavitFileName'})
+
+        if not special_resolution_file_key:
+            msg.append({'error': _('A valid special resolution key is required.'),
+                        'path': '/filing/dissolution/specialResolutionFileKey'})
+
+        if not special_resolution_file_name:
+            msg.append({'error': _('A valid special resolution file name is required.'),
+                        'path': '/filing/dissolution/specialResolutionFileName'})
+
+        if msg:
+            return msg
+
+        affidavit_err = validate_pdf(affidavit_file_key, '/filing/dissolution/affidavitFileKey')
+        if affidavit_err:
+            return affidavit_err
+
+        special_resolution_err = validate_pdf(special_resolution_file_key,
+                                              '/filing/dissolution/specialResolutionFileKey')
+        if special_resolution_err:
+            return special_resolution_err
+
+    return None

--- a/legal-api/src/legal_api/services/filings/validations/registrars_notation.py
+++ b/legal-api/src/legal_api/services/filings/validations/registrars_notation.py
@@ -16,7 +16,7 @@ from http import HTTPStatus
 from typing import Dict, Optional
 
 from flask_babel import _ as babel  # noqa: N813, I004, I001; importing camelcase '_' as a name
-
+# noqa: I004
 from legal_api.errors import Error
 from legal_api.models import Business
 

--- a/legal-api/src/legal_api/services/filings/validations/registrars_order.py
+++ b/legal-api/src/legal_api/services/filings/validations/registrars_order.py
@@ -16,7 +16,7 @@ from http import HTTPStatus
 from typing import Dict, Optional
 
 from flask_babel import _ as babel  # noqa: N813, I004, I001; importing camelcase '_' as a name
-
+# noqa: I004
 from legal_api.errors import Error
 from legal_api.models import Business
 

--- a/legal-api/tests/postman/legal-api.postman_collection.json
+++ b/legal-api/tests/postman/legal-api.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "a41d7992-7876-4656-a429-4ba9374a4ee3",
+		"_postman_id": "2aa0e30a-a181-4b1a-bc86-a6fd781f8377",
 		"name": "legal-api",
 		"description": "version=2.8 - Legal API Postman Tests",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -9971,7 +9971,8 @@
 									"});",
 									"",
 									"var jsonData = pm.response.json();",
-									"pm.environment.set(\"documnent_key\", jsonData.key);"
+									"pm.environment.set(\"documnent_key\", jsonData.key);",
+									"pm.environment.set(\"document_put_presigned_url\", jsonData.preSignedUrl);"
 								],
 								"type": "text/javascript"
 							}
@@ -10042,6 +10043,392 @@
 			"name": "Voluntary Dissolution",
 			"item": [
 				{
+					"name": "Get affidavit document signature",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response time is less than 10000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(10000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    //pm.response.to.have.jsonBody(\"\"); ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"key\");",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"pm.environment.set(\"affidavit_file_key\", jsonData.key);",
+									"pm.environment.set(\"affidavit_file_put_presigned_url\", jsonData.preSignedUrl);"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/documents/:file_name/signatures",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"documents",
+								":file_name",
+								"signatures"
+							],
+							"query": [
+								{
+									"key": "",
+									"value": "",
+									"disabled": true
+								}
+							],
+							"variable": [
+								{
+									"key": "file_name",
+									"value": "affidavit_file.pdf"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "put - affidavit document to minio",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"var today = new Date()",
+									"pm.environment.set(\"today\", today.getFullYear()+'-'+('0'+(today.getMonth()+1)).slice(-2)+'-'+('0'+today.getDate()).slice(-2))"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "X-Amz-Credential",
+								"value": "{{X-Amz-Credential}}",
+								"type": "text",
+								"disabled": true
+							},
+							{
+								"key": "X-Amz-Date",
+								"value": "{{X-Amz-Date}}",
+								"type": "text",
+								"disabled": true
+							},
+							{
+								"key": "X-Amz-Expires",
+								"value": "{{X-Amz-Expires}}",
+								"type": "text",
+								"disabled": true
+							},
+							{
+								"key": "X-Amz-SignedHeaders",
+								"value": "{{X-Amz-SignedHeaders}}",
+								"type": "text",
+								"disabled": true
+							},
+							{
+								"key": "X-Amz-Signature",
+								"value": "{{X-Amz-Signature}}",
+								"type": "text",
+								"disabled": true
+							}
+						],
+						"body": {
+							"mode": "file",
+							"file": {
+								"src": "/Users/argus/data/minio/test 34 MB.pdf"
+							},
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{affidavit_file_put_presigned_url}}",
+							"host": [
+								"{{affidavit_file_put_presigned_url}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get special resolution document signature",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response time is less than 10000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(10000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    //pm.response.to.have.jsonBody(\"\"); ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"key\");",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"pm.environment.set(\"special_resolution_file_key\", jsonData.key);",
+									"pm.environment.set(\"special_resolution_file_put_presigned_url\", jsonData.preSignedUrl);"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/documents/:file_name/signatures",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"documents",
+								":file_name",
+								"signatures"
+							],
+							"query": [
+								{
+									"key": "",
+									"value": "",
+									"disabled": true
+								}
+							],
+							"variable": [
+								{
+									"key": "file_name",
+									"value": "special_resolution_file.pdf"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "put - special resolution document to minio",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"var today = new Date()",
+									"pm.environment.set(\"today\", today.getFullYear()+'-'+('0'+(today.getMonth()+1)).slice(-2)+'-'+('0'+today.getDate()).slice(-2))"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "X-Amz-Credential",
+								"value": "{{X-Amz-Credential}}",
+								"type": "text",
+								"disabled": true
+							},
+							{
+								"key": "X-Amz-Date",
+								"value": "{{X-Amz-Date}}",
+								"type": "text",
+								"disabled": true
+							},
+							{
+								"key": "X-Amz-Expires",
+								"value": "{{X-Amz-Expires}}",
+								"type": "text",
+								"disabled": true
+							},
+							{
+								"key": "X-Amz-SignedHeaders",
+								"value": "{{X-Amz-SignedHeaders}}",
+								"type": "text",
+								"disabled": true
+							},
+							{
+								"key": "X-Amz-Signature",
+								"value": "{{X-Amz-Signature}}",
+								"type": "text",
+								"disabled": true
+							}
+						],
+						"body": {
+							"mode": "file",
+							"file": {
+								"src": "/Users/argus/data/minio/rules test.pdf"
+							},
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{special_resolution_file_put_presigned_url}}",
+							"host": [
+								"{{special_resolution_file_put_presigned_url}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "post - valid statement type - CP3490248",
 					"event": [
 						{
@@ -10107,7 +10494,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"filing\": {\n      \"header\": {\n        \"name\": \"dissolution\",\n        \"date\": \"{{today}}\",\n        \"certifiedBy\": \"full name\",\n        \"email\": \"no_one@never.get\",\n        \"effectiveDate\": \"{{today}}T00:00:00+00:00\"\n      },\n      \"business\": {\n        \"identifier\": \"CP3490248\",\n        \"legalType\": \"CP\"\n      },\n      \"dissolution\": {\n        \"dissolutionDate\": \"{{today}}\",\n        \"dissolutionType\": \"voluntary\",\n        \"dissolutionStatementType\": \"197NoAssetsNoLiabilities\",\n        \"hasLiabilities\": false,\n        \"parties\": [\n          {\n            \"officer\": {\n              \"firstName\": \"Completing\",\n              \"lastName\": \"Party\",\n              \"middleName\": \"P\",\n              \"email\": \"cp@example.com\",\n              \"orgName\": \"\",\n              \"partyType\": \"person\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Completing Party\",\n                \"appointmentDate\": \"2021-08-05\"\n\n              }\n            ]\n          },\n          {\n            \"officer\": {\n              \"firstName\": \"\",\n              \"lastName\": \"\",\n              \"middleName\": \"\",\n              \"orgName\": \"Xyz Inc.\",\n              \"partyType\": \"org\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Custodian\",\n                \"appointmentDate\": \"2021-08-05\"\n              }\n            ]\n          }\n        ],\n        \"custodialOffice\": {\n          \"deliveryAddress\": {\n            \"streetAddress\": \"records - delivery_address\",\n            \"addressCity\": \"delivery_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          },\n          \"mailingAddress\": {\n            \"streetAddress\": \"records - mailing_address\",\n            \"addressCity\": \"mailing_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          }\n        }\n      }\n    }\n}"
+							"raw": "{\n    \"filing\": {\n      \"header\": {\n        \"name\": \"dissolution\",\n        \"date\": \"{{today}}\",\n        \"certifiedBy\": \"full name\",\n        \"email\": \"no_one@never.get\",\n        \"effectiveDate\": \"{{today}}T00:00:00+00:00\"\n      },\n      \"business\": {\n        \"identifier\": \"CP3490248\",\n        \"legalType\": \"CP\"\n      },\n      \"dissolution\": {\n        \"dissolutionDate\": \"{{today}}\",\n        \"dissolutionType\": \"voluntary\",\n        \"dissolutionStatementType\": \"197NoAssetsNoLiabilities\",\n        \"hasLiabilities\": false,\n        \"parties\": [\n          {\n            \"officer\": {\n              \"firstName\": \"Completing\",\n              \"lastName\": \"Party\",\n              \"middleName\": \"P\",\n              \"email\": \"cp@example.com\",\n              \"organizationName\": \"\",\n              \"partyType\": \"person\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Completing Party\",\n                \"appointmentDate\": \"2021-08-05\"\n\n              }\n            ]\n          },\n          {\n            \"officer\": {\n              \"firstName\": \"\",\n              \"lastName\": \"\",\n              \"middleName\": \"\",\n              \"organizationName\": \"Xyz Inc.\",\n              \"partyType\": \"organization\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },            \n            \"roles\": [\n              {\n                \"roleType\": \"Custodian\",\n                \"appointmentDate\": \"2021-08-05\"\n              }\n            ]\n          }\n        ],\n        \"custodialOffice\": {\n          \"deliveryAddress\": {\n            \"streetAddress\": \"records - delivery_address\",\n            \"addressCity\": \"delivery_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          },\n          \"mailingAddress\": {\n            \"streetAddress\": \"records - mailing_address\",\n            \"addressCity\": \"mailing_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          }\n        },\n        \"affidavitFileKey\": \"{{affidavit_file_key}}\",\n        \"affidavitFileName\": \"affidavit_file.pdf\",\n        \"specialResolutionFileKey\": \"{{special_resolution_file_key}}\",\n        \"specialResolutionFileName\": \"special_resolution_file.pdf\"\n      }\n    }\n}"
 						},
 						"url": {
 							"raw": "{{url}}/api/v1/businesses/:id/filings",
@@ -10201,7 +10588,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"filing\": {\n      \"header\": {\n        \"name\": \"dissolution\",\n        \"date\": \"{{today}}\",\n        \"certifiedBy\": \"full name\",\n        \"email\": \"no_one@never.get\",\n        \"effectiveDate\": \"{{today}}T00:00:00+00:00\"\n      },\n      \"business\": {\n        \"identifier\": \"CP3490248\",\n        \"legalType\": \"CP\"\n      },\n      \"dissolution\": {\n        \"dissolutionDate\": \"{{today}}\",\n        \"dissolutionType\": \"voluntary\",\n        \"dissolutionStatementType\": \"\",\n        \"hasLiabilities\": false,\n        \"parties\": [\n          {\n            \"officer\": {\n              \"firstName\": \"Completing\",\n              \"lastName\": \"Party\",\n              \"middleName\": \"P\",\n              \"email\": \"cp@example.com\",\n              \"orgName\": \"\",\n              \"partyType\": \"person\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Completing Party\",\n                \"appointmentDate\": \"2021-08-05\"\n\n              }\n            ]\n          },\n          {\n            \"officer\": {\n              \"firstName\": \"\",\n              \"lastName\": \"\",\n              \"middleName\": \"\",\n              \"orgName\": \"Xyz Inc.\",\n              \"partyType\": \"org\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Custodian\",\n                \"appointmentDate\": \"2021-08-05\"\n              }\n            ]\n          }\n        ],\n        \"custodialOffice\": {\n          \"deliveryAddress\": {\n            \"streetAddress\": \"records - delivery_address\",\n            \"addressCity\": \"delivery_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          },\n          \"mailingAddress\": {\n            \"streetAddress\": \"records - mailing_address\",\n            \"addressCity\": \"mailing_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          }\n        }\n      }\n    }\n}"
+							"raw": "{\n    \"filing\": {\n      \"header\": {\n        \"name\": \"dissolution\",\n        \"date\": \"{{today}}\",\n        \"certifiedBy\": \"full name\",\n        \"email\": \"no_one@never.get\",\n        \"effectiveDate\": \"{{today}}T00:00:00+00:00\"\n      },\n      \"business\": {\n        \"identifier\": \"CP3490248\",\n        \"legalType\": \"CP\"\n      },\n      \"dissolution\": {\n        \"dissolutionDate\": \"{{today}}\",\n        \"dissolutionType\": \"voluntary\",\n        \"dissolutionStatementType\": \"\",\n        \"hasLiabilities\": false,\n        \"parties\": [\n          {\n            \"officer\": {\n              \"firstName\": \"Completing\",\n              \"lastName\": \"Party\",\n              \"middleName\": \"P\",\n              \"email\": \"cp@example.com\",\n              \"organizationName\": \"\",\n              \"partyType\": \"person\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Completing Party\",\n                \"appointmentDate\": \"2021-08-05\"\n\n              }\n            ]\n          },\n          {\n            \"officer\": {\n              \"firstName\": \"\",\n              \"lastName\": \"\",\n              \"middleName\": \"\",\n              \"organizationName\": \"Xyz Inc.\",\n              \"partyType\": \"organization\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Custodian\",\n                \"appointmentDate\": \"2021-08-05\"\n              }\n            ]\n          }\n        ],\n        \"custodialOffice\": {\n          \"deliveryAddress\": {\n            \"streetAddress\": \"records - delivery_address\",\n            \"addressCity\": \"delivery_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          },\n          \"mailingAddress\": {\n            \"streetAddress\": \"records - mailing_address\",\n            \"addressCity\": \"mailing_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          }\n        },\n        \"affidavitFileKey\": \"{{affidavit_file_key}}\",\n        \"affidavitFileName\": \"affidavit_file.pdf\",\n        \"specialResolutionFileKey\": \"{{special_resolution_file_key}}\",\n        \"specialResolutionFileName\": \"special_resolution_file.pdf\"\n      }\n    }\n}"
 						},
 						"url": {
 							"raw": "{{url}}/api/v1/businesses/:id/filings",
@@ -10238,7 +10625,12 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"filing\": {\n      \"header\": {\n        \"name\": \"dissolution\",\n        \"date\": \"{{today}}\",\n        \"certifiedBy\": \"full name\",\n        \"email\": \"no_one@never.get\",\n        \"effectiveDate\": \"{{today}}T00:00:00+00:00\"\n      },\n      \"business\": {\n        \"identifier\": \"CP3490248\",\n        \"legalType\": \"CP\"\n      },\n      \"dissolution\": {\n        \"dissolutionDate\": \"{{today}}\",\n        \"dissolutionType\": \"voluntary\",\n        \"dissolutionStatementType\": \"\",\n        \"hasLiabilities\": false,\n        \"parties\": [\n          {\n            \"officer\": {\n              \"firstName\": \"Completing\",\n              \"lastName\": \"Party\",\n              \"middleName\": \"P\",\n              \"email\": \"cp@example.com\",\n              \"orgName\": \"\",\n              \"partyType\": \"person\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Completing Party\",\n                \"appointmentDate\": \"2021-08-05\"\n\n              }\n            ]\n          },\n          {\n            \"officer\": {\n              \"firstName\": \"\",\n              \"lastName\": \"\",\n              \"middleName\": \"\",\n              \"orgName\": \"Xyz Inc.\",\n              \"partyType\": \"org\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Custodian\",\n                \"appointmentDate\": \"2021-08-05\"\n              }\n            ]\n          }\n        ],\n        \"custodialOffice\": {\n          \"deliveryAddress\": {\n            \"streetAddress\": \"records - delivery_address\",\n            \"addressCity\": \"delivery_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          },\n          \"mailingAddress\": {\n            \"streetAddress\": \"records - mailing_address\",\n            \"addressCity\": \"mailing_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          }\n        }\n      }\n    }\n}"
+									"raw": "{\n    \"filing\": {\n      \"header\": {\n        \"name\": \"dissolution\",\n        \"date\": \"{{today}}\",\n        \"certifiedBy\": \"full name\",\n        \"email\": \"no_one@never.get\",\n        \"effectiveDate\": \"{{today}}T00:00:00+00:00\"\n      },\n      \"business\": {\n        \"identifier\": \"CP3490248\",\n        \"legalType\": \"CP\"\n      },\n      \"dissolution\": {\n        \"dissolutionDate\": \"{{today}}\",\n        \"dissolutionType\": \"voluntary\",\n        \"dissolutionStatementType\": \"\",\n        \"hasLiabilities\": false,\n        \"parties\": [\n          {\n            \"officer\": {\n              \"firstName\": \"Completing\",\n              \"lastName\": \"Party\",\n              \"middleName\": \"P\",\n              \"email\": \"cp@example.com\",\n              \"organizationName\": \"\",\n              \"partyType\": \"person\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Completing Party\",\n                \"appointmentDate\": \"2021-08-05\"\n\n              }\n            ]\n          },\n          {\n            \"officer\": {\n              \"firstName\": \"\",\n              \"lastName\": \"\",\n              \"middleName\": \"\",\n              \"organizationName\": \"Xyz Inc.\",\n              \"partyType\": \"organization\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Custodian\",\n                \"appointmentDate\": \"2021-08-05\"\n              }\n            ]\n          }\n        ],\n        \"custodialOffice\": {\n          \"deliveryAddress\": {\n            \"streetAddress\": \"records - delivery_address\",\n            \"addressCity\": \"delivery_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          },\n          \"mailingAddress\": {\n            \"streetAddress\": \"records - mailing_address\",\n            \"addressCity\": \"mailing_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          }\n        },\n        \"affidavitFileKey\": \"011e332d-1b8e-4218-8710-ad8ac1fbc592.pdf\",\n        \"affidavitFileName\": \"affidavit_file.pdf\",\n        \"specialResolutionFileKey\": \"03c91f13-2f4d-4fe6-8792-8209723b20b6.pdf\",\n        \"specialResolutionFileName\": \"special_resolution_file.pdf\"\n\n      }\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
 								},
 								"url": {
 									"raw": "{{url}}/api/v1/businesses/:id/filings",
@@ -10302,7 +10694,7 @@
 								}
 							],
 							"cookie": [],
-							"body": "{\n    \"errors\": [\n        {\n            \"error\": \"Dissolution statement type must be provided.\",\n            \"path\": \"/filing/dissolution/dissolutionStatementType\"\n        }\n    ],\n    \"filing\": {\n        \"business\": {\n            \"identifier\": \"CP3490248\",\n            \"legalType\": \"CP\"\n        },\n        \"dissolution\": {\n            \"custodialOffice\": {\n                \"deliveryAddress\": {\n                    \"addressCity\": \"delivery_address city\",\n                    \"addressCountry\": \"CA\",\n                    \"addressRegion\": \"BC\",\n                    \"postalCode\": \"H0H0H0\",\n                    \"streetAddress\": \"records - delivery_address\"\n                },\n                \"mailingAddress\": {\n                    \"addressCity\": \"mailing_address city\",\n                    \"addressCountry\": \"CA\",\n                    \"addressRegion\": \"BC\",\n                    \"postalCode\": \"H0H0H0\",\n                    \"streetAddress\": \"records - mailing_address\"\n                }\n            },\n            \"dissolutionDate\": \"2021-09-28\",\n            \"dissolutionStatementType\": \"\",\n            \"dissolutionType\": \"voluntary\",\n            \"hasLiabilities\": false,\n            \"parties\": [\n                {\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"delivery_address city\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"postalCode\": \"H0H0H0\",\n                        \"streetAddress\": \"delivery_address - address line one\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"mailingAddress\": {\n                        \"addressCity\": \"mailing_address city\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"postalCode\": \"H0H0H0\",\n                        \"streetAddress\": \"mailing_address - address line one\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"email\": \"cp@example.com\",\n                        \"firstName\": \"Completing\",\n                        \"lastName\": \"Party\",\n                        \"middleName\": \"P\",\n                        \"orgName\": \"\",\n                        \"partyType\": \"person\"\n                    },\n                    \"roles\": [\n                        {\n                            \"appointmentDate\": \"2021-08-05\",\n                            \"roleType\": \"Completing Party\"\n                        }\n                    ]\n                },\n                {\n                    \"mailingAddress\": {\n                        \"addressCity\": \"mailing_address city\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"postalCode\": \"H0H0H0\",\n                        \"streetAddress\": \"mailing_address - address line one\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"\",\n                        \"lastName\": \"\",\n                        \"middleName\": \"\",\n                        \"orgName\": \"Xyz Inc.\",\n                        \"partyType\": \"org\"\n                    },\n                    \"roles\": [\n                        {\n                            \"appointmentDate\": \"2021-08-05\",\n                            \"roleType\": \"Custodian\"\n                        }\n                    ]\n                }\n            ]\n        },\n        \"header\": {\n            \"certifiedBy\": \"full name\",\n            \"date\": \"2021-09-28\",\n            \"effectiveDate\": \"2021-09-28T00:00:00+00:00\",\n            \"email\": \"no_one@never.get\",\n            \"name\": \"dissolution\"\n        }\n    }\n}"
+							"body": "{\n    \"errors\": [\n        {\n            \"error\": \"Dissolution statement type must be provided.\",\n            \"path\": \"/filing/dissolution/dissolutionStatementType\"\n        }\n    ],\n    \"filing\": {\n        \"business\": {\n            \"identifier\": \"CP3490248\",\n            \"legalType\": \"CP\"\n        },\n        \"dissolution\": {\n            \"affidavitFileKey\": \"011e332d-1b8e-4218-8710-ad8ac1fbc592.pdf\",\n            \"affidavitFileName\": \"affidavit_file.pdf\",\n            \"custodialOffice\": {\n                \"deliveryAddress\": {\n                    \"addressCity\": \"delivery_address city\",\n                    \"addressCountry\": \"CA\",\n                    \"addressRegion\": \"BC\",\n                    \"postalCode\": \"H0H0H0\",\n                    \"streetAddress\": \"records - delivery_address\"\n                },\n                \"mailingAddress\": {\n                    \"addressCity\": \"mailing_address city\",\n                    \"addressCountry\": \"CA\",\n                    \"addressRegion\": \"BC\",\n                    \"postalCode\": \"H0H0H0\",\n                    \"streetAddress\": \"records - mailing_address\"\n                }\n            },\n            \"dissolutionDate\": \"2021-10-06\",\n            \"dissolutionStatementType\": \"\",\n            \"dissolutionType\": \"voluntary\",\n            \"hasLiabilities\": false,\n            \"parties\": [\n                {\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"delivery_address city\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"postalCode\": \"H0H0H0\",\n                        \"streetAddress\": \"delivery_address - address line one\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"mailingAddress\": {\n                        \"addressCity\": \"mailing_address city\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"postalCode\": \"H0H0H0\",\n                        \"streetAddress\": \"mailing_address - address line one\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"email\": \"cp@example.com\",\n                        \"firstName\": \"Completing\",\n                        \"lastName\": \"Party\",\n                        \"middleName\": \"P\",\n                        \"organizationName\": \"\",\n                        \"partyType\": \"person\"\n                    },\n                    \"roles\": [\n                        {\n                            \"appointmentDate\": \"2021-08-05\",\n                            \"roleType\": \"Completing Party\"\n                        }\n                    ]\n                },\n                {\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"delivery_address city\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"postalCode\": \"H0H0H0\",\n                        \"streetAddress\": \"delivery_address - address line one\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"mailingAddress\": {\n                        \"addressCity\": \"mailing_address city\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"postalCode\": \"H0H0H0\",\n                        \"streetAddress\": \"mailing_address - address line one\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"\",\n                        \"lastName\": \"\",\n                        \"middleName\": \"\",\n                        \"organizationName\": \"Xyz Inc.\",\n                        \"partyType\": \"organization\"\n                    },\n                    \"roles\": [\n                        {\n                            \"appointmentDate\": \"2021-08-05\",\n                            \"roleType\": \"Custodian\"\n                        }\n                    ]\n                }\n            ],\n            \"specialResolutionFileKey\": \"03c91f13-2f4d-4fe6-8792-8209723b20b6.pdf\",\n            \"specialResolutionFileName\": \"special_resolution_file.pdf\"\n        },\n        \"header\": {\n            \"certifiedBy\": \"full name\",\n            \"date\": \"2021-10-06\",\n            \"effectiveDate\": \"2021-10-06T00:00:00+00:00\",\n            \"email\": \"no_one@never.get\",\n            \"name\": \"dissolution\"\n        }\n    }\n}"
 						}
 					]
 				},
@@ -10376,7 +10768,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"filing\": {\n      \"header\": {\n        \"name\": \"dissolution\",\n        \"date\": \"{{today}}\",\n        \"certifiedBy\": \"full name\",\n        \"email\": \"no_one@never.get\",\n        \"effectiveDate\": \"{{today}}T00:00:00+00:00\"\n      },\n      \"business\": {\n        \"identifier\": \"CP3490248\",\n        \"legalType\": \"CP\"\n      },\n      \"dissolution\": {\n        \"dissolutionDate\": \"{{today}}\",\n        \"dissolutionType\": \"voluntary\",\n        \"dissolutionStatementType\": \"sdfsdf\",\n        \"hasLiabilities\": false,\n        \"parties\": [\n          {\n            \"officer\": {\n              \"firstName\": \"Completing\",\n              \"lastName\": \"Party\",\n              \"middleName\": \"P\",\n              \"email\": \"cp@example.com\",\n              \"orgName\": \"\",\n              \"partyType\": \"person\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Completing Party\",\n                \"appointmentDate\": \"2021-08-05\"\n\n              }\n            ]\n          },\n          {\n            \"officer\": {\n              \"firstName\": \"\",\n              \"lastName\": \"\",\n              \"middleName\": \"\",\n              \"orgName\": \"Xyz Inc.\",\n              \"partyType\": \"org\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Custodian\",\n                \"appointmentDate\": \"2021-08-05\"\n              }\n            ]\n          }\n        ],\n        \"custodialOffice\": {\n          \"deliveryAddress\": {\n            \"streetAddress\": \"records - delivery_address\",\n            \"addressCity\": \"delivery_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          },\n          \"mailingAddress\": {\n            \"streetAddress\": \"records - mailing_address\",\n            \"addressCity\": \"mailing_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          }\n        }\n      }\n    }\n}"
+							"raw": "{\n    \"filing\": {\n      \"header\": {\n        \"name\": \"dissolution\",\n        \"date\": \"{{today}}\",\n        \"certifiedBy\": \"full name\",\n        \"email\": \"no_one@never.get\",\n        \"effectiveDate\": \"{{today}}T00:00:00+00:00\"\n      },\n      \"business\": {\n        \"identifier\": \"CP3490248\",\n        \"legalType\": \"CP\"\n      },\n      \"dissolution\": {\n        \"dissolutionDate\": \"{{today}}\",\n        \"dissolutionType\": \"voluntary\",\n        \"dissolutionStatementType\": \"sdfsdf\",\n        \"hasLiabilities\": false,\n        \"parties\": [\n          {\n            \"officer\": {\n              \"firstName\": \"Completing\",\n              \"lastName\": \"Party\",\n              \"middleName\": \"P\",\n              \"email\": \"cp@example.com\",\n              \"organizationName\": \"\",\n              \"partyType\": \"person\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Completing Party\",\n                \"appointmentDate\": \"2021-08-05\"\n\n              }\n            ]\n          },\n          {\n            \"officer\": {\n              \"firstName\": \"\",\n              \"lastName\": \"\",\n              \"middleName\": \"\",\n              \"organizationName\": \"Xyz Inc.\",\n              \"partyType\": \"organization\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Custodian\",\n                \"appointmentDate\": \"2021-08-05\"\n              }\n            ]\n          }\n        ],\n        \"custodialOffice\": {\n          \"deliveryAddress\": {\n            \"streetAddress\": \"records - delivery_address\",\n            \"addressCity\": \"delivery_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          },\n          \"mailingAddress\": {\n            \"streetAddress\": \"records - mailing_address\",\n            \"addressCity\": \"mailing_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          }\n        },\n        \"affidavitFileKey\": \"{{affidavit_file_key}}\",\n        \"affidavitFileName\": \"affidavit_file.pdf\",\n        \"specialResolutionFileKey\": \"{{special_resolution_file_key}}\",\n        \"specialResolutionFileName\": \"special_resolution_file.pdf\"\n      }\n    }\n}"
 						},
 						"url": {
 							"raw": "{{url}}/api/v1/businesses/:id/filings",
@@ -10413,7 +10805,12 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"filing\": {\n      \"header\": {\n        \"name\": \"dissolution\",\n        \"date\": \"{{today}}\",\n        \"certifiedBy\": \"full name\",\n        \"email\": \"no_one@never.get\",\n        \"effectiveDate\": \"{{today}}T00:00:00+00:00\"\n      },\n      \"business\": {\n        \"identifier\": \"CP3490248\",\n        \"legalType\": \"CP\"\n      },\n      \"dissolution\": {\n        \"dissolutionDate\": \"{{today}}\",\n        \"dissolutionType\": \"voluntary\",\n        \"dissolutionStatementType\": \"sdfsdf\",\n        \"hasLiabilities\": false,\n        \"parties\": [\n          {\n            \"officer\": {\n              \"firstName\": \"Completing\",\n              \"lastName\": \"Party\",\n              \"middleName\": \"P\",\n              \"email\": \"cp@example.com\",\n              \"orgName\": \"\",\n              \"partyType\": \"person\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Completing Party\",\n                \"appointmentDate\": \"2021-08-05\"\n\n              }\n            ]\n          },\n          {\n            \"officer\": {\n              \"firstName\": \"\",\n              \"lastName\": \"\",\n              \"middleName\": \"\",\n              \"orgName\": \"Xyz Inc.\",\n              \"partyType\": \"org\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Custodian\",\n                \"appointmentDate\": \"2021-08-05\"\n              }\n            ]\n          }\n        ],\n        \"custodialOffice\": {\n          \"deliveryAddress\": {\n            \"streetAddress\": \"records - delivery_address\",\n            \"addressCity\": \"delivery_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          },\n          \"mailingAddress\": {\n            \"streetAddress\": \"records - mailing_address\",\n            \"addressCity\": \"mailing_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          }\n        }\n      }\n    }\n}"
+									"raw": "{\n    \"filing\": {\n      \"header\": {\n        \"name\": \"dissolution\",\n        \"date\": \"{{today}}\",\n        \"certifiedBy\": \"full name\",\n        \"email\": \"no_one@never.get\",\n        \"effectiveDate\": \"{{today}}T00:00:00+00:00\"\n      },\n      \"business\": {\n        \"identifier\": \"CP3490248\",\n        \"legalType\": \"CP\"\n      },\n      \"dissolution\": {\n        \"dissolutionDate\": \"{{today}}\",\n        \"dissolutionType\": \"voluntary\",\n        \"dissolutionStatementType\": \"sdfsdf\",\n        \"hasLiabilities\": false,\n        \"parties\": [\n          {\n            \"officer\": {\n              \"firstName\": \"Completing\",\n              \"lastName\": \"Party\",\n              \"middleName\": \"P\",\n              \"email\": \"cp@example.com\",\n              \"organizationName\": \"\",\n              \"partyType\": \"person\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Completing Party\",\n                \"appointmentDate\": \"2021-08-05\"\n\n              }\n            ]\n          },\n          {\n            \"officer\": {\n              \"firstName\": \"\",\n              \"lastName\": \"\",\n              \"middleName\": \"\",\n              \"organizationName\": \"Xyz Inc.\",\n              \"partyType\": \"organization\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Custodian\",\n                \"appointmentDate\": \"2021-08-05\"\n              }\n            ]\n          }\n        ],\n        \"custodialOffice\": {\n          \"deliveryAddress\": {\n            \"streetAddress\": \"records - delivery_address\",\n            \"addressCity\": \"delivery_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          },\n          \"mailingAddress\": {\n            \"streetAddress\": \"records - mailing_address\",\n            \"addressCity\": \"mailing_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          }\n        }\n      }\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
 								},
 								"url": {
 									"raw": "{{url}}/api/v1/businesses/:id/filings",
@@ -10477,9 +10874,757 @@
 								}
 							],
 							"cookie": [],
-							"body": "{\n    \"errors\": [\n        {\n            \"error\": \"Invalid Dissolution statement type.\",\n            \"path\": \"/filing/dissolution/dissolutionStatementType\"\n        }\n    ],\n    \"filing\": {\n        \"business\": {\n            \"identifier\": \"CP3490248\",\n            \"legalType\": \"CP\"\n        },\n        \"dissolution\": {\n            \"custodialOffice\": {\n                \"deliveryAddress\": {\n                    \"addressCity\": \"delivery_address city\",\n                    \"addressCountry\": \"CA\",\n                    \"addressRegion\": \"BC\",\n                    \"postalCode\": \"H0H0H0\",\n                    \"streetAddress\": \"records - delivery_address\"\n                },\n                \"mailingAddress\": {\n                    \"addressCity\": \"mailing_address city\",\n                    \"addressCountry\": \"CA\",\n                    \"addressRegion\": \"BC\",\n                    \"postalCode\": \"H0H0H0\",\n                    \"streetAddress\": \"records - mailing_address\"\n                }\n            },\n            \"dissolutionDate\": \"2021-09-28\",\n            \"dissolutionStatementType\": \"sdfsdf\",\n            \"dissolutionType\": \"voluntary\",\n            \"hasLiabilities\": false,\n            \"parties\": [\n                {\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"delivery_address city\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"postalCode\": \"H0H0H0\",\n                        \"streetAddress\": \"delivery_address - address line one\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"mailingAddress\": {\n                        \"addressCity\": \"mailing_address city\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"postalCode\": \"H0H0H0\",\n                        \"streetAddress\": \"mailing_address - address line one\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"email\": \"cp@example.com\",\n                        \"firstName\": \"Completing\",\n                        \"lastName\": \"Party\",\n                        \"middleName\": \"P\",\n                        \"orgName\": \"\",\n                        \"partyType\": \"person\"\n                    },\n                    \"roles\": [\n                        {\n                            \"appointmentDate\": \"2021-08-05\",\n                            \"roleType\": \"Completing Party\"\n                        }\n                    ]\n                },\n                {\n                    \"mailingAddress\": {\n                        \"addressCity\": \"mailing_address city\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"postalCode\": \"H0H0H0\",\n                        \"streetAddress\": \"mailing_address - address line one\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"\",\n                        \"lastName\": \"\",\n                        \"middleName\": \"\",\n                        \"orgName\": \"Xyz Inc.\",\n                        \"partyType\": \"org\"\n                    },\n                    \"roles\": [\n                        {\n                            \"appointmentDate\": \"2021-08-05\",\n                            \"roleType\": \"Custodian\"\n                        }\n                    ]\n                }\n            ]\n        },\n        \"header\": {\n            \"certifiedBy\": \"full name\",\n            \"date\": \"2021-09-28\",\n            \"effectiveDate\": \"2021-09-28T00:00:00+00:00\",\n            \"email\": \"no_one@never.get\",\n            \"name\": \"dissolution\"\n        }\n    }\n}"
+							"body": "{\n    \"errors\": [\n        {\n            \"error\": \"Invalid Dissolution statement type.\",\n            \"path\": \"/filing/dissolution/dissolutionStatementType\"\n        }\n    ],\n    \"filing\": {\n        \"business\": {\n            \"identifier\": \"CP3490248\",\n            \"legalType\": \"CP\"\n        },\n        \"dissolution\": {\n            \"custodialOffice\": {\n                \"deliveryAddress\": {\n                    \"addressCity\": \"delivery_address city\",\n                    \"addressCountry\": \"CA\",\n                    \"addressRegion\": \"BC\",\n                    \"postalCode\": \"H0H0H0\",\n                    \"streetAddress\": \"records - delivery_address\"\n                },\n                \"mailingAddress\": {\n                    \"addressCity\": \"mailing_address city\",\n                    \"addressCountry\": \"CA\",\n                    \"addressRegion\": \"BC\",\n                    \"postalCode\": \"H0H0H0\",\n                    \"streetAddress\": \"records - mailing_address\"\n                }\n            },\n            \"dissolutionDate\": \"2021-10-06\",\n            \"dissolutionStatementType\": \"sdfsdf\",\n            \"dissolutionType\": \"voluntary\",\n            \"hasLiabilities\": false,\n            \"parties\": [\n                {\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"delivery_address city\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"postalCode\": \"H0H0H0\",\n                        \"streetAddress\": \"delivery_address - address line one\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"mailingAddress\": {\n                        \"addressCity\": \"mailing_address city\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"postalCode\": \"H0H0H0\",\n                        \"streetAddress\": \"mailing_address - address line one\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"email\": \"cp@example.com\",\n                        \"firstName\": \"Completing\",\n                        \"lastName\": \"Party\",\n                        \"middleName\": \"P\",\n                        \"organizationName\": \"\",\n                        \"partyType\": \"person\"\n                    },\n                    \"roles\": [\n                        {\n                            \"appointmentDate\": \"2021-08-05\",\n                            \"roleType\": \"Completing Party\"\n                        }\n                    ]\n                },\n                {\n                    \"deliveryAddress\": {\n                        \"addressCity\": \"delivery_address city\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"postalCode\": \"H0H0H0\",\n                        \"streetAddress\": \"delivery_address - address line one\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"mailingAddress\": {\n                        \"addressCity\": \"mailing_address city\",\n                        \"addressCountry\": \"CA\",\n                        \"addressRegion\": \"BC\",\n                        \"postalCode\": \"H0H0H0\",\n                        \"streetAddress\": \"mailing_address - address line one\",\n                        \"streetAddressAdditional\": \"\"\n                    },\n                    \"officer\": {\n                        \"firstName\": \"\",\n                        \"lastName\": \"\",\n                        \"middleName\": \"\",\n                        \"organizationName\": \"Xyz Inc.\",\n                        \"partyType\": \"organization\"\n                    },\n                    \"roles\": [\n                        {\n                            \"appointmentDate\": \"2021-08-05\",\n                            \"roleType\": \"Custodian\"\n                        }\n                    ]\n                }\n            ]\n        },\n        \"header\": {\n            \"certifiedBy\": \"full name\",\n            \"date\": \"2021-10-06\",\n            \"effectiveDate\": \"2021-10-06T00:00:00+00:00\",\n            \"email\": \"no_one@never.get\",\n            \"name\": \"dissolution\"\n        }\n    }\n}"
 						}
 					]
+				},
+				{
+					"name": "post - required affidavit key - CP3490248",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json()",
+									"pm.environment.set(\"filing_id\", jsonData.filing.header.filingId)",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Status code is 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"});",
+									"",
+									"pm.test('should return JSON', function () {",
+									"    pm.response.to.have.header('Content-Type', 'application/json');",
+									"});",
+									"",
+									"",
+									"pm.test(\"Returns dissolution filing.\", () => {",
+									"    pm.expect(jsonData.filing).to.exist",
+									"    pm.expect(jsonData.filing.business).to.exist",
+									"    pm.expect(jsonData.filing.dissolution).to.exist",
+									"    pm.expect(jsonData.filing.header).to.exist",
+									"    pm.expect(jsonData.errors).to.exist",
+									"    pm.expect(jsonData.errors.length).to.eq(1)",
+									"    pm.expect(jsonData.errors[0].error).to.eq('A valid affidavit key is required.')",
+									"    pm.expect(jsonData.errors[0].path).to.eq('/filing/dissolution/affidavitFileKey')",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"var today = new Date()",
+									"pm.environment.set(\"today\", today.getFullYear()+'-'+('0'+(today.getMonth()+1)).slice(-2)+'-'+('0'+today.getDate()).slice(-2))"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"filing\": {\n      \"header\": {\n        \"name\": \"dissolution\",\n        \"date\": \"{{today}}\",\n        \"certifiedBy\": \"full name\",\n        \"email\": \"no_one@never.get\",\n        \"effectiveDate\": \"{{today}}T00:00:00+00:00\"\n      },\n      \"business\": {\n        \"identifier\": \"CP3490248\",\n        \"legalType\": \"CP\"\n      },\n      \"dissolution\": {\n        \"dissolutionDate\": \"{{today}}\",\n        \"dissolutionType\": \"voluntary\",\n        \"dissolutionStatementType\": \"197NoAssetsNoLiabilities\",\n        \"hasLiabilities\": false,\n        \"parties\": [\n          {\n            \"officer\": {\n              \"firstName\": \"Completing\",\n              \"lastName\": \"Party\",\n              \"middleName\": \"P\",\n              \"email\": \"cp@example.com\",\n              \"organizationName\": \"\",\n              \"partyType\": \"person\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Completing Party\",\n                \"appointmentDate\": \"2021-08-05\"\n\n              }\n            ]\n          },\n          {\n            \"officer\": {\n              \"firstName\": \"\",\n              \"lastName\": \"\",\n              \"middleName\": \"\",\n              \"organizationName\": \"Xyz Inc.\",\n              \"partyType\": \"organization\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Custodian\",\n                \"appointmentDate\": \"2021-08-05\"\n              }\n            ]\n          }\n        ],\n        \"custodialOffice\": {\n          \"deliveryAddress\": {\n            \"streetAddress\": \"records - delivery_address\",\n            \"addressCity\": \"delivery_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          },\n          \"mailingAddress\": {\n            \"streetAddress\": \"records - mailing_address\",\n            \"addressCity\": \"mailing_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          }\n        },\n        \"affidavitFileKey\": \"\",\n        \"affidavitFileName\": \"affidavit_file.pdf\",\n        \"specialResolutionFileKey\": \"{{special_resolution_file_key}}\",\n        \"specialResolutionFileName\": \"special_resolution_file.pdf\"\n      }\n    }\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/businesses/:id/filings",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"businesses",
+								":id",
+								"filings"
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "CP3490248"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "post - invalid affidavit key - CP3490248",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json()",
+									"pm.environment.set(\"filing_id\", jsonData.filing.header.filingId)",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Status code is 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"});",
+									"",
+									"pm.test('should return JSON', function () {",
+									"    pm.response.to.have.header('Content-Type', 'application/json');",
+									"});",
+									"",
+									"",
+									"pm.test(\"Returns dissolution filing.\", () => {",
+									"    pm.expect(jsonData.filing).to.exist",
+									"    pm.expect(jsonData.filing.business).to.exist",
+									"    pm.expect(jsonData.filing.dissolution).to.exist",
+									"    pm.expect(jsonData.filing.header).to.exist",
+									"    pm.expect(jsonData.errors).to.exist",
+									"    pm.expect(jsonData.errors.length).to.eq(1)",
+									"    pm.expect(jsonData.errors[0].error).to.eq('Invalid file.')",
+									"    pm.expect(jsonData.errors[0].path).to.eq('/filing/dissolution/affidavitFileKey')",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"var today = new Date()",
+									"pm.environment.set(\"today\", today.getFullYear()+'-'+('0'+(today.getMonth()+1)).slice(-2)+'-'+('0'+today.getDate()).slice(-2))"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"filing\": {\n      \"header\": {\n        \"name\": \"dissolution\",\n        \"date\": \"{{today}}\",\n        \"certifiedBy\": \"full name\",\n        \"email\": \"no_one@never.get\",\n        \"effectiveDate\": \"{{today}}T00:00:00+00:00\"\n      },\n      \"business\": {\n        \"identifier\": \"CP3490248\",\n        \"legalType\": \"CP\"\n      },\n      \"dissolution\": {\n        \"dissolutionDate\": \"{{today}}\",\n        \"dissolutionType\": \"voluntary\",\n        \"dissolutionStatementType\": \"197NoAssetsNoLiabilities\",\n        \"hasLiabilities\": false,\n        \"parties\": [\n          {\n            \"officer\": {\n              \"firstName\": \"Completing\",\n              \"lastName\": \"Party\",\n              \"middleName\": \"P\",\n              \"email\": \"cp@example.com\",\n              \"organizationName\": \"\",\n              \"partyType\": \"person\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Completing Party\",\n                \"appointmentDate\": \"2021-08-05\"\n\n              }\n            ]\n          },\n          {\n            \"officer\": {\n              \"firstName\": \"\",\n              \"lastName\": \"\",\n              \"middleName\": \"\",\n              \"organizationName\": \"Xyz Inc.\",\n              \"partyType\": \"organization\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Custodian\",\n                \"appointmentDate\": \"2021-08-05\"\n              }\n            ]\n          }\n        ],\n        \"custodialOffice\": {\n          \"deliveryAddress\": {\n            \"streetAddress\": \"records - delivery_address\",\n            \"addressCity\": \"delivery_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          },\n          \"mailingAddress\": {\n            \"streetAddress\": \"records - mailing_address\",\n            \"addressCity\": \"mailing_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          }\n        },\n        \"affidavitFileKey\": \"invalid key\",\n        \"affidavitFileName\": \"affidavit_file.pdf\",\n        \"specialResolutionFileKey\": \"{{special_resolution_file_key}}\",\n        \"specialResolutionFileName\": \"special_resolution_file.pdf\"\n      }\n    }\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/businesses/:id/filings",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"businesses",
+								":id",
+								"filings"
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "CP3490248"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "post - invalid affidavit doc page size - CP3490248",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json()",
+									"pm.environment.set(\"filing_id\", jsonData.filing.header.filingId)",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Status code is 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"});",
+									"",
+									"pm.test('should return JSON', function () {",
+									"    pm.response.to.have.header('Content-Type', 'application/json');",
+									"});",
+									"",
+									"",
+									"pm.test(\"Returns dissolution filing.\", () => {",
+									"    pm.expect(jsonData.filing).to.exist",
+									"    pm.expect(jsonData.filing.business).to.exist",
+									"    pm.expect(jsonData.filing.dissolution).to.exist",
+									"    pm.expect(jsonData.filing.header).to.exist",
+									"    pm.expect(jsonData.errors).to.exist",
+									"    pm.expect(jsonData.errors.length).to.eq(1)",
+									"    pm.expect(jsonData.errors[0].error).to.eq('Document must be set to fit onto 8.5” x 11” letter-size paper.')",
+									"    pm.expect(jsonData.errors[0].path).to.eq('/filing/dissolution/affidavitFileKey')",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"var today = new Date()",
+									"pm.environment.set(\"today\", today.getFullYear()+'-'+('0'+(today.getMonth()+1)).slice(-2)+'-'+('0'+today.getDate()).slice(-2))"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"filing\": {\n      \"header\": {\n        \"name\": \"dissolution\",\n        \"date\": \"{{today}}\",\n        \"certifiedBy\": \"full name\",\n        \"email\": \"no_one@never.get\",\n        \"effectiveDate\": \"{{today}}T00:00:00+00:00\"\n      },\n      \"business\": {\n        \"identifier\": \"CP3490248\",\n        \"legalType\": \"CP\"\n      },\n      \"dissolution\": {\n        \"dissolutionDate\": \"{{today}}\",\n        \"dissolutionType\": \"voluntary\",\n        \"dissolutionStatementType\": \"197NoAssetsNoLiabilities\",\n        \"hasLiabilities\": false,\n        \"parties\": [\n          {\n            \"officer\": {\n              \"firstName\": \"Completing\",\n              \"lastName\": \"Party\",\n              \"middleName\": \"P\",\n              \"email\": \"cp@example.com\",\n              \"organizationName\": \"\",\n              \"partyType\": \"person\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Completing Party\",\n                \"appointmentDate\": \"2021-08-05\"\n\n              }\n            ]\n          },\n          {\n            \"officer\": {\n              \"firstName\": \"\",\n              \"lastName\": \"\",\n              \"middleName\": \"\",\n              \"organizationName\": \"Xyz Inc.\",\n              \"partyType\": \"organization\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Custodian\",\n                \"appointmentDate\": \"2021-08-05\"\n              }\n            ]\n          }\n        ],\n        \"custodialOffice\": {\n          \"deliveryAddress\": {\n            \"streetAddress\": \"records - delivery_address\",\n            \"addressCity\": \"delivery_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          },\n          \"mailingAddress\": {\n            \"streetAddress\": \"records - mailing_address\",\n            \"addressCity\": \"mailing_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          }\n        },\n        \"affidavitFileKey\": \"{{affidavit_file_key}}\",\n        \"affidavitFileName\": \"affidavit_file.pdf\",\n        \"specialResolutionFileKey\": \"{{special_resolution_file_key}}\",\n        \"specialResolutionFileName\": \"special_resolution_file.pdf\"\n      }\n    }\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/businesses/:id/filings",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"businesses",
+								":id",
+								"filings"
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "CP3490248"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "post - invalid affidavit doc max size - CP3490248",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"const jsonData = pm.response.json()",
+									"const jsonDataText = pm.response.text()",
+									"pm.environment.set(\"filing_id\", jsonData.filing.header.filingId)",
+									"",
+									"pm.test(\"Status code is 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"});",
+									"",
+									"pm.test('should return JSON', function () {",
+									"    pm.response.to.have.header('Content-Type', 'application/json');",
+									"});",
+									"",
+									"",
+									"pm.test(\"Returns dissolution filing.\", () => {",
+									"    pm.expect(jsonData.filing).to.exist",
+									"    pm.expect(jsonData.filing.business).to.exist",
+									"    pm.expect(jsonData.filing.dissolution).to.exist",
+									"    pm.expect(jsonData.filing.header).to.exist",
+									"    pm.expect(jsonData.errors).to.exist",
+									"    pm.expect(jsonDataText).to.include('File exceeds maximum size.')",
+									"    pm.expect(jsonDataText).to.include('/filing/dissolution/affidavitFileKey')",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"var today = new Date()",
+									"pm.environment.set(\"today\", today.getFullYear()+'-'+('0'+(today.getMonth()+1)).slice(-2)+'-'+('0'+today.getDate()).slice(-2))"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"filing\": {\n      \"header\": {\n        \"name\": \"dissolution\",\n        \"date\": \"{{today}}\",\n        \"certifiedBy\": \"full name\",\n        \"email\": \"no_one@never.get\",\n        \"effectiveDate\": \"{{today}}T00:00:00+00:00\"\n      },\n      \"business\": {\n        \"identifier\": \"CP3490248\",\n        \"legalType\": \"CP\"\n      },\n      \"dissolution\": {\n        \"dissolutionDate\": \"{{today}}\",\n        \"dissolutionType\": \"voluntary\",\n        \"dissolutionStatementType\": \"197NoAssetsNoLiabilities\",\n        \"hasLiabilities\": false,\n        \"parties\": [\n          {\n            \"officer\": {\n              \"firstName\": \"Completing\",\n              \"lastName\": \"Party\",\n              \"middleName\": \"P\",\n              \"email\": \"cp@example.com\",\n              \"organizationName\": \"\",\n              \"partyType\": \"person\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Completing Party\",\n                \"appointmentDate\": \"2021-08-05\"\n\n              }\n            ]\n          },\n          {\n            \"officer\": {\n              \"firstName\": \"\",\n              \"lastName\": \"\",\n              \"middleName\": \"\",\n              \"organizationName\": \"Xyz Inc.\",\n              \"partyType\": \"organization\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Custodian\",\n                \"appointmentDate\": \"2021-08-05\"\n              }\n            ]\n          }\n        ],\n        \"custodialOffice\": {\n          \"deliveryAddress\": {\n            \"streetAddress\": \"records - delivery_address\",\n            \"addressCity\": \"delivery_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          },\n          \"mailingAddress\": {\n            \"streetAddress\": \"records - mailing_address\",\n            \"addressCity\": \"mailing_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          }\n        },\n        \"affidavitFileKey\": \"{{affidavit_file_key}}\",\n        \"affidavitFileName\": \"affidavit_file.pdf\",\n        \"specialResolutionFileKey\": \"{{special_resolution_file_key}}\",\n        \"specialResolutionFileName\": \"special_resolution_file.pdf\"\n      }\n    }\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/businesses/:id/filings",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"businesses",
+								":id",
+								"filings"
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "CP3490248"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "post - required special resolution key - CP3490248",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json()",
+									"pm.environment.set(\"filing_id\", jsonData.filing.header.filingId)",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Status code is 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"});",
+									"",
+									"pm.test('should return JSON', function () {",
+									"    pm.response.to.have.header('Content-Type', 'application/json');",
+									"});",
+									"",
+									"",
+									"pm.test(\"Returns dissolution filing.\", () => {",
+									"    pm.expect(jsonData.filing).to.exist",
+									"    pm.expect(jsonData.filing.business).to.exist",
+									"    pm.expect(jsonData.filing.dissolution).to.exist",
+									"    pm.expect(jsonData.filing.header).to.exist",
+									"    pm.expect(jsonData.errors).to.exist",
+									"    pm.expect(jsonData.errors.length).to.eq(1)",
+									"    pm.expect(jsonData.errors[0].error).to.eq('A valid special resolution key is required.')",
+									"    pm.expect(jsonData.errors[0].path).to.eq('/filing/dissolution/specialResolutionFileKey')",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"var today = new Date()",
+									"pm.environment.set(\"today\", today.getFullYear()+'-'+('0'+(today.getMonth()+1)).slice(-2)+'-'+('0'+today.getDate()).slice(-2))"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"filing\": {\n      \"header\": {\n        \"name\": \"dissolution\",\n        \"date\": \"{{today}}\",\n        \"certifiedBy\": \"full name\",\n        \"email\": \"no_one@never.get\",\n        \"effectiveDate\": \"{{today}}T00:00:00+00:00\"\n      },\n      \"business\": {\n        \"identifier\": \"CP3490248\",\n        \"legalType\": \"CP\"\n      },\n      \"dissolution\": {\n        \"dissolutionDate\": \"{{today}}\",\n        \"dissolutionType\": \"voluntary\",\n        \"dissolutionStatementType\": \"197NoAssetsNoLiabilities\",\n        \"hasLiabilities\": false,\n        \"parties\": [\n          {\n            \"officer\": {\n              \"firstName\": \"Completing\",\n              \"lastName\": \"Party\",\n              \"middleName\": \"P\",\n              \"email\": \"cp@example.com\",\n              \"organizationName\": \"\",\n              \"partyType\": \"person\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Completing Party\",\n                \"appointmentDate\": \"2021-08-05\"\n\n              }\n            ]\n          },\n          {\n            \"officer\": {\n              \"firstName\": \"\",\n              \"lastName\": \"\",\n              \"middleName\": \"\",\n              \"organizationName\": \"Xyz Inc.\",\n              \"partyType\": \"organization\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Custodian\",\n                \"appointmentDate\": \"2021-08-05\"\n              }\n            ]\n          }\n        ],\n        \"custodialOffice\": {\n          \"deliveryAddress\": {\n            \"streetAddress\": \"records - delivery_address\",\n            \"addressCity\": \"delivery_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          },\n          \"mailingAddress\": {\n            \"streetAddress\": \"records - mailing_address\",\n            \"addressCity\": \"mailing_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          }\n        },\n        \"affidavitFileKey\": \"{{affidavit_file_key}}\",\n        \"affidavitFileName\": \"affidavit_file.pdf\",\n        \"specialResolutionFileKey\": \"\",\n        \"specialResolutionFileName\": \"special_resolution_file.pdf\"\n      }\n    }\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/businesses/:id/filings",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"businesses",
+								":id",
+								"filings"
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "CP3490248"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "post - invalid special resolution key - CP3490248",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json()",
+									"pm.environment.set(\"filing_id\", jsonData.filing.header.filingId)",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Status code is 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"});",
+									"",
+									"pm.test('should return JSON', function () {",
+									"    pm.response.to.have.header('Content-Type', 'application/json');",
+									"});",
+									"",
+									"",
+									"pm.test(\"Returns dissolution filing.\", () => {",
+									"    pm.expect(jsonData.filing).to.exist",
+									"    pm.expect(jsonData.filing.business).to.exist",
+									"    pm.expect(jsonData.filing.dissolution).to.exist",
+									"    pm.expect(jsonData.filing.header).to.exist",
+									"    pm.expect(jsonData.errors).to.exist",
+									"    pm.expect(jsonData.errors.length).to.eq(1)",
+									"    pm.expect(jsonData.errors[0].error).to.eq('Invalid file.')",
+									"    pm.expect(jsonData.errors[0].path).to.eq('/filing/dissolution/specialResolutionFileKey')",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"var today = new Date()",
+									"pm.environment.set(\"today\", today.getFullYear()+'-'+('0'+(today.getMonth()+1)).slice(-2)+'-'+('0'+today.getDate()).slice(-2))"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"filing\": {\n      \"header\": {\n        \"name\": \"dissolution\",\n        \"date\": \"{{today}}\",\n        \"certifiedBy\": \"full name\",\n        \"email\": \"no_one@never.get\",\n        \"effectiveDate\": \"{{today}}T00:00:00+00:00\"\n      },\n      \"business\": {\n        \"identifier\": \"CP3490248\",\n        \"legalType\": \"CP\"\n      },\n      \"dissolution\": {\n        \"dissolutionDate\": \"{{today}}\",\n        \"dissolutionType\": \"voluntary\",\n        \"dissolutionStatementType\": \"197NoAssetsNoLiabilities\",\n        \"hasLiabilities\": false,\n        \"parties\": [\n          {\n            \"officer\": {\n              \"firstName\": \"Completing\",\n              \"lastName\": \"Party\",\n              \"middleName\": \"P\",\n              \"email\": \"cp@example.com\",\n              \"organizationName\": \"\",\n              \"partyType\": \"person\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Completing Party\",\n                \"appointmentDate\": \"2021-08-05\"\n\n              }\n            ]\n          },\n          {\n            \"officer\": {\n              \"firstName\": \"\",\n              \"lastName\": \"\",\n              \"middleName\": \"\",\n              \"organizationName\": \"Xyz Inc.\",\n              \"partyType\": \"organization\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Custodian\",\n                \"appointmentDate\": \"2021-08-05\"\n              }\n            ]\n          }\n        ],\n        \"custodialOffice\": {\n          \"deliveryAddress\": {\n            \"streetAddress\": \"records - delivery_address\",\n            \"addressCity\": \"delivery_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          },\n          \"mailingAddress\": {\n            \"streetAddress\": \"records - mailing_address\",\n            \"addressCity\": \"mailing_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          }\n        },\n        \"affidavitFileKey\": \"{{affidavit_file_key}}\",\n        \"affidavitFileName\": \"affidavit_file.pdf\",\n        \"specialResolutionFileKey\": \"invalid key\",\n        \"specialResolutionFileName\": \"special_resolution_file.pdf\"\n      }\n    }\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/businesses/:id/filings",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"businesses",
+								":id",
+								"filings"
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "CP3490248"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "post - invalid special resolution doc page size - CP3490248",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json()",
+									"pm.environment.set(\"filing_id\", jsonData.filing.header.filingId)",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Status code is 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"});",
+									"",
+									"pm.test('should return JSON', function () {",
+									"    pm.response.to.have.header('Content-Type', 'application/json');",
+									"});",
+									"",
+									"",
+									"pm.test(\"Returns dissolution filing.\", () => {",
+									"    pm.expect(jsonData.filing).to.exist",
+									"    pm.expect(jsonData.filing.business).to.exist",
+									"    pm.expect(jsonData.filing.dissolution).to.exist",
+									"    pm.expect(jsonData.filing.header).to.exist",
+									"    pm.expect(jsonData.errors).to.exist",
+									"    pm.expect(jsonData.errors.length).to.eq(1)",
+									"    pm.expect(jsonData.errors[0].error).to.eq('Document must be set to fit onto 8.5” x 11” letter-size paper.')",
+									"    pm.expect(jsonData.errors[0].path).to.eq('/filing/dissolution/specialResolutionFileKey')",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"var today = new Date()",
+									"pm.environment.set(\"today\", today.getFullYear()+'-'+('0'+(today.getMonth()+1)).slice(-2)+'-'+('0'+today.getDate()).slice(-2))"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"filing\": {\n      \"header\": {\n        \"name\": \"dissolution\",\n        \"date\": \"{{today}}\",\n        \"certifiedBy\": \"full name\",\n        \"email\": \"no_one@never.get\",\n        \"effectiveDate\": \"{{today}}T00:00:00+00:00\"\n      },\n      \"business\": {\n        \"identifier\": \"CP3490248\",\n        \"legalType\": \"CP\"\n      },\n      \"dissolution\": {\n        \"dissolutionDate\": \"{{today}}\",\n        \"dissolutionType\": \"voluntary\",\n        \"dissolutionStatementType\": \"197NoAssetsNoLiabilities\",\n        \"hasLiabilities\": false,\n        \"parties\": [\n          {\n            \"officer\": {\n              \"firstName\": \"Completing\",\n              \"lastName\": \"Party\",\n              \"middleName\": \"P\",\n              \"email\": \"cp@example.com\",\n              \"organizationName\": \"\",\n              \"partyType\": \"person\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Completing Party\",\n                \"appointmentDate\": \"2021-08-05\"\n\n              }\n            ]\n          },\n          {\n            \"officer\": {\n              \"firstName\": \"\",\n              \"lastName\": \"\",\n              \"middleName\": \"\",\n              \"organizationName\": \"Xyz Inc.\",\n              \"partyType\": \"organization\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Custodian\",\n                \"appointmentDate\": \"2021-08-05\"\n              }\n            ]\n          }\n        ],\n        \"custodialOffice\": {\n          \"deliveryAddress\": {\n            \"streetAddress\": \"records - delivery_address\",\n            \"addressCity\": \"delivery_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          },\n          \"mailingAddress\": {\n            \"streetAddress\": \"records - mailing_address\",\n            \"addressCity\": \"mailing_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          }\n        },\n        \"affidavitFileKey\": \"{{affidavit_file_key}}\",\n        \"affidavitFileName\": \"affidavit_file.pdf\",\n        \"specialResolutionFileKey\": \"{{special_resolution_file_key}}\",\n        \"specialResolutionFileName\": \"special_resolution_file.pdf\"\n      }\n    }\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/businesses/:id/filings",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"businesses",
+								":id",
+								"filings"
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "CP3490248"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "post - invalid special resolution doc max size - CP3490248",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"const jsonData = pm.response.json()",
+									"const jsonDataText = pm.response.text()",
+									"pm.environment.set(\"filing_id\", jsonData.filing.header.filingId)",
+									"",
+									"pm.test(\"Status code is 400\", function () {",
+									"    pm.response.to.have.status(400);",
+									"});",
+									"",
+									"pm.test('should return JSON', function () {",
+									"    pm.response.to.have.header('Content-Type', 'application/json');",
+									"});",
+									"",
+									"",
+									"pm.test(\"Returns dissolution filing.\", () => {",
+									"    pm.expect(jsonData.filing).to.exist",
+									"    pm.expect(jsonData.filing.business).to.exist",
+									"    pm.expect(jsonData.filing.dissolution).to.exist",
+									"    pm.expect(jsonData.filing.header).to.exist",
+									"    pm.expect(jsonData.errors).to.exist",
+									"    pm.expect(jsonDataText).to.include('File exceeds maximum size.')",
+									"    pm.expect(jsonDataText).to.include('/filing/dissolution/specialResolutionFileKey')",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"var today = new Date()",
+									"pm.environment.set(\"today\", today.getFullYear()+'-'+('0'+(today.getMonth()+1)).slice(-2)+'-'+('0'+today.getDate()).slice(-2))"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"filing\": {\n      \"header\": {\n        \"name\": \"dissolution\",\n        \"date\": \"{{today}}\",\n        \"certifiedBy\": \"full name\",\n        \"email\": \"no_one@never.get\",\n        \"effectiveDate\": \"{{today}}T00:00:00+00:00\"\n      },\n      \"business\": {\n        \"identifier\": \"CP3490248\",\n        \"legalType\": \"CP\"\n      },\n      \"dissolution\": {\n        \"dissolutionDate\": \"{{today}}\",\n        \"dissolutionType\": \"voluntary\",\n        \"dissolutionStatementType\": \"197NoAssetsNoLiabilities\",\n        \"hasLiabilities\": false,\n        \"parties\": [\n          {\n            \"officer\": {\n              \"firstName\": \"Completing\",\n              \"lastName\": \"Party\",\n              \"middleName\": \"P\",\n              \"email\": \"cp@example.com\",\n              \"organizationName\": \"\",\n              \"partyType\": \"person\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Completing Party\",\n                \"appointmentDate\": \"2021-08-05\"\n\n              }\n            ]\n          },\n          {\n            \"officer\": {\n              \"firstName\": \"\",\n              \"lastName\": \"\",\n              \"middleName\": \"\",\n              \"organizationName\": \"Xyz Inc.\",\n              \"partyType\": \"organization\"\n            },\n            \"mailingAddress\": {\n              \"streetAddress\": \"mailing_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"mailing_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"deliveryAddress\": {\n              \"streetAddress\": \"delivery_address - address line one\",\n              \"streetAddressAdditional\": \"\",\n              \"addressCity\": \"delivery_address city\",\n              \"addressCountry\": \"CA\",\n              \"postalCode\": \"H0H0H0\",\n              \"addressRegion\": \"BC\"\n            },\n            \"roles\": [\n              {\n                \"roleType\": \"Custodian\",\n                \"appointmentDate\": \"2021-08-05\"\n              }\n            ]\n          }\n        ],\n        \"custodialOffice\": {\n          \"deliveryAddress\": {\n            \"streetAddress\": \"records - delivery_address\",\n            \"addressCity\": \"delivery_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          },\n          \"mailingAddress\": {\n            \"streetAddress\": \"records - mailing_address\",\n            \"addressCity\": \"mailing_address city\",\n            \"addressCountry\": \"CA\",\n            \"postalCode\": \"H0H0H0\",\n            \"addressRegion\": \"BC\"\n          }\n        },\n        \"affidavitFileKey\": \"{{affidavit_file_key}}\",\n        \"affidavitFileName\": \"affidavit_file.pdf\",\n        \"specialResolutionFileKey\": \"{{special_resolution_file_key}}\",\n        \"specialResolutionFileName\": \"special_resolution_file.pdf\"\n      }\n    }\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/businesses/:id/filings",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"businesses",
+								":id",
+								"filings"
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": "CP3490248"
+								}
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		}

--- a/legal-api/tests/unit/services/filings/test_utils.py
+++ b/legal-api/tests/unit/services/filings/test_utils.py
@@ -12,11 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Test suite to ensure the Common Utilities are working correctly."""
+import io
 from datetime import date
 
+import requests
 from hypothesis import example, given
 from hypothesis.strategies import text
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
 
+from legal_api.services import MinioService
 from legal_api.services.utils import get_date, get_str
 
 
@@ -42,3 +47,38 @@ def test_get_str(f, p):
         assert True
     else:
         assert isinstance(d, str)
+
+
+def _upload_file(page_size):
+    signed_url = MinioService.create_signed_put_url('cooperative-test.pdf')
+    key = signed_url.get('key')
+    pre_signed_put = signed_url.get('preSignedUrl')
+
+    requests.put(pre_signed_put, data=_create_pdf_file(page_size).read(),
+                 headers={'Content-Type': 'application/octet-stream'})
+    return key
+
+
+def _create_pdf_file(page_size):
+    buffer = io.BytesIO()
+    can = canvas.Canvas(buffer, pagesize=page_size)
+    doc_height = letter[1]
+
+    for _ in range(3):
+        text = 'This is a test document.\nThis is a test document.\nThis is a test document.'
+        text_x_margin = 100
+        text_y_margin = doc_height - 300
+        line_height = 14
+        _write_text(can, text, line_height, text_x_margin, text_y_margin)
+        can.showPage()
+
+    can.save()
+    buffer.seek(0)
+    return buffer
+
+
+def _write_text(can, text, line_height, x_margin, y_margin):
+    """Write text lines into a canvas."""
+    for line in text.splitlines():
+        can.drawString(x_margin, y_margin, line)
+        y_margin -= line_height

--- a/legal-api/tests/unit/services/filings/validations/test_dissolution.py
+++ b/legal-api/tests/unit/services/filings/validations/test_dissolution.py
@@ -14,12 +14,18 @@
 """Test suite to ensure Voluntary Dissolution is validated correctly."""
 import copy
 from http import HTTPStatus
+from unittest.mock import patch
 
 import pytest
 from registry_schemas.example_data import FILING_HEADER, DISSOLUTION
+from reportlab.lib.pagesizes import letter, legal
 
 from legal_api.models import Business
+from legal_api.services import MinioService
 from legal_api.services.filings.validations.dissolution import validate
+from legal_api.services.filings.validations import dissolution
+from tests.unit.services.filings.test_utils import _upload_file
+from tests.unit.services.filings.validations import lists_are_equal
 
 
 @pytest.mark.parametrize(
@@ -52,7 +58,8 @@ def test_dissolution_type(session, test_status, legal_type, dissolution_type,
     if legal_type != Business.LegalTypes.COOP.value:
         del filing['filing']['dissolution']['dissolutionStatementType']
 
-    err = validate(business, filing)
+    with patch.object(dissolution, 'validate_documents', return_value=None):
+        err = validate(business, filing)
 
     # validate outcomes
     if expected_code or expected_msg:
@@ -90,7 +97,8 @@ def test_dissolution_statement_type(session, test_status, legal_type, dissolutio
         del filing['filing']['dissolution']['dissolutionStatementType']
 
     # perform test
-    err = validate(business, filing)
+    with patch.object(dissolution, 'validate_documents', return_value=None):
+        err = validate(business, filing)
 
     # validate outcomes
     if expected_code or expected_msg:
@@ -141,7 +149,8 @@ def test_dissolution_address(session, test_status, legal_type, address_validatio
     elif address_validation == 'lookup_error':
         filing['filing']['dissolution']['parties'][1]['mailingAddress']['addressCountry'] = 'adssadkj'
 
-    err = validate(business, filing)
+    with patch.object(dissolution, 'validate_documents', return_value=None):
+        err = validate(business, filing)
 
     # validate outcomes
     if expected_code or expected_msg:
@@ -149,3 +158,101 @@ def test_dissolution_address(session, test_status, legal_type, address_validatio
         assert expected_msg == err.msg[0]['error']
     else:
         assert not err
+
+
+@pytest.mark.parametrize(
+    'test_name, legal_type, dissolution_type, key, scenario, identifier, expected_code, expected_msg',
+    [
+        ('SUCCESS', 'BC', 'voluntary', '', 'success', 'BC1234567', None, None),
+        ('SUCCESS', 'CP', 'voluntary', '', 'success', 'BC1234567', None, None),
+        ('FAIL_INVALID_AFFIDAVIT_FILE_KEY', 'CP', 'voluntary', 'affidavitFileKey', 'failAffidavit', 'CP1234567',
+         HTTPStatus.BAD_REQUEST, [{
+            'error': 'Invalid file.', 'path': '/filing/dissolution/affidavitFileKey'
+        }]),
+        ('FAIL_INVALID_SPECIAL_RESOLUTIONS_FILE_KEY', 'CP', 'voluntary', 'specialResolutionFileKey', 'failSpecialResolutions', 'CP1234567',
+         HTTPStatus.BAD_REQUEST, [{
+            'error': 'Invalid file.', 'path': '/filing/dissolution/specialResolutionFileKey'
+        }]),
+        ('FAIL_REQUIRED_AFFIDAVIT_FILE_KEY', 'CP', 'voluntary', 'affidavitFileKey', '', 'CP1234567',
+         HTTPStatus.BAD_REQUEST, [{
+            'error': 'A valid affidavit key is required.', 'path': '/filing/dissolution/affidavitFileKey'
+        }]),
+        ('FAIL_REQUIRED_AFFIDAVIT_FILE_NAME', 'CP', 'voluntary', 'affidavitFileName', '', 'CP1234567',
+         HTTPStatus.BAD_REQUEST, [{
+            'error': 'A valid affidavit file name is required.', 'path': '/filing/dissolution/affidavitFileName'
+        }]),
+        ('FAIL_REQUIRED_SPECIAL_RESOLUTION_FILE_KEY', 'CP', 'voluntary', 'specialResolutionFileKey', '', 'CP1234567',
+         HTTPStatus.BAD_REQUEST, [{
+            'error': 'A valid special resolution key is required.', 'path': '/filing/dissolution/specialResolutionFileKey'
+        }]),
+        ('FAIL_REQUIRED_SPECIAL_RESOLUTION_FILE_NAME', 'CP', 'voluntary', 'specialResolutionFileName', '', 'CP1234567',
+         HTTPStatus.BAD_REQUEST, [{
+            'error': 'A valid special resolution file name is required.', 'path': '/filing/dissolution/specialResolutionFileName'
+        }]),
+        ('FAIL_INVALID_AFFIDAVIT_FILE', 'CP', 'voluntary', 'affidavitFileKey', 'invalidAffidavitFileSize', 'CP1234567',
+         HTTPStatus.BAD_REQUEST, [{
+            'error': 'Document must be set to fit onto 8.5” x 11” letter-size paper.', 'path': '/filing/dissolution/affidavitFileKey'
+        }]),
+        ('FAIL_INVALID_SPECIAL_RESOLUTION_FILE', 'CP', 'voluntary', 'specialResolutionFileKey',
+         'invalidSpecialResolutionFileSize', 'CP1234567',
+         HTTPStatus.BAD_REQUEST, [{
+            'error': 'Document must be set to fit onto 8.5” x 11” letter-size paper.', 'path': '/filing/dissolution/specialResolutionFileKey'
+        }]),
+    ]
+)
+def test_dissolution_documents(session, minio_server, test_name, legal_type, dissolution_type, key, scenario, identifier,
+                               expected_code, expected_msg):  # pylint: disable=too-many-arguments
+    """Assert that a VD can be validated."""
+    # setup
+    business = Business(identifier=identifier)
+
+    filing = copy.deepcopy(FILING_HEADER)
+    filing['filing']['header']['name'] = 'dissolution'
+    filing['filing']['business']['legalType'] = legal_type
+    filing['filing']['dissolution'] = copy.deepcopy(DISSOLUTION)
+    filing['filing']['dissolution']['dissolutionType'] = dissolution_type
+    filing['filing']['dissolution']['parties'][1]['deliveryAddress'] = \
+        filing['filing']['dissolution']['parties'][1]['mailingAddress']
+
+    if scenario:
+        if scenario == 'success':
+            if legal_type != Business.LegalTypes.COOP.value:
+                del filing['filing']['dissolution']['affidavitFileKey']
+                del filing['filing']['dissolution']['affidavitFileName']
+                del filing['filing']['dissolution']['specialResolutionFileKey']
+                del filing['filing']['dissolution']['specialResolutionFileName']
+            else:
+                filing['filing']['dissolution']['affidavitFileKey'] = _upload_file(letter)
+                filing['filing']['dissolution']['specialResolutionFileKey'] = _upload_file(letter)
+        elif scenario == 'failAffidavit':
+            filing['filing']['dissolution']['affidavitFileKey'] = "invalid file key"
+            filing['filing']['dissolution']['specialResolutionFileKey'] = _upload_file(letter)
+        elif scenario == 'failSpecialResolutions':
+            filing['filing']['dissolution']['affidavitFileKey'] = _upload_file(letter)
+            filing['filing']['dissolution']['specialResolutionFileKey'] = "invalid file key"
+        elif scenario == 'invalidAffidavitFileSize':
+            filing['filing']['dissolution']['affidavitFileKey'] = _upload_file(legal)
+            filing['filing']['dissolution']['specialResolutionFileKey'] = _upload_file(letter)
+        elif scenario == 'invalidSpecialResolutionFileSize':
+            filing['filing']['dissolution']['affidavitFileKey'] = _upload_file(letter)
+            filing['filing']['dissolution']['specialResolutionFileKey'] = _upload_file(legal)
+    else:
+        # Assign key and value to test empty variables for failures
+        key_value = ''
+        filing['filing']['dissolution'][key] = key_value
+
+    # perform test
+    err = validate(business, filing)
+
+    # validate outcomes
+    if expected_code:
+        assert err.code == expected_code
+        assert lists_are_equal(err.msg, expected_msg)
+    else:
+        assert err is None
+
+    # Cleanup
+    if affidavitFileKey := filing['filing']['dissolution'].get('affidavitFileKey', None):
+        MinioService.delete_file(affidavitFileKey)
+    if specialResolutionFileKey := filing['filing']['dissolution'].get('specialResolutionFileKey', None):
+        MinioService.delete_file(specialResolutionFileKey)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#3933

*Description of changes:*

* Add affidavit/special resolution document validation to voluntary dissolution filing
* Refactored dissolution statement validation to use same approach as other voluntary dissolution validation logic.  i..e checking of legal type occurs in specific validation function instead of root validation function
* Updated non-document related validation tests to ignore document validation
* Added unit tests
* Added postman tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
