### PR TITLE
7357 update role/action used to verify authorization rules for retrieving business documents

### DIFF
--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_documents.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_documents.py
@@ -48,7 +48,7 @@ OUTPUT_DATE_FORMAT: Final = '%b %-d, %Y at %-I:%M %p Pacific time'
 def get_documents(identifier: str, filing_id: int, legal_filing_name: str = None):
     """Return a JSON object with meta information about the Service."""
     # basic checks
-    if not authorized(identifier, jwt, ['GET', ]):
+    if not authorized(identifier, jwt, ['view', ]):
         return jsonify(
             message=get_error_message(ErrorCode.NOT_AUTHORIZED, **{'identifier': identifier})
         ), HTTPStatus.UNAUTHORIZED


### PR DESCRIPTION
*Issue #:* /bcgov/entity#7357

*Description of changes:*

* Update to use `view` role as opposed to `GET` role when checking authorizing for viewing business documents. `GET` was causing an authorization error.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
