### PR TITLE
casting to JSON if the postgres db version returns it as string

### DIFF
--- a/legal-api/src/legal_api/core/meta/filing.py
+++ b/legal-api/src/legal_api/core/meta/filing.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Meta Filing support for the core domain used by the application."""
+import json
 import re
 from contextlib import suppress
 from enum import Enum, auto
@@ -202,10 +203,12 @@ class FilingMeta:  # pylint: disable=too-few-public-methods
             with suppress(Exception):
                 name = f'{name} - {FilingMeta.display_name(business, filing.children[0], False)}'
 
-        elif filing.filing_type in ('incorporationApplication') \
-            and filing.meta_data \
-                and (legal_name := filing.meta_data.get('incorporationApplication', {}).get('legalName')):
-            name = f'{name} - {legal_name}'
+        elif filing.filing_type in ('incorporationApplication') and filing.meta_data:
+            meta = filing.meta_data
+            if isinstance(meta, str):
+                meta = json.loads(meta)
+            if legal_name := meta.get('incorporationApplication', {}).get('legalName'):
+                name = f'{name} - {legal_name}'
 
         if full_name and filing.parent_filing_id and filing.status == FilingStorage.Status.CORRECTED:
             name = f'{name} - Corrected'


### PR DESCRIPTION
*Issue #:* /bcgov/entity#9500

*Description of changes:*
- seems different version of the postgres db/driver return the meta column as string instead of json

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
