### PR TITLE
#9703 Revise NR-BEFORE-EXPIRY email

### DIFF
--- a/queue_services/entity-emailer/src/entity_emailer/email_processors/nr_notification.py
+++ b/queue_services/entity-emailer/src/entity_emailer/email_processors/nr_notification.py
@@ -67,7 +67,7 @@ def process(email_info: dict, option) -> dict:  # pylint: disable-msg=too-many-l
         refund_value = email_info.get('data', {}).get('request', {}).get('refundValue', None)
 
     for n_item in nr_data['names']:
-        if (n_item['state'] == 'APPROVED') or (n_item['state'] == 'CONDITION'):
+        if n_item['state'] in ('APPROVED', 'CONDITION'):
             legal_name = n_item['name']
             break
 

--- a/queue_services/entity-emailer/src/entity_emailer/email_processors/nr_notification.py
+++ b/queue_services/entity-emailer/src/entity_emailer/email_processors/nr_notification.py
@@ -23,6 +23,7 @@ from entity_queue_common.service_utils import logger
 from flask import current_app
 from jinja2 import Template
 from legal_api.services import NameXService
+from legal_api.utils.legislation_datetime import LegislationDatetime
 from sentry_sdk import capture_message
 
 from entity_emailer.email_processors import substitute_template_parts
@@ -60,7 +61,7 @@ def process(email_info: dict, option) -> dict:  # pylint: disable-msg=too-many-l
     expiration_date = ''
     if nr_data['expirationDate']:
         exp_date = datetime.fromisoformat(nr_data['expirationDate'])
-        expiration_date = exp_date.strftime('%B %d, %Y %H:%M %p')
+        expiration_date = LegislationDatetime.format_as_report_string(exp_date)
 
     refund_value = ''
     if option == Option.REFUND.value:

--- a/queue_services/entity-emailer/src/entity_emailer/email_processors/nr_notification.py
+++ b/queue_services/entity-emailer/src/entity_emailer/email_processors/nr_notification.py
@@ -37,7 +37,8 @@ class Option(Enum):
     UPGRADE = 'upgrade'
     REFUND = 'refund'
 
-def process(email_info: dict, option) -> dict: # pylint: disable-msg=too-many-locals
+
+def process(email_info: dict, option) -> dict:  # pylint: disable-msg=too-many-locals
     """
     Build the email for Name Request notification.
 

--- a/queue_services/entity-emailer/src/entity_emailer/email_processors/nr_notification.py
+++ b/queue_services/entity-emailer/src/entity_emailer/email_processors/nr_notification.py
@@ -60,17 +60,20 @@ def process(email_info: dict, option) -> dict:
     expiration_date = ''
     if nr_data['expirationDate']:
         exp_date = datetime.fromisoformat(nr_data['expirationDate'])
-        expiration_date = exp_date.strftime('%Y-%m-%d')
+        expiration_date = exp_date.strftime('%B %d, %Y %H:%M %p')
 
     refund_value = ''
     if option == Option.REFUND.value:
         refund_value = email_info.get('data', {}).get('request', {}).get('refundValue', None)
+
+    legal_name = nr_data['legal_name']
 
     # render template with vars
     mail_template = Template(filled_template, autoescape=True)
     html_out = mail_template.render(
         nr_number=nr_number,
         expiration_date=expiration_date,
+        legal_name=legal_name,
         refund_value=refund_value
     )
 

--- a/queue_services/entity-emailer/src/entity_emailer/email_processors/nr_notification.py
+++ b/queue_services/entity-emailer/src/entity_emailer/email_processors/nr_notification.py
@@ -37,8 +37,7 @@ class Option(Enum):
     UPGRADE = 'upgrade'
     REFUND = 'refund'
 
-
-def process(email_info: dict, option) -> dict:
+def process(email_info: dict, option) -> dict: # pylint: disable-msg=too-many-locals
     """
     Build the email for Name Request notification.
 
@@ -65,10 +64,10 @@ def process(email_info: dict, option) -> dict:
     refund_value = ''
     if option == Option.REFUND.value:
         refund_value = email_info.get('data', {}).get('request', {}).get('refundValue', None)
-    
-    for x in nr_data['names']:
-        if (x['state'] == 'APPROVED') or (x['state'] == 'CONDITION'):
-            legal_name = x['name']
+
+    for n_item in nr_data['names']:
+        if (n_item['state'] == 'APPROVED') or (n_item['state'] == 'CONDITION'):
+            legal_name = n_item['name']
             break
 
     # render template with vars

--- a/queue_services/entity-emailer/src/entity_emailer/email_processors/nr_notification.py
+++ b/queue_services/entity-emailer/src/entity_emailer/email_processors/nr_notification.py
@@ -65,8 +65,11 @@ def process(email_info: dict, option) -> dict:
     refund_value = ''
     if option == Option.REFUND.value:
         refund_value = email_info.get('data', {}).get('request', {}).get('refundValue', None)
-
-    legal_name = nr_data['legal_name']
+    
+    for x in nr_data['names']:
+        if (x['state'] == 'APPROVED') or (x['state'] == 'CONDITION'):
+            legal_name = x['name']
+            break
 
     # render template with vars
     mail_template = Template(filled_template, autoescape=True)

--- a/queue_services/entity-emailer/src/entity_emailer/email_templates/NR-BEFORE-EXPIRY.html
+++ b/queue_services/entity-emailer/src/entity_emailer/email_templates/NR-BEFORE-EXPIRY.html
@@ -20,11 +20,13 @@
 
             [[whitespace-16px.html]]
             <p>
-              Your name request {{ nr_number }} is due to expire in 14 days. If your name request expires, you will need
-              to pay for another name request, and wait for it to be reviewed. As well, if your name request expires,
-              the approved name becomes available to the public. We reccomend that you use your name request within the
-              14 days, or go to <a href="www.bcregistry.ca/namerequest">www.bcregistry.ca/namerequest</a> and renew your
-              name request.
+              Your name request {{ nr_number }} for the approved name <strong>{{ legal_name }}</strong> is due to expire on {{ expiration_date }}. 
+              If your name request expires, you will need to pay for another name request, and wait for it to be reviewed. 
+              As well, if your name request expires, the approved name becomes available to the public. 
+              
+              We recommend that you use your name request before it expires, or go to <a href="www.bcregistry.ca/namerequest">www.bcregistry.ca/namerequest</a> 
+              and renew your name request.
+
             </p>
 
             [[whitespace-16px.html]]

--- a/queue_services/entity-emailer/tests/unit/email_processors/test_nr_notification.py
+++ b/queue_services/entity-emailer/tests/unit/email_processors/test_nr_notification.py
@@ -21,9 +21,12 @@ from entity_emailer.email_processors import nr_notification
 from tests import MockResponse
 
 
-names_arr = [{"name":"TEST Company Name","state":"APPROVED"}]
+names_arr = [{'name': 'TEST Company Name', 'state': 'APPROVED'}]
+
+
 @pytest.mark.parametrize(['option', 'nr_number', 'subject', 'expiration_date', 'refund_value', 'names'], [
-    ('before-expiry', 'NR 1234567', 'Expiring Soon', '2021-07-20T00:00:00+00:00', None, [{"name":"TEST Company Name","state":"NE"},{"name":"TEST2 Company Name","state":"APPROVED"},]),
+    ('before-expiry', 'NR 1234567', 'Expiring Soon', '2021-07-20T00:00:00+00:00', None,
+        [{'name': 'TEST Company Name', 'state': 'NE'}, {'name': 'TEST2 Company Name', 'state': 'APPROVED'}]),
     ('expired', 'NR 1234567', 'Expired', None, None, names_arr),
     ('renewal', 'NR 1234567', 'Confirmation of Renewal', '2021-07-20T00:00:00+00:00', None, names_arr),
     ('upgrade', 'NR 1234567', 'Confirmation of Upgrade', None, None, names_arr),

--- a/queue_services/entity-emailer/tests/unit/email_processors/test_nr_notification.py
+++ b/queue_services/entity-emailer/tests/unit/email_processors/test_nr_notification.py
@@ -21,17 +21,18 @@ from entity_emailer.email_processors import nr_notification
 from tests import MockResponse
 
 
-@pytest.mark.parametrize(['option', 'nr_number', 'subject', 'expiration_date', 'refund_value'], [
-    ('before-expiry', 'NR 1234567', 'Expiring Soon', None, None),
-    ('expired', 'NR 1234567', 'Expired', None, None),
-    ('renewal', 'NR 1234567', 'Confirmation of Renewal', '2021-07-20T00:00:00+00:00', None),
-    ('upgrade', 'NR 1234567', 'Confirmation of Upgrade', None, None),
-    ('refund', 'NR 1234567', 'Refund request confirmation', None, '123.45')
+@pytest.mark.parametrize(['option', 'nr_number', 'subject', 'expiration_date', 'refund_value', 'legal_name'], [
+    ('before-expiry', 'NR 1234567', 'Expiring Soon', '2021-07-20T00:00:00+00:00', None, 'TEST Company Name'),
+    ('expired', 'NR 1234567', 'Expired', None, None, None),
+    ('renewal', 'NR 1234567', 'Confirmation of Renewal', '2021-07-20T00:00:00+00:00', None, None),
+    ('upgrade', 'NR 1234567', 'Confirmation of Upgrade', None, None, None),
+    ('refund', 'NR 1234567', 'Refund request confirmation', None, '123.45', None)
 ])
-def test_nr_notification(app, session, option, nr_number, subject, expiration_date, refund_value):
+def test_nr_notification(app, session, option, nr_number, subject, expiration_date, refund_value, legal_name):
     """Assert that the nr notification can be processed."""
     nr_json = {
         'expirationDate': expiration_date,
+        'legal_name': legal_name,
         'applicants': {
             'emailAddress': 'test@test.com'
         }

--- a/queue_services/entity-emailer/tests/unit/email_processors/test_nr_notification.py
+++ b/queue_services/entity-emailer/tests/unit/email_processors/test_nr_notification.py
@@ -12,29 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """The Unit Tests for the name request expiry email processor."""
+from datetime import datetime
 from unittest.mock import patch
 
 import pytest
 from legal_api.services import NameXService
+from legal_api.utils.legislation_datetime import LegislationDatetime
 
 from entity_emailer.email_processors import nr_notification
 from tests import MockResponse
 
 
-names_arr = [{'name': 'TEST Company Name', 'state': 'APPROVED'}]
+default_legal_name = 'TEST COMP'
+default_names_array = [{'name': default_legal_name, 'state': 'APPROVED'}]
 
 
-@pytest.mark.parametrize(['option', 'nr_number', 'subject', 'expiration_date', 'refund_value', 'names'], [
-    ('before-expiry', 'NR 1234567', 'Expiring Soon', '2021-07-20T00:00:00+00:00', None,
+@pytest.mark.parametrize(['option', 'nr_number', 'subject', 'expiration_date', 'refund_value',
+                         'expected_legal_name', 'names'], [
+    ('before-expiry', 'NR 1234567', 'Expiring Soon', '2021-07-20T00:00:00+00:00', None, 'TEST2 Company Name',
         [{'name': 'TEST Company Name', 'state': 'NE'}, {'name': 'TEST2 Company Name', 'state': 'APPROVED'}]),
-    ('before-expiry', 'NR 1234567', 'Expiring Soon', None, None,
+    ('before-expiry', 'NR 1234567', 'Expiring Soon', '2021-07-20T00:00:00+00:00', None, 'TEST3 Company Name',
         [{'name': 'TEST3 Company Name', 'state': 'CONDITION'}, {'name': 'TEST4 Company Name', 'state': 'NE'}]),
-    ('expired', 'NR 1234567', 'Expired', None, None, names_arr),
-    ('renewal', 'NR 1234567', 'Confirmation of Renewal', '2021-07-20T00:00:00+00:00', None, names_arr),
-    ('upgrade', 'NR 1234567', 'Confirmation of Upgrade', None, None, names_arr),
-    ('refund', 'NR 1234567', 'Refund request confirmation', None, '123.45', names_arr)
+    ('expired', 'NR 1234567', 'Expired', None, None, None, default_names_array),
+    ('renewal', 'NR 1234567', 'Confirmation of Renewal', '2021-07-20T00:00:00+00:00', None, None, default_names_array),
+    ('upgrade', 'NR 1234567', 'Confirmation of Upgrade', None, None, None, default_names_array),
+    ('refund', 'NR 1234567', 'Refund request confirmation', None, '123.45', None, default_names_array)
 ])
-def test_nr_notification(app, session, option, nr_number, subject, expiration_date, refund_value, names):
+def test_nr_notification(app, session, option, nr_number, subject, expiration_date, refund_value,
+                         expected_legal_name, names):
     """Assert that the nr notification can be processed."""
     nr_json = {
         'expirationDate': expiration_date,
@@ -61,6 +66,7 @@ def test_nr_notification(app, session, option, nr_number, subject, expiration_da
                 }
             }
         }, option)
+
         assert email['content']['subject'] == f'{nr_number} - {subject}'
 
         assert 'test@test.com' in email['recipients']
@@ -69,3 +75,9 @@ def test_nr_notification(app, session, option, nr_number, subject, expiration_da
             assert f'${refund_value} CAD' in email['content']['body']
         assert email['content']['attachments'] == []
         assert mock_query_nr_number.call_args[0][0] == nr_number
+
+        if option == nr_notification.Option.BEFORE_EXPIRY.value:
+            assert nr_number in email['content']['body']
+            assert expected_legal_name in email['content']['body']
+            exp_date = LegislationDatetime.format_as_report_string(datetime.fromisoformat(expiration_date))
+            assert exp_date in email['content']['body']

--- a/queue_services/entity-emailer/tests/unit/email_processors/test_nr_notification.py
+++ b/queue_services/entity-emailer/tests/unit/email_processors/test_nr_notification.py
@@ -21,18 +21,19 @@ from entity_emailer.email_processors import nr_notification
 from tests import MockResponse
 
 
-@pytest.mark.parametrize(['option', 'nr_number', 'subject', 'expiration_date', 'refund_value', 'legal_name'], [
-    ('before-expiry', 'NR 1234567', 'Expiring Soon', '2021-07-20T00:00:00+00:00', None, 'TEST Company Name'),
-    ('expired', 'NR 1234567', 'Expired', None, None, None),
-    ('renewal', 'NR 1234567', 'Confirmation of Renewal', '2021-07-20T00:00:00+00:00', None, None),
-    ('upgrade', 'NR 1234567', 'Confirmation of Upgrade', None, None, None),
-    ('refund', 'NR 1234567', 'Refund request confirmation', None, '123.45', None)
+names_arr = [{"name":"TEST Company Name","state":"APPROVED"}]
+@pytest.mark.parametrize(['option', 'nr_number', 'subject', 'expiration_date', 'refund_value', 'names'], [
+    ('before-expiry', 'NR 1234567', 'Expiring Soon', '2021-07-20T00:00:00+00:00', None, [{"name":"TEST Company Name","state":"NE"},{"name":"TEST2 Company Name","state":"APPROVED"},]),
+    ('expired', 'NR 1234567', 'Expired', None, None, names_arr),
+    ('renewal', 'NR 1234567', 'Confirmation of Renewal', '2021-07-20T00:00:00+00:00', None, names_arr),
+    ('upgrade', 'NR 1234567', 'Confirmation of Upgrade', None, None, names_arr),
+    ('refund', 'NR 1234567', 'Refund request confirmation', None, '123.45', names_arr)
 ])
-def test_nr_notification(app, session, option, nr_number, subject, expiration_date, refund_value, legal_name):
+def test_nr_notification(app, session, option, nr_number, subject, expiration_date, refund_value, names):
     """Assert that the nr notification can be processed."""
     nr_json = {
         'expirationDate': expiration_date,
-        'legal_name': legal_name,
+        'names': names,
         'applicants': {
             'emailAddress': 'test@test.com'
         }

--- a/queue_services/entity-emailer/tests/unit/email_processors/test_nr_notification.py
+++ b/queue_services/entity-emailer/tests/unit/email_processors/test_nr_notification.py
@@ -27,6 +27,8 @@ names_arr = [{'name': 'TEST Company Name', 'state': 'APPROVED'}]
 @pytest.mark.parametrize(['option', 'nr_number', 'subject', 'expiration_date', 'refund_value', 'names'], [
     ('before-expiry', 'NR 1234567', 'Expiring Soon', '2021-07-20T00:00:00+00:00', None,
         [{'name': 'TEST Company Name', 'state': 'NE'}, {'name': 'TEST2 Company Name', 'state': 'APPROVED'}]),
+    ('before-expiry', 'NR 1234567', 'Expiring Soon', None, None,
+        [{'name': 'TEST3 Company Name', 'state': 'CONDITION'}, {'name': 'TEST4 Company Name', 'state': 'NE'}]),
     ('expired', 'NR 1234567', 'Expired', None, None, names_arr),
     ('renewal', 'NR 1234567', 'Confirmation of Renewal', '2021-07-20T00:00:00+00:00', None, names_arr),
     ('upgrade', 'NR 1234567', 'Confirmation of Upgrade', None, None, names_arr),

--- a/queue_services/entity-emailer/tests/unit/test_worker.py
+++ b/queue_services/entity-emailer/tests/unit/test_worker.py
@@ -201,18 +201,19 @@ def test_process_bn_email(app, session):
             assert mock_send_email.call_args[0][0]['content']['body']
             assert mock_send_email.call_args[0][0]['content']['attachments'] == []
 
-
-@pytest.mark.parametrize(['option', 'nr_number', 'subject', 'expiration_date', 'refund_value'], [
-    ('before-expiry', 'NR 1234567', 'Expiring Soon', None, None),
-    ('expired', 'NR 1234567', 'Expired', None, None),
-    ('renewal', 'NR 1234567', 'Confirmation of Renewal', '2021-07-20T00:00:00+00:00', None),
-    ('upgrade', 'NR 1234567', 'Confirmation of Upgrade', None, None),
-    ('refund', 'NR 1234567', 'Refund request confirmation', None, '123.45')
+names_arr = [{"name":"TEST Company Name","state":"APPROVED"}]
+@pytest.mark.parametrize(['option', 'nr_number', 'subject', 'expiration_date', 'refund_value', 'names'], [
+    ('before-expiry', 'NR 1234567', 'Expiring Soon', None, None, [{"name":"TEST Company Name","state":"NE"},{"name":"TEST2 Company Name","state":"APPROVED"}]),
+    ('expired', 'NR 1234567', 'Expired', None, None, names_arr),
+    ('renewal', 'NR 1234567', 'Confirmation of Renewal', '2021-07-20T00:00:00+00:00', None, names_arr),
+    ('upgrade', 'NR 1234567', 'Confirmation of Upgrade', None, None, names_arr),
+    ('refund', 'NR 1234567', 'Refund request confirmation', None, '123.45', names_arr)
 ])
-def test_nr_notification(app, session, option, nr_number, subject, expiration_date, refund_value):
+def test_nr_notification(app, session, option, nr_number, subject, expiration_date, refund_value, names):
     """Assert that the nr notification can be processed."""
     nr_json = {
         'expirationDate': expiration_date,
+        'names': names,
         'applicants': {
             'emailAddress': 'test@test.com'
         }

--- a/queue_services/entity-emailer/tests/unit/test_worker.py
+++ b/queue_services/entity-emailer/tests/unit/test_worker.py
@@ -208,6 +208,8 @@ names_arr = [{'name': 'TEST Company Name', 'state': 'APPROVED'}]
 @pytest.mark.parametrize(['option', 'nr_number', 'subject', 'expiration_date', 'refund_value', 'names'], [
     ('before-expiry', 'NR 1234567', 'Expiring Soon', None, None,
         [{'name': 'TEST Company Name', 'state': 'NE'}, {'name': 'TEST2 Company Name', 'state': 'APPROVED'}]),
+    ('before-expiry', 'NR 1234567', 'Expiring Soon', None, None,
+        [{'name': 'TEST3 Company Name', 'state': 'CONDITION'}, {'name': 'TEST4 Company Name', 'state': 'NE'}]),
     ('expired', 'NR 1234567', 'Expired', None, None, names_arr),
     ('renewal', 'NR 1234567', 'Confirmation of Renewal', '2021-07-20T00:00:00+00:00', None, names_arr),
     ('upgrade', 'NR 1234567', 'Confirmation of Upgrade', None, None, names_arr),

--- a/queue_services/entity-emailer/tests/unit/test_worker.py
+++ b/queue_services/entity-emailer/tests/unit/test_worker.py
@@ -201,9 +201,13 @@ def test_process_bn_email(app, session):
             assert mock_send_email.call_args[0][0]['content']['body']
             assert mock_send_email.call_args[0][0]['content']['attachments'] == []
 
-names_arr = [{"name":"TEST Company Name","state":"APPROVED"}]
+
+names_arr = [{'name': 'TEST Company Name', 'state': 'APPROVED'}]
+
+
 @pytest.mark.parametrize(['option', 'nr_number', 'subject', 'expiration_date', 'refund_value', 'names'], [
-    ('before-expiry', 'NR 1234567', 'Expiring Soon', None, None, [{"name":"TEST Company Name","state":"NE"},{"name":"TEST2 Company Name","state":"APPROVED"}]),
+    ('before-expiry', 'NR 1234567', 'Expiring Soon', None, None,
+        [{'name': 'TEST Company Name', 'state': 'NE'}, {'name': 'TEST2 Company Name', 'state': 'APPROVED'}]),
     ('expired', 'NR 1234567', 'Expired', None, None, names_arr),
     ('renewal', 'NR 1234567', 'Confirmation of Renewal', '2021-07-20T00:00:00+00:00', None, names_arr),
     ('upgrade', 'NR 1234567', 'Confirmation of Upgrade', None, None, names_arr),


### PR DESCRIPTION
*Issue #:* /bcgov/entity#9703

*Description of changes:*
- modified the nr_before_Expiry email to include legal_name and expiration_date with specific format.
- Updated the test_nr_notification to include new fields.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
