### PR TITLE
9762 fix 500 error for fetching pending correction filings

### DIFF
--- a/legal-api/src/legal_api/core/filing.py
+++ b/legal-api/src/legal_api/core/filing.py
@@ -223,6 +223,7 @@ class Filing:
         if filing_json and correction_id and self._storage and self.status in [Filing.Status.COMPLETED.value,
                                                                                Filing.Status.PAID.value,
                                                                                Filing.Status.PENDING.value,
+                                                                               Filing.Status.PENDING_CORRECTION.value
                                                                                ]:
             if corrected_filing := Filing.find_by_id(correction_id):
                 if diff_nodes := diff_dict(filing_json,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#9762

*Description of changes:*

* Update `_diff` function of Filing class to support returning diff block for correction filings with filing status of "PENDING_CORRECTION"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
