### PR TITLE
Verify Payment for Documents

### DIFF
--- a/legal-api/src/legal_api/core/filing.py
+++ b/legal-api/src/legal_api/core/filing.py
@@ -25,7 +25,6 @@ from typing import Dict, List, Optional
 from flask import current_app, url_for
 from flask_jwt_oidc import JwtManager
 from sqlalchemy import desc
-from pprint import pprint
 
 from legal_api.core.meta import FilingMeta
 from legal_api.core.utils import diff_dict, diff_list

--- a/legal-api/src/legal_api/core/filing.py
+++ b/legal-api/src/legal_api/core/filing.py
@@ -410,14 +410,7 @@ class Filing:
                                                    'legal_filing_name': None})
 
         documents = {'documents': {}}
-
-        has_payment_rules = [
-            filing.storage,
-            filing.storage.payment_status_code,
-            filing.storage.payment_status_code == 'COMPLETED'
-        ]
-
-        if all(has_payment_rules):
+        if filing.storage and filing.storage.payment_completion_date:
             documents['documents']['receipt'] = f'{base_url}{doc_url}/receipt'
 
         if filing.status in (

--- a/legal-api/src/legal_api/core/filing.py
+++ b/legal-api/src/legal_api/core/filing.py
@@ -411,13 +411,13 @@ class Filing:
 
         documents = {'documents': {}}
 
-        verifyPayment = [
+        has_payment_rules = [
             filing.storage,
             filing.storage.payment_status_code,
             filing.storage.payment_status_code == 'COMPLETED'
         ]
 
-        if all(verifyPayment):
+        if all(has_payment_rules):
             documents['documents']['receipt'] = f'{base_url}{doc_url}/receipt'
 
         if filing.status in (

--- a/legal-api/src/legal_api/core/filing.py
+++ b/legal-api/src/legal_api/core/filing.py
@@ -368,15 +368,19 @@ class Filing:
     def common_ledger_items(business_identifier: str, filing_storage: FilingStorage) -> dict:
         """Return attributes and links that also get included in T-business filings."""
         base_url = current_app.config.get('LEGAL_API_BASE_URL')
-        return {
-            'commentsCount': filing_storage.comments_count,
-            'commentsLink': f'{base_url}/{business_identifier}/filings/{filing_storage.id}/comments',
-            'documentsLink': f'{base_url}/{business_identifier}/filings/{filing_storage.id}/documents',
-            'filingLink': f'{base_url}/{business_identifier}/filings/{filing_storage.id}',
-            'isFutureEffective': (filing_storage.effective_date
-                                  and filing_storage._filing_date  # pylint: disable=protected-access
-                                  and (filing_storage.effective_date > filing_storage._filing_date)),  # pylint: disable=protected-access # noqa: E501
-        }
+        common_items = {
+           'commentsCount': filing_storage.comments_count,
+           'commentsLink': f'{base_url}/{business_identifier}/filings/{filing_storage.id}/comments',
+           'filingLink': f'{base_url}/{business_identifier}/filings/{filing_storage.id}',
+           'isFutureEffective': (filing_storage.effective_date
+                                 and filing_storage._filing_date  # pylint: disable=protected-access
+                                 and (filing_storage.effective_date > filing_storage._filing_date)),  # pylint: disable=protected-access # noqa: E501
+       }
+        """Only apply document links for filings that are paid for and completed in our system."""
+        if filing_storage.payment_status_code == 'COMPLETED':
+            common_items['documentsLink'] = f'{base_url}/{business_identifier}/filings/{filing_storage.id}/documents'
+
+        return common_items
 
     @staticmethod
     def _add_ledger_order(filing: FilingStorage, ledger_filing: dict) -> dict:

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
@@ -229,7 +229,7 @@ def test_various_filing_states(session, client, jwt,
     filing = factory_filing(business, filing_json, filing_date=filing_date)
     filing.skip_status_listener = True
     filing._status = status
-    filing._payment_status_code = payment_status
+    filing._payment_completion_date = payment_completion_date
     filing.save()
 
     if status == 'COMPLETED':

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
@@ -132,12 +132,12 @@ def test_unpaid_filing(session, client, jwt):
 
 base_url = 'https://LEGAL_API_BASE_URL'
 
-@pytest.mark.parametrize('test_name, identifier, entity_type, filing_name_1, legal_filing_1, filing_name_2, legal_filing_2, status, expected_msg, expected_http_code', [
+@pytest.mark.parametrize('test_name, identifier, entity_type, filing_name_1, legal_filing_1, filing_name_2, legal_filing_2, status, expected_msg, expected_http_code, payment_status', [
         ('special_res_paper', 'CP7654321', Business.LegalTypes.COOP.value,
-         'specialResolution', SPECIAL_RESOLUTION, None, None, Filing.Status.PAPER_ONLY, {}, HTTPStatus.NOT_FOUND
+         'specialResolution', SPECIAL_RESOLUTION, None, None, Filing.Status.PAPER_ONLY, {}, HTTPStatus.NOT_FOUND, None
         ),
         ('special_res_pending', 'CP7654321', Business.LegalTypes.COOP.value,
-         'specialResolution', SPECIAL_RESOLUTION, None, None, Filing.Status.PENDING, {}, HTTPStatus.NOT_FOUND
+         'specialResolution', SPECIAL_RESOLUTION, None, None, Filing.Status.PENDING, {}, HTTPStatus.NOT_FOUND, None
         ),
         ('special_res_paid', 'CP7654321', Business.LegalTypes.COOP.value,
          'specialResolution', SPECIAL_RESOLUTION, None, None, Filing.Status.PAID,
@@ -147,7 +147,7 @@ base_url = 'https://LEGAL_API_BASE_URL'
                         ]
                         }
          },
-        HTTPStatus.OK
+        HTTPStatus.OK, 'COMPLETED'
         ),
         ('special_res_completed', 'CP7654321', Business.LegalTypes.COOP.value,
          'specialResolution', SPECIAL_RESOLUTION, None, None, Filing.Status.COMPLETED,
@@ -157,7 +157,7 @@ base_url = 'https://LEGAL_API_BASE_URL'
                         ]
                         }
          },
-        HTTPStatus.OK
+        HTTPStatus.OK, 'COMPLETED'
         ),
         ('specres_court_completed', 'CP7654321', Business.LegalTypes.COOP.value,
          'specialResolution', SPECIAL_RESOLUTION, 'courtOrder', COURT_ORDER, Filing.Status.COMPLETED,
@@ -168,7 +168,7 @@ base_url = 'https://LEGAL_API_BASE_URL'
                         ]
                         }
          },
-        HTTPStatus.OK
+        HTTPStatus.OK, 'COMPLETED'
         ),
         ('cp_ia_completed', 'CP7654321', Business.LegalTypes.COOP.value,
          'incorporationApplication', INCORPORATION_FILING_TEMPLATE, None, None, Filing.Status.COMPLETED,
@@ -179,7 +179,7 @@ base_url = 'https://LEGAL_API_BASE_URL'
                         ]
                         }
          },
-        HTTPStatus.OK
+        HTTPStatus.OK, 'COMPLETED'
         ),
         ('ben_ia_completed', 'BC7654321', Business.LegalTypes.BCOMP.value,
          'incorporationApplication', INCORPORATION_FILING_TEMPLATE, None, None, Filing.Status.COMPLETED,
@@ -191,8 +191,19 @@ base_url = 'https://LEGAL_API_BASE_URL'
                         ]
                         }
          },
-        HTTPStatus.OK
+        HTTPStatus.OK, 'COMPLETED'
         ),
+        ('ben_ia_completed', 'BC7654321', Business.LegalTypes.BCOMP.value,
+                 'incorporationApplication', INCORPORATION_FILING_TEMPLATE, None, None, Filing.Status.COMPLETED,
+                 {'documents': {'certificate': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/certificate',
+                                'noticeOfArticles': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/noticeOfArticles',
+                                'legalFilings': [
+                                    {'incorporationApplication': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/incorporationApplication'},
+                                ]
+                                }
+                 },
+                HTTPStatus.OK, None
+                ),
     ])
 def test_various_filing_states(session, client, jwt,
                                test_name,
@@ -200,7 +211,8 @@ def test_various_filing_states(session, client, jwt,
                                entity_type,
                                filing_name_1, legal_filing_1,
                                filing_name_2, legal_filing_2,
-                               status, expected_msg, expected_http_code):
+                               status, expected_msg, expected_http_code,
+                               payment_status):
     """Test document list based on filing states."""
     # Setup
     # identifier = 'CP7654321'
@@ -217,6 +229,7 @@ def test_various_filing_states(session, client, jwt,
     filing = factory_filing(business, filing_json, filing_date=filing_date)
     filing.skip_status_listener = True
     filing._status = status
+    filing._payment_status_code = payment_status
     filing.save()
 
     if status == 'COMPLETED':

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
@@ -132,7 +132,7 @@ def test_unpaid_filing(session, client, jwt):
 
 base_url = 'https://LEGAL_API_BASE_URL'
 
-@pytest.mark.parametrize('test_name, identifier, entity_type, filing_name_1, legal_filing_1, filing_name_2, legal_filing_2, status, expected_msg, expected_http_code, payment_status', [
+@pytest.mark.parametrize('test_name, identifier, entity_type, filing_name_1, legal_filing_1, filing_name_2, legal_filing_2, status, expected_msg, expected_http_code, payment_completion_date', [
         ('special_res_paper', 'CP7654321', Business.LegalTypes.COOP.value,
          'specialResolution', SPECIAL_RESOLUTION, None, None, Filing.Status.PAPER_ONLY, {}, HTTPStatus.NOT_FOUND, None
         ),
@@ -147,7 +147,7 @@ base_url = 'https://LEGAL_API_BASE_URL'
                         ]
                         }
          },
-        HTTPStatus.OK, 'COMPLETED'
+        HTTPStatus.OK, '2017-10-01'
         ),
         ('special_res_completed', 'CP7654321', Business.LegalTypes.COOP.value,
          'specialResolution', SPECIAL_RESOLUTION, None, None, Filing.Status.COMPLETED,
@@ -157,7 +157,7 @@ base_url = 'https://LEGAL_API_BASE_URL'
                         ]
                         }
          },
-        HTTPStatus.OK, 'COMPLETED'
+        HTTPStatus.OK, '2017-10-01'
         ),
         ('specres_court_completed', 'CP7654321', Business.LegalTypes.COOP.value,
          'specialResolution', SPECIAL_RESOLUTION, 'courtOrder', COURT_ORDER, Filing.Status.COMPLETED,
@@ -168,7 +168,7 @@ base_url = 'https://LEGAL_API_BASE_URL'
                         ]
                         }
          },
-        HTTPStatus.OK, 'COMPLETED'
+        HTTPStatus.OK, '2017-10-01'
         ),
         ('cp_ia_completed', 'CP7654321', Business.LegalTypes.COOP.value,
          'incorporationApplication', INCORPORATION_FILING_TEMPLATE, None, None, Filing.Status.COMPLETED,
@@ -179,7 +179,7 @@ base_url = 'https://LEGAL_API_BASE_URL'
                         ]
                         }
          },
-        HTTPStatus.OK, 'COMPLETED'
+        HTTPStatus.OK, '2017-10-01'
         ),
         ('ben_ia_completed', 'BC7654321', Business.LegalTypes.BCOMP.value,
          'incorporationApplication', INCORPORATION_FILING_TEMPLATE, None, None, Filing.Status.COMPLETED,
@@ -191,7 +191,7 @@ base_url = 'https://LEGAL_API_BASE_URL'
                         ]
                         }
          },
-        HTTPStatus.OK, 'COMPLETED'
+        HTTPStatus.OK, '2017-10-01'
         ),
         ('ben_ia_completed', 'BC7654321', Business.LegalTypes.BCOMP.value,
                  'incorporationApplication', INCORPORATION_FILING_TEMPLATE, None, None, Filing.Status.COMPLETED,
@@ -212,7 +212,7 @@ def test_various_filing_states(session, client, jwt,
                                filing_name_1, legal_filing_1,
                                filing_name_2, legal_filing_2,
                                status, expected_msg, expected_http_code,
-                               payment_status):
+                               payment_completion_date):
     """Test document list based on filing states."""
     # Setup
     # identifier = 'CP7654321'


### PR DESCRIPTION
*Issue #:* /bcgov/entity#9638

*Description of changes:*
* Verify payment status code before applying a receipt to the documents list to the ledger item. 
* This is to prevent documents or receipts displaying for documents that have not been completed within our system.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
