### PR TITLE
9603 bumped emailer version num to correct version for name release 11.2

### DIFF
--- a/queue_services/entity-emailer/src/entity_emailer/version.py
+++ b/queue_services/entity-emailer/src/entity_emailer/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.28.0'  # pylint: disable=invalid-name
+__version__ = '2.30.0'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:* /bcgov/entity#9603

*Description of changes:*

* Bumped version num again for emailer to `2.30.0`. The last version bump was incorrect as I realized afterwards that the last lear release used `2.29.0` so updating version num to `2.28.0` would be wrong.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
