### PR TITLE
add NOA to document list, for BC type corps filing a COD.

### DIFF
--- a/legal-api/src/legal_api/core/meta/filing.py
+++ b/legal-api/src/legal_api/core/meta/filing.py
@@ -103,7 +103,10 @@ FILINGS: Final = {
                 'CP': 'OTFDR',
                 'BEN': 'BCFDR'
             }
-        }
+        },
+        'additional': [
+            {'types': 'BC,BEN', 'outputs': ['noticeOfArticles', ]},
+        ]
     },
     'changeOfName': {
         'name': 'changeOfName',

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
@@ -171,7 +171,7 @@ base_url = 'https://LEGAL_API_BASE_URL'
         HTTPStatus.OK, '2017-10-01'
         ),
         ('cp_ia_completed', 'CP7654321', Business.LegalTypes.COOP.value,
-         'incorporationApplication', INCORPORATION_FILING_TEMPLATE, None, None, Filing.Status.COMPLETED,
+         'incorporationApplication', INCORPORATION, None, None, Filing.Status.COMPLETED,
          {'documents': {'receipt': f'{base_url}/api/v2/businesses/CP7654321/filings/1/documents/receipt',
                         'certificate': f'{base_url}/api/v2/businesses/CP7654321/filings/1/documents/certificate',
                         'legalFilings': [
@@ -182,7 +182,7 @@ base_url = 'https://LEGAL_API_BASE_URL'
         HTTPStatus.OK, '2017-10-01'
         ),
         ('ben_ia_completed', 'BC7654321', Business.LegalTypes.BCOMP.value,
-         'incorporationApplication', INCORPORATION_FILING_TEMPLATE, None, None, Filing.Status.COMPLETED,
+         'incorporationApplication', INCORPORATION, None, None, Filing.Status.COMPLETED,
          {'documents': {'receipt': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/receipt',
                         'certificate': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/certificate',
                         'noticeOfArticles': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/noticeOfArticles',
@@ -194,7 +194,7 @@ base_url = 'https://LEGAL_API_BASE_URL'
         HTTPStatus.OK, '2017-10-01'
         ),
         ('ben_ia_completed', 'BC7654321', Business.LegalTypes.BCOMP.value,
-                 'incorporationApplication', INCORPORATION_FILING_TEMPLATE, None, None, Filing.Status.COMPLETED,
+                 'incorporationApplication', INCORPORATION, None, None, Filing.Status.COMPLETED,
                  {'documents': {'certificate': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/certificate',
                                 'noticeOfArticles': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/noticeOfArticles',
                                 'legalFilings': [
@@ -204,8 +204,28 @@ base_url = 'https://LEGAL_API_BASE_URL'
                  },
                 HTTPStatus.OK, None
                 ),
+        ('ben_changeOfDirector', 'BC7654321', Business.LegalTypes.BCOMP.value,
+                 'changeOfDirectors', CHANGE_OF_DIRECTORS, None, None, Filing.Status.COMPLETED,
+                 {'documents': {'noticeOfArticles': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/noticeOfArticles',
+                                'legalFilings': [
+                                    {'changeOfDirectors': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/changeOfDirectors'},
+                                ]
+                                }
+                 },
+                HTTPStatus.OK, None
+                ),
+        ('cp_changeOfDirector', 'CP7654321', Business.LegalTypes.COOP.value,
+                 'changeOfDirectors', CHANGE_OF_DIRECTORS, None, None, Filing.Status.COMPLETED,
+                 {'documents': {
+                                'legalFilings': [
+                                    {'changeOfDirectors': f'{base_url}/api/v2/businesses/CP7654321/filings/1/documents/changeOfDirectors'},
+                                ]
+                                }
+                 },
+                HTTPStatus.OK, None
+                ),
     ])
-def test_various_filing_states(session, client, jwt,
+def test_document_list_for_various_filing_states(session, client, jwt,
                                test_name,
                                identifier,
                                entity_type,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#9924

*Description of changes:*
- added the NOA to the documents list for changeOfDirectors
- limit that to BC & BEN types
- test that it shows for one of the types
- test that it doesn't show for CP business types.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
