### PR TITLE
Submitter Display Name

### DIFF
--- a/legal-api/src/legal_api/core/filing.py
+++ b/legal-api/src/legal_api/core/filing.py
@@ -34,6 +34,7 @@ from legal_api.utils.datetime import date, datetime  # noqa: I005
 
 from .constants import REDACTED_STAFF_SUBMITTER
 
+
 # @dataclass(init=False, repr=False)
 class Filing:
     """Domain class for Filings."""

--- a/legal-api/src/legal_api/core/filing.py
+++ b/legal-api/src/legal_api/core/filing.py
@@ -349,7 +349,10 @@ class Filing:
             if (submitter := filing.filing_submitter) \
                 and submitter.username and jwt \
                     and not Filing.redact_submitter(filing.submitter_roles, jwt):
-                submitter_displayname = filing._filing_json['filing']['header']['certifiedBy']
+                if not (filing.paper_only):
+                    submitter_displayname = filing._filing_json['filing']['header']['certifiedBy']
+                else:
+                    submitter_displayname = submitter.username
 
             ledger_filing = {
                 'availableOnPaperOnly': filing.paper_only,

--- a/legal-api/src/legal_api/core/filing.py
+++ b/legal-api/src/legal_api/core/filing.py
@@ -349,8 +349,8 @@ class Filing:
             if (submitter := filing.filing_submitter) \
                 and submitter.username and jwt \
                     and not Filing.redact_submitter(filing.submitter_roles, jwt):
-                if not (filing.paper_only):
-                    submitter_displayname = filing._filing_json['filing']['header']['certifiedBy']
+                if not filing.paper_only:
+                    submitter_displayname = filing._filing_json['filing']['header']['certifiedBy'] # pylint: disable=protected-access
                 else:
                     submitter_displayname = submitter.username
 

--- a/legal-api/src/legal_api/core/filing.py
+++ b/legal-api/src/legal_api/core/filing.py
@@ -14,6 +14,7 @@
 """Filings are legal documents that alter the state of a business."""
 # pylint: disable=unused-argument
 from __future__ import annotations
+from pprint import pprint
 
 # from dataclasses import dataclass, field
 import copy
@@ -27,13 +28,12 @@ from sqlalchemy import desc
 
 from legal_api.core.meta import FilingMeta
 from legal_api.core.utils import diff_dict, diff_list
-from legal_api.models import Business, Filing as FilingStorage, UserRoles  # noqa: I001
+from legal_api.models import Business, Filing as FilingStorage, User, UserRoles  # noqa: I001
 from legal_api.services import VersionedBusinessDetailsService  # noqa: I005
 from legal_api.services.authz import has_roles  # noqa: I005
 from legal_api.utils.datetime import date, datetime  # noqa: I005
 
 from .constants import REDACTED_STAFF_SUBMITTER
-
 
 # @dataclass(init=False, repr=False)
 class Filing:
@@ -349,7 +349,7 @@ class Filing:
             if (submitter := filing.filing_submitter) \
                 and submitter.username and jwt \
                     and not Filing.redact_submitter(filing.submitter_roles, jwt):
-                submitter_displayname = submitter.username
+                submitter_displayname = filing._filing_json['filing']['header']['certifiedBy']
 
             ledger_filing = {
                 'availableOnPaperOnly': filing.paper_only,

--- a/legal-api/src/legal_api/core/filing.py
+++ b/legal-api/src/legal_api/core/filing.py
@@ -14,7 +14,6 @@
 """Filings are legal documents that alter the state of a business."""
 # pylint: disable=unused-argument
 from __future__ import annotations
-from pprint import pprint
 
 # from dataclasses import dataclass, field
 import copy
@@ -28,7 +27,7 @@ from sqlalchemy import desc
 
 from legal_api.core.meta import FilingMeta
 from legal_api.core.utils import diff_dict, diff_list
-from legal_api.models import Business, Filing as FilingStorage, User, UserRoles  # noqa: I001
+from legal_api.models import Business, Filing as FilingStorage, UserRoles  # noqa: I001
 from legal_api.services import VersionedBusinessDetailsService  # noqa: I005
 from legal_api.services.authz import has_roles  # noqa: I005
 from legal_api.utils.datetime import date, datetime  # noqa: I005

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filings_ledger.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filings_ledger.py
@@ -412,7 +412,7 @@ def test_ledger_redaction(session, client, jwt, test_name, submitter_role, jwt_r
                 'header': {
                     'name': filing_name,
                     'date': '2019-04-08',
-                    'certifiedBy': expected
+                    'certifiedBy': username
                 },
                 filing_name: {
                     'resolution': 'Year challenge is hitting oppo for the win.'

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filings_ledger.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filings_ledger.py
@@ -151,7 +151,7 @@ def ledger_element_setup_filing(business, filing_name, filing_date):
     filing['filing']['header']['name'] = filing_name
     f = factory_completed_filing(business, filing, filing_date=filing_date)
     return f
- 
+
 
 def test_ledger_comment_count(session, client, jwt):
     """Assert that the ledger returns the correct number of comments."""
@@ -168,7 +168,7 @@ def test_ledger_comment_count(session, client, jwt):
     # test
     rv = client.get(f'/api/v2/businesses/{identifier}/filings',
                 headers=create_header(jwt, [UserRoles.SYSTEM.value], identifier))
-    
+
     # validate
     assert rv.json['filings'][0]['commentsCount'] == number_of_comments
 
@@ -203,7 +203,7 @@ def test_ledger_court_order(session, client, jwt, test_name, file_number, order_
     # test
     rv = client.get(f'/api/v2/businesses/{identifier}/filings',
                 headers=create_header(jwt, [UserRoles.SYSTEM.value], identifier))
-    
+
     # validate
     assert rv.json['filings'][0]
     filing_json = rv.json['filings'][0]
@@ -232,7 +232,7 @@ def test_ledger_display_name_annual_report(session, client, jwt):
     # test
     rv = client.get(f'/api/v2/businesses/{identifier}/filings',
                 headers=create_header(jwt, [UserRoles.SYSTEM.value], identifier))
-    
+
     # validate
     assert rv.json['filings'][0]
     filing_json = rv.json['filings'][0]
@@ -279,7 +279,7 @@ def test_ledger_display_alteration_report(session, client, jwt):
     # test
     rv = client.get(f'/api/v2/businesses/{identifier}/filings',
                 headers=create_header(jwt, [UserRoles.SYSTEM.value], identifier))
-    
+
     # validate
     assert rv.json['filings'][0]
     filing_json = rv.json['filings'][0]
@@ -338,7 +338,7 @@ def test_ledger_display_corrected_incorporation(session, client, jwt):
     # test
     rv = client.get(f'/api/v2/businesses/{identifier}/filings',
                 headers=create_header(jwt, [UserRoles.SYSTEM.value], identifier))
-    
+
     # validate
     assert rv.json['filings']
     for filing_json in rv.json['filings']:
@@ -366,7 +366,7 @@ def test_ledger_display_corrected_annual_report(session, client, jwt):
     # test
     rv = client.get(f'/api/v2/businesses/{identifier}/filings',
                 headers=create_header(jwt, [UserRoles.SYSTEM.value], identifier))
-    
+
     # validate
     assert rv.json['filings']
     for filing_json in rv.json['filings']:
@@ -411,7 +411,8 @@ def test_ledger_redaction(session, client, jwt, test_name, submitter_role, jwt_r
             'filing': {
                 'header': {
                     'name': filing_name,
-                    'date': '2019-04-08'
+                    'date': '2019-04-08',
+                    'certifiedBy': expected
                 },
                 filing_name: {
                     'resolution': 'Year challenge is hitting oppo for the win.'


### PR DESCRIPTION
*Issue #:* /bcgov/entity#10145

*Description of changes:*
* Return the certifiedBy value for the submitter display name.
* Updated unit testing.

*Note:* 
- Why we chose to use the certifiedBy property here is that the `USER` object first name / last name properties seem to be blank when fetching that user data, and the `username` wasn't as 'friendly' from a display point of view. 
Definitely open to any options here though if there is another means of retrieving a submitter value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
