### PR TITLE
Submitter Display Name

### DIFF
--- a/legal-api/src/legal_api/core/filing.py
+++ b/legal-api/src/legal_api/core/filing.py
@@ -364,7 +364,7 @@ class Filing:
             if (submitter := filing.filing_submitter) \
                 and submitter.username and jwt \
                     and not Filing.redact_submitter(filing.submitter_roles, jwt):
-                submitter_displayname = submitter.username
+                submitter_displayname = submitter.display_name
 
             ledger_filing = {
                 'availableOnPaperOnly': filing.paper_only,

--- a/legal-api/src/legal_api/core/filing.py
+++ b/legal-api/src/legal_api/core/filing.py
@@ -364,7 +364,7 @@ class Filing:
             if (submitter := filing.filing_submitter) \
                 and submitter.username and jwt \
                     and not Filing.redact_submitter(filing.submitter_roles, jwt):
-                submitter_displayname = submitter.display_name
+                submitter_displayname = submitter.display_name or submitter.username
 
             ledger_filing = {
                 'availableOnPaperOnly': filing.paper_only,

--- a/legal-api/tests/unit/models/__init__.py
+++ b/legal-api/tests/unit/models/__init__.py
@@ -113,9 +113,11 @@ AR_FILING = {
     }
 }
 
-def factory_user(username: str):
+def factory_user(username: str, firstname : str = None, lastname : str = None):
     user = User()
     user.username = username
+    user.firstname = firstname
+    user.lastname = lastname
     user.save()
     return user
 

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filings_ledger.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filings_ledger.py
@@ -151,7 +151,7 @@ def ledger_element_setup_filing(business, filing_name, filing_date):
     filing['filing']['header']['name'] = filing_name
     f = factory_completed_filing(business, filing, filing_date=filing_date)
     return f
- 
+
 
 def test_ledger_comment_count(session, client, jwt):
     """Assert that the ledger returns the correct number of comments."""
@@ -168,7 +168,7 @@ def test_ledger_comment_count(session, client, jwt):
     # test
     rv = client.get(f'/api/v2/businesses/{identifier}/filings',
                 headers=create_header(jwt, [UserRoles.SYSTEM.value], identifier))
-    
+
     # validate
     assert rv.json['filings'][0]['commentsCount'] == number_of_comments
 
@@ -203,7 +203,7 @@ def test_ledger_court_order(session, client, jwt, test_name, file_number, order_
     # test
     rv = client.get(f'/api/v2/businesses/{identifier}/filings',
                 headers=create_header(jwt, [UserRoles.SYSTEM.value], identifier))
-    
+
     # validate
     assert rv.json['filings'][0]
     filing_json = rv.json['filings'][0]
@@ -232,7 +232,7 @@ def test_ledger_display_name_annual_report(session, client, jwt):
     # test
     rv = client.get(f'/api/v2/businesses/{identifier}/filings',
                 headers=create_header(jwt, [UserRoles.SYSTEM.value], identifier))
-    
+
     # validate
     assert rv.json['filings'][0]
     filing_json = rv.json['filings'][0]
@@ -279,7 +279,7 @@ def test_ledger_display_alteration_report(session, client, jwt):
     # test
     rv = client.get(f'/api/v2/businesses/{identifier}/filings',
                 headers=create_header(jwt, [UserRoles.SYSTEM.value], identifier))
-    
+
     # validate
     assert rv.json['filings'][0]
     filing_json = rv.json['filings'][0]
@@ -338,7 +338,7 @@ def test_ledger_display_corrected_incorporation(session, client, jwt):
     # test
     rv = client.get(f'/api/v2/businesses/{identifier}/filings',
                 headers=create_header(jwt, [UserRoles.SYSTEM.value], identifier))
-    
+
     # validate
     assert rv.json['filings']
     for filing_json in rv.json['filings']:
@@ -366,7 +366,7 @@ def test_ledger_display_corrected_annual_report(session, client, jwt):
     # test
     rv = client.get(f'/api/v2/businesses/{identifier}/filings',
                 headers=create_header(jwt, [UserRoles.SYSTEM.value], identifier))
-    
+
     # validate
     assert rv.json['filings']
     for filing_json in rv.json['filings']:
@@ -382,14 +382,14 @@ def test_ledger_display_corrected_annual_report(session, client, jwt):
 @pytest.mark.parametrize(
     'test_name, submitter_role, jwt_role, username, expected',
     [
-        ('staff-staff', UserRoles.STAFF.value, UserRoles.STAFF.value, 'idir/staff-user', 'idir/staff-user'),
-        ('system-staff', UserRoles.SYSTEM.value, UserRoles.STAFF.value, 'system', 'system'),
-        ('unknown-staff', None, UserRoles.STAFF.value, 'some-user', 'some-user'),
+        ('staff-staff', UserRoles.STAFF.value, UserRoles.STAFF.value, 'idir/staff-user', 'firstname lastname'),
+        ('system-staff', UserRoles.SYSTEM.value, UserRoles.STAFF.value, 'system', 'firstname lastname'),
+        ('unknown-staff', None, UserRoles.STAFF.value, 'some-user', 'firstname lastname'),
         ('system-public', UserRoles.SYSTEM.value, UserRoles.PUBLIC_USER.value, 'system', 'Registry Staff'),
         ('staff-public', UserRoles.STAFF.value, UserRoles.PUBLIC_USER.value, 'idir/staff-user', 'Registry Staff'),
-        ('public-staff', UserRoles.PUBLIC_USER.value, UserRoles.STAFF.value, 'bcsc/public_user', 'bcsc/public_user'),
-        ('public-public', UserRoles.PUBLIC_USER.value, UserRoles.PUBLIC_USER.value, 'bcsc/public_user', 'bcsc/public_user'),
-        ('unknown-public', None, UserRoles.PUBLIC_USER.value, 'some-user', 'some-user'),
+        ('public-staff', UserRoles.PUBLIC_USER.value, UserRoles.STAFF.value, 'bcsc/public_user', 'firstname lastname'),
+        ('public-public', UserRoles.PUBLIC_USER.value, UserRoles.PUBLIC_USER.value, 'bcsc/public_user', 'firstname lastname'),
+        ('unknown-public', None, UserRoles.PUBLIC_USER.value, 'some-user', 'firstname lastname'),
     ]
 )
 def test_ledger_redaction(session, client, jwt, test_name, submitter_role, jwt_role, username, expected):
@@ -416,7 +416,7 @@ def test_ledger_redaction(session, client, jwt, test_name, submitter_role, jwt_r
                 filing_name: {
                     'resolution': 'Year challenge is hitting oppo for the win.'
                 }}}
-        user = factory_user(username)
+        user = factory_user(username, 'firstname', 'lastname')
         new_filing = factory_completed_filing(business, filing_submission, filing_date=filing_date)
         new_filing.submitter_id = user.id
         new_filing.submitter_roles = submitter_role

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filings_ledger.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filings_ledger.py
@@ -380,19 +380,20 @@ def test_ledger_display_corrected_annual_report(session, client, jwt):
 
 
 @pytest.mark.parametrize(
-    'test_name, submitter_role, jwt_role, username, expected',
+    'test_name, submitter_role, jwt_role, username, firstname, lastname, expected',
     [
-        ('staff-staff', UserRoles.STAFF.value, UserRoles.STAFF.value, 'idir/staff-user', 'firstname lastname'),
-        ('system-staff', UserRoles.SYSTEM.value, UserRoles.STAFF.value, 'system', 'firstname lastname'),
-        ('unknown-staff', None, UserRoles.STAFF.value, 'some-user', 'firstname lastname'),
-        ('system-public', UserRoles.SYSTEM.value, UserRoles.PUBLIC_USER.value, 'system', 'Registry Staff'),
-        ('staff-public', UserRoles.STAFF.value, UserRoles.PUBLIC_USER.value, 'idir/staff-user', 'Registry Staff'),
-        ('public-staff', UserRoles.PUBLIC_USER.value, UserRoles.STAFF.value, 'bcsc/public_user', 'firstname lastname'),
-        ('public-public', UserRoles.PUBLIC_USER.value, UserRoles.PUBLIC_USER.value, 'bcsc/public_user', 'firstname lastname'),
-        ('unknown-public', None, UserRoles.PUBLIC_USER.value, 'some-user', 'firstname lastname'),
+        ('staff-staff', UserRoles.STAFF.value, UserRoles.STAFF.value, 'idir/staff-user', 'firstname', 'lastname', 'firstname lastname'),
+        ('system-staff', UserRoles.SYSTEM.value, UserRoles.STAFF.value, 'system', 'firstname', 'lastname', 'firstname lastname'),
+        ('unknown-staff', None, UserRoles.STAFF.value, 'some-user', 'firstname', 'lastname', 'firstname lastname'),
+        ('system-public', UserRoles.SYSTEM.value, UserRoles.PUBLIC_USER.value, 'system', 'firstname', 'lastname', 'Registry Staff'),
+        ('staff-public', UserRoles.STAFF.value, UserRoles.PUBLIC_USER.value, 'idir/staff-user', 'firstname', 'lastname', 'Registry Staff'),
+        ('public-staff', UserRoles.PUBLIC_USER.value, UserRoles.STAFF.value, 'bcsc/public_user', 'firstname', 'lastname', 'firstname lastname'),
+        ('public-public', UserRoles.PUBLIC_USER.value, UserRoles.PUBLIC_USER.value, 'bcsc/public_user', 'firstname', 'lastname', 'firstname lastname'),
+        ('unknown-public', None, UserRoles.PUBLIC_USER.value, 'some-user', 'firstname', 'lastname', 'firstname lastname'),
+        ('unknown-public', None, UserRoles.PUBLIC_USER.value, 'some-user', '', '', 'some-user'),
     ]
 )
-def test_ledger_redaction(session, client, jwt, test_name, submitter_role, jwt_role, username, expected):
+def test_ledger_redaction(session, client, jwt, test_name, submitter_role, jwt_role, username, firstname, lastname, expected):
     """Assert that the core filing is saved to the backing store."""
     from legal_api.core.filing import Filing as CoreFiling
     try:
@@ -416,7 +417,7 @@ def test_ledger_redaction(session, client, jwt, test_name, submitter_role, jwt_r
                 filing_name: {
                     'resolution': 'Year challenge is hitting oppo for the win.'
                 }}}
-        user = factory_user(username, 'firstname', 'lastname')
+        user = factory_user(username, firstname, lastname)
         new_filing = factory_completed_filing(business, filing_submission, filing_date=filing_date)
         new_filing.submitter_id = user.id
         new_filing.submitter_roles = submitter_role


### PR DESCRIPTION
*Issue #:* /bcgov/entity#10145

*Description of changes:*
* Use the display_name property for Submitter name when NOT redacted.
* Updated unit testing and User Factory method to take firstname and lastname.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
