### PR TITLE
9016 - Fix for dissolution filer trying to get legal type from filing json

### DIFF
--- a/queue_services/entity-filer/src/entity_filer/filing_processors/dissolution.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/dissolution.py
@@ -71,7 +71,7 @@ def process(business: Business, filing: Dict, filing_rec: Filing, filing_meta: F
         court_order_json = dpath.util.get(dissolution_filing, '/courtOrder')
         filings.update_filing_court_order(filing, court_order_json)
 
-    if filing['business']['legalType'] == Business.LegalTypes.COOP:
+    if business.legal_type == Business.LegalTypes.COOP:
         _update_cooperative(dissolution_filing, business, filing_rec)
 
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#9016

*Description of changes:*

This is a fix for the dissolution filer failing because it was trying to get business legal type from the filing submission json. 

- Got business legal type from object

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
