### PR TITLE
Fix for duplicate outputs

### DIFF
--- a/legal-api/migrations/versions/441a5e6cf682_.py
+++ b/legal-api/migrations/versions/441a5e6cf682_.py
@@ -65,9 +65,6 @@ def upgrade():
             },
             {
                 'identifier':'recordsOffice', 'description':'Records Office'
-            },
-            {
-                'identifier':'custodialOffice', 'description':'Custodial Office'
             }
         ]
     )

--- a/legal-api/src/legal_api/core/meta/filing.py
+++ b/legal-api/src/legal_api/core/meta/filing.py
@@ -164,7 +164,7 @@ FILINGS: Final = {
             'LLC': 'DIS_VOL'
         },
         'additional': [
-            {'types': 'CP', 'outputs': ['certificateOfDissolution', 'specialResolution', 'affidavit']},
+            {'types': 'CP', 'outputs': ['certificateOfDissolution', 'affidavit']},
             {'types': 'BC,BEN,CC,ULC,LLC', 'outputs': ['certificateOfDissolution']},
         ]
     },

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
@@ -131,7 +131,7 @@ def test_unpaid_filing(session, client, jwt):
     assert rv.json == {}
 
 
-base_url = 'https://LEGAL_API_BASE_URL'
+base_url = 'http://localhost:5000'
 CORRECTION = {
     'correctedFilingId': 4,
     'correctedFilingType': 'incorporationApplication',
@@ -282,18 +282,18 @@ del ALTERATION_WITHOUT_NR['nameRequest']['legalName']
      HTTPStatus.OK, None
      ),
     ('cp_dissolution_completed', 'CP7654321', Business.LegalTypes.COOP.value,
-     'dissolution', DISSOLUTION, None, None, Filing.Status.COMPLETED,
+     'dissolution', DISSOLUTION, 'specialResolution', SPECIAL_RESOLUTION, Filing.Status.COMPLETED,
      {
          'documents': {
              'receipt': f'{base_url}/api/v2/businesses/CP7654321/filings/1/documents/receipt',
              'certificateOfDissolution':
              f'{base_url}/api/v2/businesses/CP7654321/filings/1/documents/certificateOfDissolution',
-                 'specialResolution':
-                     f'{base_url}/api/v2/businesses/CP7654321/filings/1/documents/specialResolution',
                  'affidavit':
                      f'{base_url}/api/v2/businesses/CP7654321/filings/1/documents/affidavit',
                  'legalFilings': [
                      {'dissolution': f'{base_url}/api/v2/businesses/CP7654321/filings/1/documents/dissolution'},
+                     {'specialResolution':
+                          f'{base_url}/api/v2/businesses/CP7654321/filings/1/documents/specialResolution'}
                  ]
          }
      },

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
@@ -131,7 +131,7 @@ def test_unpaid_filing(session, client, jwt):
     assert rv.json == {}
 
 
-base_url = 'http://localhost:5000'
+base_url = 'https://LEGAL_API_BASE_URL'
 CORRECTION = {
     'correctedFilingId': 4,
     'correctedFilingType': 'incorporationApplication',


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*
  Removed special resolution from the co-op voluntary dissolution additional documents list as it is present in the legal filings in 
  the filing metadata
  
  Removed the custodial office from the old migration as it is giving an error while running the test. This entry was added in a 
  new migration file today.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
