### PR TITLE
9286 hotfix for missing memorandum and rules docs in filing documents…

### DIFF
--- a/legal-api/src/legal_api/core/meta/filing.py
+++ b/legal-api/src/legal_api/core/meta/filing.py
@@ -180,7 +180,7 @@ FILINGS: Final = {
             'BEN': 'BCINC'
         },
         'additional': [
-            {'types': 'CP', 'outputs': ['certificate']},
+            {'types': 'CP', 'outputs': ['certificate', 'certifiedRules', 'certifiedMemorandum']},
             {'types': 'BC,BEN', 'outputs': ['noticeOfArticles', 'certificate']},
         ]
     },

--- a/legal-api/src/legal_api/version.py
+++ b/legal-api/src/legal_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.31.0'  # pylint: disable=invalid-name
+__version__ = '2.32.0'  # pylint: disable=invalid-name

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
@@ -185,11 +185,14 @@ del ALTERATION_WITHOUT_NR['nameRequest']['legalName']
      ),
     ('cp_ia_completed', 'CP7654321', Business.LegalTypes.COOP.value,
      'incorporationApplication', INCORPORATION, None, None, Filing.Status.COMPLETED,
-     {'documents': {'receipt': f'{base_url}/api/v2/businesses/CP7654321/filings/1/documents/receipt',
-                        'certificate': f'{base_url}/api/v2/businesses/CP7654321/filings/1/documents/certificate',
-                        'legalFilings': [
-                            {'incorporationApplication': f'{base_url}/api/v2/businesses/CP7654321/filings/1/documents/incorporationApplication'},
-                        ]
+     {'documents': {
+                    'receipt': f'{base_url}/api/v2/businesses/CP7654321/filings/1/documents/receipt',
+                    'certificate': f'{base_url}/api/v2/businesses/CP7654321/filings/1/documents/certificate',
+                    'certifiedMemorandum': f'{base_url}/api/v2/businesses/CP7654321/filings/1/documents/certifiedMemorandum',
+                    'certifiedRules': f'{base_url}/api/v2/businesses/CP7654321/filings/1/documents/certifiedRules',
+                    'legalFilings': [
+                        {'incorporationApplication': f'{base_url}/api/v2/businesses/CP7654321/filings/1/documents/incorporationApplication'},
+                    ]
                     }
       },
      HTTPStatus.OK, '2017-10-01'


### PR DESCRIPTION
Note: this PR is to get a hotfix that already went to PRD back into `main`

*Issue #:* /bcgov/entity#9286

*Description of changes:*

* add rules and memorandum to Coop IA outputs in additional section
* updated tests
* bumped version num

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
