### PR TITLE
8388 Revert code back to saving in pacific time to colin db and converting to UTC for GET calls

### DIFF
--- a/colin-api/src/colin_api/models/business.py
+++ b/colin-api/src/colin_api/models/business.py
@@ -25,7 +25,7 @@ from flask import current_app
 from colin_api.exceptions import BusinessNotFoundException
 from colin_api.models.corp_name import CorpName
 from colin_api.resources.db import DB
-from colin_api.utils import convert_to_json_date, convert_to_json_datetime, convert_to_utc_datetime, stringify_list
+from colin_api.utils import convert_to_json_date, convert_to_json_datetime, convert_to_pacific_time, stringify_list
 
 
 class Business:  # pylint: disable=too-many-instance-attributes
@@ -279,7 +279,7 @@ class Business:  # pylint: disable=too-many-instance-attributes
             business = Business()
             business.corp_name = filing_info['business']['legalName']
             business.corp_num = filing_info['business']['identifier']
-            business.founding_date = convert_to_utc_datetime(filing_info['header']['learEffectiveDate'])
+            business.founding_date = convert_to_pacific_time(filing_info['header']['learEffectiveDate'])
 
             if filing_info['business']['legalType'] in cls.CORP_TYPE_CONVERSION[cls.LearBusinessTypes.BCOMP.value]:
                 business.corp_num = business.corp_num[-7:]

--- a/colin-api/src/colin_api/models/filing.py
+++ b/colin-api/src/colin_api/models/filing.py
@@ -310,7 +310,7 @@ class Filing:  # pylint: disable=too-many-instance-attributes;
             cursor.execute(
                 """
                 INSERT INTO event (event_id, corp_num, event_typ_cd, event_timestmp, trigger_dts)
-                VALUES (:event_id, :corp_num, :event_type, current_timestamp at time zone dbtimezone, NULL)
+                VALUES (:event_id, :corp_num, :event_type, sysdate, NULL)
                 """,
                 event_id=event_id,
                 corp_num=corp_num,

--- a/colin-api/src/colin_api/resources/filing.py
+++ b/colin-api/src/colin_api/resources/filing.py
@@ -25,7 +25,7 @@ from colin_api.exceptions import GenericException
 from colin_api.models import Business
 from colin_api.models.filing import DB, Filing
 from colin_api.resources.business import API
-from colin_api.utils import convert_to_utc_datetime
+from colin_api.utils import convert_to_pacific_time
 from colin_api.utils.util import cors_preflight
 
 
@@ -194,7 +194,7 @@ class FilingInfo(Resource):
             filing.filing_sub_type = Filing.get_filing_sub_type(filing_type, filing_body)
             filing.body = filing_body
             # get utc lear effective date and convert to pacific time for insert into oracle
-            filing.effective_date = convert_to_utc_datetime(filing.header['learEffectiveDate'])
+            filing.effective_date = convert_to_pacific_time(filing.header['learEffectiveDate'])
 
             if filing_type != 'incorporationApplication':
                 filing.business = Business.find_by_identifier(identifier, corp_types, con)

--- a/colin-api/src/colin_api/utils/__init__.py
+++ b/colin-api/src/colin_api/utils/__init__.py
@@ -23,14 +23,7 @@ def convert_to_json_date(thedate: datetime.datetime) -> str:
     if not thedate:
         return None
     try:
-        utcdate = datetime.datetime(thedate.year,
-                                    thedate.month,
-                                    thedate.day,
-                                    thedate.hour,
-                                    thedate.minute,
-                                    thedate.second,
-                                    tzinfo=timezone('UTC'))
-        return utcdate.strftime('%Y-%m-%d')
+        return thedate.strftime('%Y-%m-%d')
     except Exception as err:  # pylint: disable=broad-except; want to return None in all cases where convert failed
         current_app.logger.debug('Tried to convert {date}, but failed: {error}'.format(date=thedate, error=err))
         return None
@@ -41,24 +34,19 @@ def convert_to_json_datetime(thedate: datetime.datetime) -> str:
     if not thedate:
         return None
     try:
-        # timezone info not in var
+        # timezone info not in var (they are pacififc times so add timezone)
+        thedate = thedate.astimezone(timezone('US/Pacific'))
         # convert to utc time
-        utcdate = datetime.datetime(thedate.year,
-                                    thedate.month,
-                                    thedate.day,
-                                    thedate.hour,
-                                    thedate.minute,
-                                    thedate.second,
-                                    tzinfo=timezone('UTC'))
+        thedate = thedate.astimezone(timezone('UTC'))
         # return as string
-        return utcdate.strftime('%Y-%m-%dT%H:%M:%S-00:00')
+        return thedate.strftime('%Y-%m-%dT%H:%M:%S-00:00')
     except Exception as err:  # pylint: disable=broad-except; want to return None in all cases where convert failed
         current_app.logger.debug('Tried to convert {date}, but failed: {error}'.format(date=thedate, error=err))
         return None
 
 
-def convert_to_utc_datetime(thedate: str) -> str:
-    """Convert the datetime string to utc datetime string."""
+def convert_to_pacific_time(thedate: str) -> str:
+    """Convert the datetime string to pacific time string."""
     try:
         # tries converting two formats before bailing
         try:
@@ -66,7 +54,8 @@ def convert_to_utc_datetime(thedate: str) -> str:
         except Exception:  # pylint: disable=broad-except;
             datetime_obj = datetime.datetime.strptime(thedate, '%Y-%m-%dT%H:%M:%S+00:00')
         datetime_utc = datetime_obj.replace(tzinfo=timezone('UTC'))
-        return datetime_utc.strftime('%Y-%m-%dT%H:%M:%S')
+        datetime_pst = datetime_utc.astimezone(timezone('US/Pacific'))
+        return datetime_pst.strftime('%Y-%m-%dT%H:%M:%S')
     except Exception as err:  # pylint: disable=broad-except; want to return None in all cases where convert failed
         current_app.logger.error(f'Tried to convert {thedate}, but failed: {err}')
         raise err

--- a/colin-api/src/colin_api/version.py
+++ b/colin-api/src/colin_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.33.0'  # pylint: disable=invalid-name
+__version__ = '2.34.0'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:* /bcgov/entity#8388

*Description of changes:*

* Revert code that was originally intended to save to Oracle as UTC.  This turned out to be problematic for legacy systems.  Note: the code should be essentially the same as before.  Original commits that were reverted have been included as follows:
  * https://github.com/bcgov/lear/commit/a9c878211cd95275629bc3cda11b2fe7dda91a14
  * https://github.com/bcgov/lear/commit/592bfe4b7d723c13891dfecc133959ba58ee9ad9 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
