### PR TITLE
10482 Update ledger text entries to use filing effective date

### DIFF
--- a/colin-api/src/colin_api/models/filing.py
+++ b/colin-api/src/colin_api/models/filing.py
@@ -503,9 +503,11 @@ class Filing:  # pylint: disable=too-many-instance-attributes;
             cursor.execute(
                 """
                 INSERT INTO ledger_text (event_id, ledger_text_dts, notation, dd_event_id, user_id)
-                VALUES (:event_id, sysdate, :notation, :dd_event_id, :user_id)
+                VALUES (:event_id, TO_TIMESTAMP_TZ(:ledger_text_dts, 'YYYY-MM-DD"T"HH24:MI:SS.FFTZH:TZM'), :notation,
+                        :dd_event_id, :user_id)
                 """,
                 event_id=filing.event_id,
+                ledger_text_dts=filing.effective_date,
                 notation=text,
                 dd_event_id=filing.event_id,
                 user_id=filing.user_id


### PR DESCRIPTION
*Issue #:* /bcgov/entity#10482

*Description of changes:*

* Update `_insert_ledger_text` function to use filing effective date for `ledger_text_dts` field in `ledger_text` table in COLIN db

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
