### PR TITLE
8388 Fixed colin api to return datetimes in UTC

### DIFF
--- a/colin-api/src/colin_api/utils/__init__.py
+++ b/colin-api/src/colin_api/utils/__init__.py
@@ -34,8 +34,15 @@ def convert_to_json_datetime(thedate: datetime.datetime) -> str:
     if not thedate:
         return None
     try:
-        # timezone info not in var (they are pacififc times so add timezone)
-        thedate = thedate.astimezone(timezone('US/Pacific'))
+        # timezone info not in var (they are pacific times so add timezone)
+        thedate = datetime.datetime(thedate.year,
+                                    thedate.month,
+                                    thedate.day,
+                                    thedate.hour,
+                                    thedate.minute,
+                                    thedate.second)
+        # treat date as naive date and add timezone by using localize function
+        thedate = timezone('US/Pacific').localize(thedate)
         # convert to utc time
         thedate = thedate.astimezone(timezone('UTC'))
         # return as string


### PR DESCRIPTION
*Issue #:* /bcgov/entity#8388

*Description of changes:*

* Updated `convert_to_json_datetime`(pacific to utc conversion) function to be os timezone independent.  In its previous form this function would work locally if the timezone of the environment python was running in was pacific timezone.  In my case, it was and it would work locally.  The colin api pod timezone is set to UTC so this function did not work.  The code has now been updated to ensure to treat the incoming date as a naive date and add the pacific timezone and then convert to a utc datetime string. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
