### PR TITLE
10596 create manual sql update script for existing businesses where state is null

### DIFF
--- a/legal-api/scripts/manual_db_scripts/2022_jan_6_business_state_update.sql
+++ b/legal-api/scripts/manual_db_scripts/2022_jan_6_business_state_update.sql
@@ -1,0 +1,54 @@
+-- Update for businesses where businesses.state is null to valid STATE for following scenarios:
+--    1. businesses.dissolution_date is not null and dissolution filing json has dissolutionType of
+--      'voluntary' or 'administrative'. Update businesses.state to 'HISTORICAL'
+--    2. businesses.dissolution_date is not null and dissolution filing json is not proper.  One of the businesses
+--          in PRD has a dissolution filing like this.  Update businesses.state to 'HISTORICAL'
+--    3. businesses.dissolution_date is not null and obsolete filing type of 'voluntaryDissolution` is used.
+--       Update businesses.state to 'HISTORICAL'
+--    4. businesses.dissolution_date is null.  Update businesses.state to `ACTIVE'
+
+-- scenario 1 (valid dissolution filing of sub type 'voluntary' or 'administrative')
+update businesses
+set state = 'HISTORICAL'
+where id in (
+    select b.id
+    from filings f
+             join businesses b ON f.business_id = b.id
+    where f.filing_type = 'dissolution'
+      and b.dissolution_date is not null
+      and b.state is null
+      and f.filing_json -> 'filing' -> 'dissolution' ->> 'dissolutionType' in ('voluntary', 'administrative')
+    );
+
+-- scenario 2 (dissolution filing json is incomplete but business has dissolution date)
+update businesses
+set state = 'HISTORICAL'
+where id in (
+    select b.id
+    from filings f
+             join businesses b ON f.business_id = b.id
+    where f.filing_type = 'dissolution'
+      and b.dissolution_date is not null
+      and b.state is null
+      and f.filing_json -> 'filing' -> 'dissolution' is null
+);
+
+-- scenario 3 (obsolete voluntaryDissolution filing type that was previously used)
+update businesses
+set state = 'HISTORICAL'
+where id in (
+    select b.id
+    from filings f
+             join businesses b ON f.business_id = b.id
+    where f.filing_type = 'voluntaryDissolution'
+      and b.dissolution_date is not null
+      and b.state is null);
+
+-- scenario 4 (business records that have not been dissolved)
+update businesses
+set state = 'ACTIVE'
+where id in (
+    select b.id
+    from businesses b
+    where b.state is null
+      and b.dissolution_date is null);


### PR DESCRIPTION
*Issue #:* /bcgov/entity#10596

Note: as this is a manual script, it does not need to be pushed to test for the voluntary dissolution release to go forward.  

*Description of changes:*

* Add sql script for updating business state.  
* New folder(`/legal_api/scripts/manual_db_scripts`) created to hold manual db scripts that should be run as one off and outside of alembic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
