### PR TITLE
Issue fix : Last AR and  AGM date in business summary

### DIFF
--- a/legal-api/src/legal_api/reports/business_document.py
+++ b/legal-api/src/legal_api/reports/business_document.py
@@ -118,14 +118,12 @@ class BusinessDocument:  # pylint: disable=too-few-public-methods
         business['business']['coopType'] = BusinessDocument.CP_TYPE_DESCRIPTION[self._business.association_type]\
             if self._business.association_type else 'Not Available'
         if self._business.last_ar_date:
-            last_ar_date = LegislationDatetime.as_legislation_timezone(self._business.last_ar_date).\
-                strftime('%B %-d, %Y')
+            last_ar_date = self._business.last_ar_date.strftime('%B %-d, %Y')
         else:
             last_ar_date = 'Not Available'
         business['business']['last_ar_date'] = last_ar_date
         if self._business.last_agm_date:
-            last_agm_date = LegislationDatetime.as_legislation_timezone(self._business.last_agm_date).\
-                strftime('%B %-d, %Y')
+            last_agm_date = self._business.last_agm_date.strftime('%B %-d, %Y')
         else:
             last_agm_date = 'Not Available'
         business['business']['last_agm_date'] = last_agm_date


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*
The last AR and AGM date has time stamp of 00:00:00+00. So converting it to Pacific Time Zone will show the previous date. There is no need for converting this date to Pacific Time Zone. Only format needs to be changed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
