### PR TITLE
10801 Updates and datafix script for fixing AR filing history displaying wrong year

### DIFF
--- a/legal-api/scripts/manual_db_scripts/2022_jan_31_add_ar_filing_year_to_meta_data.sql
+++ b/legal-api/scripts/manual_db_scripts/2022_jan_31_add_ar_filing_year_to_meta_data.sql
@@ -1,0 +1,80 @@
+-- Description:
+-- Update meta data for AR filings to include new annualReportFilingYear property so ledger filing display name for AR
+-- filings can be displayed correctly.  Previously, the ledger display name logic for AR filings was using the
+-- annualReportDate found in the filing meta_data field.  This worked for COLIN filings but not for LEAR COOP filings.
+-- With LEAR COOP filings there is a scenario where the user can select an annual report date from the UI that results
+-- in more than one LEAR AR filing with the same year for the annualReportDate property in the filing meta_data.
+-- Scenarios involved:
+--    1. COLIN AR filings have the correct year found in annualReportDate property of the filing meta data.
+--       Add annualReportFilingYear property to filing.meta_data by extracting year from existing  annualReportDate
+--       property found in the meta data for the COLIN AR filing.
+--    2. LEAR AR filings can populate the new annualReportFilingYear property in the filing meta data by joining
+--       against businesses_version table using the business id and transaction id.  The last_ar_year column value from
+--       the matching businesses_version row can then be used for the new annualReportFilingYear property value in
+--       the filing meta data.  Note: some LEAR AR filings json did have a ARFilingYear property that could be used
+--       to determine the value for annualReportFilingYear but not all LEAR AR filings had this property.  As such,
+--       we will just use the matching businesses_version table entries to populate the new annualReportFilingYear property
+--       in the filing meta data.
+
+-- start a transaction
+begin;
+
+-- scenario 1 (COLIN AR filings)
+with t as (
+    select f.id,
+           f.business_id,
+           f.source,
+           EXTRACT(YEAR FROM
+                   cast(f.meta_data -> 'annualReport' ->> 'annualReportDate' AS DATE)) AS annualReportFilingYear,
+           f.meta_data                                                                 as md
+    from filings f
+    where f.source = 'COLIN'
+      and f.filing_type = 'annualReport'
+      and f.meta_data is not null
+      and f.meta_data -> 'annualReport' -> 'annualReportFilingYear' is null
+)
+-- Add annualReportFilingYear to annualReport object of filing meta data
+UPDATE filings f
+SET meta_data=jsonb_insert(meta_data::jsonb, '{annualReport, annualReportFilingYear}',
+                           cast('' || t.annualReportFilingYear || '' as jsonb))
+    FROM t
+WHERE f.id = t.id;
+
+-- scenario 2 (LEAR AR filings)
+with t as (
+    select f.id,
+           f.business_id,
+           f.source,
+           f.transaction_id,
+           bv.last_ar_year as annualReportFilingYear,
+           f.meta_data     as md
+    from filings f
+             join businesses_version bv ON f.business_id = bv.id AND f.transaction_id = bv.transaction_id
+    where f.source = 'LEAR'
+      and f.filing_type = 'annualReport'
+      and f.meta_data is not null
+      and f.meta_data -> 'annualReport' -> 'annualReportFilingYear' is null
+)
+-- Add annualReportFilingYear to annualReport object of filing meta data
+UPDATE filings f
+SET meta_data=jsonb_insert(meta_data::jsonb, '{annualReport, annualReportFilingYear}',
+                           cast('' || t.annualReportFilingYear || '' as jsonb))
+    FROM t
+WHERE f.id = t.id;
+
+-- Verify - all AR filings have annualReportFilingYear property in filing meta data
+-- Expected value: 0
+select count(f.*) as cnt
+from filings f
+where f.filing_type = 'annualReport'
+  and f.meta_data is not null
+  and f.meta_data -> 'annualReport' -> 'annualReportFilingYear' is null;
+
+
+-- COMMIT OR ROLLBACK above updates after verification.  i.e. uncomment one of COMMIT or ROLLBACK commands below.
+
+-- uncomment COMMIT; command on next line execute if commit transaction if all verification checks out
+-- commit;
+
+-- uncomment ROLLBACK; command on next line and execute to rollback transaction if verification doesn't checkout
+-- rollback;

--- a/legal-api/src/legal_api/core/meta/filing.py
+++ b/legal-api/src/legal_api/core/meta/filing.py
@@ -19,7 +19,6 @@ from typing import Final, MutableMapping, Optional
 
 from legal_api.models import Business
 from legal_api.models import Filing as FilingStorage
-from legal_api.utils.datetime import date
 
 
 class AutoName(str, Enum):
@@ -247,8 +246,7 @@ class FilingMeta:  # pylint: disable=too-few-public-methods
     def get_effective_display_year(filing_meta_data: dict) -> Optional[str]:
         """Render a year as a string, given all filing mechanisms."""
         with suppress(IndexError, KeyError, TypeError):
-            report_date = filing_meta_data['annualReport']['annualReportDate']
-            return str(date.fromisoformat(report_date).year)
+            return str(filing_meta_data['annualReport']['annualReportFilingYear'])
         return None
 
     @staticmethod

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filings_ledger.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filings_ledger.py
@@ -221,7 +221,8 @@ def test_ledger_display_name_annual_report(session, client, jwt):
     today = date.today().isoformat()
     annual_report_meta = {'annualReport':{
         'annualReportDate': today,
-        'annualGeneralMeetingDate': today
+        'annualGeneralMeetingDate': today,
+        'annualReportFilingYear': date.fromisoformat(today).year
     }}
     meta_data = {**{'applicationDate': today}, **annual_report_meta}
 

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/annual_report.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/annual_report.py
@@ -28,16 +28,13 @@ def process(business: Business, filing: Dict, filing_meta: FilingMeta):
     legal_filing_name = 'annualReport'
     agm_date = filing[legal_filing_name].get('annualGeneralMeetingDate')
     ar_date = filing[legal_filing_name].get('annualReportDate')
+
     if ar_date:
         ar_date = datetime.date.fromisoformat(ar_date)
     else:
         # should never get here (schema validation should prevent this from making it to the filer)
         logger.error('No annualReportDate given for in annual report. Filing id: %s', filing.id)
 
-    # save the annual report date to the filing meta info
-    filing_meta.application_date = ar_date
-    filing_meta.annual_report = {'annualReportDate': ar_date.isoformat(),
-                                 'annualGeneralMeetingDate': agm_date}
     business.last_ar_date = ar_date
     if agm_date and validations.annual_report.requires_agm(business):
         with suppress(ValueError):
@@ -46,3 +43,9 @@ def process(business: Business, filing: Dict, filing_meta: FilingMeta):
             business.last_ar_date = agm_date
 
     business.last_ar_year = business.last_ar_year + 1 if business.last_ar_year else business.founding_date.year + 1
+
+    # save the annual report date to the filing meta info
+    filing_meta.application_date = ar_date
+    filing_meta.annual_report = {'annualReportDate': ar_date.isoformat(),
+                                 'annualGeneralMeetingDate': agm_date,
+                                 'annualReportFilingYear': business.last_ar_year}


### PR DESCRIPTION
*Issue #:* /bcgov/entity#10801

*Description of changes:*

* Update filer to include a new property in filing meta data for tracking annual report filing year
* Update legal api GET filing endpoint display logic for annual reports to use new filing meta data property for annual report filing year
* Fix broken legal api ledger AR test
* Manual sql script for updating COLIN and LEAR AR filings to have new annual report filing year property in filing meta data

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
