### PR TITLE
10311 before expiry set datetime correctly

### DIFF
--- a/queue_services/entity-emailer/src/entity_emailer/email_processors/nr_notification.py
+++ b/queue_services/entity-emailer/src/entity_emailer/email_processors/nr_notification.py
@@ -61,7 +61,8 @@ def process(email_info: dict, option) -> dict:  # pylint: disable-msg=too-many-l
     expiration_date = ''
     if nr_data['expirationDate']:
         exp_date = datetime.fromisoformat(nr_data['expirationDate'])
-        expiration_date = LegislationDatetime.format_as_report_string(exp_date)
+        exp_date_tz = LegislationDatetime.as_legislation_timezone(exp_date)
+        expiration_date = LegislationDatetime.format_as_report_string(exp_date_tz)
 
     refund_value = ''
     if option == Option.REFUND.value:

--- a/queue_services/entity-emailer/tests/unit/email_processors/test_nr_notification.py
+++ b/queue_services/entity-emailer/tests/unit/email_processors/test_nr_notification.py
@@ -83,7 +83,7 @@ def test_nr_notification(app, session, option, nr_number, subject, expiration_da
             exp_date = datetime.fromisoformat(expiration_date)
             exp_date_tz = LegislationDatetime.as_legislation_timezone(exp_date)
             assert_expiration_date = LegislationDatetime.format_as_report_string(exp_date_tz)
-            assert assert_expiration_date in call_args[0][0]['content']['body']
+            assert assert_expiration_date in email[0][0]['content']['body']
 
         if option == nr_notification.Option.EXPIRED.value:
             assert nr_number in email['content']['body']

--- a/queue_services/entity-emailer/tests/unit/email_processors/test_nr_notification.py
+++ b/queue_services/entity-emailer/tests/unit/email_processors/test_nr_notification.py
@@ -80,8 +80,10 @@ def test_nr_notification(app, session, option, nr_number, subject, expiration_da
         if option == nr_notification.Option.BEFORE_EXPIRY.value:
             assert nr_number in email['content']['body']
             assert expected_legal_name in email['content']['body']
-            exp_date = LegislationDatetime.format_as_report_string(datetime.fromisoformat(expiration_date))
-            assert exp_date in email['content']['body']
+            exp_date = datetime.fromisoformat(expiration_date)
+            exp_date_tz = LegislationDatetime.as_legislation_timezone(exp_date)
+            assert_expiration_date = LegislationDatetime.format_as_report_string(exp_date_tz)
+            assert assert_expiration_date in call_args[0][0]['content']['body']
 
         if option == nr_notification.Option.EXPIRED.value:
             assert nr_number in email['content']['body']

--- a/queue_services/entity-emailer/tests/unit/email_processors/test_nr_notification.py
+++ b/queue_services/entity-emailer/tests/unit/email_processors/test_nr_notification.py
@@ -83,7 +83,7 @@ def test_nr_notification(app, session, option, nr_number, subject, expiration_da
             exp_date = datetime.fromisoformat(expiration_date)
             exp_date_tz = LegislationDatetime.as_legislation_timezone(exp_date)
             assert_expiration_date = LegislationDatetime.format_as_report_string(exp_date_tz)
-            assert assert_expiration_date in email[0][0]['content']['body']
+            assert assert_expiration_date in email['content']['body']
 
         if option == nr_notification.Option.EXPIRED.value:
             assert nr_number in email['content']['body']

--- a/queue_services/entity-emailer/tests/unit/test_worker.py
+++ b/queue_services/entity-emailer/tests/unit/test_worker.py
@@ -266,8 +266,10 @@ def test_nr_notification(app, session, option, nr_number, subject, expiration_da
                 if option == nr_notification.Option.BEFORE_EXPIRY.value:
                     assert nr_number in call_args[0][0]['content']['body']
                     assert expected_legal_name in call_args[0][0]['content']['body']
-                    exp_date = LegislationDatetime.format_as_report_string(datetime.fromisoformat(expiration_date))
-                    assert exp_date in call_args[0][0]['content']['body']
+                    exp_date = datetime.fromisoformat(expiration_date)
+                    exp_date_tz = LegislationDatetime.as_legislation_timezone(exp_date)
+                    assert_expiration_date = LegislationDatetime.format_as_report_string(exp_date_tz)
+                    assert assert_expiration_date in call_args[0][0]['content']['body']
 
                 if option == nr_notification.Option.EXPIRED.value:
                     assert nr_number in call_args[0][0]['content']['body']


### PR DESCRIPTION
*Issue #:* /bcgov/entity#10311

*Description of changes:*


Before Expiry email display UTC time, set it to actual time
