### PR TITLE
Disable show documents for filing types with no outputs such as admin…

### DIFF
--- a/legal-api/src/legal_api/core/filing.py
+++ b/legal-api/src/legal_api/core/filing.py
@@ -401,13 +401,15 @@ class Filing:
     @staticmethod
     def common_ledger_items(business_identifier: str, filing_storage: FilingStorage) -> dict:
         """Return attributes and links that also get included in T-business filings."""
+        no_output_filing_types = ['Involuntary Dissolution']
         base_url = current_app.config.get('LEGAL_API_BASE_URL')
         filing = Filing()
         filing._storage = filing_storage  # pylint: disable=protected-access
         return {
             'commentsCount': filing_storage.comments_count,
             'commentsLink': f'{base_url}/{business_identifier}/filings/{filing_storage.id}/comments',
-            'documentsLink': f'{base_url}/{business_identifier}/filings/{filing_storage.id}/documents',
+            'documentsLink': f'{base_url}/{business_identifier}/filings/{filing_storage.id}/documents' if
+            filing_storage.filing_type not in no_output_filing_types else None,
             'filingLink': f'{base_url}/{business_identifier}/filings/{filing_storage.id}',
             'isFutureEffective': filing.is_future_effective,
         }

--- a/legal-api/tests/unit/core/test_filing_ledger.py
+++ b/legal-api/tests/unit/core/test_filing_ledger.py
@@ -71,3 +71,25 @@ def test_simple_ledger_search(session):
     # assert alteration['commentsLink']
     # assert alteration['correctionLink']
     # assert alteration['filingLink']
+
+
+def test_common_ledger_items(session):
+    """Assert that common ledger items works as expected."""
+    identifier = 'BC1234567'
+    founding_date = datetime.utcnow() - datedelta.datedelta(months=len(Filing.FILINGS.keys()))
+    business = factory_business(identifier=identifier, founding_date=founding_date, last_ar_date=None,
+                                entity_type=Business.LegalTypes.BCOMP.value)
+    filing = copy.deepcopy(FILING_TEMPLATE)
+    filing['filing']['header']['name'] = 'Involuntary Dissolution'
+    completed_filing = \
+        factory_completed_filing(business, filing, filing_date=founding_date + datedelta.datedelta(months=1))
+    common_ledger_items = CoreFiling.common_ledger_items(identifier, completed_filing)
+    assert common_ledger_items['documentsLink'] is None
+
+    filing['filing']['header']['name'] = 'dissolution'
+    completed_filing = \
+        factory_completed_filing(business, filing, filing_date=founding_date + datedelta.datedelta(months=1))
+    common_ledger_items = CoreFiling.common_ledger_items(identifier, completed_filing)
+    assert common_ledger_items['documentsLink'] is not None
+
+


### PR DESCRIPTION
…istrative dissolution

*Issue #:* /bcgov/entity#10933

*Description of changes:*
Some filing types such as Involuntary Dissolution will not have any reports available. This is to  indicate to the UI that  documents are not available at all. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
