### PR TITLE
8300 incorrect legal type displayed in ledger and IA output fix

### DIFF
--- a/legal-api/report-templates/incorporationApplication.html
+++ b/legal-api/report-templates/incorporationApplication.html
@@ -27,7 +27,7 @@
          </table>
          <div class="business-name-header">
             <label class="lbl-business-name">
-            {% if not incorporationApplication.nameRequest.nrNumber %}
+            {% if business.legalType == 'BEN' and not incorporationApplication.nameRequest.nrNumber %}
                Numbered Benefit Company
             {% else %}
                {{ incorporationApplication.nameRequest.legalName }}

--- a/legal-api/report-templates/template-parts/common/directors.html
+++ b/legal-api/report-templates/template-parts/common/directors.html
@@ -15,9 +15,9 @@
                   <span class="capitalize-text">{{ party.officer.middleName }}</span>
                 {% endif %}
               </div>
-              {% if party.hasCorrected %}
+              {% if party.hasCorrected is defined and party.hasCorrected %}
                 <span class="chip">CORRECTED</span>
-              {% elif party.hasRemoved %}
+              {% elif party.hasRemoved is defined and party.hasRemoved %}
                 <span class="chip">REMOVED</span>
               {% endif %}
             </td>

--- a/legal-api/src/legal_api/services/business_details_version.py
+++ b/legal-api/src/legal_api/services/business_details_version.py
@@ -218,6 +218,19 @@ class VersionedBusinessDetailsService:  # pylint: disable=too-many-public-method
         return VersionedBusinessDetailsService.business_revision_json(business_revision, business.json())
 
     @staticmethod
+    def get_business_revision_obj(transaction_id, business):
+        """Return business version object associated with a given transaction id for a business."""
+        business_version = version_class(Business)
+        business_revision = db.session.query(business_version) \
+            .filter(business_version.transaction_id <= transaction_id) \
+            .filter(business_version.operation_type != 2) \
+            .filter(business_version.id == business.id) \
+            .filter(or_(business_version.end_transaction_id == None,  # pylint: disable=singleton-comparison # noqa: E711,E501;
+                        business_version.end_transaction_id > transaction_id)) \
+            .order_by(business_version.transaction_id).one_or_none()
+        return business_revision
+
+    @staticmethod
     def get_business_revision_before_filing(filing_id, business_id) -> dict:
         """Consolidates the business info of the previous filing."""
         business = Business.find_by_internal_id(business_id)

--- a/legal-api/src/legal_api/services/filings/validations/registration.py
+++ b/legal-api/src/legal_api/services/filings/validations/registration.py
@@ -19,6 +19,7 @@ from typing import Dict, Final, Optional
 import pycountry
 from dateutil.relativedelta import relativedelta
 from flask_babel import _ as babel  # noqa: N813, I004, I001, I003
+
 from legal_api.errors import Error
 from legal_api.models import Business, PartyRole
 from legal_api.services import namex


### PR DESCRIPTION
*Issue #:* /bcgov/entity#8300

*Description of changes:*

* Update to retrieve legal type from business version table when retrieving display name for ledger items
* Fix IA output header to fix bug where header would display as "Numbered Benefit Company" for LTD IA
* Fixed misc linting error for registration validation
* Fix issue with `common/directors.html` where directors in IA filing were not being displayed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
