### PR TITLE
id for addresses

### DIFF
--- a/legal-api/src/legal_api/models/address.py
+++ b/legal-api/src/legal_api/models/address.py
@@ -67,6 +67,7 @@ class Address(db.Model):  # pylint: disable=too-many-instance-attributes
     def json(self):
         """Return a dict of this object, with keys in JSON format."""
         return {
+            'id': self.id,
             'streetAddress': self.street,
             'streetAddressAdditional': self.street_additional,
             'addressType': self.address_type,

--- a/legal-api/tests/unit/models/test_address.py
+++ b/legal-api/tests/unit/models/test_address.py
@@ -31,8 +31,9 @@ def test_address_json(session):
         region='BC',
         address_type=Address.MAILING
     )
-
+    address.save()
     address_json = {
+        'id': address.id,
         'streetAddress': address.street,
         'streetAddressAdditional': address.street_additional,
         'addressType': address.address_type,


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*
The data returned by the addresses endpoint must have id. That id will have to be passed back to the API for an edit request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
