### PR TITLE
11795 Fix issue retrieving draft correction filing via v2 endpoint

### DIFF
--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
@@ -259,8 +259,9 @@ class ListFilingResource():
             return jsonify(rv.redacted(rv.raw, jwt))
 
         if rv.filing_type == CoreFiling.FilingTypes.CORRECTION.value:
-            # This is required until #5302 ticket implements
-            rv.storage._filing_json['filing']['correction']['diff'] = rv.json['filing']['correction']['diff']  # pylint: disable=protected-access; # noqa: E501;
+            if diff := rv.json['filing']['correction'].get('diff'):
+                # This is required until #5302 ticket implements
+                rv.storage._filing_json['filing']['correction']['diff'] = diff  # pylint: disable=protected-access; # noqa: E501;
 
         if str(request.accept_mimetypes) == 'application/pdf':
             report_type = request.args.get('type', None)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#11795

*Description of changes:*

* Fix issue where draft correction was erroring out on no diff block for v2 filings endpoint

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
