### PR TITLE
11790 Add jupyter notebook for backfilling lear user data from auth

### DIFF
--- a/tests/data/common/auth_api_utils.ipynb
+++ b/tests/data/common/auth_api_utils.ipynb
@@ -152,6 +152,24 @@
     "    r = requests.get(url, headers=headers, verify=verify_ssl)\n",
     "    return r"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "066f05ca-38f2-41ff-9ac1-7908865a526d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_user_by_username(auth_token: str, username: str, verify_ssl = True):\n",
+    "    url = f'{AUTH_URL}/users/{username}'\n",
+    "    \n",
+    "    headers = {\n",
+    "      'Authorization': f'Bearer {auth_token}'\n",
+    "    }\n",
+    "\n",
+    "    r = requests.get(url, headers=headers, verify=verify_ssl)\n",
+    "    return r"
+   ]
   }
  ],
  "metadata": {

--- a/tests/data/misc/backfill_user_data.ipynb
+++ b/tests/data/misc/backfill_user_data.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "# Backfill Lear User Data from Auth\n",
-    "This notebook updates entries in the `users` table in lear db where first/last name are missing with data from the auth api. "
+    "This notebook updates entries in the `users` table in lear db where first/last name are missing with data from the auth api."
    ]
   },
   {
@@ -123,17 +123,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# loop through lear users with missing info and make call to auth users endpoint.  if valid response comes back, populate lear user \n",
+    "# loop through lear users with missing info and make call to auth users endpoint.  if valid response comes back, populate lear user\n",
     "# with missing info(first name, last name, email) where possible\n",
     "for lear_user in lear_users:\n",
-    "    \n",
+    "\n",
     "    try:\n",
     "        user_name = lear_user.username\n",
-    "        r = get_user_by_username(auth_token, user_name)\n",
+    "        r = get_user_by_username(auth_token, user_name, verify_ssl)\n",
     "\n",
     "        if r.status_code != 200:\n",
     "            raise Exception(f'error {r.status_code}, {r.text}')\n",
-    "            \n",
+    "\n",
     "        auth_user_dict = json.loads(r.text)\n",
     "        first_name = auth_user_dict.get('firstname')\n",
     "        last_name = auth_user_dict.get('lastname')\n",
@@ -145,11 +145,18 @@
     "            lear_user.save()\n",
     "        else:\n",
     "            raise Exception('no first name or last name provided by auth response')\n",
-    "        \n",
+    "\n",
     "        print(f'lear user user_name: {user_name} updated succeeded')\n",
     "    except Exception as err:\n",
     "        print(f'lear user user_name: {user_name} updated failed, {err}')\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",

--- a/tests/data/misc/backfill_user_data.ipynb
+++ b/tests/data/misc/backfill_user_data.ipynb
@@ -1,0 +1,183 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Backfill Lear User Data from Auth\n",
+    "This notebook updates entries in the `users` table in lear db where first/last name are missing with data from the auth api. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup environment\n",
+    "Before running following environment setup snippets, ensure environment variables found in `default-bcr-business-setup-TEST` notebook contain the correct values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%run /workspaces/lear/tests/data/default-bcr-business-setup-TEST.ipynb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%run /workspaces/lear/tests/data/common/legal_api_utils.ipynb\n",
+    "%run /workspaces/lear/tests/data/common/auth_api_utils.ipynb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from sqlalchemy import and_, or_\n",
+    "from legal_api.models import User"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Input Values for filing\n",
+    "Please update following values to appropriate values before running subsequent code snippets!!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "verify_ssl=True # set to False if using proxy to debug requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Tokens"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auth_token = get_auth_token(verify_ssl)\n",
+    "assert auth_token\n",
+    "# auth_token"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Update Lear Users"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get lear users with no first/last names and has a username\n",
+    "query = db.session.query(User) \\\n",
+    "    .filter(\n",
+    "        or_(\n",
+    "            User.firstname == None,\n",
+    "            User.firstname == ''\n",
+    "        ),\n",
+    "        or_(\n",
+    "            User.lastname == None,\n",
+    "            User.lastname == ''\n",
+    "        ),\n",
+    "        User.username != None,\n",
+    "        User.username != ''\n",
+    "    )\n",
+    "\n",
+    "lear_users = query.all()\n",
+    "assert(lear_users)\n",
+    "lear_users_count = len(lear_users)\n",
+    "print(f'lear users to process: {lear_users_count}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# loop through lear users with missing info and make call to auth users endpoint.  if valid response comes back, populate lear user \n",
+    "# with missing info(first name, last name, email) where possible\n",
+    "for lear_user in lear_users:\n",
+    "    \n",
+    "    try:\n",
+    "        user_name = lear_user.username\n",
+    "        r = get_user_by_username(auth_token, user_name)\n",
+    "\n",
+    "        if r.status_code != 200:\n",
+    "            raise Exception(f'error {r.status_code}, {r.text}')\n",
+    "            \n",
+    "        auth_user_dict = json.loads(r.text)\n",
+    "        first_name = auth_user_dict.get('firstname')\n",
+    "        last_name = auth_user_dict.get('lastname')\n",
+    "        email = auth_user_dict.get('email')\n",
+    "        if first_name or last_name or email:\n",
+    "            lear_user.firstname = first_name\n",
+    "            lear_user.lastname = last_name\n",
+    "            lear_user.email = email\n",
+    "            lear_user.save()\n",
+    "        else:\n",
+    "            raise Exception('no first name or last name provided by auth response')\n",
+    "        \n",
+    "        print(f'lear user user_name: {user_name} updated succeeded')\n",
+    "    except Exception as err:\n",
+    "        print(f'lear user user_name: {user_name} updated failed, {err}')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
*Issue #:* /bcgov/entity#11790

The notebook added in this PR for backfilling lear user data fixes a lot of instances where the lear user was missing first name and last name data.  This caused the ledger to fallback to displaying the username for the `filed by` value.

*Description of changes:*
* Added notebook(`/tests/data/misc/backfill_user_data.ipynb`) for backfilling lear user data from auth
* Added `get_user_by_username` function to `auth_api_utils.ipynb`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
