### PR TITLE
11771 Create SP/GP ETL pipeline for processing registration filings

### DIFF
--- a/data-tool/flows/common/event_filing_service.py
+++ b/data-tool/flows/common/event_filing_service.py
@@ -1,0 +1,49 @@
+import pandas as pd
+from sqlalchemy import engine, text
+from .firm_queries import get_firm_event_filing_data_query, \
+                          get_firm_event_filing_corp_party_data_query, \
+                          get_firm_event_filing_office_data_query
+from .query_utils import convert_result_set_to_dict
+
+class EventFilingService:
+    def __init__(self, db_engine: engine):
+        self.db_engine = db_engine
+
+    def get_registration_filing_data(self, corp_num: str, event_id: int):
+        with self.db_engine.connect() as conn:
+
+            # get base aggregated registration data that fits on one row
+            sql_text = get_firm_event_filing_data_query(corp_num, event_id)
+            rs = conn.execute(sql_text)
+            event_filing_data_dict = convert_result_set_to_dict(rs)
+            event_filing_data_dict = event_filing_data_dict[0]
+            # todo remove next 3 lines - for testing purposes only
+            corp_name = event_filing_data_dict['cn_corp_name']
+            corp_name = f'{corp_name} - IMPORT_TEST'
+            event_filing_data_dict['cn_corp_name'] = corp_name
+
+            # get corp party data
+            sql_text = get_firm_event_filing_corp_party_data_query(corp_num, event_id)
+            rs = conn.execute(sql_text)
+            event_filing_corp_party_data_dict = convert_result_set_to_dict(rs)
+            event_filing_data_dict['corp_parties'] = event_filing_corp_party_data_dict
+
+            # get office data
+            sql_text = get_firm_event_filing_office_data_query(corp_num, event_id)
+            rs = conn.execute(sql_text)
+            event_filing_office_data_dict = convert_result_set_to_dict(rs)
+            event_filing_data_dict['offices'] = event_filing_office_data_dict
+
+            return event_filing_data_dict
+
+    def get_event_filing_data(self, corp_num: str, event_id: int, event_file_type: str):
+        if event_file_type == 'FILE_FRREG':
+            return self.get_registration_filing_data(corp_num, event_id)
+
+        return None
+
+    def get_event_filing_is_supported(self, event_file_type: str):
+        if event_file_type == 'FILE_FRREG':
+            return True
+
+        return False

--- a/data-tool/flows/common/firm_filing_base_json.py
+++ b/data-tool/flows/common/firm_filing_base_json.py
@@ -1,0 +1,107 @@
+
+def get_base_sp_registration_json(num_parties: int):
+    registration_json = get_base_registration_json()
+    parties = registration_json['filing']['registration']['parties']
+    for x in range(num_parties):
+        parties.append(get_base_party_json())
+    return registration_json
+
+
+def get_base_registration_json():
+    registration_json = {
+        'filing': {
+            'header': {
+                'date': None,
+                'name': 'registration',
+                'certifiedBy': None,
+                'folioNumber': '',
+                'isFutureEffective': False
+            },
+            'business': {
+                'legalType': None,
+                'identifier': None,
+                'foundingDate': None
+            },
+            'registration': {
+                'offices': {
+                    'businessOffice': {
+                        'mailingAddress': {
+                            'postalCode': None,
+                            'addressCity': None,
+                            'addressRegion': None,
+                            'streetAddress': None,
+                            'addressCountry': None,
+                            'streetAddressAdditional': None,
+                            'deliveryInstructions': None
+                        },
+                        'deliveryAddress': {
+                            'postalCode': None,
+                            'addressCity': None,
+                            'addressRegion': None,
+                            'streetAddress': None,
+                            'addressCountry': None,
+                            'streetAddressAdditional': None,
+                            'deliveryInstructions': None
+                        }
+                    }
+                },
+                'parties': [],
+                'business': {
+                    'naics': {
+                        'naicsCode': None,
+                        'naicsDescription': None
+                    },
+                    'identifier': None
+                },
+                'startDate': None,
+                'nameRequest': {
+                    'nrNumber': None,
+                    'legalName': None,
+                    'legalType': None
+                },
+                'businessType': None,
+                'contactPoint': {
+                    'email': None,
+                    'phone': None
+                }
+            }
+        }
+    }
+    return registration_json
+
+
+def get_base_party_json():
+    party_json = {
+            'roles': [
+                {
+                    'roleType': None
+                }
+            ],
+            'officer': {
+                'email': None,
+                'lastName': None,
+                'firstName': None,
+                'partyType': None,
+                'middleName': None,
+                'organizationName': None,
+                'identifier': None
+            },
+            'mailingAddress': {
+                'postalCode': None,
+                'addressCity': None,
+                'addressRegion': None,
+                'streetAddress': None,
+                'addressCountry': None,
+                'streetAddressAdditional': None
+            },
+            'deliveryAddress': {
+                'postalCode': None,
+                'addressCity': None,
+                'addressRegion': None,
+                'streetAddress': None,
+                'addressCountry': None,
+                'streetAddressAdditional': None,
+                'deliveryInstructions': None
+            }
+        }
+    return party_json

--- a/data-tool/flows/common/firm_filing_data_utils.py
+++ b/data-tool/flows/common/firm_filing_data_utils.py
@@ -1,0 +1,46 @@
+
+
+def get_certified_by(filing_data: dict):
+    user_id = filing_data.get('u_user_id')
+    if user_id:
+        first_name = filing_data.get('u_first_name')
+        middle_name = filing_data.get('u_middle_name')
+        last_name = filing_data.get('u_last_name')
+        if first_name or middle_name or last_name:
+            result = f'{first_name} {middle_name} {last_name}'
+            result = result.strip()
+            return result
+        return user_id
+
+    return ''
+
+
+def get_street_additional(addr_line_2: str, addr_line_3: str):
+    addr_line_2 = addr_line_2 if addr_line_2 else ''
+    addr_line_2 = addr_line_2.strip()
+    addr_line_3 = addr_line_3 if addr_line_3 else ''
+    result = f'{addr_line_2} {addr_line_3}'
+    result = result.strip()
+    return result
+
+
+def get_party_role_type(corp_type_cd: str, role_type: str):
+    if role_type == 'FCP':
+        return 'Completing Party'
+    elif role_type == 'FIO' or role_type == 'FBO':
+        if corp_type_cd == 'SP':
+            return 'Proprietor'
+        elif corp_type_cd == 'GP':
+            return 'Partner'
+        else:
+            return None
+    else:
+        return None
+
+
+def get_party_type(role_type: str, filing_party_data: dict):
+    corp_party_business_name = filing_party_data['cp_business_name']
+    if corp_party_business_name:
+        return 'organization'
+
+    return 'person'

--- a/data-tool/flows/common/firm_filing_json_factory.py
+++ b/data-tool/flows/common/firm_filing_json_factory.py
@@ -1,0 +1,186 @@
+from .firm_filing_base_json import get_base_sp_registration_json
+from .firm_filing_data_utils import get_certified_by, get_street_additional, get_party_role_type, get_party_type
+
+def get_registration_sp_filing_json(filing_data: dict):
+    result = build_registration_sp_filing(filing_data)
+    return result
+
+
+def build_registration_sp_filing(filing_data: dict):
+    num_parties = len(filing_data['corp_parties'])
+    filing_dict = get_base_sp_registration_json(num_parties)
+    corp_type_cd = filing_data['c_corp_type_cd']
+
+    populate_header(filing_dict, filing_data)
+    populate_filing_business(filing_dict, filing_data)
+    populate_registration(filing_dict, filing_data, corp_type_cd)
+    return filing_dict
+
+
+def populate_header(filing_dict: dict, filing_data: dict):
+    header = filing_dict['filing']['header']
+    effective_dts = filing_data['f_effective_dts']
+    effective_dt_str = effective_dts.strftime('%Y-%m-%d')
+    header['date'] = effective_dt_str
+
+    certified_by = get_certified_by(filing_data)
+    header['certifiedBy'] = certified_by
+    header['folioNumber'] = filing_data['p_folio_num']
+
+
+def populate_filing_business(filing_dict: dict, filing_data: dict):
+    business_dict = filing_dict['filing']['business']
+    business_dict['legalType'] = filing_data['c_corp_type_cd']
+    business_dict['identifier'] = filing_data['c_corp_num']
+    business_dict['foundingDate'] = str(filing_data['bd_business_start_date'])
+
+def populate_registration(filing_dict: dict, filing_data: dict, corp_type_cd: str):
+    registration_dict = filing_dict['filing']['registration']
+
+    registration_dict['businessType'] = filing_data['c_corp_type_cd']
+    registration_dict['startDate'] = str(filing_data['c_recognition_dts'])
+
+    populate_registration_business(registration_dict, filing_data)
+    populate_registration_offices(registration_dict, filing_data)
+    populate_registration_parties(registration_dict, filing_data, corp_type_cd)
+    populate_registration_nr(registration_dict, filing_data)
+
+
+def populate_registration_offices(registration_dict: dict, filing_data: dict):
+    office = registration_dict['offices']['businessOffice']
+    filing_data_office = filing_data['offices'][0]
+
+    mailing_addr = office['mailingAddress']
+    populate_address(mailing_addr, filing_data_office, 'ma_')
+
+    delivery_addr = office['deliveryAddress']
+    populate_address(delivery_addr, filing_data_office, 'da_')
+
+
+def populate_registration_parties(registration_dict: dict, filing_data: dict, corp_type_cd: str):
+    parties = registration_dict['parties']
+
+    for idx, party in enumerate(parties):
+        filing_data_party = filing_data['corp_parties'][idx]
+        populate_registration_party(party, filing_data_party, corp_type_cd)
+
+        mailing_addr_id = filing_data_party['ma_addr_id']
+        if mailing_addr_id:
+            mailing_addr = party['mailingAddress']
+            populate_address(mailing_addr, filing_data_party, 'ma_')
+        else:
+            del party['mailingAddress']
+
+        delivery_addr_id = filing_data_party['da_addr_id']
+        if delivery_addr_id:
+            delivery_addr = party['deliveryAddress']
+            populate_address(delivery_addr, filing_data_party, 'da_')
+        else:
+            del party['deliveryAddress']
+
+
+def populate_registration_party(party_dict: dict, filing_party_data: dict, corp_type_cd: str):
+    party_role_dict = party_dict['roles'][0]
+    party_officer_dict = party_dict['officer']
+
+    populate_party_role(party_role_dict, filing_party_data, corp_type_cd)
+    populate_party_officer(party_officer_dict, filing_party_data)
+
+
+def populate_party_role(party_role: dict, filing_party_data: dict, corp_type_cd: str):
+    party_role_type = get_party_role_type(corp_type_cd, filing_party_data['cp_party_typ_cd'])
+    party_role['roleType'] = party_role_type
+    party_role['appointmentDate'] = filing_party_data['cp_appointment_dt']
+
+
+def populate_party_officer(party_officer: dict, filing_party_data: dict):
+    party_role_type = filing_party_data['cp_party_typ_cd']
+    party_type = get_party_type(party_role_type, filing_party_data)
+    party_officer['email'] = filing_party_data['cp_email_address']
+    party_officer['lastName'] = filing_party_data['cp_last_name']
+    party_officer['firstName'] = filing_party_data['cp_first_name']
+    party_officer['middleName'] = filing_party_data['cp_middle_name']
+    party_officer['partyType'] = party_type
+    party_officer['organizationName'] = filing_party_data['cp_business_name']
+    party_officer['identifier'] = filing_party_data['cp_bus_company_num']
+
+
+def populate_address(address_dict: dict, filing_data: dict, address_key_prefix: str):
+    address_format_type_key = f'{address_key_prefix}address_format_type'
+    address_format_type = filing_data[address_format_type_key]
+
+    if address_format_type == 'BAS':
+        # todo sort out how basic should work
+        # populate_basic_address(address_dict, filing_data, address_key_prefix)
+        populate_foreign_address(address_dict, filing_data, address_key_prefix)
+    elif address_format_type == 'FOR':
+        populate_foreign_address(address_dict, filing_data, address_key_prefix)
+    elif address_format_type == 'ADV':
+        # todo sort out how advanced should work
+        # populate_advanced_address(address_dict, filing_data, address_key_prefix)
+        populate_foreign_address(address_dict, filing_data, address_key_prefix)
+    else:
+        raise Exception('unknown address format type: ' + address_format_type)
+
+
+def populate_basic_address(address_dict: dict, filing_data: dict, address_key_prefix: str):
+
+    unit_type_key = f'{address_key_prefix}unit_type'
+    unit_no_key = f'{address_key_prefix}unit_no'
+    civic_no_key = f'{address_key_prefix}civic_no'
+    civic_no_suffix_key = f'{address_key_prefix}civic_no_suffix'
+    street_name_key = f'{address_key_prefix}street_name'
+    street_type_key = f'{address_key_prefix}street_type'
+    street_direction_key = f'{address_key_prefix}street_direction'
+
+    postal_code_key = f'{address_key_prefix}postal_cd'
+    city_key = f'{address_key_prefix}city'
+    province_key = f'{address_key_prefix}province'
+
+
+def populate_advanced_address(address_dict: dict, filing_data: dict, address_key_prefix: str):
+    raise Exception('still need to implement')
+
+
+def populate_foreign_address(address_dict: dict, filing_data: dict, address_key_prefix: str):
+    postal_code_key = f'{address_key_prefix}postal_cd'
+    city_key = f'{address_key_prefix}city'
+    province_key = f'{address_key_prefix}province'
+    country_key = f'{address_key_prefix}country_typ_cd'
+    delivery_instructions_key = f'{address_key_prefix}delivery_instructions'
+    addr_line_1_key = f'{address_key_prefix}addr_line_1'
+    addr_line_2_key = f'{address_key_prefix}addr_line_2'
+    addr_line_3_key = f'{address_key_prefix}addr_line_3'
+    addr_line_2 = filing_data[addr_line_2_key]
+    addr_line_3 = filing_data[addr_line_3_key]
+    street_additional = get_street_additional(addr_line_2, addr_line_3)
+
+    address_dict['postalCode'] = filing_data[postal_code_key]
+    address_dict['addressCity'] = filing_data[city_key]
+    address_dict['addressRegion'] = filing_data[province_key]
+    address_dict['addressCountry'] = filing_data[country_key]
+    address_dict['streetAddress'] = filing_data[addr_line_1_key]
+    address_dict['streetAddressAdditional'] = street_additional
+    address_dict['deliveryInstructions'] = filing_data[delivery_instructions_key]
+
+
+def populate_registration_business(registration_dict: dict, filing_data: dict):
+    business_dict = registration_dict['business']
+    naics_dict = business_dict['naics']
+
+    business_dict['identifier'] = filing_data['c_corp_num']
+
+    populate_naics(naics_dict, filing_data)
+
+
+def populate_naics(naics_dict: dict, filing_data: dict):
+    naics_dict['naicsCode'] = filing_data['bd_naics_code']
+    naics_dict['naicsDescription'] = filing_data['bd_description']
+
+
+def populate_registration_nr(registration_dict: dict, filing_data: dict):
+    nr_dict = registration_dict['nameRequest']
+
+    nr_dict['nrNumber'] = filing_data['f_nr_num']
+    nr_dict['legalName'] = filing_data['cn_corp_name']
+    nr_dict['legalType'] = filing_data['c_corp_type_cd']

--- a/data-tool/flows/common/firm_queries.py
+++ b/data-tool/flows/common/firm_queries.py
@@ -1,0 +1,249 @@
+def get_unprocessed_firms_query():
+    query = f"""
+            select tbl_fe.*, cp.flow_name, cp.processed_status
+            from (select e.corp_num,
+                         count(e.corp_num)                         as cnt,
+                         string_agg(e.event_type_cd || '_' || COALESCE(f.filing_type_cd, 'NULL'), ', '
+                                    order by e.event_id)           as event_file_types,
+                         array_agg(e.event_id order by e.event_id) as event_ids,
+                         min(e.event_id)                           as first_event_id
+                  from event e
+                           left outer join filing f on e.event_id = f.event_id
+                  where 1 = 1
+                  group by e.corp_num) as tbl_fe
+                     left outer join corp_processing cp on cp.corp_num = tbl_fe.corp_num and cp.flow_name = 'sp-gp-flow'
+            where 1 = 1
+             and tbl_fe.event_file_types like 'FILE_FRREG%'
+              and (cp.processed_status is null or cp.processed_status <> 'COMPLETED')
+            order by tbl_fe.first_event_id
+            limit 100
+            ;
+        """
+    return query
+
+
+def get_firm_event_filing_data_query(corp_num: str, event_id: int):
+    query = f"""
+        select
+            -- event
+            e.event_id             as e_event_id,
+            e.corp_num             as e_corp_num,
+            e.event_type_cd        as e_event_type_cd,
+            e.trigger_dts          as e_trigger_dts,
+            -- filing
+            f.event_id             as f_event_id,
+            f.filing_type_cd       as f_filing_type_cd,
+            TO_TIMESTAMP(to_char(f.effective_dt, 'YYYY-MM-DD'), 'YYYY-MM-DD') as f_effective_dts,
+            f.withdrawn_event_id   as f_withdrawn_event_id,
+            f.ods_type_cd          as f_ods_type,
+            f.nr_num               as f_nr_num,
+            -- corporation
+            c.corp_num             as c_corp_num,
+            c.corp_frozen_type_cd  as c_corp_frozen_type_cd,
+            c.corp_type_cd         as c_corp_type_cd,
+            TO_TIMESTAMP(to_char(c.recognition_dts, 'YYYY-MM-DD'), 'YYYY-MM-DD') as c_recognition_dts,
+            c.bn_9                 as c_bn_9,
+            c.bn_15                as c_bn_15,
+            c.admin_email          as c_admin_email,
+            -- corp_name
+            cn.corp_num            as cn_corp_num,
+            cn.corp_name_typ_cd    as cn_corp_name_typ_cd,
+            cn.start_event_id      as cn_start_event_id,
+            cn.end_event_id        as cn_end_event_id,
+            cn.corp_name           as cn_corp_name,
+            -- corp_state
+            cs.corp_num            as cs_corp_num,
+            cs.start_event_id      as cs_start_event_id,
+            cs.end_event_id        as cs_end_event_id,
+            cs.state_type_cd       as cs_corp_state_typ_cd,
+            -- business_description
+            bd.corp_num            as bd_corp_num,
+            bd.start_event_id      as bd_start_event_id,
+            bd.end_event_id        as bd_end_event_id,
+            TO_TIMESTAMP(to_char(bd.business_start_date, 'YYYY-MM-DD'), 'YYYY-MM-DD') as bd_business_start_date,
+            bd.naics_code          as bd_naics_code,
+            bd.description         as bd_description,
+            -- ledger_text
+            lt.event_id            as lt_event_id,
+            lt.notation            as lt_notation,
+            -- payment
+            p.event_id             as p_event_id,
+            p.payment_typ_cd       as payment_typ_cd,
+            p.fee_cd               as p_fee_cd,
+            p.gst_num              as p_gst_num,
+            p.bcol_account_num     as p_bcol_account_num,
+            p.payment_total        as p_payment_total,
+            p.folio_num            as p_folio_num,
+            p.dat_num              as p_dat_num,
+            p.routing_slip         as p_routing_slip,
+            p.fas_balance          as p_fas_balance,
+            -- filing user
+            u.event_id             as u_event_id,
+            u.user_id              as u_user_id,
+            u.last_name            as u_last_name,
+            u.first_name           as u_first_name,
+            u.middle_name          as u_middle_name,
+            u.email_addr           as u_email_addr
+        from event e
+                 left outer join filing f on e.event_id = f.event_id
+                 left outer join corporation c on c.corp_num = e.corp_num
+                 left outer join corp_name cn on cn.start_event_id = e.event_id
+                 left outer join corp_state cs on cs.start_event_id = e.event_id
+                 left outer join business_description bd on bd.start_event_id = e.event_id
+                 left outer join ledger_text lt on lt.event_id = e.event_id
+                 left outer join payment p on p.event_id = e.event_id
+                 left outer join filing_user u on u.event_id = e.event_id
+        where 1 = 1
+          and e.corp_num = '{corp_num}'
+          and e.event_id = {event_id}
+        order by e.event_id
+        ;
+        """
+    return query
+
+
+def get_firm_event_filing_corp_party_data_query(corp_num: str, event_id: int):
+    query = f"""
+        select cp.corp_party_id                                                     as cp_corp_party_id,
+               cp.mailing_addr_id                                                   as cp_mailing_addr_id,
+               cp.delivery_addr_id                                                  as cp_delivery_addr_id,
+               cp.corp_num                                                          as cp_corp_num,
+               cp.party_typ_cd                                                      as cp_party_typ_cd,
+               cp.start_event_id                                                    as cp_start_event_id,
+               cp.end_event_id                                                      as cp_end_event_id,
+               cp.prev_party_id                                                     as cp_prev_party_id,
+               TO_CHAR(cp.appointment_dt, 'YYYY-MM-DD')                             as cp_appointment_dt,
+               cp.last_name              as cp_last_name,
+               cp.middle_name            as cp_middle_name,
+               cp.first_name             as cp_first_name,
+               cp.business_name          as cp_business_name,
+               NULLIF(cp.bus_company_num, '')                                       as cp_bus_company_num,
+               cp.email_address          as cp_email_address,
+               cp.phone                  as cp_phone,
+               -- mailing address
+               ma.addr_id                as ma_addr_id,
+               ma.province               as ma_province,
+               ma.country_typ_cd         as ma_country_typ_cd,
+               ma.postal_cd              as ma_postal_cd,
+               ma.addr_line_1            as ma_addr_line_1,
+               ma.addr_line_2            as ma_addr_line_2,
+               ma.addr_line_3            as ma_addr_line_3,
+               ma.city                   as ma_city,
+               ma.address_format_type    as ma_address_format_type,
+               ma.delivery_instructions  as ma_delivery_instructions,
+               ma.unit_no                as ma_unit_no,
+               ma.unit_type              as ma_unit_type,
+               ma.civic_no               as ma_civic_no,
+               ma.civic_no_suffix        as ma_civic_no_suffix,
+               ma.street_name            as ma_street_name,
+               ma.street_type            as ma_street_type,
+               ma.street_direction       as ma_street_direction,
+               ma.lock_box_no            as ma_lock_box_no,
+               ma.installation_type      as ma_installation_type,
+               ma.installation_name      as ma_installation_name,
+               ma.installation_qualifier as ma_installation_qualifier,
+               ma.route_service_type     as ma_route_service_type,
+               ma.route_service_no       as ma_route_service_no,
+               -- delivery address
+               da.addr_id                as da_addr_id,
+               da.province               as da_province,
+               da.country_typ_cd         as da_country_typ_cd,
+               da.postal_cd              as da_postal_cd,
+               da.addr_line_1            as da_addr_line_1,
+               da.addr_line_2            as da_addr_line_2,
+               da.addr_line_3            as da_addr_line_3,
+               da.city                   as da_city,
+               da.address_format_type    as da_address_format_type,
+               da.delivery_instructions  as da_delivery_instructions,
+               da.unit_no                as da_unit_no,
+               da.unit_type              as da_unit_type,
+               da.civic_no               as da_civic_no,
+               da.civic_no_suffix        as da_civic_no_suffix,
+               da.street_name            as da_street_name,
+               da.street_type            as da_street_type,
+               da.street_direction       as da_street_direction,
+               da.lock_box_no            as da_lock_box_no,
+               da.installation_type      as da_installation_type,
+               da.installation_name      as da_installation_name,
+               da.installation_qualifier as da_installation_qualifier,
+               da.route_service_type     as da_route_service_type,
+               da.route_service_no       as da_route_service_no
+        from event e
+                 join corp_party cp on cp.start_event_id = e.event_id
+                 left outer join address ma on cp.mailing_addr_id = ma.addr_id
+                 left outer join address da on cp.delivery_addr_id = da.addr_id
+        where 1 = 1
+          and e.corp_num = '{corp_num}'
+          and e.event_id = {event_id}
+        order by e.event_id
+        ;
+        """
+    return query
+
+
+def get_firm_event_filing_office_data_query(corp_num: str, event_id: int):
+    query = f"""
+        select o.corp_num                as o_corp_num,
+               o.office_typ_cd           as o_office_typ_cd,
+               o.start_event_id          as o_start_event_id,
+               o.end_event_id            as o_end_event_id,
+               o.mailing_addr_id         as o_mailing_addr_id,
+               o.delivery_addr_id        as o_delivery_addr_id,
+               -- mailing address
+               ma.addr_id                as ma_addr_id,
+               ma.province               as ma_province,
+               ma.country_typ_cd         as ma_country_typ_cd,
+               ma.postal_cd              as ma_postal_cd,
+               ma.addr_line_1            as ma_addr_line_1,
+               ma.addr_line_2            as ma_addr_line_2,
+               ma.addr_line_3            as ma_addr_line_3,
+               ma.city                   as ma_city,
+               ma.address_format_type    as ma_address_format_type,
+               ma.delivery_instructions  as ma_delivery_instructions,
+               ma.unit_no                as ma_unit_no,
+               ma.unit_type              as ma_unit_type,
+               ma.civic_no               as ma_civic_no,
+               ma.civic_no_suffix        as ma_civic_no_suffix,
+               ma.street_name            as ma_street_name,
+               ma.street_type            as ma_street_type,
+               ma.street_direction       as ma_street_direction,
+               ma.lock_box_no            as ma_lock_box_no,
+               ma.installation_type      as ma_installation_type,
+               ma.installation_name      as ma_installation_name,
+               ma.installation_qualifier as ma_installation_qualifier,
+               ma.route_service_type     as ma_route_service_type,
+               ma.route_service_no       as ma_route_service_no,
+               -- delivery address
+               da.addr_id                as da_addr_id,
+               da.province               as da_province,
+               da.country_typ_cd         as da_country_typ_cd,
+               da.postal_cd              as da_postal_cd,
+               da.addr_line_1            as da_addr_line_1,
+               da.addr_line_2            as da_addr_line_2,
+               da.addr_line_3            as da_addr_line_3,
+               da.city                   as da_city,
+               da.address_format_type    as da_address_format_type,
+               da.delivery_instructions  as da_delivery_instructions,
+               da.unit_no                as da_unit_no,
+               da.unit_type              as da_unit_type,
+               da.civic_no               as da_civic_no,
+               da.civic_no_suffix        as da_civic_no_suffix,
+               da.street_name            as da_street_name,
+               da.street_type            as da_street_type,
+               da.street_direction       as da_street_direction,
+               da.lock_box_no            as da_lock_box_no,
+               da.installation_type      as da_installation_type,
+               da.installation_name      as da_installation_name,
+               da.installation_qualifier as da_installation_qualifier,
+               da.route_service_type     as da_route_service_type,
+               da.route_service_no       as da_route_service_no
+        from event e
+                 join office o on o.start_event_id = e.event_id
+                 left outer join address ma on o.mailing_addr_id = ma.addr_id
+                 left outer join address da on o.delivery_addr_id = da.addr_id
+        where 1 = 1
+          and e.corp_num = '{corp_num}'
+          and e.event_id = {event_id}
+        ;
+        """
+    return query

--- a/data-tool/flows/common/processing_status_service.py
+++ b/data-tool/flows/common/processing_status_service.py
@@ -1,0 +1,25 @@
+from sqlalchemy import engine, text
+
+
+class ProcessingStatusService:
+    def __init__(self, db_engine: engine):
+        self.db_engine = db_engine
+
+    def update_flow_status(self, flow_name: str, corp_num:str, corp_name: str, processed_status: str):
+        query = f"""
+            insert into corp_processing (corp_num, corp_name, flow_name, processed_status)
+            VALUES (:corp_num, :corp_name, :flow_name, :processed_status)
+            ON CONFLICT (corp_num, flow_name)
+                DO UPDATE SET processed_status = :processed_status;
+        """
+
+        with self.db_engine.connect() as conn:
+            sql_text = text(query)
+            rs = conn.execute(sql_text,
+                              corp_num=corp_num,
+                              corp_name=corp_name,
+                              flow_name=flow_name,
+                              processed_status=processed_status)
+
+
+

--- a/data-tool/flows/common/query_utils.py
+++ b/data-tool/flows/common/query_utils.py
@@ -1,0 +1,6 @@
+import pandas as pd
+
+def convert_result_set_to_dict(rs):
+    df = pd.DataFrame(rs, columns=rs.keys())
+    result_dict = df.to_dict('records')
+    return result_dict

--- a/data-tool/flows/config.py
+++ b/data-tool/flows/config.py
@@ -79,6 +79,14 @@ class _Config():  # pylint: disable=too-few-public-methods
         name=DB_NAME,
     )
 
+    # service accounts
+    ACCOUNT_SVC_AUTH_URL = os.getenv('ACCOUNT_SVC_AUTH_URL')
+    ACCOUNT_SVC_ENTITY_URL = os.getenv('ACCOUNT_SVC_ENTITY_URL')
+    ACCOUNT_SVC_AFFILIATE_URL = os.getenv('ACCOUNT_SVC_AFFILIATE_URL')
+    ACCOUNT_SVC_CLIENT_ID = os.getenv('ACCOUNT_SVC_CLIENT_ID')
+    ACCOUNT_SVC_CLIENT_SECRET = os.getenv('ACCOUNT_SVC_CLIENT_SECRET')
+    ACCOUNT_SVC_TIMEOUT = os.getenv('ACCOUNT_SVC_TIMEOUT')
+
     TESTING = False
     DEBUG = False
 

--- a/data-tool/flows/custom_filer/__init__.py
+++ b/data-tool/flows/custom_filer/__init__.py
@@ -1,0 +1,13 @@
+# Copyright © 2022 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/data-tool/flows/custom_filer/filer.py
+++ b/data-tool/flows/custom_filer/filer.py
@@ -1,0 +1,127 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The unique worker functionality for this service is contained here.
+
+The entry-point is the **cb_subscription_handler**
+
+The design and flow leverage a few constraints that are placed upon it
+by NATS Streaming and using AWAIT on the default loop.
+- NATS streaming queues require one message to be processed at a time.
+- AWAIT on the default loop effectively runs synchronously
+
+If these constraints change, the use of Flask-SQLAlchemy would need to change.
+Flask-SQLAlchemy currently allows the base model to be changed, or reworking
+the model to a standalone SQLAlchemy usage with an async engine would need
+to be pursued.
+"""
+import json
+from typing import Dict
+
+from flask import Flask
+from legal_api.core import Filing as FilingCore
+from legal_api.models import Business, Filing
+from sqlalchemy_continuum import versioning_manager
+
+from .filing_meta import FilingMeta, json_serial
+from .filing_processors import registration
+
+
+def get_filing_types(legal_filings: dict):
+    """Get the filing type fee codes for the filing.
+
+    Returns: {
+        list: a list of filing types.
+    }
+    """
+    filing_types = []
+    for k in legal_filings['filing'].keys():
+        if Filing.FILINGS.get(k, None):
+            filing_types.append(k)
+    return filing_types
+
+
+def process_filing(filing_id: int, filing_event_data: Dict, db: any):
+    """Render the filings contained in the submission.
+
+    Start the migration to using core/Filing
+    """
+
+    filing_submission = Filing.find_by_id(filing_id)
+    filing_core_submission = FilingCore.find_by_id(filing_id)
+
+
+    if not filing_core_submission:
+        raise Exception('not filing_core_submission')
+
+    filing_submission = filing_core_submission.storage
+
+    if filing_core_submission.status == Filing.Status.COMPLETED:
+        print(f"""QueueFiler: Attempting to reprocess business.id={filing_submission.business_id}, 
+                  filing.id={filing_submission.id}""")
+        return None, None
+
+    # convenience flag to set that the envelope is a correction
+    is_correction = (filing_core_submission.filing_type == FilingCore.FilingTypes.CORRECTION)
+
+    if legal_filings := filing_core_submission.legal_filings(with_diff=False):
+        uow = versioning_manager.unit_of_work(db.session)
+        transaction = uow.create_transaction(db.session)
+
+        business = Business.find_by_internal_id(filing_submission.business_id)
+
+        filing_meta = FilingMeta(application_date=filing_submission.effective_date,
+                                 legal_filings=[item for sublist in
+                                                [list(x.keys()) for x in legal_filings]
+                                                for item in sublist])
+        if is_correction:
+            filing_meta.correction = {}
+
+        for filing in legal_filings:
+
+            if filing.get('registration'):
+                business, filing_submission, filing_meta = registration.process(business,
+                                                                                filing_core_submission.json,
+                                                                                filing_submission,
+                                                                                filing_meta,
+                                                                                filing_event_data)
+
+            # elif filing.get('changeOfRegistration'):
+            #     change_of_registration.process(business, filing_submission, filing, filing_meta)
+            #
+
+        filing_submission.transaction_id = transaction.id
+        filing_submission.set_processed()
+        filing_submission._meta_data = json.loads(  # pylint: disable=W0212
+            json.dumps(filing_meta.asjson, default=json_serial)
+        )
+
+        db.session.add(business)
+        db.session.add(filing_submission)
+        db.session.commit()
+
+        #
+        # if any('changeOfRegistration' in x for x in legal_filings):
+        #     change_of_registration.post_process(business, filing_submission)
+        #     AccountService.update_entity(
+        #         business_registration=business.identifier,
+        #         business_name=business.legal_name,
+        #         corp_type_code=business.legal_type
+        #     )
+        #
+
+        if any('registration' in x for x in legal_filings):
+            filing_submission.business_id = business.id
+            db.session.add(filing_submission)
+            db.session.commit()
+            registration.update_affiliation(business, filing_submission)

--- a/data-tool/flows/custom_filer/filing_meta.py
+++ b/data-tool/flows/custom_filer/filing_meta.py
@@ -1,0 +1,76 @@
+# Copyright © 2021 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Track the meta information for a filing_submission.
+
+Alternate to pydantic just using regular dataclass to track meta info
+and custom serialization with the goodness of typing.
+
+Also supporting the dynamic class behavior found in Python to make adoption easier.
+"""
+import re
+from dataclasses import dataclass, field, fields
+from datetime import date, datetime
+from typing import Optional
+
+
+def to_camel(string: str) -> Optional[str]:
+    """Convert snake_case to camelCase.
+
+    This does not strip punctuation or whitespace characters.
+    """
+    if not isinstance(string, str):
+        return None
+
+    return ''.join(word.lower() if idx == 0 else
+                   word.capitalize()
+                   for idx, word in enumerate(string.split('_')))
+
+
+def to_snake(string: str) -> Optional[str]:
+    """Convert camelCase to snake_case.
+
+    This does not strip punctuation or whitespace characters.
+    """
+    if not isinstance(string, str):
+        return None
+
+    return re.sub(r'([A-Z])', r'_\1', string).lower()
+
+
+def json_serial(obj):
+    """JSON serializer for datetime and dates."""
+    if isinstance(obj, (datetime, date)):
+        return obj.isoformat()
+    raise TypeError(f'Type {type(obj)} not serializable')
+
+
+@dataclass
+class FilingMeta:
+    """Holds the variable metadata about a filing."""
+
+    application_date: Optional[datetime] = None
+    legal_filings: list = field(default_factory=list)
+
+    @property
+    def asjson(self):
+        """Return the json formatted dict for this instance."""
+        d = {}
+        for f in fields(self):
+            d[to_camel(f.name)] = self.__dict__[f.name]
+
+        if len(self.__dict__) != len(fields(self)):
+            additional_fields = set(self.__dict__) - {x.name for x in fields(self)}
+            for f in additional_fields:
+                d[to_camel(f)] = self.__dict__[f]
+        return d

--- a/data-tool/flows/custom_filer/filing_processors/__init__.py
+++ b/data-tool/flows/custom_filer/filing_processors/__init__.py
@@ -1,0 +1,17 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This module contains all of the Legal Filing specific processors.
+
+Processors hold the business logic for how a filing is interpreted and saved to the legal database.
+"""

--- a/data-tool/flows/custom_filer/filing_processors/filing_components/__init__.py
+++ b/data-tool/flows/custom_filer/filing_processors/filing_components/__init__.py
@@ -1,0 +1,174 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This module contains all of the Legal Filing specific component processors."""
+from __future__ import annotations
+
+from typing import Dict
+
+import pycountry
+from legal_api.models import Address, Business, Office, Party, PartyRole, ShareClass, ShareSeries
+
+JSON_ROLE_CONVERTER = {
+    'custodian': PartyRole.RoleTypes.CUSTODIAN.value,
+    'completing party': PartyRole.RoleTypes.COMPLETING_PARTY.value,
+    'director': PartyRole.RoleTypes.DIRECTOR.value,
+    'incorporator': PartyRole.RoleTypes.INCORPORATOR.value,
+    'proprietor': PartyRole.RoleTypes.PROPRIETOR.value,
+    'partner': PartyRole.RoleTypes.PARTNER.value,
+}
+
+
+def create_address(address_info: Dict, address_type: str) -> Address:
+    """Create an address."""
+    if not address_info:
+        return Address()
+
+    db_address_type = address_type.replace('Address', '')
+
+    address = Address(street=address_info.get('streetAddress'),
+                      street_additional=address_info.get('streetAddressAdditional'),
+                      city=address_info.get('addressCity'),
+                      region=address_info.get('addressRegion'),
+                      country=pycountry.countries.search_fuzzy(address_info.get('addressCountry'))[0].alpha_2,
+                      postal_code=address_info.get('postalCode'),
+                      delivery_instructions=address_info.get('deliveryInstructions'),
+                      address_type=db_address_type
+                      )
+    return address
+
+
+def update_address(address: Address, new_info: dict) -> Address:
+    """Update address with new info."""
+    address.street = new_info.get('streetAddress')
+    address.street_additional = new_info.get('streetAddressAdditional')
+    address.city = new_info.get('addressCity')
+    address.region = new_info.get('addressRegion')
+    address.country = pycountry.countries.search_fuzzy(new_info.get('addressCountry'))[0].alpha_2
+    address.postal_code = new_info.get('postalCode')
+    address.delivery_instructions = new_info.get('deliveryInstructions')
+
+    return address
+
+
+def create_office(business, office_type, addresses) -> Office:
+    """Create a new office for incorporation."""
+    office = Office()
+    office.office_type = office_type
+    office.addresses = []
+    # Iterate addresses and add to this office
+    for k, v in addresses.items():
+        address = create_address(v, k)
+        address.business_id = business.id
+        if address:
+            office.addresses.append(address)
+    return office
+
+
+def create_party(business_id: int, party_info: dict, create: bool = True) -> Party:
+    """Create a new party or get them if they already exist."""
+    party = None
+    if not (middle_initial := party_info['officer'].get('middleInitial')):
+        middle_initial = party_info['officer'].get('middleName', '')
+
+    if create:
+        party = PartyRole.find_party_by_name(
+            business_id=business_id,
+            first_name=party_info['officer'].get('firstName', '').upper(),
+            last_name=party_info['officer'].get('lastName', '').upper(),
+            middle_initial=middle_initial.upper(),
+            org_name=party_info['officer'].get('organizationName', '').upper()
+        )
+    if not party:
+        party = Party(
+            first_name=party_info['officer'].get('firstName', '').upper(),
+            last_name=party_info['officer'].get('lastName', '').upper(),
+            middle_initial=middle_initial.upper(),
+            title=party_info.get('title', '').upper(),
+            organization_name=party_info['officer'].get('organizationName', '').upper(),
+            email=party_info['officer'].get('email'),
+            identifier=party_info['officer'].get('identifier'),
+            tax_id=party_info['officer'].get('taxId'),
+            party_type=party_info['officer'].get('partyType')
+        )
+
+    # add addresses to party
+    if party_info.get('deliveryAddress', None):
+        address = create_address(party_info['deliveryAddress'], Address.DELIVERY)
+        party.delivery_address = address
+    if party_info.get('mailingAddress', None):
+        mailing_address = create_address(party_info['mailingAddress'], Address.MAILING)
+        party.mailing_address = mailing_address
+    return party
+
+
+def create_role(party: Party, role_info: dict) -> PartyRole:
+    """Create a new party role and link to party."""
+    party_role = PartyRole(
+        role=JSON_ROLE_CONVERTER.get(role_info.get('roleType').lower(), ''),
+        appointment_date=role_info['appointmentDate'],
+        cessation_date=role_info['cessationDate'],
+        party=party
+    )
+    return party_role
+
+
+def update_director(director: PartyRole, new_info: dict) -> PartyRole:
+    """Update director with new info."""
+    director.party.first_name = new_info['officer'].get('firstName', '').upper()
+    director.party.middle_initial = new_info['officer'].get('middleInitial', '').upper()
+    director.party.last_name = new_info['officer'].get('lastName', '').upper()
+    director.party.title = new_info.get('title', '').upper()
+
+    if director.party.delivery_address:
+        director.party.delivery_address = update_address(
+            director.party.delivery_address, new_info['deliveryAddress'])
+    else:
+        director.party.delivery_address = create_address(new_info['deliveryAddress'], Address.DELIVERY)
+
+    if new_info.get('mailingAddress', None):
+        if director.party.mailing_address is None:
+            director.party.mailing_address = create_address(new_info['mailingAddress'], Address.MAILING)
+        else:
+            director.party.mailing_address = update_address(
+                director.party.mailing_address, new_info['mailingAddress']
+            )
+    director.cessation_date = new_info.get('cessationDate')
+
+    return director
+
+
+def create_share_class(share_class_info: dict) -> ShareClass:
+    """Create a new share class and associated series."""
+    share_class = ShareClass(
+        name=share_class_info['name'],
+        priority=share_class_info['priority'],
+        max_share_flag=share_class_info['hasMaximumShares'],
+        max_shares=share_class_info.get('maxNumberOfShares', None),
+        par_value_flag=share_class_info['hasParValue'],
+        par_value=share_class_info.get('parValue', None),
+        currency=share_class_info.get('currency', None),
+        special_rights_flag=share_class_info['hasRightsOrRestrictions']
+    )
+    share_class.series = []
+    for series in share_class_info['series']:
+        share_series = ShareSeries(
+            name=series['name'],
+            priority=series['priority'],
+            max_share_flag=series['hasMaximumShares'],
+            max_shares=series.get('maxNumberOfShares', None),
+            special_rights_flag=series['hasRightsOrRestrictions']
+        )
+        share_class.series.append(share_series)
+
+    return share_class

--- a/data-tool/flows/custom_filer/filing_processors/filing_components/aliases.py
+++ b/data-tool/flows/custom_filer/filing_processors/filing_components/aliases.py
@@ -1,0 +1,37 @@
+# Copyright © 2020 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Manages the  names of a Business."""
+from typing import Dict
+
+from flask_babel import _ as babel  # noqa: N813
+from legal_api.models import Alias, Business
+
+
+def update_aliases(business: Business, aliases) -> Dict:
+    """Update the aliases of the business."""
+    if not business:
+        return {'error': babel('Business required before alternate names can be set.')}
+
+    for alias in aliases:
+        if (alias_id := alias.get('id')) and \
+                (existing_alias := next((x for x in business.aliases.all() if str(x.id) == alias_id), None)):
+            existing_alias.alias = alias['name'].upper()
+        else:
+            new_alias = Alias(alias=alias['name'].upper(), type=Alias.AliasType.TRANSLATION.value)
+            business.aliases.append(new_alias)
+
+    for current_alias in business.aliases.all():
+        if not next((x for x in aliases if x['name'].upper() == current_alias.alias.upper()), None):
+            business.aliases.remove(current_alias)
+    return None

--- a/data-tool/flows/custom_filer/filing_processors/filing_components/business_info.py
+++ b/data-tool/flows/custom_filer/filing_processors/filing_components/business_info.py
@@ -1,0 +1,96 @@
+# Copyright © 2020 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Manages the type of Business."""
+from typing import Dict
+
+import requests
+from flask import current_app
+from flask_babel import _ as babel  # noqa: N813
+from legal_api.core import BusinessIdentifier, BusinessType
+from legal_api.models import Business, Filing
+from legal_api.services import NaicsService
+
+
+def set_corp_type(business: Business, business_info: Dict) -> Dict:
+    """Set the legal type of the business."""
+    if not business:
+        return {'error': babel('Business required before type can be set.')}
+
+    try:
+        legal_type = business_info.get('legalType')
+        if legal_type:
+            business.legal_type = legal_type
+    except (IndexError, KeyError, TypeError):
+        return {'error': babel('A valid legal type must be provided.')}
+
+    return None
+
+
+def set_legal_name(corp_num: str, business: Business, business_info: Dict):
+    """Set the legal_name in the business object."""
+    legal_name = business_info.get('legalName', None)
+    business.legal_name = legal_name if legal_name else corp_num[2:] + ' B.C. LTD.'
+
+
+def update_business_info(corp_num: str, tax_id: str, business: Business, business_info: Dict, filing: Filing):
+    """Format and update the business entity from incorporation filing."""
+    if corp_num and business and business_info and filing:
+        set_legal_name(corp_num, business, business_info)
+        business.identifier = corp_num
+        business.legal_type = business_info.get('legalType', None)
+        business.founding_date = filing.effective_date
+        business.last_coa_date = filing.effective_date
+        business.last_cod_date = filing.effective_date
+        business.tax_id = tax_id
+        return business
+    return None
+
+
+def update_naics_info(business: Business, naics: Dict):
+    """Update naics info."""
+    business.naics_code = naics.get('naicsCode')
+    # TODO resolve 150 length issue
+    # business.naics_description = naics.get('naicsDescription')
+    naics_desc = naics.get('naicsDescription')
+    if naics_desc:
+        naics_desc = naics_desc[0:150]
+        business.naics_description = naics_desc
+
+
+def get_next_corp_num(legal_type: str):
+    """Retrieve the next available sequential corp-num from Lear or fallback to COLIN."""
+    # this gets called if the new services are generating the Business.identifier.
+    if legal_type in BusinessType:
+        if business_type := BusinessType.get_enum_by_value(legal_type):
+            return BusinessIdentifier.next_identifier(business_type)
+        return None
+
+    # legacy Business.Identifier generation
+    try:
+        # TODO: update this to grab the legal 'class' after legal classes have been defined in lear
+        if legal_type == Business.LegalTypes.BCOMP.value:
+            business_type = 'BC'
+        else:
+            business_type = legal_type
+        resp = requests.post(f'{current_app.config["COLIN_API"]}/{business_type}')
+    except requests.exceptions.ConnectionError:
+        current_app.logger.error(f'Failed to connect to {current_app.config["COLIN_API"]}')
+        return None
+
+    if resp.status_code == 200:
+        new_corpnum = int(resp.json()['corpNum'])
+        if new_corpnum and new_corpnum <= 9999999:
+            # TODO: Fix endpoint
+            return f'{business_type}{new_corpnum:07d}'
+    return None

--- a/data-tool/flows/custom_filer/filing_processors/filing_components/business_profile.py
+++ b/data-tool/flows/custom_filer/filing_processors/filing_components/business_profile.py
@@ -1,0 +1,78 @@
+# Copyright © 2020 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Manages the type of Business."""
+import json
+from http import HTTPStatus
+from typing import Dict
+
+import requests
+from flask import current_app
+from flask_babel import _ as babel  # noqa: N813
+from legal_api.models import Business
+from legal_api.services.bootstrap import AccountService
+
+
+def update_business_profile(business: Business, profile_info: Dict) -> Dict:
+    """Set the legal type of the business."""
+    if not business or not profile_info:
+        return {'error': babel('Business and profile_info required.')}
+
+    # contact phone is optional
+    phone = profile_info.get('phone', '')
+
+    error = {'error': 'Unknown handling'}
+    if email := profile_info.get('email'):
+        # assume the JSONSchema ensures it is a valid email format
+        token = AccountService.get_bearer_token()
+        account_svc_entity_url = current_app.config['ACCOUNT_SVC_ENTITY_URL']
+
+        # Create an entity record
+        data = json.dumps(
+            {'email': email,
+             'phone': phone,
+             'phoneExtension': ''
+             }
+        )
+        url = ''.join([account_svc_entity_url, '/', business.identifier, '/contacts'])
+        rv = requests.post(
+            url=url,
+            headers={**AccountService.CONTENT_TYPE_JSON,
+                     'Authorization': AccountService.BEARER + token},
+            data=data,
+            timeout=AccountService.timeout
+        )
+        if rv.status_code in (HTTPStatus.OK, HTTPStatus.CREATED):
+            error = None
+
+        if rv.status_code == HTTPStatus.NOT_FOUND:
+            error = {'error': 'No business profile found.'}
+
+        if rv.status_code == HTTPStatus.METHOD_NOT_ALLOWED:
+            error = {'error': 'Service account missing privileges to update business profiles'}
+
+        if rv.status_code == HTTPStatus.BAD_REQUEST and \
+                'DATA_ALREADY_EXISTS' in rv.text:
+            put = requests.put(
+                url=''.join([account_svc_entity_url, '/', business.identifier]),
+                headers={**AccountService.CONTENT_TYPE_JSON,
+                         'Authorization': AccountService.BEARER + token},
+                data=data,
+                timeout=AccountService.timeout
+            )
+            if put.status_code in (HTTPStatus.OK, HTTPStatus.CREATED):
+                error = None
+            else:
+                error = {'error': 'Unable to update existing business profile.'}
+
+    return error

--- a/data-tool/flows/custom_filer/filing_processors/filing_components/filings.py
+++ b/data-tool/flows/custom_filer/filing_processors/filing_components/filings.py
@@ -1,0 +1,34 @@
+# Copyright © 2021 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Manages the  names of a Business."""
+from contextlib import suppress
+from typing import Dict, Optional
+
+from flask_babel import _ as babel  # noqa: N813
+from legal_api.models import Filing
+from legal_api.utils.datetime import datetime
+
+
+def update_filing_court_order(filing_submission: Filing, court_order_json: Dict) -> Optional[Dict]:
+    """Update the court_order info for a Filing."""
+    if not Filing:
+        return {'error': babel('Filing required before alternate names can be set.')}
+
+    filing_submission.court_order_file_number = court_order_json.get('fileNumber')
+    filing_submission.court_order_effect_of_order = court_order_json.get('effectOfOrder')
+
+    with suppress(IndexError, KeyError, TypeError, ValueError):
+        filing_submission.court_order_date = datetime.fromisoformat(court_order_json.get('orderDate'))
+
+    return None

--- a/data-tool/flows/custom_filer/filing_processors/filing_components/name_request.py
+++ b/data-tool/flows/custom_filer/filing_processors/filing_components/name_request.py
@@ -1,0 +1,72 @@
+# Copyright © 2020 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Actions related to the name requests of a business."""
+import json
+from http import HTTPStatus
+
+import requests
+import sentry_sdk
+# from entity_queue_common.service_utils import QueueException
+from flask import current_app
+from legal_api.models import Business, Filing, RegistrationBootstrap
+from legal_api.services.bootstrap import AccountService
+from legal_api.services.utils import get_str
+
+
+# def consume_nr(business: Business, filing: Filing, filing_type='incorporationApplication'):
+#     """Update the nr to a consumed state."""
+#     try:
+#         # skip this if none (nrNumber will not be available for numbered company)
+#         if nr_num := get_str(filing.filing_json, f'/filing/{filing_type}/nameRequest/nrNumber'):
+#
+#             namex_svc_url = current_app.config.get('NAMEX_API')
+#             token = AccountService.get_bearer_token()
+#
+#             # Create an entity record
+#             data = json.dumps({'consume': {'corpNum': business.identifier}})
+#             rv = requests.patch(
+#                 url=''.join([namex_svc_url, nr_num]),
+#                 headers={**AccountService.CONTENT_TYPE_JSON,
+#                          'Authorization': AccountService.BEARER + token},
+#                 data=data,
+#                 timeout=AccountService.timeout
+#             )
+#             if not rv.status_code == HTTPStatus.OK:
+#                 raise QueueException
+#
+#             # remove the NR from the account
+#             if filing.temp_reg and (bootstrap := RegistrationBootstrap.find_by_identifier(filing.temp_reg)):
+#                 AccountService.delete_affiliation(bootstrap.account, nr_num)
+#     except KeyError:
+#         pass  # return
+#     except Exception:  # pylint: disable=broad-except; note out any exception, but don't fail the call
+#         sentry_sdk.capture_message(f'Queue Error: Consume NR error for filing:{filing.id}', level='error')
+
+
+def set_legal_name(business: Business, name_request_info: dict):
+    """Set the legal_name in the business object."""
+    if legal_name := name_request_info.get('legalName', None):
+        business.legal_name = legal_name
+
+
+def has_new_nr_for_correction(filing: dict):
+    """Return whether a correction filing has new NR."""
+    new_nr_number = filing.get('filing').get('incorporationApplication').get('nameRequest').get('nrNumber', None)
+    if new_nr_number:
+        corrected_filing = Filing.find_by_id(filing['filing']['correction']['correctedFilingId'])
+        corrected_filing_json = corrected_filing.filing_json
+        old_nr_number = corrected_filing_json.get('filing').get('incorporationApplication').\
+            get('nameRequest').get('nrNumber', None)
+        return old_nr_number != new_nr_number
+    return False

--- a/data-tool/flows/custom_filer/filing_processors/filing_components/offices.py
+++ b/data-tool/flows/custom_filer/filing_processors/filing_components/offices.py
@@ -1,0 +1,63 @@
+# Copyright © 2020 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Manages the offices for a business."""
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from legal_api.models import Business
+
+# from flows.custom_filer.filing_processors.filing_components import create_office
+from . import create_office
+
+def update_offices(business: Business, offices_structure: Dict) -> Optional[List]:
+    """Manage the office for a business.
+
+    Assumption: The structure has already been validated, upon submission.
+
+    Other errors are recorded and will be managed out of band.
+    """
+    if not business:
+        # if nothing is passed in, we don't care and it's not an error
+        return None
+
+    err = []
+
+    if offices_structure:
+        try:
+            delete_existing_offices(business)
+        except:  # noqa:E722 pylint: disable=bare-except; catch all exceptions
+            err.append(
+                {'error_code': 'FILER_UNABLE_TO_DELETE_OFFICES',
+                 'error_message': f"Filer: unable to delete offices for :'{business.identifier}'"}
+            )
+            return err
+
+        try:
+            for office_type, addresses in offices_structure.items():
+                office = create_office(business, office_type, addresses)
+                business.offices.append(office)
+        except KeyError:
+            err.append(
+                {'error_code': 'FILER_UNABLE_TO_SAVE_OFFICES',
+                 'error_message': f"Filer: unable to save new offices for :'{business.identifier}'"}
+            )
+    return err
+
+
+def delete_existing_offices(business: Business):
+    """Delete the existing offices for a business."""
+    if existing_offices := business.offices.all():
+        for office in existing_offices:
+            business.offices.remove(office)

--- a/data-tool/flows/custom_filer/filing_processors/filing_components/parties.py
+++ b/data-tool/flows/custom_filer/filing_processors/filing_components/parties.py
@@ -1,0 +1,76 @@
+# Copyright © 2020 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Manages the parties and party roles for a business."""
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from legal_api.models import Business, Filing, PartyRole
+
+# from flows.custom_filer.filing_processors.filing_components import create_party, create_role
+from . import create_party, create_role
+
+def update_parties(business: Business, parties_structure: Dict, filing: Filing, delete_existing=True) -> Optional[List]:
+    """Manage the party and party roles for a business.
+
+    Assumption: The structure has already been validated, upon submission.
+
+    Other errors are recorded and will be managed out of band.
+    """
+    if not business:
+        # if nothing is passed in, we don't care and it's not an error
+        return None
+
+    err = []
+
+    if parties_structure:
+        if delete_existing:
+            try:
+                delete_parties(business)
+            except:  # noqa:E722 pylint: disable=bare-except; catch all exceptions
+                err.append(
+                    {'error_code': 'FILER_UNABLE_TO_DELETE_PARTY_ROLES',
+                     'error_message': f"Filer: unable to delete party roles for :'{business.identifier}'"}
+                )
+                return err
+
+        try:
+            for party_info in parties_structure:
+                party = create_party(business_id=business.id, party_info=party_info, create=False)
+                for role_type in party_info.get('roles'):
+                    role_str = role_type.get('roleType', '').lower()
+                    role = {
+                        'roleType': role_str,
+                        'appointmentDate': role_type.get('appointmentDate', None),
+                        'cessationDate': role_type.get('cessationDate', None)
+                    }
+                    party_role = create_role(party=party, role_info=role)
+                    if party_role.role in [PartyRole.RoleTypes.COMPLETING_PARTY.value,
+                                           PartyRole.RoleTypes.INCORPORATOR.value]:
+                        filing.filing_party_roles.append(party_role)
+                    else:
+                        business.party_roles.append(party_role)
+        except KeyError:
+            err.append(
+                {'error_code': 'FILER_UNABLE_TO_SAVE_PARTIES',
+                 'error_message': f"Filer: unable to save new parties for :'{business.identifier}'"}
+            )
+    return err
+
+
+def delete_parties(business: Business):
+    """Delete the party_roles for a business."""
+    if existing_party_roles := business.party_roles.all():
+        for role in existing_party_roles:
+            business.party_roles.remove(role)

--- a/data-tool/flows/custom_filer/filing_processors/filing_components/shares.py
+++ b/data-tool/flows/custom_filer/filing_processors/filing_components/shares.py
@@ -1,0 +1,104 @@
+# Copyright © 2020 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Manages the share structure for a business."""
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from dateutil.parser import parse
+from legal_api.models import Business, Resolution, ShareClass, ShareSeries
+
+
+def update_share_structure(business: Business, share_structure: Dict) -> Optional[List]:
+    """Manage the share structure for a business.
+
+    Assumption: The structure has already been validated, upon submission.
+
+    Other errors are recorded and will be managed out of band.
+    """
+    if not business or not share_structure:
+        # if nothing is passed in, we don't care and it's not an error
+        return None
+
+    err = []
+
+    if resolution_dates := share_structure.get('resolutionDates'):
+        for resolution_dt in resolution_dates:
+            try:
+                d = Resolution(
+                    resolution_date=parse(resolution_dt).date(),
+                    resolution_type=Resolution.ResolutionType.SPECIAL.value
+                )
+                business.resolutions.append(d)
+            except (ValueError, OverflowError):
+                err.append(
+                    {'error_code': 'FILER_INVALID_RESOLUTION_DATE',
+                     'error_message': f"Filer: invalid resolution date:'{resolution_dt}'"}
+                )
+
+    if share_classes := share_structure.get('shareClasses'):
+        try:
+            delete_existing_shares(business)
+        except:  # noqa:E722 pylint: disable=bare-except; catch all exceptions
+            err.append(
+                {'error_code': 'FILER_UNABLE_TO_DELETE_SHARES',
+                 'error_message': f"Filer: unable to delete shares for :'{business.identifier}'"}
+            )
+            # we're FUBAR, do not load the new shares
+            return err
+
+        try:
+            for share_class_info in share_classes:
+                share_class = create_share_class(share_class_info)
+                business.share_classes.append(share_class)
+        except KeyError:
+            err.append(
+                {'error_code': 'FILER_UNABLE_TO_SAVE_SHARES',
+                 'error_message': f"Filer: unable to save new shares for :'{business.identifier}'"}
+            )
+
+    return err
+
+
+def delete_existing_shares(business: Business):
+    """Delete the existing share classes and series for a business."""
+    if existing_shares := business.share_classes.all():
+        for share_class in existing_shares:
+            business.share_classes.remove(share_class)
+
+
+def create_share_class(share_class_info: dict) -> ShareClass:
+    """Create a new share class and associated series."""
+    share_class = ShareClass(
+        name=share_class_info['name'],
+        priority=share_class_info['priority'],
+        max_share_flag=share_class_info['hasMaximumShares'],
+        max_shares=share_class_info.get('maxNumberOfShares', None),
+        par_value_flag=share_class_info['hasParValue'],
+        par_value=share_class_info.get('parValue', None),
+        currency=share_class_info.get('currency', None),
+        special_rights_flag=share_class_info['hasRightsOrRestrictions']
+    )
+    share_class.series = []
+    for series in share_class_info['series']:
+        share_series = ShareSeries(
+            name=series['name'],
+            priority=series['priority'],
+            max_share_flag=series['hasMaximumShares'],
+            max_shares=series.get('maxNumberOfShares', None),
+            special_rights_flag=series['hasRightsOrRestrictions']
+        )
+        share_class.series.append(share_series)
+
+    return share_class

--- a/data-tool/flows/custom_filer/filing_processors/registration.py
+++ b/data-tool/flows/custom_filer/filing_processors/registration.py
@@ -1,0 +1,135 @@
+# Copyright © 2022 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""File processing rules and actions for the registration of a business."""
+import copy, json, requests
+from contextlib import suppress
+from http import HTTPStatus
+from typing import Dict
+
+import dpath
+from legal_api.models import Business, Filing, RegistrationBootstrap
+from legal_api.services.bootstrap import AccountService
+from legal_api.utils.datetime import datetime
+
+from ..filing_meta import FilingMeta
+from .filing_components import business_info, business_profile, filings
+from .filing_components.offices import update_offices
+from .filing_components.parties import update_parties
+from flask import current_app
+
+def update_affiliation(business: Business, filing: Filing):
+    """Create an affiliation for the business and remove the bootstrap."""
+    try:
+
+        # TODO affiliation to an account does not need to happen.  only entity creation in auth is req'd.
+        #  used for testing purposes to see how things look in entity dashboard - remove when done testing
+        # rv = AccountService.create_affiliation(
+        #     # account=bootstrap.account,
+        #     account=2596,
+        #     business_registration=business.identifier,
+        #     business_name=business.legal_name,
+        #     corp_type_code=business.legal_type
+        # )
+
+        account_svc_entity_url = current_app.config.get('ACCOUNT_SVC_ENTITY_URL')
+        token = AccountService.get_bearer_token()
+
+        if not token:
+            return HTTPStatus.UNAUTHORIZED
+
+        # Create an entity record
+        entity_data = json.dumps({'businessIdentifier': business.identifier,
+                                  'corpTypeCode': business.legal_type,
+                                  'name': business.legal_name
+                                  })
+        entity_record = requests.post(
+            url=account_svc_entity_url,
+            headers={**AccountService.CONTENT_TYPE_JSON,
+                     'Authorization': AccountService.BEARER + token},
+            data=entity_data,
+            timeout=AccountService.timeout
+        )
+
+
+    except Exception as err:  # pylint: disable=broad-except; note out any exception, but don't fail the call
+        # sentry_sdk.capture_message(
+        #     f'Queue Error: Affiliation error for filing:{filing.id}, with err:{err}',
+        #     level='error'
+        # )
+        print(f'Queue Error: Affiliation error for filing:{filing.id}, with err:{err}')
+
+
+
+def process(business: Business,  # pylint: disable=too-many-branches
+            filing: Dict,
+            filing_rec: Filing,
+            filing_meta: FilingMeta,
+            filing_event_data: Dict):  # pylint: disable=too-many-branches
+    """Process the incoming registration filing."""
+    # Extract the filing information for registration
+    registration_filing = filing.get('filing', {}).get('registration')
+    filing_meta.registration = {}
+    corp_num = registration_filing['business']['identifier']
+    tax_id = filing_event_data['c_bn_15']
+
+    if not registration_filing:
+        # raise QueueException(f'Registration legal_filing:registration missing from {filing_rec.id}')
+        raise Exception(f'Registration legal_filing:registration missing from {filing_rec.id}')
+
+    if business:
+        # raise QueueException(f'Business Already Exist: Registration legal_filing:registration {filing_rec.id}')
+        raise Exception(f'Business Already Exist: Registration legal_filing:registration {filing_rec.id}')
+
+    business_info_obj = registration_filing.get('nameRequest')
+
+    # Initial insert of the business record
+    business = Business()
+    business = business_info.update_business_info(corp_num, tax_id, business, business_info_obj, filing_rec)
+    business.founding_date = datetime.fromisoformat(registration_filing.get('startDate'))
+    if (naics := registration_filing.get('business', {}).get('naics')):
+        # TODO resolve 150 length issue
+        business_info.update_naics_info(business, naics)
+
+    business.state = Business.State.ACTIVE
+
+    if nr_number := business_info_obj.get('nrNumber', None):
+        filing_meta.registration = {**filing_meta.registration,
+                                    **{'nrNumber': nr_number,
+                                       'legalName': business_info_obj.get('legalName', None)}}
+
+    if not business:
+        # raise QueueException(f'Registration {filing_rec.id}, Unable to create business.')
+        raise Exception(f'Registration {filing_rec.id}, Unable to create business.')
+
+    if offices := registration_filing['offices']:
+        update_offices(business, offices)
+
+    if parties := registration_filing.get('parties'):
+        update_parties(business, parties, filing_rec)
+
+    # update court order, if any is present
+    with suppress(IndexError, KeyError, TypeError):
+        court_order_json = dpath.util.get(filing, '/registration/courtOrder')
+        filings.update_filing_court_order(filing_rec, court_order_json)
+
+    # Update the filing json with identifier and founding date.
+    registration_json = copy.deepcopy(filing_rec.filing_json)
+    registration_json['filing']['business'] = {}
+    registration_json['filing']['business']['identifier'] = business.identifier
+    registration_json['filing']['registration']['business']['identifier'] = business.identifier
+    registration_json['filing']['business']['legalType'] = business.legal_type
+    registration_json['filing']['business']['foundingDate'] = business.founding_date.isoformat()
+    filing_rec._filing_json = registration_json  # pylint: disable=protected-access; bypass to update filing data
+
+    return business, filing_rec, filing_meta

--- a/data-tool/flows/migrate_sp_gp_flow.py
+++ b/data-tool/flows/migrate_sp_gp_flow.py
@@ -1,0 +1,198 @@
+from datetime import datetime, timedelta
+
+import pandas as pd
+import prefect
+from legal_api.models import Filing
+from prefect import task, Flow, unmapped
+from prefect.executors import LocalDaskExecutor
+from prefect.schedules import IntervalSchedule
+
+from config import get_named_config
+from common.firm_queries import get_unprocessed_firms_query
+from common.event_filing_service import EventFilingService
+from common.firm_filing_json_factory import get_registration_sp_filing_json
+from common.firm_filing_data_cleaning_utils import clean_naics_data, clean_corp_party_data, clean_offices_data
+from common.processing_status_service import ProcessingStatusService
+from custom_filer.filer import process_filing
+from common.custom_exceptions import CustomException
+from tasks.task_utils import ColinInitTask, LearInitTask
+from sqlalchemy import engine, text
+
+
+colin_init_task = ColinInitTask(name='init_colin')
+lear_init_task = LearInitTask(name='init_lear', flask_app_name='lear-test-etl', nout=2)
+
+
+@task
+def get_config():
+    config = get_named_config()
+    return config
+
+
+@task(name='get_unprocessed_firms')
+def get_unprocessed_firms(db_engine: engine):
+    logger = prefect.context.get("logger")
+
+    query = get_unprocessed_firms_query()
+    sql_text = text(query)
+
+    with db_engine.connect() as conn:
+        rs = conn.execute(sql_text)
+        df = pd.DataFrame(rs, columns=rs.keys())
+        raw_data_dict = df.to_dict('records')
+        corp_nums = [x.get('corp_num') for x in raw_data_dict]
+        logger.info(f'{len(raw_data_dict)} corp_nums to process from colin data: {corp_nums}')
+
+    return raw_data_dict
+
+
+@task(name='get_event_filing_data')
+def get_event_filing_data(colin_db_engine: engine, unprocessed_firm_dict: dict):
+    logger = prefect.context.get("logger")
+    event_filing_service = EventFilingService(colin_db_engine)
+    corp_num = unprocessed_firm_dict.get('corp_num')
+    print(f'get event filing data for {corp_num}')
+
+    event_ids = unprocessed_firm_dict.get('event_ids')
+    event_file_types = unprocessed_firm_dict.get('event_file_types')
+    event_file_types = event_file_types.split(',')
+    event_filing_data_arr = []
+
+    for idx, event_id in enumerate(event_ids):
+        event_file_type = event_file_types[idx]
+        is_supported_event_filing = event_filing_service.get_event_filing_is_supported(event_file_type)
+        print(f'event_id: {event_id}, event_file_type: {event_file_type}, is_supported_event_filing: {is_supported_event_filing}')
+        if is_supported_event_filing:
+            event_filing_data_dict = event_filing_service.get_event_filing_data(corp_num, event_id, event_file_type)
+            event_filing_data_arr.append({
+                'processed': True,
+                'data': event_filing_data_dict
+            })
+        else:
+            event_filing_data_arr.append({
+                'processed': False,
+                'data': None
+            })
+    unprocessed_firm_dict['event_filing_data'] = event_filing_data_arr
+    return unprocessed_firm_dict
+
+
+@task(name='clean_event_filing_data')
+def clean_event_filing_data(colin_db_engine: engine, event_filing_data_dict: dict):
+    logger = prefect.context.get("logger")
+    status_service = ProcessingStatusService(colin_db_engine)
+    corp_num = event_filing_data_dict['corp_num']
+    corp_name = 'Unknown'
+
+    try:
+        event_filing_data_arr = event_filing_data_dict['event_filing_data']
+        for event_filing_data in event_filing_data_arr:
+            if event_filing_data['processed']:
+                filing_data = event_filing_data['data']
+                corp_name = filing_data['cn_corp_name']
+                clean_naics_data(filing_data)
+                clean_corp_party_data(filing_data)
+                clean_offices_data(filing_data)
+    except Exception as err:
+        logger.error(f'error cleaning business {corp_num}, {corp_name}, {err}')
+        status_service.update_flow_status('sp-gp-flow', corp_num, corp_name, 'FAILED')
+        raise CustomException(f'error cleaning business {corp_num}, {corp_name}, {err}', event_filing_data_dict)
+
+    return event_filing_data_dict
+
+
+@task(name='transform_event_filing_data')
+def transform_event_filing_data(colin_db_engine: engine, event_filing_data_dict: dict):
+    logger = prefect.context.get("logger")
+    status_service = ProcessingStatusService(colin_db_engine)
+    corp_num = event_filing_data_dict['corp_num']
+    corp_name = 'Unknown'
+
+    try:
+        event_filing_data_arr = event_filing_data_dict['event_filing_data']
+        for event_filing_data in event_filing_data_arr:
+            if event_filing_data['processed']:
+                # process and create LEAR json filing dict
+                filing_data = event_filing_data['data']
+                corp_name = filing_data['cn_corp_name']
+                filing_json = get_registration_sp_filing_json(filing_data)
+                event_filing_data['filing_json'] = filing_json
+    except Exception as err:
+        logger.error(f'error transforming business {corp_num}, {corp_name}, {err}')
+        status_service.update_flow_status('sp-gp-flow', corp_num, corp_name, 'FAILED')
+        raise CustomException(f'error transforming business {corp_num}, {corp_name}, {err}', event_filing_data_dict)
+
+    return event_filing_data_dict
+
+
+@task(name='load_event_filing_data')
+def load_event_filing_data(app: any, colin_db_engine: engine, db_lear, event_filing_data_dict: dict):
+    logger = prefect.context.get("logger")
+    status_service = ProcessingStatusService(colin_db_engine)
+    corp_num = event_filing_data_dict['corp_num']
+    corp_name = 'Unknown'
+
+    try:
+        with app.app_context():
+            event_filing_data_arr = event_filing_data_dict['event_filing_data']
+            for event_filing_data in event_filing_data_arr:
+                if event_filing_data['processed']:
+                    filing_data = event_filing_data['data']
+                    filing_json = event_filing_data['filing_json']
+                    effective_date = filing_data['f_effective_dts']
+                    corp_name = filing_data['cn_corp_name']
+
+                    # save filing to filing table
+                    filing = Filing()
+                    filing.effective_date = effective_date
+                    filing._filing_json = filing_json
+                    filing._filing_type = 'registration'
+                    filing.filing_date = effective_date
+
+                    # Override the state setting mechanism
+                    filing.source = Filing.Source.COLIN.value
+                    db_lear.session.add(filing)
+                    db_lear.session.commit()
+
+                    # process filing with custom filer function
+                    process_filing(filing.id, filing_data, db_lear)
+                    status_service.update_flow_status('sp-gp-flow', corp_num, corp_name, 'COMPLETED')
+
+                    # confirm can access from dashboard if we use existing account for now
+    except Exception as err:
+        logger.error(f'error loading business {corp_num}, {corp_name}, {err}')
+        status_service.update_flow_status('sp-gp-flow', corp_num, corp_name, 'FAILED')
+        db_lear.session.rollback()
+
+
+now = datetime.utcnow()
+schedule = IntervalSchedule(interval=timedelta(minutes=10), start_date=now)
+
+with Flow("SP-GP-Migrate-ETL", schedule=schedule, executor=LocalDaskExecutor(scheduler="threads")) as f:
+
+    # setup
+    config = get_config()
+    db_colin_engine = colin_init_task(config)
+    FLASK_APP, db_lear = lear_init_task(config)
+
+    unprocessed_firms = get_unprocessed_firms(db_colin_engine)
+
+    # get event/filing related data for each firm
+    event_filing_data = get_event_filing_data.map(colin_db_engine=unmapped(db_colin_engine),
+                                                  unprocessed_firm_dict=unprocessed_firms)
+
+    # clean/validate filings for a given business
+    cleaned_event_filing_data = clean_event_filing_data.map(unmapped(db_colin_engine),
+                                                            event_filing_data)
+
+    # transform data to appropriate format in preparation for data loading into LEAR
+    transformed_event_filing_data = transform_event_filing_data.map(unmapped(db_colin_engine),
+                                                                    cleaned_event_filing_data)
+
+    # load all filings for a given business sequentially
+    # if a filing fails, flag business as failed indicating which filing it failed at
+    loaded_event_filing_data = load_event_filing_data.map(unmapped(FLASK_APP),
+                                                          unmapped(db_colin_engine),
+                                                          unmapped(db_lear),
+                                                          transformed_event_filing_data)
+

--- a/data-tool/flows/tasks/task_utils.py
+++ b/data-tool/flows/tasks/task_utils.py
@@ -1,4 +1,7 @@
+from flask_sqlalchemy import SQLAlchemy
 from prefect import Task
+from sqlalchemy import create_engine
+
 
 class LearInitTask(Task):
 
@@ -13,6 +16,16 @@ class LearInitTask(Task):
         FLASK_APP.config.from_object(config)
         db.init_app(FLASK_APP)
         FLASK_APP.app_context().push()
-        return db
+        return FLASK_APP, db
+
+
+class ColinInitTask(Task):
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def run(self, config):
+        engine = create_engine(config.SQLALCHEMY_DATABASE_URI_COLIN_MIGR)
+        return engine
 
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#11771

*Description of changes:*

* Create Prefect flow(`data-tool/flows/migrate_sg_gp_flow.py`) for data loading SP/GP registrations from COLIN into LEAR.  It has been structured to process other filings in the near future but for now the pipeline only supports registration filings.
  At a high level, essentially the workflow does the following:
  1. Query all filing events from COLIN postgres db prepared by Richard and David Roberts.  The events will be grouped by corp num.   
  2. Clean data associated with each registration filing event sequentially for a given corp num.
  3. Create filing json for corp and save filing to LEAR db.
  4. Run customized registration filer processor so business is made operational.  An auth entity record is also created during this process.  
  5. Update processing status to COMPLETE/FAILED in corp processing table in COLIN postgres db.
* Added customized versions of filer code(`data-tool/custom_filer`) to process registrations.  This was done as using the existing implementation of the filer code would lead to unwanted events triggering(email messages, BN message retrieval, generating new business identifier, affiliation to account and etc).  There is also a need to populate data not provided in the filing json which has been included in the custom filer code where req'd


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
