### PR TITLE
11912 fix tasks endpoint issue not returning required tasks for SP/GPs

### DIFF
--- a/legal-api/src/legal_api/resources/v2/business/business_tasks.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_tasks.py
@@ -61,13 +61,6 @@ def get_tasks(identifier):
         else:
             rv = []
     else:
-        compliance_warnings = check_compliance(business)
-        if len(compliance_warnings) > 0:
-            rv = []
-            business.compliance_warnings = compliance_warnings
-            rv.append(create_conversion_filing_todo(business, 1, True))
-            return jsonify(tasks=rv)
-
         rv = construct_task_list(business)
         if not rv and is_nr:
             paid_completed_filings = Filing.get_filings_by_status(business.id, [Filing.Status.PAID.value,
@@ -101,11 +94,11 @@ def construct_task_list(business):  # pylint: disable=too-many-locals; only 2 ex
     tasks = []
     order = 1
 
-    is_firm = bool(business and business.legal_type in (Business.LegalTypes.SOLE_PROP.value,
-                                                        Business.LegalTypes.PARTNERSHIP.value))
-    # SP/GPs don’t have annual reports or other legislated filings that they need to do
-    if is_firm:
-        return []
+    compliance_warnings = check_compliance(business)
+    if len(compliance_warnings) > 0:
+        business.compliance_warnings = compliance_warnings
+        tasks.append(create_conversion_filing_todo(business, order, True))
+        order += 1
 
 # Retrieve filings that are either incomplete, or drafts
     pending_filings = Filing.get_filings_by_status(business.id, [Filing.Status.DRAFT.value,

--- a/legal-api/tests/unit/resources/v2/test_business_tasks.py
+++ b/legal-api/tests/unit/resources/v2/test_business_tasks.py
@@ -308,11 +308,14 @@ def test_conversion_filing_task(session, client, jwt, test_name, legal_type, ide
     rv_json = rv.json
 
     if conversion_task_expected:
-        assert len(rv_json['tasks']) == 1
-        assert rv_json['tasks'][0]['task']['todo']['header']['name'] == 'conversion'
-        assert rv_json['tasks'][0]['task']['todo']['header']['status'] == 'NEW'
+        conversion_to_do = any(x['task']['todo']['header']['name'] == 'conversion'
+                                and x['task']['todo']['header']['status'] == 'NEW'
+                                for x in rv_json['tasks'])
+        assert conversion_to_do
     else:
-        conversion_to_do = any(x['task']['todo']['header']['name'] == 'conversion' for x in rv_json['tasks'])
+        conversion_to_do = any(x['task']['todo']['header']['name'] == 'conversion'
+                               and x['task']['todo']['header']['status'] == 'NEW'
+                               for x in rv_json['tasks'])
         assert not conversion_to_do
 
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#11912

*Description of changes:*

* Updated task endpoint to in addition to returning conversion todo when required to also return all other todos.  Originally I tried to implement functionality of how the task endpoint works specific to SP/GPs as a part of the incomplete business info work in this ticket.  But given that it is not as simple as expected, we should groom another ticket to cover this work.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
