### PR TITLE
Fix filer where UI party guids causes error to be thrown

### DIFF
--- a/queue_services/entity-filer/src/entity_filer/filing_processors/change_of_registration.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/change_of_registration.py
@@ -89,7 +89,8 @@ def update_parties(business: Business, parties: dict, change_filing_rec: Filing)
     # Create and Update
     for party_info in parties:
         # Create if id not present
-        if not party_info.get('officer').get('id'):
+        if not party_info.get('officer').get('id') or \
+                (party_info.get('officer').get('id') and not isinstance(party_info.get('officer').get('id'), int)):
             _create_party_info(business, change_filing_rec, party_info)
         else:
             # Update if id is present

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/change_of_registration.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/change_of_registration.py
@@ -89,6 +89,8 @@ def update_parties(business: Business, parties: dict, change_filing_rec: Filing)
     # Create and Update
     for party_info in parties:
         # Create if id not present
+        # If id is present and is a GUID then this is an id specific to the UI which is not relevant to the backend.
+        # The backend will have an id of type int
         if not party_info.get('officer').get('id') or \
                 (party_info.get('officer').get('id') and not isinstance(party_info.get('officer').get('id'), int)):
             _create_party_info(business, change_filing_rec, party_info)


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*

* Update `update_parties` function in change of registration processor to ignore FE party guids

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
