### PR TITLE
Fix no current event loop queue error when gunicorn runs with more than one worker and thread

### DIFF
--- a/legal-api/src/legal_api/services/queue.py
+++ b/legal-api/src/legal_api/services/queue.py
@@ -93,7 +93,7 @@ class QueueService():
     def teardown(self, exception):  # pylint: disable=unused-argument; flask method signature
         """Destroy all objects created by this extension."""
         try:
-            this_loop = asyncio.get_event_loop()
+            this_loop = self.loop or asyncio.get_event_loop()
             this_loop.run_until_complete(self.close())
         except RuntimeError as e:
             self.logger.error(e)


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
