### PR TITLE
12199 Update Doc List: Suppress output for Coop Annual Report Correction for all Coop records

### DIFF
--- a/legal-api/src/legal_api/core/meta/filing.py
+++ b/legal-api/src/legal_api/core/meta/filing.py
@@ -153,7 +153,7 @@ FILINGS: Final = {
             'CP': 'CRCTN'
         },
         'additional': [
-            {'types': 'CP,BEN', 'outputs': ['noticeOfArticles', ]},
+            {'types': 'BEN', 'outputs': ['noticeOfArticles', ]},
         ]
     },
     'courtOrder': {

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
@@ -226,8 +226,7 @@ del ALTERATION_WITHOUT_NR['nameRequest']['legalName']
      ),
     ('ben_correction_completed', 'BC7654321', Business.LegalTypes.BCOMP.value,
      'correction', CORRECTION, 'incorporationApplication', INCORPORATION, Filing.Status.COMPLETED,
-     {'documents': {'noticeOfArticles': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/noticeOfArticles',
-                    'legalFilings': [
+     {'documents': {'legalFilings': [
                         {'correction': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/correction'},
                         {'incorporationApplication': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/incorporationApplication'},
                     ]
@@ -238,7 +237,6 @@ del ALTERATION_WITHOUT_NR['nameRequest']['legalName']
     ('ben_correction_with_nr_completed', 'BC7654321', Business.LegalTypes.BCOMP.value,
      'correction', CORRECTION, 'incorporationApplication', CORRECTED_INCORPORATION, Filing.Status.COMPLETED,
      {'documents': {'certificate': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/certificate',
-                    'noticeOfArticles': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/noticeOfArticles',
                     'legalFilings': [
                         {'correction': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/correction'},
                         {'incorporationApplication': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/incorporationApplication'},

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
@@ -278,6 +278,15 @@ del ALTERATION_WITHOUT_NR['nameRequest']['legalName']
       },
      HTTPStatus.OK, None
      ),
+    ('cp_correction_ar', 'CP7654321', Business.LegalTypes.COOP.value,
+     'correction', CORRECTION_AR, None, None , Filing.Status.COMPLETED,
+     {'documents': {'legalFilings': [
+                        {'correction': f'{base_url}/api/v2/businesses/CP7654321/filings/1/documents/correction'},
+                    ]
+                    }
+     },
+     HTTPStatus.OK, None
+     ),
     ('cp_changeOfDirector', 'CP7654321', Business.LegalTypes.COOP.value,
      'changeOfDirectors', CHANGE_OF_DIRECTORS, None, None, Filing.Status.COMPLETED,
      {'documents': {

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
@@ -226,7 +226,8 @@ del ALTERATION_WITHOUT_NR['nameRequest']['legalName']
      ),
     ('ben_correction_completed', 'BC7654321', Business.LegalTypes.BCOMP.value,
      'correction', CORRECTION, 'incorporationApplication', INCORPORATION, Filing.Status.COMPLETED,
-     {'documents': {'legalFilings': [
+     {'documents': {'noticeOfArticles': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/noticeOfArticles',
+                    'legalFilings': [
                         {'correction': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/correction'},
                         {'incorporationApplication': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/incorporationApplication'},
                     ]
@@ -237,6 +238,7 @@ del ALTERATION_WITHOUT_NR['nameRequest']['legalName']
     ('ben_correction_with_nr_completed', 'BC7654321', Business.LegalTypes.BCOMP.value,
      'correction', CORRECTION, 'incorporationApplication', CORRECTED_INCORPORATION, Filing.Status.COMPLETED,
      {'documents': {'certificate': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/certificate',
+                    'noticeOfArticles': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/noticeOfArticles',
                     'legalFilings': [
                         {'correction': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/correction'},
                         {'incorporationApplication': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/incorporationApplication'},


### PR DESCRIPTION
*Issue #:* [/bcgov/entity#12199](https://app.zenhub.com/workspaces/entities-team-space-6143567664fb320019b81f39/issues/bcgov/entity/12199)

*Description of changes:*
- suppress `Notice of Articles` item for "Correction - Annual Report" in Recent Filing History, for all of the following conditions
  - the filing type is `CP`
  - the display name is `Correction - Annual Report`
  - the document link is for `noticeOfArticles`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
