### PR TITLE
12845 Fix firm affiliation bug (part 2)

### DIFF
--- a/queue_services/entity-filer/setup.cfg
+++ b/queue_services/entity-filer/setup.cfg
@@ -54,7 +54,7 @@ per-file-ignores =
 
 [pylint]
 ignore=migrations,test
-max_line_length=120
+max-line-length=120
 notes=FIXME,XXX,TODO
 ignored-modules=flask_sqlalchemy,sqlalchemy,SQLAlchemy,alembic,scoped_session
 ignored-classes=scoped_session

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/business_info.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/business_info.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Manages the type of Business."""
+from datetime import datetime
 from typing import Dict
 
 import requests
 from flask import current_app
 from flask_babel import _ as babel  # noqa: N813
 from legal_api.core import BusinessIdentifier, BusinessType
-from legal_api.models import Business, Filing
+from legal_api.models import Business, Filing, PartyRole
 from legal_api.services import NaicsService
 
 
@@ -91,3 +92,24 @@ def get_next_corp_num(legal_type: str):
             # TODO: Fix endpoint
             return f'{business_type}{new_corpnum:07d}'
     return None
+
+
+def get_firm_affiliation_passcode(business_id: int):
+    """Return a firm passcode for a given business identifier."""
+    pass_code = None
+    end_date = datetime.utcnow().date()
+    party_roles = PartyRole.get_party_roles(business_id, end_date)
+
+    if len(party_roles) == 0:
+        return pass_code
+
+    party = party_roles[0].party
+
+    if party.party_type == 'organization':
+        pass_code = party.organization_name
+    else:
+        pass_code = party.last_name + ', ' + party.first_name
+        if hasattr(party, 'middle_initial') and party.middle_initial:
+            pass_code = pass_code + ' ' + party.middle_initial
+
+    return pass_code

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/registration.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/registration.py
@@ -35,12 +35,14 @@ def update_affiliation(business: Business, filing: Filing):
     """Create an affiliation for the business and remove the bootstrap."""
     try:
         bootstrap = RegistrationBootstrap.find_by_identifier(filing.temp_reg)
+        pass_code = business_info.get_firm_affiliation_passcode(business.id)
 
         rv = AccountService.create_affiliation(
             account=bootstrap.account,
             business_registration=business.identifier,
             business_name=business.legal_name,
-            corp_type_code=business.legal_type
+            corp_type_code=business.legal_type,
+            pass_code=pass_code
         )
 
         if rv not in (HTTPStatus.OK, HTTPStatus.CREATED):


### PR DESCRIPTION
*Issue #:* /bcgov/entity#12845

*Description of changes:*

* Added `pass_code` parameter to `update_affiliation` function in `AccountService` class.  This was needed to pass firm party(partner or proprietor) names as a pass code to the auth api affiliation endpoint
* Updated registration filer processor to use updated `update_affiliation` function in `AccountService` class to pass party name as pass code
* Added test for firm affiliation verification in registration processor 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
