### PR TITLE
Turn Sentry Off by using SENTRY_ENABLE FLAG instead of SENTRY_DSN#12422

### DIFF
--- a/colin-api/devops/vaults.json
+++ b/colin-api/devops/vaults.json
@@ -3,8 +3,13 @@
         "vault": "entity",
         "application": [
             "colin-api",
-            "test-oracle",
-            "sentry"
+            "test-oracle"
+        ]
+    },
+    {
+        "vault": "sentry",
+        "application": [
+            "entity"
         ]
     }
 ]

--- a/colin-api/src/colin_api/__init__.py
+++ b/colin-api/src/colin_api/__init__.py
@@ -39,14 +39,15 @@ def create_app(run_mode=os.getenv('FLASK_ENV', 'production')):
     app = Flask(__name__)
     app.config.from_object(config.CONFIGURATION[run_mode])
     # Configure Sentry
-    if app.config.get('SENTRY_DSN', None):
-        sentry_sdk.init(  # pylint: disable=abstract-class-instantiated
-            dsn=app.config.get('SENTRY_DSN'),
-            integrations=[FlaskIntegration()]
-        )
-    app.register_blueprint(API_BLUEPRINT)
-    app.register_blueprint(OPS_BLUEPRINT)
-    # setup_jwt_manager(app, jwt)
+    if str(app.config.get('SENTRY_ENABLE')).lower() == 'true':
+        if app.config.get('SENTRY_DSN', None):
+            sentry_sdk.init(  # pylint: disable=abstract-class-instantiated
+                dsn=app.config.get('SENTRY_DSN'),
+                integrations=[FlaskIntegration()]
+            )
+        app.register_blueprint(API_BLUEPRINT)
+        app.register_blueprint(OPS_BLUEPRINT)
+        # setup_jwt_manager(app, jwt)
 
     @app.after_request
     def add_version(response):  # pylint: disable=unused-variable

--- a/colin-api/src/colin_api/config.py
+++ b/colin-api/src/colin_api/config.py
@@ -62,6 +62,8 @@ class _Config:  # pylint: disable=too-few-public-methods
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
+    SENTRY_ENABLE = os.getenv('SENTRY_ENABLE', 'False')
+
     SENTRY_DSN = os.getenv('SENTRY_DSN', '')
 
     # ORACLE - CDEV/CTST/CPRD

--- a/jobs/email-reminder/config.py
+++ b/jobs/email-reminder/config.py
@@ -47,6 +47,7 @@ class _Config(object):  # pylint: disable=too-few-public-methods
     PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
     SEND_OUTSTANDING_BCOMPS = os.getenv('SEND_OUTSTANDING_BCOMPS', None)
+    SENTRY_ENABLE = os.getenv('SENTRY_ENABLE', 'False')
     SENTRY_DSN = os.getenv('SENTRY_DSN', '')
 
     ACCOUNT_SVC_AUTH_URL = os.getenv('ACCOUNT_SVC_AUTH_URL', None)

--- a/jobs/email-reminder/devops/vaults.json
+++ b/jobs/email-reminder/devops/vaults.json
@@ -12,8 +12,13 @@
             "filings-jobs",
             "nats-emailer",
             "entity-service-account",
-            "sentry",
             "email-reminder"
+        ]
+    },
+    {
+        "vault": "sentry",
+        "application": [
+            "entity"
         ]
     }
 ]

--- a/jobs/email-reminder/email_reminder.py
+++ b/jobs/email-reminder/email_reminder.py
@@ -47,11 +47,12 @@ def create_app(run_mode=os.getenv('FLASK_ENV', 'production')):
     db.init_app(app)
 
     # Configure Sentry
-    if app.config.get('SENTRY_DSN', None):
-        sentry_sdk.init(
-            dsn=app.config.get('SENTRY_DSN'),
-            integrations=[SENTRY_LOGGING]
-        )
+    if str(app.config.get('SENTRY_ENABLE')).lower() == 'true':
+        if app.config.get('SENTRY_DSN', None):
+            sentry_sdk.init(
+                dsn=app.config.get('SENTRY_DSN'),
+                integrations=[SENTRY_LOGGING]
+            )
 
     register_shellcontext(app)
 

--- a/jobs/future-effective-filings/config.py
+++ b/jobs/future-effective-filings/config.py
@@ -83,6 +83,7 @@ class _Config(object):  # pylint: disable=too-few-public-methods
     AUTH_URL = os.getenv('AUTH_URL', '')
     USERNAME = os.getenv('AUTH_USERNAME', '')
     PASSWORD = os.getenv('AUTH_PASSWORD', '')
+    SENTRY_ENABLE = os.getenv('SENTRY_ENABLE', 'False')
     SENTRY_DSN = os.getenv('SENTRY_DSN', '')
 
     SECRET_KEY = 'a secret'
@@ -130,6 +131,7 @@ class TestConfig(_Config):  # pylint: disable=too-few-public-methods
     AUTH_URL = os.getenv('AUTH_URL_TEST', '')
     USERNAME = os.getenv('AUTH_USERNAME_TEST', '')
     PASSWORD = os.getenv('AUTH_PASSWORD_TEST', '')
+    SENTRY_ENABLE = os.getenv('SENTRY_ENABLE_TEST', 'False')
     SENTRY_DSN = os.getenv('SENTRY_DSN_TEST', '')
 
 

--- a/jobs/future-effective-filings/devops/vaults.json
+++ b/jobs/future-effective-filings/devops/vaults.json
@@ -10,8 +10,13 @@
         "application": [
             "filings-jobs",
             "nats-filer",
-            "entity-service-account",
-            "sentry"
+            "entity-service-account"
+        ]
+    },
+    {
+        "vault": "sentry",
+        "application": [
+            "entity"
         ]
     }
 ]

--- a/jobs/future-effective-filings/file_future_effective.py
+++ b/jobs/future-effective-filings/file_future_effective.py
@@ -65,11 +65,12 @@ def create_app(run_mode=os.getenv('FLASK_ENV', 'production')):
     app = Flask(__name__)
     app.config.from_object(config.CONFIGURATION[run_mode])
     # Configure Sentry
-    if app.config.get('SENTRY_DSN', None):
-        sentry_sdk.init(
-            dsn=app.config.get('SENTRY_DSN'),
-            integrations=[SENTRY_LOGGING]
-        )
+    if str(app.config.get('SENTRY_ENABLE')).lower() == 'true':
+        if app.config.get('SENTRY_DSN', None):
+            sentry_sdk.init(
+                dsn=app.config.get('SENTRY_DSN'),
+                integrations=[SENTRY_LOGGING]
+            )
 
     return app
 

--- a/jobs/update-colin-filings/config.py
+++ b/jobs/update-colin-filings/config.py
@@ -48,6 +48,7 @@ class _Config(object):  # pylint: disable=too-few-public-methods
 
     COLIN_URL = os.getenv('COLIN_URL', '')
     LEGAL_URL = os.getenv('LEGAL_URL', '')
+    SENTRY_ENABLE = os.getenv('SENTRY_ENABLE', 'False')
     SENTRY_DSN = os.getenv('SENTRY_DSN', '')
 
     ACCOUNT_SVC_AUTH_URL = os.getenv('ACCOUNT_SVC_AUTH_URL', None)

--- a/jobs/update-colin-filings/devops/vaults.json
+++ b/jobs/update-colin-filings/devops/vaults.json
@@ -3,8 +3,13 @@
         "vault": "entity",
         "application": [
             "filings-jobs",
-            "entity-service-account",
-            "sentry"
+            "entity-service-account"
+        ]
+    },
+    {
+        "vault": "sentry",
+        "application": [
+            "entity"
         ]
     }
 ]

--- a/jobs/update-colin-filings/update_colin_filings.py
+++ b/jobs/update-colin-filings/update_colin_filings.py
@@ -41,11 +41,12 @@ def create_app(run_mode=os.getenv('FLASK_ENV', 'production')):
     app = Flask(__name__)
     app.config.from_object(config.CONFIGURATION[run_mode])
     # Configure Sentry
-    if app.config.get('SENTRY_DSN', None):
-        sentry_sdk.init(
-            dsn=app.config.get('SENTRY_DSN'),
-            integrations=[SENTRY_LOGGING]
-        )
+    if str(app.config.get('SENTRY_ENABLE')).lower() == 'true':
+        if app.config.get('SENTRY_DSN', None):
+            sentry_sdk.init(
+                dsn=app.config.get('SENTRY_DSN'),
+                integrations=[SENTRY_LOGGING]
+            )
 
     register_shellcontext(app)
 

--- a/jobs/update-legal-filings/config.py
+++ b/jobs/update-legal-filings/config.py
@@ -48,6 +48,7 @@ class _Config(object):  # pylint: disable=too-few-public-methods
 
     COLIN_URL = os.getenv('COLIN_URL', '')
     LEGAL_URL = os.getenv('LEGAL_URL', '')
+    SENTRY_ENABLE = os.getenv('SENTRY_ENABLE', 'False')
     SENTRY_DSN = os.getenv('SENTRY_DSN', '')
 
     ACCOUNT_SVC_AUTH_URL = os.getenv('ACCOUNT_SVC_AUTH_URL', None)

--- a/jobs/update-legal-filings/devops/vaults.json
+++ b/jobs/update-legal-filings/devops/vaults.json
@@ -10,8 +10,13 @@
         "application": [
             "filings-jobs",
             "nats-emailer",
-            "entity-service-account",
-            "sentry"
+            "entity-service-account"
+        ]
+    },
+    {
+        "vault": "sentry",
+        "application": [
+            "entity"
         ]
     }
 ]

--- a/jobs/update-legal-filings/update_legal_filings.py
+++ b/jobs/update-legal-filings/update_legal_filings.py
@@ -48,11 +48,12 @@ def create_app(run_mode=os.getenv('FLASK_ENV', 'production')):
     app = Flask(__name__)
     app.config.from_object(config.CONFIGURATION[run_mode])
     # Configure Sentry
-    if app.config.get('SENTRY_DSN', None):
-        sentry_sdk.init(
-            dsn=app.config.get('SENTRY_DSN'),
-            integrations=[SENTRY_LOGGING]
-        )
+    if str(app.config.get('SENTRY_ENABLE')).lower() == 'true':
+        if app.config.get('SENTRY_DSN', None):
+            sentry_sdk.init(
+                dsn=app.config.get('SENTRY_DSN'),
+                integrations=[SENTRY_LOGGING]
+            )
 
     register_shellcontext(app)
 

--- a/legal-api/devops/vaults.json
+++ b/legal-api/devops/vaults.json
@@ -21,8 +21,13 @@
             "legal-api",
             "nats-filer",
             "entity-service-account",
-            "launchdarkly",
-            "sentry"
+            "launchdarkly"
+        ]
+    },
+    {
+        "vault": "sentry",
+        "application": [
+            "entity"
         ]
     }
 ]

--- a/legal-api/env-wf
+++ b/legal-api/env-wf
@@ -1,3 +1,4 @@
+SENTRY_ENABLE=false
 SENTRY_DSN=
 PAYMENT_SVC_URL=https://mock-server/api/v1/payments
 

--- a/legal-api/src/legal_api/config.py
+++ b/legal-api/src/legal_api/config.py
@@ -69,6 +69,7 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     GO_LIVE_DATE = os.getenv('GO_LIVE_DATE')
 
+    SENTRY_ENABLE = os.getenv('SENTRY_ENABLE', 'False')
     SENTRY_DSN = os.getenv('SENTRY_DSN', None)
     LD_SDK_KEY = os.getenv('LD_SDK_KEY', None)
     SECRET_KEY = 'a secret'

--- a/legal-api/tests/pytest_marks.py
+++ b/legal-api/tests/pytest_marks.py
@@ -49,6 +49,9 @@ integration_payment = pytest.mark.skipif((os.getenv('RUN_PAYMENT_TESTS', False) 
 integration_reports = pytest.mark.skipif((os.getenv('RUN_REPORT_TESTS', False) is False),
                                          reason='Report tests are only run when requested.')
 
+integration_sentry_enable = pytest.mark.skipif((os.getenv('SENTRY_ENABLE', False) is False),
+                                        reason='SENTRY tests run when SENTRY_ENABLE is set.')
+
 integration_sentry = pytest.mark.skipif((os.getenv('SENTRY_DSN', False) is False),
                                         reason='SENTRY tests run when SENTRY_DSN is set.')
 

--- a/legal-api/tests/unit/conf/test_configuration.py
+++ b/legal-api/tests/unit/conf/test_configuration.py
@@ -81,6 +81,7 @@ def test_config_dsn_key():
 
     # Assert that the SENTRY_DSN is set to the assigned environment value
     dsn = 'http://secret_key@localhost:9000/project_id'
+    config._Config.SENTRY_ENABLE = True
     config._Config.SENTRY_DSN = dsn
     reload(config)
     app = create_app()

--- a/queue_services/common/src/entity_queue_common/service_utils/service_logger.py
+++ b/queue_services/common/src/entity_queue_common/service_utils/service_logger.py
@@ -29,16 +29,17 @@ def before_breadcrumb(crumb, hint):  # pylint: disable=unused-argument; callback
 
 # Configure Sentry
 SENTRY_DSN = os.getenv('SENTRY_DSN', None)
-if SENTRY_DSN:
+if str(os.getenv('SENTRY_ENABLE', 'False')).lower() == 'true':
+    if SENTRY_DSN:
 
-    SENTRY_LOGGING = LoggingIntegration(
-        event_level=logging.ERROR  # Send errors as events
-    )
-    sentry_sdk.init(
-        dsn=SENTRY_DSN,
-        integrations=[SENTRY_LOGGING],
-        before_breadcrumb=before_breadcrumb
-    )
+        SENTRY_LOGGING = LoggingIntegration(
+            event_level=logging.ERROR  # Send errors as events
+        )
+        sentry_sdk.init(
+            dsn=SENTRY_DSN,
+            integrations=[SENTRY_LOGGING],
+            before_breadcrumb=before_breadcrumb
+        )
 
 logging.basicConfig(
     level=logging.INFO,

--- a/queue_services/common/tests/config.py
+++ b/queue_services/common/tests/config.py
@@ -62,6 +62,8 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     PAYMENT_SVC_URL = os.getenv('PAYMENT_SVC_URL', '')
 
+    SENTRY_ENABLE = os.getenv('SENTRY_ENABLE', 'False')
+
     SENTRY_DSN = os.getenv('SENTRY_DSN', None)
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/queue_services/entity-bn/src/entity_bn/config.py
+++ b/queue_services/entity-bn/src/entity_bn/config.py
@@ -60,6 +60,7 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
+    SENTRY_ENABLE = os.getenv('SENTRY_ENABLE', 'False')
     SENTRY_DSN = os.getenv('SENTRY_DSN', None)
     COLIN_API = f"{os.getenv('COLIN_SVC_URL', '')}{os.getenv('COLIN_SVC_VERSION', '')}"
 

--- a/queue_services/entity-emailer/devops/vaults.json
+++ b/queue_services/entity-emailer/devops/vaults.json
@@ -11,8 +11,13 @@
             "postgres-legal",
             "entity-emailer",
             "nats-emailer",
-            "entity-service-account",
-            "sentry"
+            "entity-service-account"
+        ]
+    },
+    {
+        "vault": "sentry",
+        "application": [
+            "entity"
         ]
     }
 ]

--- a/queue_services/entity-emailer/src/entity_emailer/config.py
+++ b/queue_services/entity-emailer/src/entity_emailer/config.py
@@ -61,6 +61,7 @@ class _Config():  # pylint: disable=too-few-public-methods
     PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
     # monitoring
+    SENTRY_ENABLE = os.getenv('SENTRY_ENABLE', 'False')
     SENTRY_DSN = os.getenv('SENTRY_DSN', None)
     # urls
     DASHBOARD_URL = os.getenv('DASHBOARD_URL', None)

--- a/queue_services/entity-filer/devops/vaults.json
+++ b/queue_services/entity-filer/devops/vaults.json
@@ -19,8 +19,13 @@
             "postgres-legal",
             "entity-filer",
             "nats-filer",
-            "entity-service-account",
-            "sentry"
+            "entity-service-account"
+        ]
+    },
+    {
+        "vault": "sentry",
+        "application": [
+            "entity"
         ]
     }
 ]

--- a/queue_services/entity-filer/src/entity_filer/config.py
+++ b/queue_services/entity-filer/src/entity_filer/config.py
@@ -62,6 +62,8 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     PAYMENT_SVC_URL = os.getenv('PAYMENT_SVC_URL', '')
 
+    SENTRY_ENABLE = os.getenv('SENTRY_ENABLE', 'False')
+
     SENTRY_DSN = os.getenv('SENTRY_DSN', None)
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/queue_services/entity-pay/devops/vaults.json
+++ b/queue_services/entity-pay/devops/vaults.json
@@ -10,8 +10,13 @@
         "application": [
             "postgres-legal",
             "entity-pay",
-            "nats-pay",
-            "sentry"
+            "nats-pay"
+        ]
+    },
+    {
+        "vault": "sentry",
+        "application": [
+            "entity"
         ]
     }
 ]

--- a/queue_services/entity-pay/src/entity_pay/config.py
+++ b/queue_services/entity-pay/src/entity_pay/config.py
@@ -62,6 +62,7 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     PAYMENT_SVC_URL = os.getenv('PAYMENT_SVC_URL', '')
 
+    SENTRY_ENABLE = os.getenv('SENTRY_ENABLE', 'False')
     SENTRY_DSN = os.getenv('SENTRY_DSN', None)
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False


### PR DESCRIPTION
Signed-off-by: Steven Chen <steven.chen@gov.bc.ca>

*Issue #:* /bcgov/entity12422

*Description of changes:*
Turn Sentry Off by using SENTRY_ENABLE FLAG instead of SENTRY_DSN

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
