### PR TITLE
12895 - Add in associationType for business call for Coop Association Type

### DIFF
--- a/legal-api/src/legal_api/models/business.py
+++ b/legal-api/src/legal_api/models/business.py
@@ -341,6 +341,7 @@ class Business(db.Model):  # pylint: disable=too-many-instance-attributes
             'nextAnnualReport': LegislationDatetime.as_legislation_timezone_from_date(
                 self.next_anniversary
             ).astimezone(timezone.utc).isoformat(),
+            'associationType': self.association_type
         }
 
         if self.last_coa_date:

--- a/legal-api/tests/unit/models/test_business.py
+++ b/legal-api/tests/unit/models/test_business.py
@@ -241,7 +241,8 @@ def test_business_json(session):
                         last_modified=EPOCH_DATETIME,
                         last_ar_date=EPOCH_DATETIME,
                         last_agm_date=EPOCH_DATETIME,
-                        restriction_ind=True
+                        restriction_ind=True,
+                        association_type='CP'
                         )
     # basic json
     base_url = current_app.config.get('LEGAL_API_BASE_URL')
@@ -268,7 +269,8 @@ def test_business_json(session):
         'state': 'ACTIVE',
         'complianceWarnings': [],
         'warnings': [],
-        'hasCorrections': False
+        'hasCorrections': False,
+        'associationType': 'CP'
     }
 
     assert business.json() == d


### PR DESCRIPTION
*Issue #:* /bcgov/entity#12895

*Description of changes:*
Add in   'associationType': self.association_type to business call. 

Example URL:
GET <lear dev>/api/v2/businesses/CP1002552

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
