### PR TITLE
13046 Add middle name column to user model to support COLIN firm filing user data

### DIFF
--- a/legal-api/migrations/versions/8fef256bf5d7_add_middle_name_to_users.py
+++ b/legal-api/migrations/versions/8fef256bf5d7_add_middle_name_to_users.py
@@ -1,0 +1,26 @@
+"""add_middle_name_to_users
+
+Revision ID: 8fef256bf5d7
+Revises: ee956cbf198a
+Create Date: 2022-08-18 11:59:34.054976
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '8fef256bf5d7'
+down_revision = 'ee956cbf198a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('users', sa.Column('middlename', sa.String(length=1000), nullable=True))
+    op.add_column('users_version', sa.Column('middlename', sa.String(length=1000), nullable=True))
+
+
+def downgrade():
+    op.drop_column('users_version', 'middlename')
+    op.drop_column('users', 'middlename')

--- a/legal-api/src/legal_api/models/user.py
+++ b/legal-api/src/legal_api/models/user.py
@@ -56,6 +56,7 @@ class User(db.Model):
     username = db.Column(db.String(1000), index=True)
     firstname = db.Column(db.String(1000))
     lastname = db.Column(db.String(1000))
+    middlename = db.Column(db.String(1000))
     email = db.Column(db.String(1024))
     sub = db.Column(db.String(36), unique=True)
     iss = db.Column(db.String(1024))

--- a/legal-api/tests/unit/models/test_user.py
+++ b/legal-api/tests/unit/models/test_user.py
@@ -27,7 +27,12 @@ def test_user(session):
 
     Start with a blank database.
     """
-    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss')
+    user = User(username='username',
+                firstname='firstname',
+                middlename='middlename',
+                lastname='lastname',
+                sub='sub',
+                iss='iss')
 
     session.add(user)
     session.commit()
@@ -141,21 +146,21 @@ def test_user_delete(session):
 
 
 TEST_USER_DISPLAY_NAME = [
-    ('nothing to show', '', '', '', None),
-    ('simple username', 'someone', '', '', 'someone'),
+    ('nothing to show', '', '', '', '', None),
+    ('simple username', 'someone', '', '', '', 'someone'),
     # below: idir is idir\blablabla; flake thinks we're trying to escape a character, hence the double slashes
-    ('username - idir with slash', 'idir\\joefresh', '', '', 'joefresh'),
-    ('username - idir with @', 'joefresh@idir', '', '', 'joefresh'),
-    ('username - services card', 'bcsc/abc123', '', '', None),
-    ('simple name', 'anything', 'First', 'Last', 'First Last'),
-    ('name - first name only', 'anything', 'First', '', 'First'),
-    ('name - last name only', 'anything', '', 'Last', 'Last'),
+    ('username - idir with slash', 'idir\\joefresh', '', '', '', 'joefresh'),
+    ('username - idir with @', 'joefresh@idir', '', '', '', 'joefresh'),
+    ('username - services card', 'bcsc/abc123', '', '', '', None),
+    ('simple name', 'anything', 'First', 'Last', 'Middle', 'First Last'),
+    ('name - first name only', 'anything', 'First', '', 'Middle', 'First'),
+    ('name - last name only', 'anything', '', 'Last', 'Middle', 'Last'),
 ]
 
 
-@pytest.mark.parametrize('test_description, username, firstname, lastname, display_name', TEST_USER_DISPLAY_NAME)
-def test_user_display_name(session, test_description, username, firstname, lastname, display_name):
+@pytest.mark.parametrize('test_description, username, firstname, lastname, middlename, display_name', TEST_USER_DISPLAY_NAME)
+def test_user_display_name(session, test_description, username, firstname, lastname, middlename, display_name):
     """Assert the User record is deleted."""
-    user = User(username=username, firstname=firstname, lastname=lastname, sub='sub', iss='iss')
+    user = User(username=username, firstname=firstname, lastname=lastname, middlename=middlename, sub='sub', iss='iss')
 
     assert display_name == user.display_name


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13046

*Description of changes:*
* Add middle name column to user table.  
Note that this is used to support middle name data being loaded from firm filing user data in COLIN.  Currently, new user entries via LEAR only make use of the first/last name fields.  It seems like middle names are entered via either the first or last name field at times.  It was decided in discussion with @rarmitag  not to add the middle name to one of these fields during the data loading process in order to be able to be able to definitively know what the middle name was for the filing user data ported over from COLIN.
* Update user model tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
