### PR TITLE
13168 Update sp/gp pipeline to set paper only flag to false for registration related filings meeting specific criteria

### DIFF
--- a/data-tool/flows/common/firm_filing_data_cleaning_utils.py
+++ b/data-tool/flows/common/firm_filing_data_cleaning_utils.py
@@ -149,7 +149,7 @@ def clean_event_data(filing_data: dict):
     e_event_dts = filing_data['e_event_dts_pacific']
     # for events where date created is not known, use previous event/filing data.
     # LEAR has issues re-creating versioning history for outputs if we don't do this
-    if e_event_dts.year == 1:
+    if e_event_dts.year == 1 and len(filing_data.get('prev_event_filing_data')) > 0:
         prev_f_effective_dt_str = filing_data['prev_event_filing_data']['f_effective_dt_str']
         prev_f_effective_dts_pacific = filing_data['prev_event_filing_data']['f_effective_dts_pacific']
         new_f_effective_dts_pacific = prev_f_effective_dts_pacific + datetime.timedelta(seconds=1)

--- a/data-tool/flows/config.py
+++ b/data-tool/flows/config.py
@@ -90,6 +90,7 @@ class _Config():  # pylint: disable=too-few-public-methods
     )
 
     # service accounts
+    AUTH_SVC_URL = os.getenv('AUTH_SVC_URL', 'https://')
     ACCOUNT_SVC_AUTH_URL = os.getenv('ACCOUNT_SVC_AUTH_URL')
     ACCOUNT_SVC_ENTITY_URL = os.getenv('ACCOUNT_SVC_ENTITY_URL')
     ACCOUNT_SVC_AFFILIATE_URL = os.getenv('ACCOUNT_SVC_AFFILIATE_URL')


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13168

*Description of changes:*

* Update pipeline query to make registration related filings between march 15, 2004 and april 8, 2011 to be available electronically. 
* Add `AUTH_SVC_URL` to fix auth related issue
* Fix cleaning error where pipeline cannot handle invalid event timestamp for first firm filing record

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
