### PR TITLE
13515 Fix FILE_FRCHG event/file type loading issue in SP/GP pipeline

### DIFF
--- a/data-tool/flows/common/firm_queries.py
+++ b/data-tool/flows/common/firm_queries.py
@@ -80,6 +80,8 @@ def get_unprocessed_firms_query(data_load_env: str):
 --                         and e.corp_num in ('FM0367712', 'FM0474350', 'FM0554151')
                        -- firms with only one filing and with no known effective date
 --                         and e.corp_num in ('FM0346815', 'FM0346781', 'FM0346897')
+                       -- firms with dissolutions
+--                         and e.corp_num in ('FM0439147', 'FM0272498', 'FM0354293', 'FM0274699', 'FM0272756')
                   group by e.corp_num) as tbl_fe
                      left outer join corp_processing cp on 
                         cp.corp_num = tbl_fe.corp_num 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13515

*Description of changes:*

* Fixed bug in pipeline where parties data was being cleared for dissolution filings.  This caused loading errors for subsequent processing of filings for a SP/GP as previous filing party data could not be used to reconstruct the filing history. 
* Refactored to have specific function to populate completing party filing json

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
