### PR TITLE
10911 co-op filing AR, director effective dates fix

### DIFF
--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -426,9 +426,7 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
         """Assign the completion and effective dates, unless they are already set."""
         if not self._completion_date:
             self._completion_date = datetime.utcnow()
-        if (self.effective_date is None or
-            (self.payment_completion_date
-             and self.effective_date < self.payment_completion_date)):  # pylint: disable=W0143; hybrid property
+        if (self.effective_date is None and self.payment_completion_date):  # pylint: disable=W0143; hybrid property
             self.effective_date = self.payment_completion_date
 
     @staticmethod

--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -426,9 +426,8 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
         """Assign the completion and effective dates, unless they are already set."""
         if not self._completion_date:
             self._completion_date = datetime.utcnow()
-        if self.effective_date_can_be_before_payment_completion_date(business_type):
-            pass  # prevents the effective date from being set to payment completion date for AR COD for CP and BEN
-        elif (self.effective_date is None or (
+        if not self.effective_date_can_be_before_payment_completion_date(business_type) and (
+            self.effective_date is None or (
                 self.payment_completion_date
                 and self.effective_date < self.payment_completion_date
                 )):  # pylint: disable=W0143; hybrid property

--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -422,11 +422,14 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
 
         return False
 
-    def set_processed(self):
+    def set_processed(self, business_type):
         """Assign the completion and effective dates, unless they are already set."""
         if not self._completion_date:
             self._completion_date = datetime.utcnow()
-        if (self.effective_date is None and self.payment_completion_date):  # pylint: disable=W0143; hybrid property
+        # In the case of an annual report or change of director filings on a COOP or BEN then the effective date can be before the payment date
+        if((self.filing_type == Filing.FILINGS['annualReport'] or self.filing_type == Filing.FILINGS['changeOfDirectors']) and (business_type in {'CP', 'BEN'})):
+            pass
+        elif (self.effective_date is None or (self.payment_completion_date and self.effective_date < self.payment_completion_date)):  # pylint: disable=W0143; hybrid property
             self.effective_date = self.payment_completion_date
 
     @staticmethod

--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -427,7 +427,7 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
         if not self._completion_date:
             self._completion_date = datetime.utcnow()
         # In the case of an annual report or change of director filings on a COOP or BEN then the effective date can be before the payment date
-        if((self.filing_type == Filing.FILINGS['annualReport'] or self.filing_type == Filing.FILINGS['changeOfDirectors']) and (business_type in {'CP', 'BEN'})):
+        if(self.filing_type in {Filing.FILINGS['annualReport'], Filing.FILINGS['changeOfDirectors']} and business_type in {'CP', 'BEN'}):
             pass
         elif (self.effective_date is None or (self.payment_completion_date and self.effective_date < self.payment_completion_date)):  # pylint: disable=W0143; hybrid property
             self.effective_date = self.payment_completion_date

--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -427,7 +427,7 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
         if not self._completion_date:
             self._completion_date = datetime.utcnow()
         # In the case of an annual report or change of director filings on a COOP or BEN then the effective date can be before the payment date
-        if(self.filing_type in {Filing.FILINGS['annualReport'], Filing.FILINGS['changeOfDirectors']} and business_type in {'CP', 'BEN'}):
+        if(self.filing_type in (Filing.FILINGS['annualReport'], Filing.FILINGS['changeOfDirectors']) and business_type in {'CP', 'BEN'}):
             pass
         elif (self.effective_date is None or (self.payment_completion_date and self.effective_date < self.payment_completion_date)):  # pylint: disable=W0143; hybrid property
             self.effective_date = self.payment_completion_date

--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -437,7 +437,7 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
     def effective_date_can_be_before_payment_completion_date(self, business_type):
         """For AR or COD filings on CP or BEN then the effective date can be before the payment date."""
         return self.filing_type in (Filing.FILINGS['annualReport'].get('name'),
-                                    Filing.FILINGS['changeOfDirecotrs'].get('name')) and business_type in {'CP', 'BEN'}
+                                    Filing.FILINGS['changeOfDirectors'].get('name')) and business_type in {'CP', 'BEN'}
 
     @staticmethod
     def _raise_default_lock_exception():

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -313,7 +313,7 @@ class Report:  # pylint: disable=too-few-public-methods
             else:
                 filing['agm_date'] = 'No AGM'
                 # When AR indicates NO AGM the effective date of the filing is Dec 31st of the AR year
-                ar_year_str = str(filing.get('annualReport', {}).get('annualReportDate').year)
+                ar_year_str = str(filing.get('annualReport', {}).get('annualReportDate', datetime).year)
                 filing['effective_date'] = 'December 31, ' + ar_year_str
         if filing.get('correction'):
             original_filing = Filing.find_by_id(filing.get('correction').get('correctedFilingId'))

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -313,7 +313,7 @@ class Report:  # pylint: disable=too-few-public-methods
             else:
                 filing['agm_date'] = 'No AGM'
                 # When AR indicates NO AGM the effective date of the filing is Dec 31st of the AR year
-                ar_year_str = filing['annualReport']['annualReportDate'][0:4]
+                ar_year_str = filing.get('annualReport', {}).get('annualReportDate')[0:4]
                 filing['effective_date'] = 'December 31, ' + ar_year_str
         if filing.get('correction'):
             original_filing = Filing.find_by_id(filing.get('correction').get('correctedFilingId'))

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -312,9 +312,6 @@ class Report:  # pylint: disable=too-few-public-methods
                 filing['effective_date'] = agm_date.strftime('%B %-d, %Y')
             else:
                 filing['agm_date'] = 'No AGM'
-                # When AR indicates NO AGM the effective date of the filing is Dec 31st of the AR year
-                ar_year_str = str(filing.get('annualReport', {}).get('annualReportDate', datetime).year)
-                filing['effective_date'] = 'December 31, ' + ar_year_str
         if filing.get('correction'):
             original_filing = Filing.find_by_id(filing.get('correction').get('correctedFilingId'))
             original_filing_datetime = LegislationDatetime.as_legislation_timezone(original_filing.filing_date)

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -312,6 +312,9 @@ class Report:  # pylint: disable=too-few-public-methods
                 filing['effective_date'] = agm_date.strftime('%B %-d, %Y')
             else:
                 filing['agm_date'] = 'No AGM'
+                # When AR indicates NO AGM the effective date of the filing is Dec 31st of the AR year
+                ar_year_str = filing['annualReport']['annualReportDate'][0:4]
+                filing['effective_date'] = 'December 31, ' + ar_year_str
         if filing.get('correction'):
             original_filing = Filing.find_by_id(filing.get('correction').get('correctedFilingId'))
             original_filing_datetime = LegislationDatetime.as_legislation_timezone(original_filing.filing_date)

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -313,7 +313,7 @@ class Report:  # pylint: disable=too-few-public-methods
             else:
                 filing['agm_date'] = 'No AGM'
                 # When AR indicates NO AGM the effective date of the filing is Dec 31st of the AR year
-                ar_year_str = filing.get('annualReport', {}).get('annualReportDate')[0:4]
+                ar_year_str = str(filing.get('annualReport', {}).get('annualReportDate').year)
                 filing['effective_date'] = 'December 31, ' + ar_year_str
         if filing.get('correction'):
             original_filing = Filing.find_by_id(filing.get('correction').get('correctedFilingId'))

--- a/legal-api/src/legal_api/resources/v1/business/business_filings.py
+++ b/legal-api/src/legal_api/resources/v1/business/business_filings.py
@@ -450,7 +450,7 @@ class ListFilingResource(Resource):
                 ) and \
                     ListFilingResource._is_before_epoch_filing(filing.filing_json, business):
                 filing.transaction_id = epoch_filing[0].transaction_id
-                filing.set_processed()
+                filing.set_processed(business.legal_type)
                 filing.save()
             else:
                 payload = {'filing': {'id': filing.id}}

--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
@@ -499,7 +499,7 @@ class ListFilingResource():
                 ) and \
                     ListFilingResource.is_before_epoch_filing(filing.filing_json, business):
                 filing.transaction_id = epoch_filing[0].transaction_id
-                filing.set_processed()
+                filing.set_processed(business.legal_type)
                 filing.save()
             else:
                 payload = {'filing': {'id': filing.id}}

--- a/legal-api/tests/unit/core/test_filing.py
+++ b/legal-api/tests/unit/core/test_filing.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Tests to assure the Filing Domain is working as expected."""
+from lib2to3.pygram import pattern_symbols
 import datedelta
 import pytest
 from freezegun import freeze_time
@@ -198,7 +199,7 @@ def test_set_effective(session):
         assert filing.is_future_effective
 
         past_date = now - datedelta.DAY
-        filing.storage.effective_date = now
+        filing.storage.effective_date = past_date
         filing._storage.skip_status_listener = True
         filing._storage.payment_completion_date = payment_date
         filing._storage.save()

--- a/legal-api/tests/unit/core/test_filing.py
+++ b/legal-api/tests/unit/core/test_filing.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 """Tests to assure the Filing Domain is working as expected."""
-from lib2to3.pygram import pattern_symbols
 import datedelta
 import pytest
 from freezegun import freeze_time
@@ -209,6 +208,7 @@ def test_set_effective(session):
 
         # assert that the effective date is unchanged by payment date
         assert filing._storage.effective_date
+        assert filing._storage.effective_date == past_date
         assert filing._storage.effective_date.replace(tzinfo=None) != payment_date.replace(tzinfo=None)
         assert not filing.is_future_effective
 

--- a/legal-api/tests/unit/core/test_filing.py
+++ b/legal-api/tests/unit/core/test_filing.py
@@ -163,6 +163,7 @@ def test_set_effective(session):
     with freeze_time(now):
 
         payment_date  = now + datedelta.DAY
+        legal_type = 'SP'
 
         filing = Filing()
         filing_type = 'annualReport'
@@ -171,12 +172,12 @@ def test_set_effective(session):
 
         filing.storage._payment_token = '12345'
         filing.storage._filing_type = filing_type
-        filing.storage.effective_date = None
+        filing.storage.effective_date = now
         filing._storage.skip_status_listener = True
         filing._storage.payment_completion_date = payment_date
         filing._storage.save()
 
-        filing.storage.set_processed()
+        filing.storage.set_processed(legal_type)
 
         # assert that the effective date is the payment date
         assert filing._storage.effective_date
@@ -189,10 +190,24 @@ def test_set_effective(session):
         filing._storage.payment_completion_date = alt_payment_date
         filing._storage.save()
 
-        filing.storage.set_processed()
+        filing.storage.set_processed(legal_type)
 
         # assert that the effective date is the future date
         assert filing._storage.effective_date
         assert filing._storage.effective_date.replace(tzinfo=None) == future_date.replace(tzinfo=None)
         assert filing.is_future_effective
+
+        past_date = now - datedelta.DAY
+        filing.storage.effective_date = now
+        filing._storage.skip_status_listener = True
+        filing._storage.payment_completion_date = payment_date
+        filing._storage.save()
+
+        legal_type = 'CP'
+        filing.storage.set_processed(legal_type)
+
+        # assert that the effective date is unchanged by payment date
+        assert filing._storage.effective_date
+        assert filing._storage.effective_date.replace(tzinfo=None) != payment_date.replace(tzinfo=None)
+        assert not filing.is_future_effective
 

--- a/legal-api/tests/unit/core/test_filing.py
+++ b/legal-api/tests/unit/core/test_filing.py
@@ -171,7 +171,7 @@ def test_set_effective(session):
 
         filing.storage._payment_token = '12345'
         filing.storage._filing_type = filing_type
-        filing.storage.effective_date = now
+        filing.storage.effective_date = None
         filing._storage.skip_status_listener = True
         filing._storage.payment_completion_date = payment_date
         filing._storage.save()


### PR DESCRIPTION
*Issue #:* /bcgov/entity#10911

*Description of changes:*
- effective_date is now not overridden by payment date if the effective_date was before the effective date (every time due to date selector in front end)
- When there is NO AGM for an AR the effective_date is defaulted to December 31, of the AR year.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
