### PR TITLE
update account lookup to return accounts not affiliated with the current user

### DIFF
--- a/legal-api/src/legal_api/services/__init__.py
+++ b/legal-api/src/legal_api/services/__init__.py
@@ -21,7 +21,7 @@ from .authz import (
     get_account_by_affiliated_identifier,
     has_roles,
 )
-from .bootstrap import RegistrationBootstrapService
+from .bootstrap import AccountService, RegistrationBootstrapService
 from .business_details_version import VersionedBusinessDetailsService
 from .digital_credentials import DigitalCredentialsService
 from .document_meta import DocumentMetaService

--- a/legal-api/src/legal_api/services/bootstrap.py
+++ b/legal-api/src/legal_api/services/bootstrap.py
@@ -239,3 +239,19 @@ class AccountService:
                 or entity_record.status_code not in (HTTPStatus.OK, HTTPStatus.NO_CONTENT):
             return HTTPStatus.BAD_REQUEST
         return HTTPStatus.OK
+
+    @classmethod
+    def get_account_by_affiliated_identifier(cls, identifier: str):
+        """Return the account affiliated to the business."""
+        token = cls.get_bearer_token()
+        auth_url = current_app.config.get('AUTH_SVC_URL')
+        url = f'{auth_url}/orgs?affiliation={identifier}'
+
+        res = requests.get(url,
+                           headers={**cls.CONTENT_TYPE_JSON,
+                                    'Authorization': cls.BEARER + token})
+        try:
+            return res.json()
+        except Exception:  # noqa B902; pylint: disable=W0703;
+            current_app.logger.error('Failed to get response')
+            return None


### PR DESCRIPTION
*Issue #:* n/a

*Description of changes:*
Updated the account lookup for businesses, to return for a new role and for businesses not necessarily affiliated to the calling user.
This supports adding the **accountId** to a business struct, if request by a users with the correct roles

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
