### PR TITLE
13784 SP/GP pipeline update to push contact info to auth and misc updates

### DIFF
--- a/data-tool/flows/common/firm_filing_json_factory_service.py
+++ b/data-tool/flows/common/firm_filing_json_factory_service.py
@@ -159,7 +159,10 @@ class FirmFilingJsonFactoryService:
         self.populate_offices(registration_dict)
         self.populate_parties(registration_dict)
         self.populate_nr(registration_dict)
-        self.populate_contact_point(registration_dict)
+        if self._filing_data['c_admin_email']:
+            self.populate_contact_point(registration_dict)
+        else:
+            del registration_dict['contactPoint']
 
 
     def populate_change_registration(self, filing_dict: dict):
@@ -185,7 +188,10 @@ class FirmFilingJsonFactoryService:
         else:
             del change_registration_dict['nameRequest']
 
-        self.populate_contact_point(change_registration_dict)
+        if self._filing_data['c_admin_email']:
+            self.populate_contact_point(change_registration_dict)
+        else:
+            del change_registration_dict['contactPoint']
 
 
     def populate_correction(self, filing_dict: dict):
@@ -217,7 +223,11 @@ class FirmFilingJsonFactoryService:
         else:
             del correction_dict['nameRequest']
 
-        self.populate_contact_point(correction_dict)
+        if self._filing_data['c_admin_email']:
+            self.populate_contact_point(correction_dict)
+        else:
+            del correction_dict['contactPoint']
+
 
 
     def populate_conversion(self, filing_dict: dict):
@@ -244,7 +254,11 @@ class FirmFilingJsonFactoryService:
         else:
             del conversion_dict['nameRequest']
 
-        self.populate_contact_point(conversion_dict)
+        if self._filing_data['c_admin_email']:
+            self.populate_contact_point(conversion_dict)
+        else:
+            del conversion_dict['contactPoint']
+
 
 
     def populate_offices(self, registration_dict: dict):
@@ -523,5 +537,4 @@ class FirmFilingJsonFactoryService:
 
     def populate_contact_point(self, filing_dict: dict):
         contact_point_dict = filing_dict['contactPoint']
-        if email := self._filing_data['c_admin_email']:
-            contact_point_dict['email'] = email
+        contact_point_dict['email'] = self._filing_data['c_admin_email']

--- a/data-tool/flows/common/firm_queries.py
+++ b/data-tool/flows/common/firm_queries.py
@@ -84,6 +84,9 @@ def get_unprocessed_firms_query(data_load_env: str):
 --                         and e.corp_num in ('FM0439147', 'FM0272498', 'FM0354293', 'FM0274699', 'FM0272756')
                        -- firms that test corp party business company number scenarios
 --                         and e.corp_num in ('FM0554987', 'FM0557171', 'FM0563506', 'FM0566805')
+                       -- contact info test
+--                         and e.corp_num in ('FM0558990') -- has contact email
+--                         and e.corp_num in ('FM0887464') -- has no contact email
                   group by e.corp_num) as tbl_fe
                      left outer join corp_processing cp on 
                         cp.corp_num = tbl_fe.corp_num 

--- a/data-tool/flows/common/lear_data_utils.py
+++ b/data-tool/flows/common/lear_data_utils.py
@@ -106,7 +106,9 @@ def populate_filing(business: Business, event_filing_data: dict, filing_data: di
     effective_date = filing_data['f_effective_dts_pacific']
 
     filing = Filing()
+    filing.skip_status_listener = True
     filing.effective_date = effective_date
+    filing._status = Filing.Status.PENDING.value
     filing._filing_json = filing_json
     filing._filing_type = target_lear_filing_type
     filing.filing_date = effective_date

--- a/data-tool/flows/custom_filer/filer.py
+++ b/data-tool/flows/custom_filer/filer.py
@@ -129,6 +129,7 @@ def process_filing(config, filing_id: int, event_filing_data_dict: Dict, filing_
         update_filing_user(filing_submission, filing_data)
 
         filing_submission.transaction_id = transaction.id
+        filing_submission._status = Filing.Status.COMPLETED.value
         business_type = business.legal_type if business else filing_submission['business']['legal_type']
         filing_submission.set_processed(business_type)
 
@@ -160,6 +161,7 @@ def process_filing(config, filing_id: int, event_filing_data_dict: Dict, filing_
             db.session.commit()
             if config.UPDATE_ENTITY:
                 registration.update_affiliation(config, business, filing_submission)
+                registration.post_process(business, filing_submission)
 
         if any('conversion' in x for x in legal_filings):
             filing_submission.business_id = business.id

--- a/data-tool/flows/custom_filer/filing_processors/registration.py
+++ b/data-tool/flows/custom_filer/filing_processors/registration.py
@@ -149,3 +149,16 @@ def process(business: Business,  # pylint: disable=too-many-branches
     filing_rec._filing_json = registration_json  # pylint: disable=protected-access; bypass to update filing data
 
     return business, filing_rec, filing_meta
+
+
+def post_process(business: Business, filing: Filing):
+    """Post processing activities for registration.
+
+    THIS SHOULD NOT ALTER THE MODEL
+    """
+    with suppress(IndexError, KeyError, TypeError):
+        if err := business_profile.update_business_profile(
+                business,
+                filing.json['filing']['registration']['contactPoint']
+        ):
+            print(f'Queue Error: Update Business for filing:{filing.id}, error:{err}')

--- a/data-tool/flows/sp_gp_affiliation_flow.py
+++ b/data-tool/flows/sp_gp_affiliation_flow.py
@@ -52,9 +52,8 @@ def get_unaffiliated_firms(config, db_engine: engine):
 @task(name='clean_unaffiliated_firm_data')
 def clean_unaffiliated_firm_data(unaffiliated_firm: dict):
     email = None
-    if unaffiliated_firm.get('admin_email'):
-        email = unaffiliated_firm.get('admin_email')
-    elif unaffiliated_firm.get('contact_email'):
+    # assume that if admin_email exists, that the SP/GP pipeline has already pushed contact information to auth
+    if not unaffiliated_firm.get('admin_email') and unaffiliated_firm.get('contact_email'):
         email = unaffiliated_firm.get('contact_email')
     unaffiliated_firm['email'] = email
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13784

*Description of changes:*

* Update SP/GP pipeline to push contact info to auth when processing registrations
* Update affiliation pipeline to not push contact info to auth if corporation.admin_email has a value.  This is an assumption that the SP/GP pipeline should have pushed the contact info already.
* Fix a bug where a filing processed unsuccessfully would be stuck in PAID state.  PAID state is problematic as other jobs may pick it up such as the future effective date job.  Updated to use PENDING state instead.
* Add more debug logging and error handling states.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
