### PR TITLE
13834 Add dissolution date to filing meta data

### DIFF
--- a/data-tool/flows/custom_filer/filing_processors/dissolution.py
+++ b/data-tool/flows/custom_filer/filing_processors/dissolution.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """File processing rules and actions for Dissolution and Liquidation filings."""
+from datetime import datetime
 from contextlib import suppress
 from typing import Dict
 
@@ -40,10 +41,6 @@ def process(business: Business,
     filing_meta.dissolution = {}
     dissolution_type = dpath.util.get(filing, '/dissolution/dissolutionType')
 
-    with suppress(IndexError, KeyError, TypeError):
-        filing_meta.dissolution = {**filing_meta.dissolution,
-                                   **{'dissolutionType': dissolution_type}}
-
     # hasLiabilities can be derived from dissolutionStatementType
     # FUTURE: remove hasLiabilities from schema
     # has_liabilities = filing['dissolution'].get('hasLiabilities')
@@ -61,6 +58,11 @@ def process(business: Business,
 
     # only dealing with voluntary dissolutions for now so commenting this out
     # filings.update_filing_order_details(filing_rec, filing_event_data)
+
+    with suppress(IndexError, KeyError, TypeError):
+        filing_meta.dissolution = {**filing_meta.dissolution,
+                                   **{'dissolutionType': dissolution_type},
+                                   **{'dissolutionDate': datetime.date(business.dissolution_date).isoformat()}}
 
     if lt_notation := filing_event_data.get('lt_notation'):
         filing_rec.comments.append(

--- a/legal-api/src/legal_api/models/business.py
+++ b/legal-api/src/legal_api/models/business.py
@@ -376,7 +376,7 @@ class Business(db.Model):  # pylint: disable=too-many-instance-attributes
             ).isoformat()
 
         if self.dissolution_date:
-            d['dissolutionDate'] = self.dissolution_date.isoformat()
+            d['dissolutionDate'] = datetime.date(self.dissolution_date).isoformat()
         if self.fiscal_year_end_date:
             d['fiscalYearEndDate'] = datetime.date(self.fiscal_year_end_date).isoformat()
         if self.tax_id:

--- a/legal-api/tests/unit/__init__.py
+++ b/legal-api/tests/unit/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Centralized setup of logging for the service."""
+from datetime import datetime
+
 
 class MockResponse:
     """Mock http response."""
@@ -23,3 +25,12 @@ class MockResponse:
     def json(self):
         """Return mock json data."""
         return self.json_data
+
+
+def has_expected_date_str_format(date_str: str, format: str) -> bool:
+    "Determine if date string confirms to expected format"
+    try:
+        datetime.strptime(date_str, format)
+    except ValueError:
+        return False
+    return True

--- a/legal-api/tests/unit/models/test_business.py
+++ b/legal-api/tests/unit/models/test_business.py
@@ -26,6 +26,7 @@ from legal_api.exceptions import BusinessException
 from legal_api.models import Business
 from legal_api.utils.legislation_datetime import LegislationDatetime
 from tests import EPOCH_DATETIME, TIMEZONE_OFFSET
+from tests.unit import has_expected_date_str_format
 
 
 def factory_business(designation: str = '001'):
@@ -290,8 +291,13 @@ def test_business_json(session):
 
     # include dissolutionDate
     business.dissolution_date = EPOCH_DATETIME
-    d['dissolutionDate'] = business.dissolution_date.isoformat()
-    assert business.json() == d
+    d['dissolutionDate'] = datetime.date(business.dissolution_date).isoformat()
+    business_json = business.json()
+    assert business_json == d
+    dissolution_date_str = business_json['dissolutionDate']
+    dissolution_date_format_correct = has_expected_date_str_format(dissolution_date_str, '%Y-%m-%d')
+    assert dissolution_date_format_correct
+
     business.dissolution_date = None
     d.pop('dissolutionDate')
 

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/dissolution.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/dissolution.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """File processing rules and actions for Dissolution and Liquidation filings."""
 from contextlib import suppress
+from datetime import datetime
 from typing import Dict
 
 import dpath
@@ -39,10 +40,6 @@ def process(business: Business, filing: Dict, filing_rec: Filing, filing_meta: F
 
     filing_meta.dissolution = {}
     dissolution_type = dpath.util.get(filing, '/dissolution/dissolutionType')
-
-    with suppress(IndexError, KeyError, TypeError):
-        filing_meta.dissolution = {**filing_meta.dissolution,
-                                   **{'dissolutionType': dissolution_type}}
 
     # hasLiabilities can be derived from dissolutionStatementType
     # FUTURE: remove hasLiabilities from schema
@@ -77,6 +74,11 @@ def process(business: Business, filing: Dict, filing_rec: Filing, filing_meta: F
 
     if business.legal_type == Business.LegalTypes.COOP:
         _update_cooperative(dissolution_filing, business, filing_rec, dissolution_type)
+
+    with suppress(IndexError, KeyError, TypeError):
+        filing_meta.dissolution = {**filing_meta.dissolution,
+                                   **{'dissolutionType': dissolution_type},
+                                   **{'dissolutionDate': datetime.date(filing_rec.effective_date).isoformat()}}
 
 
 def _update_cooperative(dissolution_filing: Dict, business: Business, filing: Filing, dissolution_type):

--- a/queue_services/entity-filer/tests/unit/filing_processors/test_dissolution.py
+++ b/queue_services/entity-filer/tests/unit/filing_processors/test_dissolution.py
@@ -24,7 +24,7 @@ from legal_api.models.document import DocumentType
 from legal_api.services.minio import MinioService
 from registry_schemas.example_data import DISSOLUTION, FILING_HEADER
 from entity_filer.filing_meta import FilingMeta
-from tests.utils import upload_file, assert_pdf_contains_text
+from tests.utils import upload_file, assert_pdf_contains_text, has_expected_date_str_format
 
 from entity_filer.filing_processors import dissolution
 from tests.unit import create_business, create_filing
@@ -39,6 +39,7 @@ from tests.unit import create_business, create_filing
     ('CP', 'CP1234567', 'voluntary'),
     ('BC', 'BC1234567', 'administrative'),
     ('SP', 'FM1234567', 'administrative'),
+    ('GP', 'FM1234567', 'administrative'),
 ])
 def test_dissolution(app, session, minio_server, legal_type, identifier, dissolution_type):
     """Assert that the dissolution is processed."""
@@ -117,6 +118,11 @@ def test_dissolution(app, session, minio_server, legal_type, identifier, dissolu
         assert_pdf_contains_text('Filed on ', affidavit_obj.read())
 
     assert filing_meta.dissolution['dissolutionType'] == dissolution_type
+
+    dissolution_date_str = datetime.date(filing.effective_date).isoformat()
+    dissolution_date_format_correct = has_expected_date_str_format(dissolution_date_str, '%Y-%m-%d')
+    assert dissolution_date_format_correct
+    assert filing_meta.dissolution['dissolutionDate'] == dissolution_date_str
 
 
 @pytest.mark.parametrize('legal_type,identifier,dissolution_type', [
@@ -202,6 +208,11 @@ def test_administrative_dissolution(app, session, minio_server, legal_type, iden
         assert_pdf_contains_text('Filed on ', affidavit_obj.read())
 
     assert filing_meta.dissolution['dissolutionType'] == dissolution_type
+
+    dissolution_date_str = datetime.date(filing.effective_date).isoformat()
+    dissolution_date_format_correct = has_expected_date_str_format(dissolution_date_str, '%Y-%m-%d')
+    assert dissolution_date_format_correct
+    assert filing_meta.dissolution['dissolutionDate'] == dissolution_date_str
 
     final_filing = Filing.find_by_id(filing_id)
     assert filing_json['filing']['dissolution']['details'] == final_filing.order_details

--- a/queue_services/entity-filer/tests/utils.py
+++ b/queue_services/entity-filer/tests/utils.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Util functions for testing."""
 import io
+from datetime import datetime
+
 import requests
 import PyPDF2
 from legal_api.services.minio import MinioService
@@ -54,3 +56,11 @@ def assert_pdf_contains_text(search_text, pdf_raw_bytes: bytes):
     pdf_page = pdf_obj.getPage(0)
     text = pdf_page.extractText()
     assert search_text in text
+
+def has_expected_date_str_format(date_str: str, format: str) -> bool:
+    "Determine if date string confirms to expected format"
+    try:
+        datetime.strptime(date_str, format)
+    except ValueError:
+        return False
+    return True


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13834

*Description of changes:*

* Update filer to add dissolution date to filing meta data
* Update filer test
* Update custom SP/GP pipeline filer to add dissolution date to filing meta data
* Update business endpoint to return dissolution date in same format as all other places.  i.e. only the date and not timestamp
* Update business json test


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
