### PR TITLE
13036 13833 13774 Dashboard output fixes

### DIFF
--- a/legal-api/report-templates/template-parts/common/businessDetails.html
+++ b/legal-api/report-templates/template-parts/common/businessDetails.html
@@ -145,7 +145,7 @@
             </td>
             <td>
                <div>{{business.identifier}}</div>
-               <div class="pt-2">{{effective_date}}</div>
+               <div class="pt-2">{{formatted_founding_date}}</div>
                <div class="pt-2">{{filing_date_time}}</div>
                <div class="pt-2">
                   {% if taxId is defined %}

--- a/legal-api/report-templates/template-parts/common/businessDetails.html
+++ b/legal-api/report-templates/template-parts/common/businessDetails.html
@@ -127,8 +127,8 @@
                <div class="pt-2">{{recognition_date_utc}}</div>
                <div class="pt-2">{{filing_date_time}}</div>
                <div class="pt-2">
-                  {% if taxId is defined %}
-                      <span>{{ taxId }}</span>
+                  {% if business.taxId is defined %}
+                      <span>{{ business.taxId }}</span>
                   {% else %}
                       <span>Not Available</span>
                   {% endif %}
@@ -148,8 +148,8 @@
                <div class="pt-2">{{formatted_founding_date}}</div>
                <div class="pt-2">{{filing_date_time}}</div>
                <div class="pt-2">
-                  {% if taxId is defined %}
-                      <span>{{ taxId }}</span>
+                  {% if business.taxId is defined %}
+                      <span>{{ business.taxId }}</span>
                   {% else %}
                       <span>Not Available</span>
                   {% endif %}

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -564,7 +564,8 @@ class Report:  # pylint: disable=too-few-public-methods
         if party_json.get('officer').get('partyType') == 'person':
             last_name = party_json['officer'].get('lastName')
             first_name = party_json['officer'].get('firstName')
-            middle_initial = party_json['officer'].get('middleInitial') if party_json['officer'].get('middleInitial') else ''
+            middle_initial = party_json['officer'].get('middleInitial')\
+                if party_json['officer'].get('middleInitial') else ''
             party_name = f'{last_name}, {first_name} {middle_initial}'
         elif party_json.get('officer').get('partyType') == 'organization':
             party_name = party_json['officer'].get('organizationName')

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -564,7 +564,8 @@ class Report:  # pylint: disable=too-few-public-methods
         if party_json.get('officer').get('partyType') == 'person':
             last_name = party_json['officer'].get('lastName')
             first_name = party_json['officer'].get('firstName')
-            party_name = f'{last_name}, {first_name}'
+            middle_initial = party_json['officer'].get('middleInitial') if party_json['officer'].get('middleInitial') else ''
+            party_name = f'{last_name}, {first_name} {middle_initial}'
         elif party_json.get('officer').get('partyType') == 'organization':
             party_name = party_json['officer'].get('organizationName')
         return party_name


### PR DESCRIPTION
*Issue #:* /
bcgov/entity#13036
bcgov/entity#13833
bcgov/entity#13774

*Description of changes:*
 - For change of registration  filings the registration date is set to the business founding date for dashboard outputs.
 - Missing BN now displays Not available instead of None
 - Middle initial has been added to previous name


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
