### PR TITLE
Multiple affiliation fix 

### DIFF
--- a/legal-api/src/legal_api/services/bootstrap.py
+++ b/legal-api/src/legal_api/services/bootstrap.py
@@ -130,7 +130,8 @@ class AccountService:
                            business_registration: str,
                            business_name: str = None,
                            corp_type_code: str = 'TMP',
-                           pass_code: str = ''):
+                           pass_code: str = '',
+                           details:dict = None):
         """Affiliate a business to an account."""
         auth_url = current_app.config.get('AUTH_SVC_URL')
         account_svc_entity_url = f'{auth_url}/entities'
@@ -146,6 +147,8 @@ class AccountService:
                                   'corpTypeCode': corp_type_code,
                                   'name': business_name or business_registration
                                   })
+        if details:
+            entity_data['details'] = details
         entity_record = requests.post(
             url=account_svc_entity_url,
             headers={**cls.CONTENT_TYPE_JSON,

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/registration.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/registration.py
@@ -37,12 +37,20 @@ def update_affiliation(business: Business, filing: Filing):
         bootstrap = RegistrationBootstrap.find_by_identifier(filing.temp_reg)
         pass_code = business_info.get_firm_affiliation_passcode(business.id)
 
+        nr_number = filing.filing_json.get('filing').get('registration', {}).get('nameRequest', {}).get('nrNumber')
+        details = {
+            'bootstrapIdentifier': bootstrap.identifier,
+            'identifier': business.identifier,
+            'nrNumber': nr_number
+        }
+
         rv = AccountService.create_affiliation(
             account=bootstrap.account,
             business_registration=business.identifier,
             business_name=business.legal_name,
             corp_type_code=business.legal_type,
-            pass_code=pass_code
+            pass_code=pass_code,
+            details = details
         )
 
         if rv not in (HTTPStatus.OK, HTTPStatus.CREATED):


### PR DESCRIPTION
Experimental deploy to DEV

*Description of changes:*
Send over extra information to make it possible to synchronize affiliations in Auth to point at one entity instead of two entities.
This allows STAFF to use a client's affiliated NR, to register a business and at the end of the process show the same information in both the client's and staff's business dashboards.

Thank you Lekshmi for these changes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
