### PR TITLE
12918 SP/GP pipeline - add support for ADFIRM events with no filings

### DIFF
--- a/data-tool/flows/common/affiliation_queries.py
+++ b/data-tool/flows/common/affiliation_queries.py
@@ -4,8 +4,9 @@ def get_unaffiliated_firms_query(data_load_env: str):
             from affiliation_processing ap
                      join corporation c on ap.corp_num = c.corp_num
             where environment = '{data_load_env}'
-               and processed_status is null
-              or processed_status <> 'COMPLETED'
+              -- and processed_status is null
+              --or processed_status <> 'COMPLETED'
+              and (processed_status is null or processed_status not in ('COMPLETED', 'FAILED'))
             limit 5
             ;
         """

--- a/data-tool/flows/common/event_filing_service.py
+++ b/data-tool/flows/common/event_filing_service.py
@@ -59,6 +59,8 @@ class ChangeRegistrationEventFilings(str, Enum):
     FILE_FRACH = 'FILE_FRACH'
     FILE_FRARG = 'FILE_FRARG'
 
+    ADFIRM_NULL = 'ADFIRM_NULL'
+
     @classmethod
     def has_value(cls, value):
         return value in cls._value2member_map_
@@ -138,6 +140,8 @@ EVENT_FILING_LEAR_TARGET_MAPPING = {
     ChangeRegistrationEventFilings.FILE_AMDSP: FilingCore.FilingTypes.CHANGEOFREGISTRATION.value,
     ChangeRegistrationEventFilings.FILE_FRACH: FilingCore.FilingTypes.CHANGEOFREGISTRATION.value,
     ChangeRegistrationEventFilings.FILE_FRARG: FilingCore.FilingTypes.CHANGEOFREGISTRATION.value,
+
+    ChangeRegistrationEventFilings.ADFIRM_NULL: FilingCore.FilingTypes.CHANGEOFREGISTRATION.value,
 
     DissolutionEventFilings.CONVFMDISS_FRDIS: FilingCore.FilingTypes.DISSOLUTION.value,
     DissolutionEventFilings.FILE_DISGP: FilingCore.FilingTypes.DISSOLUTION.value,

--- a/data-tool/flows/common/firm_filing_data_utils.py
+++ b/data-tool/flows/common/firm_filing_data_utils.py
@@ -2,6 +2,8 @@ from enum import Enum
 
 import pandas as pd
 
+from flows.common.event_filing_service import ChangeRegistrationEventFilings
+
 
 class AddressFormatType(str, Enum):
     BASIC = 'BAS'
@@ -111,11 +113,31 @@ def get_party_type(filing_party_data: dict):
 
 
 def get_is_paper_only(filing_data: dict):
+    if (event_filing_type := filing_data['event_file_type']) and \
+            event_filing_type == ChangeRegistrationEventFilings.ADFIRM_NULL:
+        return True
+
     if (ods_type_cd := filing_data['f_ods_type']) and \
             ods_type_cd == 'P':
         return True
 
     return False
+
+
+def get_effective_date(filing_data: dict):
+    if (event_filing_type := filing_data['event_file_type']) and \
+            event_filing_type == ChangeRegistrationEventFilings.ADFIRM_NULL:
+        return filing_data['e_event_dts_pacific']
+
+    return filing_data['f_effective_dts_pacific']
+
+
+def get_effective_date_str(filing_data: dict):
+    if (event_filing_type := filing_data['event_file_type']) and \
+            event_filing_type == ChangeRegistrationEventFilings.ADFIRM_NULL:
+        return filing_data['e_event_dt_str']
+
+    return filing_data['f_effective_dt_str']
 
 
 def get_event_info_to_retrieve(unprocessed_firm_dict: dict):

--- a/data-tool/flows/common/firm_filing_json_factory_service.py
+++ b/data-tool/flows/common/firm_filing_json_factory_service.py
@@ -2,7 +2,7 @@ from .firm_filing_base_json import get_base_registration_filing_json, get_base_c
     get_base_dissolution_filing_json, get_base_conversion_filing_json, get_base_put_back_on_filing_json, \
     get_base_correction_filing_json
 from .firm_filing_data_utils import get_certified_by, get_party_role_type, get_party_type, \
-    get_street_address, get_street_additional, AddressFormatType
+    get_street_address, get_street_additional, AddressFormatType, get_effective_date_str
 
 
 class FirmFilingJsonFactoryService:
@@ -22,7 +22,7 @@ class FirmFilingJsonFactoryService:
             if filing_data_completing_party:
                 self._completing_party = filing_data_completing_party
 
-        self._event_id = self._filing_data['f_event_id']
+        self._event_id = self._filing_data['e_event_id']
         self._prev_event_id = self._filing_data.get('prev_event_filing_data', {}).get('e_event_id', None)
         self._corp_type_cd = self._filing_data['c_corp_type_cd']
 
@@ -135,7 +135,7 @@ class FirmFilingJsonFactoryService:
 
     def populate_header(self, filing_root_dict: dict):
         header = filing_root_dict['filing']['header']
-        effective_dt_str= self._filing_data['f_effective_dt_str']
+        effective_dt_str = get_effective_date_str(self._filing_data)
         header['date'] = effective_dt_str
 
         certified_by = get_certified_by(self._filing_data)

--- a/data-tool/flows/common/firm_queries.py
+++ b/data-tool/flows/common/firm_queries.py
@@ -90,6 +90,11 @@ def get_unprocessed_firms_query(data_load_env: str):
                        -- bn num tests
 --                         and e.corp_num in ('FM0476538') -- has bn 15
 --                         and e.corp_num in ('FM0046262') -- has bn 9
+                       -- adfirm events with no filing 
+--                         and e.corp_num in ('FM0055113', 'FM0416637', 'FM0445808', 'FM0020924', 'FM0054588', 
+--                                            'FM0067077', 'FM0070431', 'FM0109121', 'FM0116406', 'FM0159962', 
+--                                            'FM0187352', 'FM0601717', 'FM0601877', 'FM0668295', 'FM0711517', 
+--                                            'FM0809641', 'FM0864098')
                   group by e.corp_num) as tbl_fe
                      left outer join corp_processing cp on 
                         cp.corp_num = tbl_fe.corp_num 

--- a/data-tool/flows/common/lear_data_utils.py
+++ b/data-tool/flows/common/lear_data_utils.py
@@ -4,7 +4,7 @@ from legal_api.models import Party, PartyRole, Business, Office, Address, Filing
 from legal_api.models.colin_event_id import ColinEventId
 
 from .event_filing_service import RegistrationEventFilings, CorrectionEventFilings
-from .firm_filing_data_utils import get_is_paper_only
+from .firm_filing_data_utils import get_is_paper_only, get_effective_date
 
 
 def get_party_match(db: any, party_dict: dict, corp_num: str):
@@ -103,7 +103,7 @@ def get_colin_event(db: any, event_id: int):
 def populate_filing(business: Business, event_filing_data: dict, filing_data: dict):
     target_lear_filing_type = filing_data['target_lear_filing_type']
     filing_json = event_filing_data['filing_json']
-    effective_date = filing_data['f_effective_dts_pacific']
+    effective_date = get_effective_date(filing_data)
 
     filing = Filing()
     filing.skip_status_listener = True


### PR DESCRIPTION
*Issue #:* /bcgov/entity#12918

*Description of changes:*

* Updated SP/GP pipeline to support ADFIRM_NULL filing/event type.  This filing/event type maps to the change registration filing
* Misc update to SP/GP affiliation flow to not try to reprocess FAILED affiliations by default

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
