### PR TITLE
Patch release commits

### DIFF
--- a/legal-api/requirements.txt
+++ b/legal-api/requirements.txt
@@ -58,5 +58,5 @@ urllib3==1.26.4
 minio==7.0.2
 PyPDF2==1.26.0
 reportlab==3.6.1
-git+https://github.com/bcgov/business-schemas.git@2.15.34#egg=registry_schemas
+git+https://github.com/bcgov/business-schemas.git@2.15.35#egg=registry_schemas
 

--- a/legal-api/src/legal_api/version.py
+++ b/legal-api/src/legal_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.62.0b'  # pylint: disable=invalid-name
+__version__ = '2.63.0a'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*

* Cherry picked commit to extend max length of party organization length by using latest schema version
* bumped legal api version num to 2.63.0a for patch release

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
