### PR TITLE
13938 Update IA and registration filing processor affiliation logic

### DIFF
--- a/queue_services/entity-filer/src/entity_filer/filing_processors/incorporation_filing.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/incorporation_filing.py
@@ -50,21 +50,16 @@ def update_affiliation(business: Business, filing: Filing):
                 level='error'
             )
         else:
-            # flip the registration
-            # recreate the bootstrap, but point to the new business in the name
-            old_bs_affiliation = AccountService.delete_affiliation(bootstrap.account, bootstrap.identifier)
-            new_bs_affiliation = AccountService.create_affiliation(
-                account=bootstrap.account,
+            # update the bootstrap to use the new business identifier for the name
+            bootstrap_update = AccountService.update_entity(
                 business_registration=bootstrap.identifier,
                 business_name=business.identifier,
                 corp_type_code='TMP'
             )
-            reaffiliate = bool(new_bs_affiliation in (HTTPStatus.OK, HTTPStatus.CREATED)
-                               and old_bs_affiliation == HTTPStatus.OK)
 
         if rv not in (HTTPStatus.OK, HTTPStatus.CREATED) \
-                or ('deaffiliation' in locals() and deaffiliation != HTTPStatus.OK)\
-                or ('reaffiliate' in locals() and not reaffiliate):
+                or ('deaffiliation' in locals() and deaffiliation != HTTPStatus.OK) \
+                or ('bootstrap_update' in locals() and bootstrap_update != HTTPStatus.OK):
             raise QueueException
     except Exception as err:  # pylint: disable=broad-except; note out any exception, but don't fail the call
         sentry_sdk.capture_message(

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/registration.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/registration.py
@@ -60,21 +60,16 @@ def update_affiliation(business: Business, filing: Filing):
                 level='error'
             )
         else:
-            # flip the registration
-            # recreate the bootstrap, but point to the new business in the name
-            old_bs_affiliation = AccountService.delete_affiliation(bootstrap.account, bootstrap.identifier)
-            new_bs_affiliation = AccountService.create_affiliation(
-                account=bootstrap.account,
+            # update the bootstrap to use the new business identifier for the name
+            bootstrap_update = AccountService.update_entity(
                 business_registration=bootstrap.identifier,
                 business_name=business.identifier,
                 corp_type_code='RTMP'
             )
-            reaffiliate = bool(new_bs_affiliation in (HTTPStatus.OK, HTTPStatus.CREATED)
-                               and old_bs_affiliation == HTTPStatus.OK)
 
         if rv not in (HTTPStatus.OK, HTTPStatus.CREATED) \
                 or ('deaffiliation' in locals() and deaffiliation != HTTPStatus.OK)\
-                or ('reaffiliate' in locals() and not reaffiliate):
+                or ('bootstrap_update' in locals() and bootstrap_update != HTTPStatus.OK):
             raise QueueException
     except Exception as err:  # pylint: disable=broad-except; note out any exception, but don't fail the call
         sentry_sdk.capture_message(

--- a/queue_services/entity-filer/tests/unit/test_worker/test_incorporation.py
+++ b/queue_services/entity-filer/tests/unit/test_worker/test_incorporation.py
@@ -16,12 +16,15 @@ import asyncio
 import copy
 import datetime
 import random
+from http import HTTPStatus
+from unittest.mock import patch, call
 
 import pytest
 from entity_queue_common.messages import get_data_from_msg
 from entity_queue_common.service_utils import subscribe_to_queue
-from legal_api.models import Business, Filing, PartyRole
+from legal_api.models import Business, Filing, PartyRole, RegistrationBootstrap
 from legal_api.services import RegistrationBootstrapService
+from legal_api.services.bootstrap import AccountService
 from registry_schemas.example_data import INCORPORATION_FILING_TEMPLATE
 
 from entity_filer.worker import process_filing
@@ -82,6 +85,38 @@ async def test_incorporation_filing(app, session, bootstrap):
     completing_party = (PartyRole.get_parties_by_role(business.id, 'completing_party'))[0]
     assert incorporator.appointment_date
     assert completing_party.appointment_date
+
+
+def test_update_affiliation():
+    """Assert that affiliation for IA results in expected Auth API calls."""
+    from entity_filer.filing_processors import incorporation_filing
+
+    business = Business(identifier='FM1234567', legal_type='BEN', legal_name='Test')
+    filing = Filing(id=1)
+    bootstrap = RegistrationBootstrap(account=1111111, _identifier='TNpUnst/Va')
+
+    with patch.object(AccountService, 'create_affiliation', return_value=HTTPStatus.OK):
+        with patch.object(AccountService, 'delete_affiliation', return_value=HTTPStatus.OK):
+            with patch.object(AccountService, 'update_entity', return_value=HTTPStatus.OK):
+                with patch.object(RegistrationBootstrap, 'find_by_identifier', return_value=bootstrap):
+                    incorporation_filing.update_affiliation(business, filing)
+
+                    assert AccountService.create_affiliation.call_count == 1
+                    assert AccountService.delete_affiliation.call_count == 0
+                    assert AccountService.update_entity.call_count == 1
+
+                    first_affiliation_call_args = AccountService.create_affiliation.call_args_list[0]
+                    expected_affiliation_call_args = call(account=bootstrap.account,
+                                                          business_registration=business.identifier,
+                                                          business_name=business.legal_name,
+                                                          corp_type_code=business.legal_type)
+                    assert first_affiliation_call_args == expected_affiliation_call_args
+
+                    first_update_entity_call_args = AccountService.update_entity.call_args_list[0]
+                    expected_update_entity_call_args = call(business_registration=bootstrap.identifier,
+                                                            business_name=business.identifier,
+                                                            corp_type_code='TMP')
+                    assert first_update_entity_call_args == expected_update_entity_call_args
 
 
 def test_update_affiliation_error(mocker):


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13938

*Description of changes:*

* Update IA and registration filing processor to update bootstrap entity instead of re-creating affiliation and entity.  Note: this bypasses having to delete the existing bootstrap affiliation and entity which was causing a timing issue in some instances for the FE.
* Add & update IA & registration tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
