### PR TITLE
14071 do not show BN9 in reports

### DIFF
--- a/legal-api/report-templates/template-parts/business-summary/parties.html
+++ b/legal-api/report-templates/template-parts/business-summary/parties.html
@@ -30,10 +30,6 @@
                 <div class="pt-2">Incorporation Number:</div>
                 <div class="upper-text">{{ party.officer.identifier }}</div>
               {% endif %}
-              {% if party.officer.taxId %}
-                <div class="pt-2">Business Number:</div>
-                <div class="upper-text">{{ party.officer.taxId }}</div>
-              {% endif %}
             </td>
             <td>
               <div class="section-sub-title">Mailing Address</div>

--- a/legal-api/report-templates/template-parts/change-of-registration/partner.html
+++ b/legal-api/report-templates/template-parts/change-of-registration/partner.html
@@ -25,10 +25,6 @@
                   <div class="pt-2">Incorporation Number:</div>
                   <div class="upper-text">{{ party.officer.identifier }}</div>
                 {% endif %}
-                {% if party.officer.taxId %}
-                  <div class="pt-2">Business Number:</div>
-                  <div class="upper-text">{{ party.officer.taxId }}</div>
-                {% endif %}
               </td>
               {% if party.mailingAddress is defined %}
               <td>
@@ -109,10 +105,6 @@
                 {% if party.officer.identifier %}
                   <div class="pt-2">Incorporation Number:</div>
                   <div class="upper-text">{{ party.officer.identifier }}</div>
-                {% endif %}
-                {% if party.officer.taxId %}
-                  <div class="pt-2">Business Number:</div>
-                  <div class="upper-text">{{ party.officer.taxId }}</div>
                 {% endif %}
               </td>
               {% if party.mailingAddress is defined %}
@@ -200,10 +192,6 @@
                 {% if party.officer.identifier %}
                   <div class="pt-2">Incorporation Number:</div>
                   <div class="upper-text">{{ party.officer.identifier }}</div>
-                {% endif %}
-                {% if party.officer.taxId %}
-                  <div class="pt-2">Business Number:</div>
-                  <div class="upper-text">{{ party.officer.taxId }}</div>
                 {% endif %}
               </td>
               {% if party.mailingAddress is defined %}

--- a/legal-api/report-templates/template-parts/change-of-registration/proprietor.html
+++ b/legal-api/report-templates/template-parts/change-of-registration/proprietor.html
@@ -37,10 +37,6 @@
               <div class="pt-2">Incorporation Number:</div>
               <div class="upper-text">{{ party.officer.identifier }}</div>
             {% endif %}
-            {% if party.officer.taxId %}
-              <div class="pt-2">Business Number:</div>
-              <div class="upper-text">{{ party.officer.taxId }}</div>
-            {% endif %}
           </td>
           {% if party.mailingAddress is defined %}
           <td>

--- a/legal-api/report-templates/template-parts/common/businessDetails.html
+++ b/legal-api/report-templates/template-parts/common/businessDetails.html
@@ -20,7 +20,7 @@
               <td class="col-67">
                  <div>{{business.identifier}}</div>
                  <div class="pt-2">
-                   {% if business.taxId is defined %}
+                   {% if business.taxId is defined and business.taxId|length > 9 %}
                       <span>{{ business.taxId }}</span>
                    {% else %}
                       <span>Not Available</span>
@@ -106,8 +106,8 @@
                <div>{{business.identifier}}</div>
                <div class="pt-2">{{filing_date_time}}</div>
                <div class="pt-2">
-                  {% if business.taxId is defined %}
-                      <span>{{ business.taxId }}</span>
+                  {% if taxId is defined and taxId|length > 9 %}
+                      <span>{{ taxId }}</span>
                   {% else %}
                       <span>Not Available</span>
                   {% endif %}
@@ -127,8 +127,8 @@
                <div class="pt-2">{{recognition_date_utc}}</div>
                <div class="pt-2">{{filing_date_time}}</div>
                <div class="pt-2">
-                  {% if business.taxId is defined %}
-                      <span>{{ business.taxId }}</span>
+                  {% if taxId is defined and taxId|length > 9 %}
+                      <span>{{ taxId }}</span>
                   {% else %}
                       <span>Not Available</span>
                   {% endif %}
@@ -148,8 +148,8 @@
                <div class="pt-2">{{recognition_date_utc}}</div>
                <div class="pt-2">{{filing_date_time}}</div>
                <div class="pt-2">
-                  {% if business.taxId is defined %}
-                      <span>{{ business.taxId }}</span>
+                  {% if taxId is defined and taxId|length > 9 %}
+                      <span>{{ taxId }}</span>
                   {% else %}
                       <span>Not Available</span>
                   {% endif %}
@@ -186,7 +186,7 @@
          {% elif header.name == 'annualReport' %}
             <td>
                <div class="bold">Incorporation Number:</div>
-               {% if taxId %}
+               {% if taxId and taxId|length > 9 %}
                <div class="bold pt-2">Business Number:</div>
                {% endif %}
                <div class="bold pt-2">Filed Date and Time:</div>
@@ -196,7 +196,7 @@
             </td>
             <td>
                <div>{{business.identifier}}</div>
-               {% if taxId %}
+               {% if taxId and taxId|length > 9 %}
                <div class="pt-2">{{taxId}}</div>
                {% endif %}
                <div class="pt-2">{{filing_date_time}}</div>
@@ -276,8 +276,8 @@
                   <div class="pt-2">{{effective_date_time}}</div>
                {% endif %}
                {% if business.legalType in ['GP', 'SP'] %}
-                   {% if business.taxId is defined %}
-                      <div class="pt-2">{{ business.taxId }}</div>
+                   {% if taxId is defined and taxId|length > 9 %}
+                      <div class="pt-2">{{ taxId }}</div>
                    {% else %}
                       <div class="pt-2">Not Available</div>
                    {% endif %}

--- a/legal-api/report-templates/template-parts/registration-statement/party.html
+++ b/legal-api/report-templates/template-parts/registration-statement/party.html
@@ -27,10 +27,6 @@
               <div class="pt-2">Incorporation Number:</div>
               <div class="upper-text">{{ party.officer.identifier }}</div>
             {% endif %}
-            {% if party.officer.taxId %}
-              <div class="pt-2">Business Number:</div>
-              <div class="upper-text">{{ party.officer.taxId }}</div>
-            {% endif %}
           </td>
           {% if party.mailingAddress is defined %}
           <td>

--- a/legal-api/report-templates/template-parts/registration/party.html
+++ b/legal-api/report-templates/template-parts/registration/party.html
@@ -34,10 +34,6 @@
               <div class="pt-2">Incorporation Number:</div>
               <div class="upper-text">{{ party.officer.identifier }}</div>
             {% endif %}
-            {% if party.officer.taxId %}
-              <div class="pt-2">Business Number:</div>
-              <div class="upper-text">{{ party.officer.taxId }}</div>
-            {% endif %}
           </td>
           {% if party.mailingAddress is defined %}
           <td>


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14071

*Description of changes:*
 - show BN15 once received from CRA
 - using taxId instead of business.taxId to get the updated business number (business.taxId is coming from version table and the taxId is updated as part of separate transaction) except business summary
 - party.tax_id is obsolete. removing from reports (we have a separate cleanup ticket to remove from schema and table)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
