### PR TITLE
14120 Update party first and middle name validation for BEN & COOP IAs

### DIFF
--- a/legal-api/requirements.txt
+++ b/legal-api/requirements.txt
@@ -58,5 +58,5 @@ urllib3==1.26.4
 minio==7.0.2
 PyPDF2==1.26.0
 reportlab==3.6.1
-git+https://github.com/bcgov/business-schemas.git@2.15.35#egg=registry_schemas
+git+https://github.com/bcgov/business-schemas.git@2.15.36#egg=registry_schemas
 

--- a/legal-api/tests/unit/services/filings/validations/__init__.py
+++ b/legal-api/tests/unit/services/filings/validations/__init__.py
@@ -30,24 +30,36 @@ def lists_are_equal(list_1, list_2) -> bool:
 
 
 def create_party(roles: list,
-                 party_id,
-                 mailing_addr,
-                 delivery_addr):
+                 party_id=None,
+                 mailing_addr=None,
+                 delivery_addr=None,
+                 officer=None):
     """Create party object with custom roles, mailing addresses and delivery aadresses."""
-    party = {
-        'officer': {
-            'id': party_id,
-            'firstName': 'Joe',
-            'lastName': 'Swanson',
-            'middleName': 'P',
-            'email': 'joe@email.com',
-            'organizationName': '',
-            'partyType': 'person'
-        },
-        'mailingAddress': None,
-        'deliveryAddress': None,
-        'roles': []
-    }
+
+    if officer:
+        party = {
+            'officer': officer,
+            'mailingAddress': None,
+            'deliveryAddress': None,
+            'roles': []
+        }
+        if party_id:
+            party.id = party_id
+    else:
+        party = {
+            'officer': {
+                'id': party_id,
+                'firstName': 'Joe',
+                'lastName': 'Swanson',
+                'middleName': 'P',
+                'email': 'joe@email.com',
+                'organizationName': '',
+                'partyType': 'person'
+            },
+            'mailingAddress': None,
+            'deliveryAddress': None,
+            'roles': []
+        }
 
     for role in roles:
         party['roles'].append({
@@ -92,6 +104,32 @@ def create_party_address(base_address=None,
            }
 
     return party_address
+
+
+def create_officer(base_officer=None,
+                   first_name=None,
+                   middle_name=None,
+                   last_name=None,
+                   organization_name=None,
+                   party_type=None):
+    if base_officer:
+        officer = base_officer
+        base_officer['firstName'] = first_name if first_name is not None else officer['firstName']
+        base_officer['middleName'] = middle_name if middle_name is not None else officer['middleName']
+        base_officer['lastName'] = last_name if last_name is not None else officer['lastName']
+        base_officer['organizationName'] = organization_name if organization_name is not None \
+                                            else officer['organizationName']
+        base_officer['partyType'] = party_type if party_type is not None else officer['partyType']
+        return officer
+    else:
+        return {
+            'firstName': first_name,
+            'middleName': middle_name,
+            'lastName': last_name,
+            'organizationName': organization_name,
+            'partyType': party_type
+        }
+
 
 def create_utc_future_date_str(days: int):
     """Create a future utc date and return as string."""


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14120

*Description of changes:*

* Add parties name validation to IA validation such that BENs and COOPs can only have first and middle name of max length 20
* Add tests for IA party names validation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
