### PR TITLE
14182 Fix NAICS validation issue for firm corrections

### DIFF
--- a/legal-api/src/legal_api/services/filings/validations/correction.py
+++ b/legal-api/src/legal_api/services/filings/validations/correction.py
@@ -19,8 +19,10 @@ from flask_babel import _
 
 from legal_api.errors import Error
 from legal_api.models import Business, Filing, PartyRole
-from legal_api.services.filings.validations.registration import validate_naics, validate_name_request, validate_offices
+from legal_api.services import NaicsService
+from legal_api.services.filings.validations.registration import validate_name_request, validate_offices
 
+from ...utils import get_str
 from .common_validations import has_at_least_one_share_class
 
 
@@ -47,7 +49,7 @@ def validate(business: Business, filing: Dict) -> Error:
     # validations for firms
     legal_type = filing.get('filing', {}).get('business', {}).get('legalType')
     if legal_type and legal_type in [Business.LegalTypes.SOLE_PROP.value, Business.LegalTypes.PARTNERSHIP.value]:
-        _validate_firms_correction(filing, legal_type, msg)
+        _validate_firms_correction(business, filing, legal_type, msg)
 
     if msg:
         return Error(HTTPStatus.BAD_REQUEST, msg)
@@ -55,7 +57,7 @@ def validate(business: Business, filing: Dict) -> Error:
     return None
 
 
-def _validate_firms_correction(filing, legal_type, msg):
+def _validate_firms_correction(business: Business, filing, legal_type, msg):
     filing_type = 'correction'
     if filing.get('filing', {}).get('correction', {}).get('nameRequest', {}).get('nrNumber', None):
         msg.extend(validate_name_request(filing, filing_type))
@@ -63,7 +65,7 @@ def _validate_firms_correction(filing, legal_type, msg):
         msg.extend(validate_party(filing, legal_type))
     if filing.get('filing', {}).get('correction', {}).get('offices', None):
         msg.extend(validate_offices(filing, filing_type))
-    msg.extend(validate_naics(filing, filing_type))
+    msg.extend(validate_naics(business, filing, filing_type))
 
 
 def validate_party(filing: Dict, legal_type: str) -> list:
@@ -96,5 +98,21 @@ def validate_party(filing: Dict, legal_type: str) -> list:
             msg.append({'error': '1 Proprietor and a Completing Party is required.', 'path': party_path})
         elif legal_type == Business.LegalTypes.PARTNERSHIP.value and (completing_parties < 1 or partner_parties < 2):
             msg.append({'error': '2 Partners and a Completing Party is required.', 'path': party_path})
+
+    return msg
+
+
+def validate_naics(business: Business, filing: Dict, filing_type: str) -> list:
+    """Validate naics."""
+    msg = []
+    naics_code_path = f'/filing/{filing_type}/business/naics/naicsCode'
+    naics_code = get_str(filing, naics_code_path)
+    naics_desc = get_str(filing, f'/filing/{filing_type}/business/naics/naicsDescription')
+
+    # Note: if existing naics code and description has not changed, no NAICS validation is required
+    if naics_code and (business.naics_code != naics_code or business.naics_description != naics_desc):
+        naics = NaicsService.find_by_code(naics_code)
+        if not naics or naics['classTitle'] != naics_desc:
+            msg.append({'error': 'Invalid naics code or description.', 'path': naics_code_path})
 
     return msg

--- a/legal-api/tests/unit/models/__init__.py
+++ b/legal-api/tests/unit/models/__init__.py
@@ -123,9 +123,13 @@ def factory_user(username: str, firstname: str = None, lastname: str = None):
     return user
 
 
-def factory_business(identifier, founding_date=EPOCH_DATETIME, last_ar_date=None,
+def factory_business(identifier,
+                     founding_date=EPOCH_DATETIME,
+                     last_ar_date=None,
                      entity_type=Business.LegalTypes.COOP.value,
-                     state=Business.State.ACTIVE):
+                     state=Business.State.ACTIVE,
+                     naics_code=None,
+                     naics_desc=None):
     """Create a business entity with a versioned business."""
     last_ar_year = None
     if last_ar_date:
@@ -140,7 +144,9 @@ def factory_business(identifier, founding_date=EPOCH_DATETIME, last_ar_date=None
                         tax_id='BN123456789',
                         fiscal_year_end_date=FROZEN_DATETIME,
                         legal_type=entity_type,
-                        state=state)
+                        state=state,
+                        naics_code=naics_code,
+                        naics_description=naics_desc)
 
     # Versioning business
     uow = versioning_manager.unit_of_work(db.session)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14182

*Description of changes:*

* Add correction filing specific `validate_naics` function.  This function is a bit different from the generic one used across other filing types as it needs to avoid NAICS validation when the existing NAICS code and/or description have not changed.
* Added tests for correction NAICS validation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
