### PR TITLE
14190 Add mapping for numbered company legal name suffixes

### DIFF
--- a/legal-api/src/legal_api/models/business.py
+++ b/legal-api/src/legal_api/models/business.py
@@ -138,6 +138,21 @@ class Business(db.Model):  # pylint: disable=too-many-instance-attributes
         SP_SOLE_PROPRIETORSHIP = 'SP'
         SP_DOING_BUSINESS_AS = 'DBA'
 
+    BUSINESSES = {
+        LegalTypes.BCOMP: {
+            'numberedLegalNameSuffix': 'B.C. LTD.'
+        },
+        LegalTypes.COMP: {
+            'numberedLegalNameSuffix': 'B.C. LTD.'
+        },
+        LegalTypes.BC_ULC_COMPANY: {
+            'numberedLegalNameSuffix': 'B.C. UNLIMITED LIABILITY COMPANY'
+        },
+        LegalTypes.BC_CCC: {
+            'numberedLegalNameSuffix': 'B.C. COMMUNITY CONTRIBUTION COMPANY LTD.'
+        }
+    }
+
     __versioned__ = {}
     __tablename__ = 'businesses'
     __mapper_args__ = {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14190

*Description of changes:*

* Add a mapping for legal types to numbered company legal  name suffixes.  This can be extended for other things related to a legal type in the future.  

  For the purposes of #14190, this will be used to append the appropriate legal name suffix for numbered companies of legal type BC, BEN, CC and ULC when the IA is processed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
