### PR TITLE
14190 Update IA filer processor to support ULC, CCC and BC

### DIFF
--- a/queue_services/entity-filer/requirements.txt
+++ b/queue_services/entity-filer/requirements.txt
@@ -23,6 +23,6 @@ urllib3==1.26.4
 minio==7.0.2
 PyPDF2==1.26.0
 reportlab==3.6.1
-git+https://github.com/bcgov/business-schemas.git@2.15.34#egg=registry_schemas
+git+https://github.com/bcgov/business-schemas.git@2.15.38#egg=registry_schemas
 git+https://github.com/bcgov/lear.git#egg=legal_api&subdirectory=legal-api
 git+https://github.com/bcgov/lear.git#egg=entity_queue_common&subdirectory=queue_services/common

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/business_info.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/business_info.py
@@ -102,8 +102,8 @@ def get_next_corp_num(legal_type: str):
     try:
         # TODO: update this to grab the legal 'class' after legal classes have been defined in lear
         if legal_type in (Business.LegalTypes.BCOMP.value,
-                          Business.LegalTypes.BC_ULC_COMPANY,
-                          Business.LegalTypes.BC_CCC,
+                          Business.LegalTypes.BC_ULC_COMPANY.value,
+                          Business.LegalTypes.BC_CCC.value,
                           Business.LegalTypes.COMP.value):
             business_type = 'BC'
         else:

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/business_info.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/business_info.py
@@ -57,7 +57,12 @@ def set_association_type(business: Business, association_type: String) -> Dict:
 def set_legal_name(corp_num: str, business: Business, business_info: Dict):
     """Set the legal_name in the business object."""
     legal_name = business_info.get('legalName', None)
-    business.legal_name = legal_name if legal_name else corp_num[2:] + ' B.C. LTD.'
+    if legal_name:
+        business.legal_name = legal_name
+    else:
+        legal_type = business_info.get('legalType', None)
+        numbered_legal_name_suffix = Business.BUSINESSES[legal_type]['numberedLegalNameSuffix']
+        business.legal_name = f'{corp_num[2:]} {numbered_legal_name_suffix}'
 
 
 def update_business_info(corp_num: str, business: Business, business_info: Dict, filing: Filing):
@@ -96,7 +101,10 @@ def get_next_corp_num(legal_type: str):
     # legacy Business.Identifier generation
     try:
         # TODO: update this to grab the legal 'class' after legal classes have been defined in lear
-        if legal_type == Business.LegalTypes.BCOMP.value:
+        if legal_type in (Business.LegalTypes.BCOMP.value,
+                          Business.LegalTypes.BC_ULC_COMPANY,
+                          Business.LegalTypes.BC_CCC,
+                          Business.LegalTypes.COMP.value):
             business_type = 'BC'
         else:
             business_type = legal_type

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/incorporation_filing.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/incorporation_filing.py
@@ -25,7 +25,7 @@ from legal_api.services.bootstrap import AccountService
 from legal_api.services.minio import MinioService
 
 from entity_filer.filing_meta import FilingMeta
-from entity_filer.filing_processors.filing_components import aliases, business_info, business_profile, shares
+from entity_filer.filing_processors.filing_components import aliases, business_info, business_profile, filings, shares
 from entity_filer.filing_processors.filing_components.offices import update_offices
 from entity_filer.filing_processors.filing_components.parties import update_parties
 from entity_filer.utils import replace_file_with_certified_copy
@@ -105,7 +105,7 @@ def _update_cooperative(incorp_filing: Dict, business: Business, filing: Filing)
     return business
 
 
-def process(business: Business,  # pylint: disable=too-many-branches
+def process(business: Business,  # pylint: disable=too-many-branches,too-many-locals
             filing: Dict,
             filing_rec: Filing,
             filing_meta: FilingMeta):  # pylint: disable=too-many-branches
@@ -165,6 +165,9 @@ def process(business: Business,  # pylint: disable=too-many-branches
 
     if name_translations := incorp_filing.get('nameTranslations'):
         aliases.update_aliases(business, name_translations)
+
+    if court_order := incorp_filing.get('courtOrder'):
+        filings.update_filing_court_order(filing_rec, court_order)
 
     if not is_correction and not filing_rec.colin_event_ids:
         # Update the filing json with identifier and founding date.

--- a/queue_services/entity-filer/tests/conftest.py
+++ b/queue_services/entity-filer/tests/conftest.py
@@ -147,9 +147,6 @@ def db(app):  # pylint: disable=redefined-outer-name, invalid-name
         # Clear out any existing tables
         metadata = MetaData(_db.engine)
         metadata.reflect()
-        for table in metadata.tables.values():
-            for fk in table.foreign_keys:  # pylint: disable=invalid-name
-                _db.engine.execute(DropConstraint(fk.constraint))
         metadata.drop_all()
         _db.drop_all()
 

--- a/queue_services/entity-filer/tests/unit/filing_processors/test_conversion.py
+++ b/queue_services/entity-filer/tests/unit/filing_processors/test_conversion.py
@@ -82,6 +82,7 @@ def test_conversion_coop_from_colin(app, session):
     """Assert that an existing coop incorporation is loaded corrrectly."""
     # setup
     identifier = 'CP0000001'
+    nr_num = 'NR 1234567'
     colind_id = 1
     filing = copy.deepcopy(CONVERSION_FILING_TEMPLATE)
 
@@ -89,6 +90,8 @@ def test_conversion_coop_from_colin(app, session):
     filing['filing']['business']['legalType'] = 'CP'
     filing['filing']['business']['identifier'] = identifier
     filing['filing']['conversion']['nameRequest']['legalType'] = 'CP'
+    filing['filing']['conversion']['nameRequest']['legalName'] = 'Test'
+    filing['filing']['conversion']['nameRequest']['nrNumber'] = nr_num
     filing['filing']['conversion'].pop('shareStructure')
     effective_date = datetime.utcnow()
     # Create the Filing obeject in the DB
@@ -110,16 +113,16 @@ def test_conversion_coop_from_colin(app, session):
     assert business.identifier == identifier
     assert business.founding_date.replace(tzinfo=None) == effective_date.replace(tzinfo=None)
     assert business.legal_type == filing['filing']['conversion']['nameRequest']['legalType']
-    assert business.legal_name == business.identifier[2:] + ' B.C. LTD.'
+    assert business.legal_name == 'Test'
     assert len(business.offices.all()) == 2  # One office is created in create_business method.
 
 
-@pytest.mark.parametrize('legal_type', [
-    ('BC'),
-    ('ULC'),
-    ('CC'),
+@pytest.mark.parametrize('legal_type, legal_name_suffix', [
+    ('BC', 'B.C. LTD.'),
+    ('ULC', 'B.C. UNLIMITED LIABILITY COMPANY'),
+    ('CC', 'B.C. COMMUNITY CONTRIBUTION COMPANY LTD.'),
 ])
-def test_conversion_bc_company_from_colin(app, session, legal_type):
+def test_conversion_bc_company_from_colin(app, session, legal_type, legal_name_suffix):
     """Assert that an existing bc company(LTD, ULC, CCC) incorporation is loaded corrrectly."""
     # setup
     identifier = 'BC0000001'
@@ -150,7 +153,7 @@ def test_conversion_bc_company_from_colin(app, session, legal_type):
     assert business.identifier == identifier
     assert business.founding_date.replace(tzinfo=None) == effective_date.replace(tzinfo=None)
     assert business.legal_type == filing['filing']['conversion']['nameRequest']['legalType']
-    assert business.legal_name == business.identifier[2:] + ' B.C. LTD.'
+    assert business.legal_name == f'{business.identifier[2:]} {legal_name_suffix}'
     assert len(business.offices.all()) == 2  # One office is created in create_business method.
     assert len(business.share_classes.all()) == 2
     assert len(business.party_roles.all()) == 1

--- a/queue_services/entity-filer/tests/unit/test_worker/test_incorporation.py
+++ b/queue_services/entity-filer/tests/unit/test_worker/test_incorporation.py
@@ -87,11 +87,18 @@ async def test_incorporation_filing(app, session, bootstrap):
     assert completing_party.appointment_date
 
 
-def test_update_affiliation():
+@pytest.mark.parametrize('legal_type, corp_num', [
+    ('BC', 'BC0001095'),
+    ('BEN', 'BC0001095'),
+    ('CP', 'CP0001095'),
+    ('ULC', 'BC0001095'),
+    ('CC', 'BC0001095'),
+])
+def test_update_affiliation(legal_type, corp_num):
     """Assert that affiliation for IA results in expected Auth API calls."""
     from entity_filer.filing_processors import incorporation_filing
 
-    business = Business(identifier='FM1234567', legal_type='BEN', legal_name='Test')
+    business = Business(identifier=corp_num, legal_type=legal_type, legal_name='Test')
     filing = Filing(id=1)
     bootstrap = RegistrationBootstrap(account=1111111, _identifier='TNpUnst/Va')
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14190

*Description of changes:*

* Update to latest schema version
* Added court order processing to IA filing processor
* Added logic to ensure business identifier is retrieved from COLIN for new legal types
* Updated numbered company legal name logic to append legal name suffix using a new map provided in business model
* Update existing IA tests to support new legal types
* Update tests in `test_conversion.py` as they were breaking.  I think these can actually be removed as well as some other tests in `test_incorporation_filing.py` as they either related to syncing back to COLIN or it has to do with the dataloader which is no longer used.  This will need to be addressed in future tickets
* Fixed issue in `conftest.py` where tests only ran successfully every other run locally

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
