### PR TITLE
14190 Revert unneeded colin api change

### DIFF
--- a/colin-api/src/colin_api/models/business.py
+++ b/colin-api/src/colin_api/models/business.py
@@ -37,8 +37,6 @@ class Business:  # pylint: disable=too-many-instance-attributes
         COOP = 'CP'
         BCOMP = 'BEN'
         BC_COMP = 'BC'
-        ULC_COMP = 'ULC'
-        CCC_COMP = 'CC'
 
     class TypeCodes(Enum):
         """Render an Enum of the Corporation Type Codes."""


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14190

*Description of changes:*

* Revert additions for ULC and CCC legal types in Colin API.  Initially added this thinking it was required for business identifier retrieval/generation for these legal types.  It turns out that "BC" is used for these legal types so these additions are not required.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
