### PR TITLE
14254 Update document list and ledger display name for IAs to support ULC, CC and BC

### DIFF
--- a/legal-api/src/legal_api/core/meta/filing.py
+++ b/legal-api/src/legal_api/core/meta/filing.py
@@ -203,7 +203,9 @@ FILINGS: Final = {
         'name': 'incorporationApplication',
         'title': FilingTitles.INCORPORATION_APPLICATION_DEFAULT,
         'displayName': {
-            'BC': FilingTitles.INCORPORATION_APPLICATION_DEFAULT,
+            'BC': 'BC Limited Company Incorporation Application',
+            'ULC': 'BC Unlimited Liability Company Incorporation Application',
+            'CC': 'BC Community Contribution Company Incorporation Application',
             'BEN': 'BC Benefit Company Incorporation Application',
             'CP': FilingTitles.INCORPORATION_APPLICATION_DEFAULT,
         },
@@ -212,7 +214,7 @@ FILINGS: Final = {
         },
         'additional': [
             {'types': 'CP', 'outputs': ['certificate', 'certifiedRules', 'certifiedMemorandum']},
-            {'types': 'BC,BEN', 'outputs': ['noticeOfArticles', 'certificate']},
+            {'types': 'BC,BEN,ULC,CC', 'outputs': ['noticeOfArticles', 'certificate']},
         ]
     },
     'registrarsNotation': {

--- a/legal-api/tests/conftest.py
+++ b/legal-api/tests/conftest.py
@@ -112,10 +112,6 @@ def db(app):  # pylint: disable=redefined-outer-name, invalid-name
         # Clear out any existing tables
         metadata = MetaData(_db.engine)
         metadata.reflect()
-        for table in metadata.tables.values():
-            for fk in table.foreign_keys:  # pylint: disable=invalid-name
-                with suppress(Exception):
-                    _db.engine.execute(DropConstraint(fk.constraint))
         with suppress(Exception):
             metadata.drop_all()
         with suppress(Exception):

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
@@ -558,7 +558,79 @@ del ALTERATION_WITHOUT_NR['nameRequest']['legalName']
          }
      },
      HTTPStatus.OK, '2017-10-01'
-     )
+     ),
+    ('ulc_ia_paid', 'BC7654321', Business.LegalTypes.BC_ULC_COMPANY.value,
+     'incorporationApplication', INCORPORATION, None, None, Filing.Status.PAID,
+     {'documents': {'receipt': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/receipt',
+                    'legalFilings': [
+                        {'incorporationApplication':
+                             f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/incorporationApplication'},
+                    ]
+                    }
+      },
+     HTTPStatus.OK, '2017-10-01'
+     ),
+    ('ulc_ia_completed', 'BC7654321', Business.LegalTypes.BC_ULC_COMPANY.value,
+     'incorporationApplication', INCORPORATION, None, None, Filing.Status.COMPLETED,
+     {'documents': {'receipt': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/receipt',
+                    'certificate': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/certificate',
+                    'noticeOfArticles': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/noticeOfArticles',
+                    'legalFilings': [
+                        {'incorporationApplication':
+                             f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/incorporationApplication'},
+                    ]
+                    }
+     },
+     HTTPStatus.OK, '2017-10-01'
+     ),
+    ('cc_ia_paid', 'BC7654321', Business.LegalTypes.BC_CCC.value,
+     'incorporationApplication', INCORPORATION, None, None, Filing.Status.PAID,
+     {'documents': {'receipt': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/receipt',
+                    'legalFilings': [
+                        {'incorporationApplication':
+                             f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/incorporationApplication'},
+                    ]
+                    }
+      },
+     HTTPStatus.OK, '2017-10-01'
+     ),
+    ('cc_ia_completed', 'BC7654321', Business.LegalTypes.BC_CCC.value,
+     'incorporationApplication', INCORPORATION, None, None, Filing.Status.COMPLETED,
+     {'documents': {'receipt': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/receipt',
+                    'certificate': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/certificate',
+                    'noticeOfArticles': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/noticeOfArticles',
+                    'legalFilings': [
+                        {'incorporationApplication':
+                             f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/incorporationApplication'},
+                    ]
+                    }
+      },
+     HTTPStatus.OK, '2017-10-01'
+     ),
+    ('bc_ia_paid', 'BC7654321', Business.LegalTypes.COMP.value,
+     'incorporationApplication', INCORPORATION, None, None, Filing.Status.PAID,
+     {'documents': {'receipt': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/receipt',
+                    'legalFilings': [
+                        {'incorporationApplication':
+                             f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/incorporationApplication'},
+                    ]
+                    }
+      },
+     HTTPStatus.OK, '2017-10-01'
+     ),
+    ('bc_ia_completed', 'BC7654321', Business.LegalTypes.COMP.value,
+     'incorporationApplication', INCORPORATION, None, None, Filing.Status.COMPLETED,
+     {'documents': {'receipt': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/receipt',
+                    'certificate': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/certificate',
+                    'noticeOfArticles': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/noticeOfArticles',
+                    'legalFilings': [
+                        {'incorporationApplication':
+                             f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/incorporationApplication'},
+                    ]
+                    }
+      },
+     HTTPStatus.OK, '2017-10-01'
+     ),
 ])
 def test_document_list_for_various_filing_states(session, client, jwt,
                                                  test_name,
@@ -575,6 +647,9 @@ def test_document_list_for_various_filing_states(session, client, jwt,
 
     filing_json = copy.deepcopy(FILING_HEADER)
     filing_json['filing']['header']['name'] = filing_name_1
+    filing_json['filing']['business']['legalType'] = entity_type
+    if filing_name_1 == 'incorporationApplication':
+        legal_filing_1['nameRequest']['legalType'] = entity_type
     filing_json['filing'][filing_name_1] = legal_filing_1
 
     if legal_filing_2:


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14254

*Description of changes:*

* Update filings document endpoint to support new legal types for IA filing
* Update IA display name to return non-empty value for new legal types
* Update filing ledger and filing documents list tests
* Update `conftest.py` to fix problem where tests would fail every other run when running locally

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
