### PR TITLE
14277 Fix registration app output download issue when business.tax_id is null

### DIFF
--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -271,7 +271,7 @@ class Report:  # pylint: disable=too-few-public-methods
             filing['registrarInfo'] = {**RegistrarInfo.get_registrar_info(self._filing.effective_date)}
 
     def _set_tax_id(self, filing):
-        if self._business:
+        if self._business and self._business.tax_id:
             filing['taxId'] = self._business.tax_id
 
     def _set_description(self, filing):


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14277

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
