### PR TITLE
14282 Update dependencies

### DIFF
--- a/legal-api/requirements.txt
+++ b/legal-api/requirements.txt
@@ -10,12 +10,12 @@ Flask==1.1.2
 Jinja2==2.11.3
 Mako==1.1.4
 MarkupSafe==1.1.1
-SQLAlchemy-Continuum==1.3.11
+SQLAlchemy-Continuum==1.3.13
 SQLAlchemy-Utils==0.37.8
-SQLAlchemy==1.3.24
+SQLAlchemy==1.4.44
 Werkzeug==1.0.1
 nest_asyncio
-alembic==1.6.0
+alembic==1.7.5
 aniso8601==9.0.1
 asyncio-nats-client==0.11.4
 asyncio-nats-streaming==0.4.0
@@ -58,5 +58,6 @@ urllib3==1.26.4
 minio==7.0.2
 PyPDF2==1.26.0
 reportlab==3.6.1
+sqlalchemy-json
 git+https://github.com/bcgov/business-schemas.git@2.15.38#egg=registry_schemas
 

--- a/legal-api/requirements/dev.txt
+++ b/legal-api/requirements/dev.txt
@@ -11,7 +11,7 @@ requests-mock
 
 # Lint and code style
 autopep8
-flake8
+flake8==5.0.4
 flake8-blind-except
 flake8-debugger
 flake8-docstrings

--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -22,6 +22,7 @@ from sqlalchemy import desc, event, func, inspect, or_, select
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import backref
+from sqlalchemy_json import mutable_json_type
 
 from legal_api.exceptions import BusinessException
 from legal_api.models.colin_event_id import ColinEventId
@@ -250,8 +251,8 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
     _completion_date = db.Column('completion_date', db.DateTime(timezone=True))
     _filing_date = db.Column('filing_date', db.DateTime(timezone=True), default=datetime.utcnow)
     _filing_type = db.Column('filing_type', db.String(30))
-    _filing_json = db.Column('filing_json', JSONB)
-    _meta_data = db.Column('meta_data', JSONB)
+    _filing_json = db.Column('filing_json', mutable_json_type(dbtype=JSONB, nested=True))
+    _meta_data = db.Column('meta_data', mutable_json_type(dbtype=JSONB, nested=True))
     _payment_status_code = db.Column('payment_status_code', db.String(50))
     _payment_token = db.Column('payment_id', db.String(4096))
     _payment_completion_date = db.Column('payment_completion_date', db.DateTime(timezone=True))
@@ -262,7 +263,7 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
     payment_account = db.Column('payment_account', db.String(30))
     effective_date = db.Column('effective_date', db.DateTime(timezone=True), default=datetime.utcnow)
     submitter_roles = db.Column('submitter_roles', db.String(200))
-    tech_correction_json = db.Column('tech_correction_json', JSONB)
+    tech_correction_json = db.Column('tech_correction_json', mutable_json_type(dbtype=JSONB, nested=True))
     court_order_file_number = db.Column('court_order_file_number', db.String(20))
     court_order_date = db.Column('court_order_date', db.DateTime(timezone=True), default=None)
     court_order_effect_of_order = db.Column('court_order_effect_of_order', db.String(500))

--- a/legal-api/tests/unit/models/test_registration_bootstrap.py
+++ b/legal-api/tests/unit/models/test_registration_bootstrap.py
@@ -17,7 +17,7 @@
 Test-Suite to ensure that the RegistrationBootstrap Model is working as expected.
 """
 import pytest
-from sqlalchemy.orm.exc import FlushError
+import sqlalchemy
 
 from legal_api.models import RegistrationBootstrap
 
@@ -29,7 +29,7 @@ def test_only_one_registration_bootstrap(session):
     r = RegistrationBootstrap(identifier=identifier, account=12)
     r.save()
 
-    with pytest.raises(FlushError):
+    with pytest.raises(sqlalchemy.exc.IntegrityError):
         p = RegistrationBootstrap(identifier=identifier, account=12)
         p.save()
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14282

*Description of changes:*

* Updated dependencies to support Prefect 2 which will be used for corps(BC/ULC/CCC) data migration pipeline
* Pinned down flake8 version as latest one results in linting errors
* Fixed broken tests
* Updated JSONB columns in filings model to use `sqlalchemy-json` to resolve issue where partial JSON field value updates weren't being persisted to the database after upgrading `SQLAlchemy` version in `requirements.txt`.  More details of the problem can be found here https://amercader.net/blog/beware-of-json-fields-in-sqlalchemy/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
