### PR TITLE
use idp guid to uniquely identify users

### DIFF
--- a/legal-api/migrations/versions/bddd732a9269_index_by_idp_guid.py
+++ b/legal-api/migrations/versions/bddd732a9269_index_by_idp_guid.py
@@ -1,0 +1,26 @@
+"""index-by-idp-guid
+
+Revision ID: bddd732a9269
+Revises: 5ee13998918d
+Create Date: 2022-12-13 09:20:50.961105
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'bddd732a9269'
+down_revision = '5ee13998918d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(op.f('ix_user_idp_userid'), 'users', ['idp_userid'], unique=True)
+    op.create_unique_constraint('users_idp_userid_key', 'users', ['idp_userid'])
+
+
+def downgrade():
+    op.drop_index(op.f('ix_user_idp_userid'), table_name='users')
+    op.drop_constraint('users_idp_userid_key', 'users', ['idp_userid'])

--- a/legal-api/src/legal_api/models/user.py
+++ b/legal-api/src/legal_api/models/user.py
@@ -94,10 +94,6 @@ class User(db.Model):
     @classmethod
     def find_by_jwt_token(cls, token: dict):
         """Return a User if they exist and match the provided JWT."""
-        return cls.query.filter_by(sub=token['sub']).one_or_none()
-
-    @classmethod
-    def find_by_jwt_idp_userid(cls, token):
         return cls.query.filter_by(sub=token['idp_userid']).one_or_none()
 
     @classmethod
@@ -128,7 +124,7 @@ class User(db.Model):
         """Return a valid user for audit tracking purposes."""
         # GET existing or CREATE new user based on the JWT info
         try:
-            user = User.find_by_jwt_idp_userid(jwt_oidc_token)
+            user = User.find_by_jwt_token(jwt_oidc_token)
             current_app.logger.debug(f'finding user: {jwt_oidc_token}')
             if not user:
                 current_app.logger.debug(f'didnt find user, attempting to create new user:{jwt_oidc_token}')

--- a/legal-api/src/legal_api/models/user.py
+++ b/legal-api/src/legal_api/models/user.py
@@ -94,7 +94,7 @@ class User(db.Model):
     @classmethod
     def find_by_jwt_token(cls, token: dict):
         """Return a User if they exist and match the provided JWT."""
-        return cls.query.filter_by(sub=token['idp_userid']).one_or_none()
+        return cls.query.filter_by(idp_userid=token['idp_userid']).one_or_none()
 
     @classmethod
     def create_from_jwt_token(cls, token: dict):

--- a/legal-api/tests/unit/models/test_user.py
+++ b/legal-api/tests/unit/models/test_user.py
@@ -40,17 +40,17 @@ def test_user(session):
     assert user.id is not None
 
 
-def test_user_find_by_jwt_token(session):
+def test_user_find_by_jwt_idp_userid(session):
     """Assert that a User can be stored in the service.
 
     Start with a blank database.
     """
-    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss')
+    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss', idp_userid='123', login_source='IDIR')
     session.add(user)
     session.commit()
 
-    token = {'sub': 'sub'}
-    u = User.find_by_jwt_token(token)
+    token = {'idp_userid': '123'}
+    u = User.find_by_jwt_idp_userid(token)
 
     assert u.id is not None
 
@@ -108,7 +108,7 @@ def test_create_from_invalid_jwt_token_no_token(session):
 
 def test_find_by_username(session):
     """Assert User can be found by the most current username."""
-    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss')
+    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss', idp_userid='123', login_source='IDIR')
     session.add(user)
     session.commit()
 
@@ -119,7 +119,7 @@ def test_find_by_username(session):
 
 def test_find_by_sub(session):
     """Assert find User by the unique sub key."""
-    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss')
+    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss', idp_userid='123', login_source='IDIR')
     session.add(user)
     session.commit()
 
@@ -130,7 +130,7 @@ def test_find_by_sub(session):
 
 def test_user_save(session):
     """Assert User record is saved."""
-    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss')
+    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss', idp_userid='123', login_source='IDIR')
     user.save()
 
     assert user.id is not None
@@ -138,7 +138,7 @@ def test_user_save(session):
 
 def test_user_delete(session):
     """Assert the User record is deleted."""
-    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss')
+    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss', idp_userid='123', login_source='IDIR')
     user.save()
     user.delete()
 
@@ -163,6 +163,6 @@ TEST_USER_DISPLAY_NAME = [
 @pytest.mark.parametrize('test_description, username, firstname, lastname, middlename, display_name', TEST_USER_DISPLAY_NAME)
 def test_user_display_name(session, test_description, username, firstname, lastname, middlename, display_name):
     """Assert the User record is deleted."""
-    user = User(username=username, firstname=firstname, lastname=lastname, middlename=middlename, sub='sub', iss='iss')
+    user = User(username=username, firstname=firstname, lastname=lastname, middlename=middlename, sub='sub', iss='iss', idp_userid='123', login_source='IDIR')
 
     assert display_name == user.display_name

--- a/legal-api/tests/unit/models/test_user.py
+++ b/legal-api/tests/unit/models/test_user.py
@@ -34,7 +34,7 @@ def test_user(session):
                 sub='sub',
                 iss='iss',
                 idp_userid='123',
-                login_source='source'
+                login_source='IDIR'
     )
 
     session.add(user)
@@ -66,7 +66,7 @@ def test_create_from_jwt_token(session):
              'iss': 'iss',
              'sub': 'sub',
              'idp_userid': '123',
-             'loginSource': 'source'
+             'loginSource': 'IDIR'
              }
     u = User.create_from_jwt_token(token)
     assert u.id is not None
@@ -80,7 +80,7 @@ def test_get_or_create_user_by_jwt(session):
              'iss': 'iss',
              'sub': 'sub',
              'idp_userid': '123',
-             'loginSource': 'source'
+             'loginSource': 'IDIR'
              }
     u = User.get_or_create_user_by_jwt(token)
     assert u.id is not None

--- a/legal-api/tests/unit/models/test_user.py
+++ b/legal-api/tests/unit/models/test_user.py
@@ -40,7 +40,7 @@ def test_user(session):
     assert user.id is not None
 
 
-def test_user_find_by_jwt_idp_userid(session):
+def test_user_find_by_jwt_token(session):
     """Assert that a User can be stored in the service.
 
     Start with a blank database.
@@ -50,7 +50,7 @@ def test_user_find_by_jwt_idp_userid(session):
     session.commit()
 
     token = {'idp_userid': '123'}
-    u = User.find_by_jwt_idp_userid(token)
+    u = User.find_by_jwt_token(token)
 
     assert u.id is not None
 

--- a/legal-api/tests/unit/models/test_user.py
+++ b/legal-api/tests/unit/models/test_user.py
@@ -33,7 +33,7 @@ def test_user(session):
                 lastname='lastname',
                 sub='sub',
                 iss='iss',
-                idp_userid='idp_userid',
+                idp_userid='123',
                 login_source='source'
     )
 

--- a/legal-api/tests/unit/models/test_user.py
+++ b/legal-api/tests/unit/models/test_user.py
@@ -32,7 +32,10 @@ def test_user(session):
                 middlename='middlename',
                 lastname='lastname',
                 sub='sub',
-                iss='iss')
+                iss='iss',
+                idp_userid='idp_userid',
+                login_source='source'
+    )
 
     session.add(user)
     session.commit()
@@ -61,7 +64,9 @@ def test_create_from_jwt_token(session):
              'given_name': 'given_name',
              'family_name': 'family_name',
              'iss': 'iss',
-             'sub': 'sub'
+             'sub': 'sub',
+             'idp_userid': 'idp_userid',
+             'loginSource': 'source'
              }
     u = User.create_from_jwt_token(token)
     assert u.id is not None
@@ -73,7 +78,9 @@ def test_get_or_create_user_by_jwt(session):
              'given_name': 'given_name',
              'family_name': 'family_name',
              'iss': 'iss',
-             'sub': 'sub'
+             'sub': 'sub',
+             'idp_userid': 'idp_userid',
+             'loginSource': 'source'
              }
     u = User.get_or_create_user_by_jwt(token)
     assert u.id is not None

--- a/legal-api/tests/unit/models/test_user.py
+++ b/legal-api/tests/unit/models/test_user.py
@@ -65,7 +65,7 @@ def test_create_from_jwt_token(session):
              'family_name': 'family_name',
              'iss': 'iss',
              'sub': 'sub',
-             'idp_userid': 'idp_userid',
+             'idp_userid': '123',
              'loginSource': 'source'
              }
     u = User.create_from_jwt_token(token)
@@ -79,7 +79,7 @@ def test_get_or_create_user_by_jwt(session):
              'family_name': 'family_name',
              'iss': 'iss',
              'sub': 'sub',
-             'idp_userid': 'idp_userid',
+             'idp_userid': '123',
              'loginSource': 'source'
              }
     u = User.get_or_create_user_by_jwt(token)

--- a/legal-api/tests/unit/resources/v1/test_business_comments.py
+++ b/legal-api/tests/unit/resources/v1/test_business_comments.py
@@ -90,7 +90,7 @@ def test_business_comment_json_output(session, client, jwt):
     """Assert the json output of a comment is correctly formatted."""
     identifier = 'CP7654321'
     b = factory_business(identifier)
-    u = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss')
+    u = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss', idp_userid='123', login_source='IDIR')
     u.save()
 
     now = datetime.datetime(1970, 1, 1, 0, 0).replace(tzinfo=datetime.timezone.utc)

--- a/legal-api/tests/unit/resources/v1/test_filing_comments.py
+++ b/legal-api/tests/unit/resources/v1/test_filing_comments.py
@@ -96,7 +96,7 @@ def test_comment_json_output(session, client, jwt):
     identifier = 'CP7654321'
     b = factory_business(identifier)
     f = factory_filing(b, ANNUAL_REPORT)
-    u = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss')
+    u = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss', idp_userid='123', login_source='IDIR')
     u.save()
 
     now = datetime.datetime(1970, 1, 1, 0, 0).replace(tzinfo=datetime.timezone.utc)

--- a/legal-api/tests/unit/resources/v2/test_business_comments.py
+++ b/legal-api/tests/unit/resources/v2/test_business_comments.py
@@ -90,7 +90,7 @@ def test_business_comment_json_output(session, client, jwt):
     """Assert the json output of a comment is correctly formatted."""
     identifier = 'CP7654321'
     b = factory_business(identifier)
-    u = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss')
+    u = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss', idp_userid='123', login_source='IDIR')
     u.save()
 
     now = datetime.datetime(1970, 1, 1, 0, 0).replace(tzinfo=datetime.timezone.utc)

--- a/legal-api/tests/unit/resources/v2/test_filing_comments.py
+++ b/legal-api/tests/unit/resources/v2/test_filing_comments.py
@@ -96,7 +96,7 @@ def test_comment_json_output(session, client, jwt):
     identifier = 'CP7654321'
     b = factory_business(identifier)
     f = factory_filing(b, ANNUAL_REPORT)
-    u = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss')
+    u = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss', idp_userid='123', login_source='IDIR')
     u.save()
 
     now = datetime.datetime(1970, 1, 1, 0, 0).replace(tzinfo=datetime.timezone.utc)

--- a/legal-api/tests/unit/services/test_flags.py
+++ b/legal-api/tests/unit/services/test_flags.py
@@ -163,7 +163,7 @@ def test_flag_bool_unique_user():
     app.env = 'development'
     app.config['LD_SDK_KEY'] = 'https://no.flag/avail'
 
-    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss')
+    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss', idp_userid='123', login_source='IDIR')
 
     app_env = app.env
     try:

--- a/legal-api/tests/unit/services/utils.py
+++ b/legal-api/tests/unit/services/utils.py
@@ -35,6 +35,7 @@ def helper_create_jwt(jwt_manager, roles: List[str] = [], username: str = 'test-
         'typ': 'Bearer',
         'username': f'{username}',
         'idp_userid': '123',
+        'loginSource': 'IDIR',
         'realm_access': {
             'roles': [] + roles
         }

--- a/legal-api/tests/unit/services/utils.py
+++ b/legal-api/tests/unit/services/utils.py
@@ -34,6 +34,7 @@ def helper_create_jwt(jwt_manager, roles: List[str] = [], username: str = 'test-
         'jti': 'flask-jwt-oidc-test-support',
         'typ': 'Bearer',
         'username': f'{username}',
+        'idp_userid': '123',
         'realm_access': {
             'roles': [] + roles
         }


### PR DESCRIPTION
*Issue #:* /bcgov/entity###
bcgov/entity#14596

*Description of changes:*

after keycloak migration to gold, sub from jwt token (i.e. keycloak guid) will be changed for users, as it is tied to a specific IDP instance, and idp guid should be used instead to uniquely identify users

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
