### PR TITLE
14844 remove sentry errors

### DIFF
--- a/queue_services/entity-bn/src/entity_bn/bn_processors/change_of_registration.py
+++ b/queue_services/entity-bn/src/entity_bn/bn_processors/change_of_registration.py
@@ -17,7 +17,6 @@ from contextlib import suppress
 from http import HTTPStatus
 
 import dpath
-from entity_queue_common.service_utils import QueueException
 from flask import current_app
 from legal_api.models import Address, Business, Filing, Party, PartyRole, RequestTracker, db
 from legal_api.utils.datetime import datetime
@@ -32,7 +31,7 @@ from entity_bn.bn_processors import (
     get_splitted_business_number,
     request_bn_hub,
 )
-from entity_bn.exceptions import BNException
+from entity_bn.exceptions import BNException, BNRetryExceededException
 
 
 def process(business: Business, filing: Filing):  # pylint: disable=too-many-branches
@@ -129,7 +128,7 @@ def change_name(business: Business, filing: Filing,  # pylint: disable=too-many-
             raise BNException(f'Retry number: {request_tracker.retry_number + 1}' +
                               f' for {business.identifier}, TrackerId: {request_tracker.id}.')
 
-        raise QueueException(
+        raise BNRetryExceededException(
             f'Retry exceeded the maximum count for {business.identifier}, TrackerId: {request_tracker.id}.')
 
 
@@ -197,7 +196,7 @@ def change_address(business: Business, filing: Filing,  # pylint: disable=too-ma
             raise BNException(f'Retry number: {request_tracker.retry_number + 1}' +
                               f' for {business.identifier}, TrackerId: {request_tracker.id}.')
 
-        raise QueueException(
+        raise BNRetryExceededException(
             f'Retry exceeded the maximum count for {business.identifier}, TrackerId: {request_tracker.id}.')
 
 

--- a/queue_services/entity-bn/src/entity_bn/bn_processors/dissolution_or_put_back_on.py
+++ b/queue_services/entity-bn/src/entity_bn/bn_processors/dissolution_or_put_back_on.py
@@ -16,14 +16,13 @@ import xml.etree.ElementTree as Et
 from contextlib import suppress
 from http import HTTPStatus
 
-from entity_queue_common.service_utils import QueueException
 from flask import current_app
 from legal_api.models import Business, Filing, RequestTracker
 from legal_api.utils.datetime import datetime
 from legal_api.utils.legislation_datetime import LegislationDatetime
 
 from entity_bn.bn_processors import bn_note, build_input_xml, get_splitted_business_number, request_bn_hub
-from entity_bn.exceptions import BNException
+from entity_bn.exceptions import BNException, BNRetryExceededException
 
 
 def process(business: Business, filing: Filing):  # pylint: disable=too-many-branches
@@ -89,5 +88,5 @@ def process(business: Business, filing: Filing):  # pylint: disable=too-many-bra
             raise BNException(f'Retry number: {request_tracker.retry_number + 1}' +
                               f' for {business.identifier}, TrackerId: {request_tracker.id}.')
 
-        raise QueueException(
+        raise BNRetryExceededException(
             f'Retry exceeded the maximum count for {business.identifier}, TrackerId: {request_tracker.id}.')

--- a/queue_services/entity-bn/src/entity_bn/bn_processors/registration.py
+++ b/queue_services/entity-bn/src/entity_bn/bn_processors/registration.py
@@ -32,7 +32,7 @@ from entity_bn.bn_processors import (
     publish_event,
     request_bn_hub,
 )
-from entity_bn.exceptions import BNException
+from entity_bn.exceptions import BNException, BNRetryExceededException
 
 
 async def process(business: Business,  # pylint: disable=too-many-branches, too-many-arguments, too-many-statements
@@ -79,7 +79,7 @@ async def process(business: Business,  # pylint: disable=too-many-branches, too-
             raise BNException(f'Retry number: {inform_cra_tracker.retry_number + 1}' +
                               f' for {business.identifier}, TrackerId: {inform_cra_tracker.id}.')
 
-        raise QueueException(
+        raise BNRetryExceededException(
             f'Retry exceeded the maximum count for {business.identifier}, TrackerId: {inform_cra_tracker.id}.')
 
     root = Et.fromstring(inform_cra_tracker.response_object)
@@ -110,7 +110,7 @@ async def process(business: Business,  # pylint: disable=too-many-branches, too-
             raise BNException(f'Retry number: {get_bn_tracker.retry_number + 1}' +
                               f' for {business.identifier}, TrackerId: {get_bn_tracker.id}.')
 
-        raise QueueException(
+        raise BNRetryExceededException(
             f'Retry exceeded the maximum count for {business.identifier}, TrackerId: {get_bn_tracker.id}.')
 
     try:

--- a/queue_services/entity-bn/src/entity_bn/exceptions.py
+++ b/queue_services/entity-bn/src/entity_bn/exceptions.py
@@ -16,3 +16,7 @@
 
 class BNException(Exception):
     """BN exception for the Queue Services."""
+
+
+class BNRetryExceededException(Exception):
+    """BN retry exceeded exception for the Queue Services."""

--- a/queue_services/entity-bn/tests/unit/bn_processors/test_change_of_registration.py
+++ b/queue_services/entity-bn/tests/unit/bn_processors/test_change_of_registration.py
@@ -15,11 +15,10 @@
 import xml.etree.ElementTree as Et
 
 import pytest
-from entity_queue_common.service_utils import QueueException
 from legal_api.models import RequestTracker
 
 from entity_bn.bn_processors import bn_note
-from entity_bn.exceptions import BNException
+from entity_bn.exceptions import BNException, BNRetryExceededException
 from entity_bn.worker import process_event
 from tests.unit import create_filing, create_registration_data
 
@@ -247,7 +246,7 @@ async def test_retry_change_of_registration(app, session, mocker, request_type, 
 
         except BNException:
             continue
-        except QueueException:
+        except BNRetryExceededException:
             break
 
     request_trackers = RequestTracker.find_by(business_id, RequestTracker.ServiceName.BN_HUB,

--- a/queue_services/entity-bn/tests/unit/bn_processors/test_correction.py
+++ b/queue_services/entity-bn/tests/unit/bn_processors/test_correction.py
@@ -15,11 +15,10 @@
 import xml.etree.ElementTree as Et
 
 import pytest
-from entity_queue_common.service_utils import QueueException
 from legal_api.models import RequestTracker
 
 from entity_bn.bn_processors import bn_note
-from entity_bn.exceptions import BNException
+from entity_bn.exceptions import BNException, BNRetryExceededException
 from entity_bn.worker import process_event
 from tests.unit import create_filing, create_registration_data
 
@@ -247,7 +246,7 @@ async def test_retry_correction(app, session, mocker, request_type, data):
 
         except BNException:
             continue
-        except QueueException:
+        except BNRetryExceededException:
             break
 
     request_trackers = RequestTracker.find_by(business_id, RequestTracker.ServiceName.BN_HUB,

--- a/queue_services/entity-bn/tests/unit/bn_processors/test_dissolution_or_put_back_on.py
+++ b/queue_services/entity-bn/tests/unit/bn_processors/test_dissolution_or_put_back_on.py
@@ -15,11 +15,10 @@
 import xml.etree.ElementTree as Et
 
 import pytest
-from entity_queue_common.service_utils import QueueException
 from legal_api.models import RequestTracker
 
 from entity_bn.bn_processors import bn_note
-from entity_bn.exceptions import BNException
+from entity_bn.exceptions import BNException, BNRetryExceededException
 from entity_bn.worker import process_event
 from tests.unit import create_filing, create_registration_data
 
@@ -161,7 +160,7 @@ async def test_retry_change_of_status(app, session, mocker):
 
         except BNException:
             continue
-        except QueueException:
+        except BNRetryExceededException:
             break
 
     request_trackers = RequestTracker.find_by(business_id,

--- a/queue_services/entity-bn/tests/unit/bn_processors/test_registration.py
+++ b/queue_services/entity-bn/tests/unit/bn_processors/test_registration.py
@@ -15,10 +15,9 @@
 import xml.etree.ElementTree as Et
 
 import pytest
-from entity_queue_common.service_utils import QueueException
 from legal_api.models import Business, RequestTracker
 
-from entity_bn.exceptions import BNException
+from entity_bn.exceptions import BNException, BNRetryExceededException
 from entity_bn.worker import process_event
 from tests.unit import create_registration_data
 
@@ -120,7 +119,7 @@ async def test_retry_registration(app, session, mocker, request_type):
 
         except BNException:
             continue
-        except QueueException:
+        except BNRetryExceededException:
             break
 
     request_trackers = RequestTracker.find_by(business_id,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14844

*Description of changes:*
  - introduced `BNRetryExceededException` to handle retry exceeded exception.
  - skip messaging `BNRetryExceededException` to Sentry


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
