### PR TITLE
14978 Add fee code and allowable filings support for restoration filings

### DIFF
--- a/legal-api/src/legal_api/resources/v1/business/business_filings.py
+++ b/legal-api/src/legal_api/resources/v1/business/business_filings.py
@@ -600,6 +600,7 @@ class ListFilingResource(Resource):
 
     @staticmethod
     def _get_filing_types(business: Business, filing_json: dict):
+        # pylint: disable=too-many-branches
         """Get the filing type fee codes for the filing.
 
         Returns: {
@@ -649,8 +650,13 @@ class ListFilingResource(Resource):
             })
         else:
             for k in filing_json['filing'].keys():
-                filing_type_code = Filing.FILINGS.get(k, {}).get('codes', {}).get(legal_type)
+                filing_sub_type = Filing.get_filings_sub_type(k, filing_json)
                 priority = priority_flag
+                if filing_sub_type:
+                    filing_type_code = \
+                        Filing.FILINGS.get(k, {}).get(filing_sub_type, {}).get('codes', {}).get(legal_type)
+                else:
+                    filing_type_code = Filing.FILINGS.get(k, {}).get('codes', {}).get(legal_type)
 
                 # check if changeOfDirectors is a free filing
                 if k == 'changeOfDirectors':

--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
@@ -691,8 +691,13 @@ class ListFilingResource():
             })
         else:
             for k in filing_json['filing'].keys():
-                filing_type_code = Filing.FILINGS.get(k, {}).get('codes', {}).get(legal_type)
+                filing_sub_type = Filing.get_filings_sub_type(k, filing_json)
                 priority = priority_flag
+                if filing_sub_type:
+                    filing_type_code = \
+                        Filing.FILINGS.get(k, {}).get(filing_sub_type, {}).get('codes', {}).get(legal_type)
+                else:
+                    filing_type_code = Filing.FILINGS.get(k, {}).get('codes', {}).get(legal_type)
 
                 # check if changeOfDirectors is a free filing
                 if k == 'changeOfDirectors':

--- a/legal-api/src/legal_api/services/authz.py
+++ b/legal-api/src/legal_api/services/authz.py
@@ -137,6 +137,12 @@ ALLOWABLE_FILINGS: Final = {
             'specialResolution': ['CP'],
             'transition': ['BC', 'BEN', 'CC', 'ULC'],
         },
+        Business.State.HISTORICAL: {
+            'restoration': {
+                'fullRestoration': ['BC', 'BEN', 'CC', 'ULC'],
+                'limitedRestoration': ['BC', 'BEN', 'CC', 'ULC']
+            }
+        }
     }
 }
 

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filings.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filings.py
@@ -27,7 +27,7 @@ import pytest
 from dateutil.parser import parse
 from flask import current_app
 from minio.error import S3Error
-from registry_schemas.example_data.schema_data import COURT_ORDER_FILING_TEMPLATE
+from registry_schemas.example_data.schema_data import COURT_ORDER_FILING_TEMPLATE, RESTORATION
 from reportlab.lib.pagesizes import letter
 from registry_schemas.example_data import (
     ALTERATION_FILING_TEMPLATE,
@@ -1005,11 +1005,47 @@ DISSOLUTION_FILING = {
     }
 }
 
+# FUTURE: use RESTORATION_FILING from business schema data when restoration filing work has been done
+RESTORATION_FILING = {
+    'filing': {
+        'header': {
+            'name': 'dissolution',
+            'availableOnPaperOnly': False,
+            'certifiedBy': 'full name',
+            'email': 'no_one@never.get',
+            'date': '2020-02-18',
+            'routingSlipNumber': '123456789'
+        },
+        'business': {
+            'cacheId': 1,
+            'foundingDate': '2007-04-08T00:00:00+00:00',
+            'identifier': 'BC1234567',
+            'lastLedgerTimestamp': '2019-04-15T20:05:49.068272+00:00',
+            'lastPreBobFilingTimestamp': '2019-01-01T20:05:49.068272+00:00',
+            'legalName': 'legal name - BC1234567',
+            'legalType': 'BEN'
+        },
+        'restoration': RESTORATION
+    }
+}
 
-def _get_expected_fee_code(free, filing_name, legal_type):
+RESTORATION_FULL_FILING = copy.deepcopy(RESTORATION_FILING)
+RESTORATION_FULL_FILING['filing']['restoration']['type'] = 'fullRestoration'
+
+RESTORATION_LIMITED_FILING = copy.deepcopy(RESTORATION_FILING)
+RESTORATION_LIMITED_FILING['filing']['restoration']['type'] = 'limitedRestoration'
+
+def _get_expected_fee_code(free, filing_name, filing_json: dict, legal_type):
     """Return fee codes for legal type."""
+    filing_sub_type = Filing.get_filings_sub_type(filing_name, filing_json)
     if free:
-        return Filing.FILINGS[filing_name].get('free', {}).get('codes', {}).get(legal_type)
+        if filing_sub_type:
+            return Filing.FILINGS[filing_name].get(filing_sub_type, {}).get('free', {}).get('codes', {}).get(legal_type)
+        else:
+            return Filing.FILINGS[filing_name].get('free', {}).get('codes', {}).get(legal_type)
+
+    if filing_sub_type:
+        return Filing.FILINGS[filing_name].get(filing_sub_type, {}).get('codes', {}).get(legal_type)
 
     return Filing.FILINGS[filing_name].get('codes', {}).get(legal_type)
 
@@ -1045,13 +1081,21 @@ def _get_expected_fee_code(free, filing_name, legal_type):
             False, []),
         ('BC1234567', DISSOLUTION_FILING, 'dissolution', Business.LegalTypes.LIMITED_CO.value, None,
             False, []),
+        ('BC1234567', RESTORATION_FULL_FILING, 'restoration', Business.LegalTypes.BCOMP.value, None, False, []),
+        ('BC1234567', RESTORATION_FULL_FILING, 'restoration', Business.LegalTypes.COMP.value, None, False, []),
+        ('BC1234567', RESTORATION_FULL_FILING, 'restoration', Business.LegalTypes.BC_ULC_COMPANY.value, None, False, []),
+        ('BC1234567', RESTORATION_FULL_FILING, 'restoration', Business.LegalTypes.BC_CCC.value, None, False, []),
+        ('BC1234567', RESTORATION_LIMITED_FILING, 'restoration', Business.LegalTypes.BCOMP.value, None, False, []),
+        ('BC1234567', RESTORATION_LIMITED_FILING, 'restoration', Business.LegalTypes.COMP.value, None, False, []),
+        ('BC1234567', RESTORATION_LIMITED_FILING, 'restoration', Business.LegalTypes.BC_ULC_COMPANY.value, None, False, []),
+        ('BC1234567', RESTORATION_LIMITED_FILING, 'restoration', Business.LegalTypes.BC_CCC.value, None, False, []),
     ]
 )
 def test_get_correct_fee_codes(
         session, identifier, base_filing, filing_name, orig_legal_type, new_legal_type, free, additional_fee_codes):
     """Assert fee codes are properly assigned to filings before sending to payment."""
     # setup
-    expected_fee_code = _get_expected_fee_code(free, filing_name, orig_legal_type)
+    expected_fee_code = _get_expected_fee_code(free, filing_name, base_filing, orig_legal_type)
 
     business = None
     if not identifier.startswith('T'):

--- a/legal-api/tests/unit/services/test_authorization.py
+++ b/legal-api/tests/unit/services/test_authorization.py
@@ -313,7 +313,15 @@ def test_authorized_invalid_roles(monkeypatch, app, jwt):
         ('staff_historical_gp', Business.State.HISTORICAL, 'GP', 'staff', [STAFF_ROLE],
          ['courtOrder', 'registrarsNotation', 'registrarsOrder', {'restoration': []}, 'putBackOn']),
 
-        ('user_historical_llc', Business.State.HISTORICAL, 'LLC', 'user', [BASIC_USER], []),
+        ('user_historical_bc', Business.State.HISTORICAL, 'BC', 'staff', [BASIC_USER],
+         [{'restoration': ['fullRestoration', 'limitedRestoration']}]),
+        ('user_historical_ben', Business.State.HISTORICAL, 'BEN', 'staff', [BASIC_USER],
+         [{'restoration': ['fullRestoration', 'limitedRestoration']}]),
+        ('user_historical_cc', Business.State.HISTORICAL, 'CC', 'staff', [BASIC_USER],
+         [{'restoration': ['fullRestoration', 'limitedRestoration']}]),
+        ('user_historical_ulc', Business.State.HISTORICAL, 'ULC', 'staff', [BASIC_USER],
+         [{'restoration': ['fullRestoration', 'limitedRestoration']}]),
+        ('user_historical_llc', Business.State.HISTORICAL, 'LLC', 'user', [BASIC_USER], [{'restoration': []}]),
     ]
 )
 def test_get_allowed(monkeypatch, app, jwt, test_name, state, legal_type, username, roles, expected):
@@ -531,10 +539,10 @@ def test_get_allowed(monkeypatch, app, jwt, test_name, state, legal_type, userna
          ['CP', 'BC', 'BEN', 'CC', 'ULC', 'LLC'], 'user', [BASIC_USER], False),
 
         ('user_historical', Business.State.HISTORICAL, 'restoration', 'fullRestoration',
-         ['CP', 'BC', 'BEN', 'CC', 'ULC', 'LLC'], 'user', [BASIC_USER], False),
+         ['BC', 'BEN', 'CC', 'ULC'], 'user', [BASIC_USER], True),
 
         ('user_historical', Business.State.HISTORICAL, 'restoration', 'limitedRestoration',
-         ['CP', 'BC', 'BEN', 'CC', 'ULC', 'LLC'], 'user', [BASIC_USER], False),
+         ['BC', 'BEN', 'CC', 'ULC'], 'user', [BASIC_USER], True),
 
         ('user_historical', Business.State.HISTORICAL, 'specialResolution', None,
          ['CP', 'BC', 'BEN', 'CC', 'ULC', 'LLC'], 'user', [BASIC_USER], False),


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14978

*Description of changes:*

* Add fee code and allowable filings support for restoration filings(full restoration & limited restoration)
Note: this PR is only for full restoration and limited restoration as still need to determine whether limited restoration extension/conversionFullRestoration will use restoration schema.  Subsequent PR will follow to address remaining two filings.
* Add and update tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
