### PR TITLE
15003 set common LOG_LEVEL from environment var

### DIFF
--- a/queue_services/common/src/entity_queue_common/service_utils/service_logger.py
+++ b/queue_services/common/src/entity_queue_common/service_utils/service_logger.py
@@ -29,6 +29,10 @@ def before_breadcrumb(crumb, hint):  # pylint: disable=unused-argument; callback
 
 # Configure Sentry
 SENTRY_DSN = os.getenv('SENTRY_DSN', None)
+
+# Configure default log level to ERROR
+# Override with envirionment variable if needed
+LOG_LEVEL = os.getenv('LOG_LEVEL', logging.ERROR).upper()
 if SENTRY_DSN:
 
     SENTRY_LOGGING = LoggingIntegration(
@@ -41,14 +45,11 @@ if SENTRY_DSN:
     )
 
 logging.basicConfig(
-    level=logging.INFO,
+    level=LOG_LEVEL,
     format='%(asctime)s,%(msecs)d-%(name)s-%(levelname)s > %(module)s:%(filename)s:%(lineno)d-%(funcName)s:%(message)s',
     datefmt='%H:%M:%S',
 )
-logging.getLogger('asyncio').setLevel(logging.DEBUG)
-
-if os.getenv('DISABLE_HTTP_ACCESS_LOGS', 'False').lower() == 'true':
-    # This disables the healthz / readyz / meta logging messsages.
-    logging.getLogger('aiohttp.access').setLevel(logging.ERROR)
+logging.getLogger('asyncio').setLevel(LOG_LEVEL)
+logging.getLogger('aiohttp.access').setLevel(LOG_LEVEL)
 
 logger = logging.getLogger('asyncio')


### PR DESCRIPTION
*Issue #:* /bcgov/entity15003

Set default common log level to `ERROR` for the following queue_services:
- entity-bn
- entity-emailer
- entity-filer
- entity-pay

Anyone with access to change the environment variables, can use the `LOG_LEVEL` environment variable to change the log level in containers as needed.  Admittedly, we don't have the flexibility to set the log level for `asyncio` separately from `aiohttp.access`.  Let me know if you see that as a problem.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
