### PR TITLE
15003 - default to 'ERROR' string not integer

### DIFF
--- a/queue_services/common/src/entity_queue_common/service_utils/service_logger.py
+++ b/queue_services/common/src/entity_queue_common/service_utils/service_logger.py
@@ -32,7 +32,7 @@ SENTRY_DSN = os.getenv('SENTRY_DSN', None)
 
 # Configure default log level to ERROR
 # Override with envirionment variable if needed
-LOG_LEVEL = os.getenv('LOG_LEVEL', logging.ERROR).upper()
+LOG_LEVEL = os.getenv('LOG_LEVEL', 'ERROR').upper()
 if SENTRY_DSN:
 
     SENTRY_LOGGING = LoggingIntegration(


### PR DESCRIPTION
*Issue #:* /bcgov/entity15003

When LOG_LEVEL not provided, default to `ERROR` string not the integer `logging.ERROR`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
