### PR TITLE
15114 Update create invoice logic to pass filing id

### DIFF
--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
@@ -790,6 +790,7 @@ class ListFilingResource():
                                 'country': mailing_address.country}
             },
             'filingInfo': {
+                'filingIdentifier': f'{filing.id}',
                 'filingTypes': filing_types
             },
             'details': ListFilingResource.details_for_invoice(business.identifier, corp_type)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15114

*Description of changes:*

* Update create invoice logic to pass filing id.  The pay api will use this to populate the `filingIdentifier` property in the payment queue message that it sends to the entity pay listener.  This will allow entity pay to not require the sleep/retry code it currently has in place as it tries to determine which filing to process by looking for the `filing.payment_id` instead of the `filing.id`.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
