### PR TITLE
15114 Update entity pay to support payment queue message with filing id and corp type code fields

### DIFF
--- a/queue_services/entity-pay/Makefile
+++ b/queue_services/entity-pay/Makefile
@@ -61,6 +61,8 @@ install-dev: ## Install local application
 #################################################################################
 ci: pylint flake8 test ## CI flow
 
+lint: pylint flake8
+
 pylint: ## Linting with pylint
 	. venv/bin/activate && pylint --rcfile=setup.cfg src/$(PROJECT_NAME)
 

--- a/queue_services/entity-pay/requirements.txt
+++ b/queue_services/entity-pay/requirements.txt
@@ -2,7 +2,7 @@ Flask==1.1.2
 Jinja2==2.11.2
 MarkupSafe==1.1.1
 Werkzeug==0.16.1
-asyncio-nats-client==0.10.0
+asyncio-nats-client==0.11.4
 asyncio-nats-streaming==0.4.0
 attrs==19.3.0
 blinker==1.4

--- a/queue_services/entity-pay/requirements/dev.txt
+++ b/queue_services/entity-pay/requirements/dev.txt
@@ -3,7 +3,7 @@
 # Testing
 pytest
 pytest-aiohttp
-pytest-asyncio
+pytest-asyncio==0.18.3
 pytest-mock
 requests
 pyhamcrest
@@ -11,7 +11,7 @@ dpath
 
 # Lint and code style
 pydocstyle<4
-flake8
+flake8==5.0.4
 flake8-blind-except
 flake8-debugger
 flake8-docstrings
@@ -22,9 +22,8 @@ autopep8
 coverage
 pylint
 pylint-flask
-isort<5,>=4.2.5
+isort
 pytest-cov
 
 # docker
 lovely-pytest-docker
-pytest_docker

--- a/queue_services/entity-pay/setup.cfg
+++ b/queue_services/entity-pay/setup.cfg
@@ -39,9 +39,9 @@ max-line-length = 120
 docstring-min-length=10
 per-file-ignores =
     */__init__.py:F401
-    
+
 [pycodestyle]
-max_line_length = 120
+max-line-length = 120
 ignore = E501
 docstring-min-length=10
 notes=FIXME,XXX # TODO is ignored
@@ -70,7 +70,7 @@ good-names=
 
 [pylint]
 ignore=migrations,test
-max_line_length=120
+max-line-length=120
 notes=FIXME,XXX,TODO
 ignored-modules=flask_sqlalchemy,sqlalchemy,SQLAlchemy,alembic,scoped_session
 ignored-classes=scoped_session
@@ -79,8 +79,9 @@ disable=C0301,W0511,R0801,R0902
 [isort]
 line_length = 120
 indent = 4
-multi_line_output = 4
+multi_line_output = 3
 lines_after_imports = 2
+include_trailing_comma = True
 
 [tool:pytest]
 minversion = 2.0

--- a/queue_services/entity-pay/tests/conftest.py
+++ b/queue_services/entity-pay/tests/conftest.py
@@ -26,7 +26,7 @@ from legal_api import db as _db
 from legal_api import jwt as _jwt
 from nats.aio.client import Client as Nats
 from sqlalchemy import event, text
-from sqlalchemy.schema import DropConstraint, MetaData
+from sqlalchemy.schema import MetaData
 from stan.aio.client import Client as Stan
 
 from entity_pay.config import get_named_config
@@ -113,9 +113,6 @@ def db(app):  # pylint: disable=redefined-outer-name, invalid-name
         # Clear out any existing tables
         metadata = MetaData(_db.engine)
         metadata.reflect()
-        for table in metadata.tables.values():
-            for fk in table.foreign_keys:  # pylint: disable=invalid-name
-                _db.engine.execute(DropConstraint(fk.constraint))
         metadata.drop_all()
         _db.drop_all()
 

--- a/queue_services/entity-pay/tests/integration/utils.py
+++ b/queue_services/entity-pay/tests/integration/utils.py
@@ -20,8 +20,12 @@ import stan
 async def helper_add_payment_to_queue(stan_client: stan.aio.client.Client,
                                       subject: str,
                                       payment_id: str,
-                                      status_code: str):
+                                      status_code: str,
+                                      filing_id: int):
     """Add a payment token to the Queue."""
-    payload = {'paymentToken': {'id': payment_id, 'statusCode': status_code}}
+    payload = {'paymentToken': {'id': payment_id,
+                                'statusCode': status_code,
+                                'filingIdentifier': f'{filing_id}',
+                                'corpTypeCode': 'BC'}}
     await stan_client.publish(subject=subject,
                               payload=json.dumps(payload).encode('utf-8'))

--- a/queue_services/entity-pay/tests/unit/test_worker.py
+++ b/queue_services/entity-pay/tests/unit/test_worker.py
@@ -23,9 +23,10 @@ from tests.unit import create_business, create_filing  # noqa I001, E501;
 
 def test_extract_payment_token():
     """Assert that the payment token can be extracted from the Queue delivered Msg."""
-    from entity_pay.worker import extract_payment_token
-    from stan.aio.client import Msg
     import stan.pb.protocol_pb2 as protocol
+    from stan.aio.client import Msg
+
+    from entity_pay.worker import extract_payment_token
 
     # setup
     token = {'paymentToken': {'id': 1234, 'statusCode': 'COMPLETED'}}
@@ -37,24 +38,24 @@ def test_extract_payment_token():
     assert extract_payment_token(msg) == token
 
 
-def test_get_filing_by_payment_id(app, session):
-    """Assert that a unique filling gets retrieved for a payment_id."""
-    from entity_pay.worker import get_filing_by_payment_id
+def test_get_filing_by_id(app, session):
+    """Assert that a unique filling gets retrieved for a filing id."""
+    from entity_pay.worker import get_filing_by_id
 
     payment_id = str(random.SystemRandom().getrandbits(0x58))
+    new_filing = create_filing(payment_id)
 
-    create_filing(payment_id)
-
-    filing = get_filing_by_payment_id(str(payment_id))
+    filing = get_filing_by_id(new_filing.id)
 
     assert filing
-    assert filing.payment_token == payment_id
+    assert filing.id == new_filing.id
 
 
 async def test_process_payment_missing_app(app, session):
     """Assert that a filling will fail with no flask app supplied."""
-    from entity_pay.worker import process_payment
     from legal_api.models import Filing
+
+    from entity_pay.worker import process_payment
 
     # vars
     payment_id = str(random.SystemRandom().getrandbits(0x58))
@@ -62,8 +63,10 @@ async def test_process_payment_missing_app(app, session):
 
     # setup
     business = create_business(identifier)
-    create_filing(payment_id, None, business.id)
-    payment_token = {'paymentToken': {'id': payment_id, 'statusCode': Filing.Status.COMPLETED.value}}
+    filing = create_filing(payment_id, None, business.id)
+    payment_token = {'paymentToken': {'id': payment_id,
+                                      'statusCode': Filing.Status.COMPLETED.value,
+                                      'filingIdentifier': f'{filing.id}'}}
 
     # TEST
     with pytest.raises(Exception):
@@ -72,8 +75,9 @@ async def test_process_payment_missing_app(app, session):
 
 async def test_process_empty_filing(app, session):
     """Assert that an AR filling can be applied to the model correctly."""
-    from entity_pay.worker import get_filing_by_payment_id, process_payment
     from legal_api.models import Filing
+
+    from entity_pay.worker import get_filing_by_id, process_payment
 
     # vars
     payment_id = str(random.SystemRandom().getrandbits(0x58))
@@ -82,14 +86,16 @@ async def test_process_empty_filing(app, session):
     # setup
     business = create_business(identifier)
     business_id = business.id
-    create_filing(payment_id, None, business.id)
-    payment_token = {'paymentToken': {'id': payment_id, 'statusCode': Filing.Status.COMPLETED.value}}
+    initial_filing = create_filing(payment_id, None, business.id)
+    payment_token = {'paymentToken': {'id': payment_id,
+                                      'statusCode': Filing.Status.COMPLETED.value,
+                                      'filingIdentifier': f'{initial_filing.id}'}}
 
     # TEST
     await process_payment(payment_token, app)
 
     # Get modified data
-    filing = get_filing_by_payment_id(payment_id)
+    filing = get_filing_by_id(initial_filing.id)
 
     # check it out
     assert filing.business_id == business_id
@@ -98,9 +104,9 @@ async def test_process_empty_filing(app, session):
 
 async def test_process_payment_failed(app, session):
     """Assert that an AR filling status is set to error if payment transaction failed."""
-    from entity_pay.worker import process_payment
-    from entity_pay.worker import get_filing_by_payment_id
     from legal_api.models import Business, Filing
+
+    from entity_pay.worker import get_filing_by_id, process_payment
 
     # vars
     payment_id = str(random.SystemRandom().getrandbits(0x58))
@@ -109,14 +115,16 @@ async def test_process_payment_failed(app, session):
     # setup
     business = create_business(identifier)
     business_id = business.id
-    create_filing(payment_id, None, business.id)
-    payment_token = {'paymentToken': {'id': payment_id, 'statusCode': 'TRANSACTION_FAILED'}}
+    filing = create_filing(payment_id, None, business.id)
+    payment_token = {'paymentToken': {'id': payment_id,
+                                      'statusCode': 'TRANSACTION_FAILED',
+                                      'filingIdentifier': f'{filing.id}'}}
 
     # TEST
     await process_payment(payment_token, app)
 
     # Get modified data
-    filing = get_filing_by_payment_id(payment_id)
+    filing = get_filing_by_id(filing.id)
     business = Business.find_by_internal_id(business_id)
 
     # check it out
@@ -124,3 +132,33 @@ async def test_process_payment_failed(app, session):
     assert filing.status == Filing.Status.PENDING.value
     assert not business.last_agm_date
     assert not business.last_ar_date
+
+
+@pytest.mark.parametrize('name,filing_id,corp_type_code,expected_result', [
+    ('success', '1', 'BEN', True),
+    ('success', '1', 'CP', True),
+    ('success', '1', 'SP', True),
+    ('success', '1', 'GP', True),
+    ('success', '1', 'BC', True),
+    ('success', '1', 'ULC', True),
+    ('success', '1', 'CC', True),
+    ('fail_invalid_corp_type', '1', None, False),
+    ('fail_invalid_corp_type', '1', 'CSO', False),
+    ('fail_no_filing_id', None, 'BC', False),
+    ('fail_no_payment_token', '1', 'BC', False),
+])
+def test_is_processable_message(app, session, name, filing_id, corp_type_code, expected_result):
+    """Assert that the queue message is processable only when msg meets required criteria."""
+    from entity_pay.worker import is_processable_message
+
+    # setup
+    if name == 'fail_no_payment_token':
+        msg = {'paymentToken': None}
+    else:
+        msg = {'paymentToken': {'id': 1234,
+                                'statusCode': 'COMPLETED',
+                                'filingIdentifier': filing_id,
+                                'corpTypeCode': corp_type_code}}
+
+    # test and verify
+    assert is_processable_message(msg) == expected_result


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15114

NOTE: do not merge until pay api updates the queue message to populate the `filingIdentifier` field with the filing id.

*Description of changes:*

* Update entity pay to use `filingIdentifier` and `corp_type_code` fields from incoming payment token. 
* Remove sleep/retry logic as using filing id should always be findable as opposed to the original implementation which used the payment id. 
* Add `is_processable_message` function to only look at relevant queue messages
* Add/update tests
* Update linting config and fix linting issues

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
