### PR TITLE
2180 include owner when businessNumber is unavailable

### DIFF
--- a/queue_services/entity-bn/src/entity_bn/bn_templates/create_program_account_request.xml
+++ b/queue_services/entity-bn/src/entity_bn/bn_templates/create_program_account_request.xml
@@ -60,18 +60,20 @@
       <postalCode>{{mailingAddress.postalCode | replace(' ', '')}}</postalCode>
       <countryCode>{{mailingAddress.addressCountry}}</countryCode>
     </mailingAddress>
-    {% for party in parties %}
-    <owner>
-      <ownerIndividual>
-      {% if party.officer.partyType == 'person' %}
-        <lastName>{{party.officer.lastName}}</lastName>
-        <givenName>{{party.officer.firstName}}</givenName>
-      {% elif party.officer.partyType == 'organization' %}
-        <lastName>{{party.officer.organizationName}}</lastName>
-      {% endif %}
-      </ownerIndividual>
-    </owner>
-    {% endfor %}
+    {% if businessNumber is none %}
+      {% for party in parties %}
+      <owner>
+        <ownerIndividual>
+        {% if party.officer.partyType == 'person' %}
+          <lastName>{{party.officer.lastName}}</lastName>
+          <givenName>{{party.officer.firstName}}</givenName>
+        {% elif party.officer.partyType == 'organization' %}
+          <lastName>{{party.officer.organizationName[0:30]}}</lastName>
+        {% endif %}
+        </ownerIndividual>
+      </owner>
+      {% endfor %}
+    {% endif %}
     <businessActivityDeclaration>
       <businessActivityDescription>{{business.naicsDescription}}</businessActivityDescription>
     </businessActivityDeclaration>


### PR DESCRIPTION
*Issue #:* bcgov-registries/ops-support/issues/2180

*Description of changes:*
  - include owner when businessNumber is unavailable
  - Limit length of organizationName to 30


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
