### PR TITLE
To fix all notebook reports Sent but not delivered Issue#2247

### DIFF
--- a/jobs/filings-notebook-report/notebookreport.py
+++ b/jobs/filings-notebook-report/notebookreport.py
@@ -4,7 +4,6 @@ import ast
 import fnmatch
 import logging
 import os
-import shutil
 import smtplib
 import sys
 import time
@@ -85,7 +84,7 @@ def send_email(note_book, data_directory, emailtype, errormessage):  # pylint: d
             recipients = os.getenv('BC_STATS_MONTHLY_REPORT_RECIPIENTS', '')
 
         # Add body to email
-        message.attach(MIMEText('Please see attached.', 'plain'))
+        message.attach(MIMEText('Please see the attachment(s).', 'plain'))
 
         # Open file in binary mode
         with open(data_directory+filename, 'rb') as attachment:


### PR DESCRIPTION
*Issue #:* /bcgov/entity 2247

*Description of changes:*
All notebook reports (including Namex, LEAR, PAY notebook reports) were sent but didn't deliver to the receivers. The reason for this is that the contents in the email body were filter by the email server. Need to update codes to fix this issue.

https://app.zenhub.com/workspaces/entity-5bf2f2164b5806bc2bf60531/issues/gh/bcgov-registries/ops-support/2247

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
