### PR TITLE
15479 Fix NR validation logic for restorations

### DIFF
--- a/legal-api/src/legal_api/services/filings/validations/restoration.py
+++ b/legal-api/src/legal_api/services/filings/validations/restoration.py
@@ -40,8 +40,13 @@ def validate(business: Business, restoration: Dict) -> Optional[Error]:
     elif restoration_type in ('fullRestoration', 'limitedRestorationToFull'):
         msg.extend(validate_relationship(restoration))
 
-    if restoration.get('filing', {}).get('restoration', {}).get('nameRequest', {}).get('nrNumber', None):
+    name_request = restoration.get('filing', {}).get('restoration', {}).get('nameRequest', {})
+    if name_request.get('nrNumber', None):
         msg.extend(validate_name_request(restoration, business.legal_type, filing_type))
+    else:
+        if not name_request.get('legalName', None):
+            msg.append({'error': 'Legal name is missing in nameRequest.',
+                        'path': '/filing/restoration/nameRequest/legalName'})
     msg.extend(validate_party(restoration))
     msg.extend(validate_offices(restoration, filing_type))
 

--- a/legal-api/src/legal_api/services/filings/validations/restoration.py
+++ b/legal-api/src/legal_api/services/filings/validations/restoration.py
@@ -40,7 +40,8 @@ def validate(business: Business, restoration: Dict) -> Optional[Error]:
     elif restoration_type in ('fullRestoration', 'limitedRestorationToFull'):
         msg.extend(validate_relationship(restoration))
 
-    msg.extend(validate_name_request(restoration, business.legal_type, filing_type))
+    if restoration.get('filing', {}).get('restoration', {}).get('nameRequest', {}).get('nrNumber', None):
+        msg.extend(validate_name_request(restoration, business.legal_type, filing_type))
     msg.extend(validate_party(restoration))
     msg.extend(validate_offices(restoration, filing_type))
 

--- a/legal-api/tests/unit/services/filings/validations/test_restoration.py
+++ b/legal-api/tests/unit/services/filings/validations/test_restoration.py
@@ -77,6 +77,7 @@ def test_validate_party(session, test_name, party_role, expected_msg):
     filing['filing']['restoration'] = copy.deepcopy(RESTORATION)
     filing['filing']['header']['name'] = 'restoration'
     filing['filing']['restoration']['relationships'] = relationships
+    filing['filing']['restoration']['nameRequest']['legalName'] = legal_name
 
     if party_role:
         filing['filing']['restoration']['parties'][0]['roles'][0]['roleType'] = party_role
@@ -110,6 +111,7 @@ def test_validate_relationship(session, test_status, restoration_type, expected_
     filing['filing']['restoration'] = copy.deepcopy(RESTORATION)
     filing['filing']['header']['name'] = 'restoration'
     filing['filing']['restoration']['type'] = restoration_type
+    filing['filing']['restoration']['nameRequest']['legalName'] = legal_name
 
     if restoration_type in ('limitedRestoration', 'limitedRestorationExtension'):
         expiry_date = LegislationDatetime.now() + relativedelta(months=1)
@@ -152,6 +154,7 @@ def test_validate_expiry_date(session, test_name, restoration_type, delta_date, 
     filing = copy.deepcopy(FILING_HEADER)
     filing['filing']['restoration'] = copy.deepcopy(RESTORATION)
     filing['filing']['header']['name'] = 'restoration'
+    filing['filing']['restoration']['nameRequest']['legalName'] = legal_name
 
     filing['filing']['restoration']['type'] = restoration_type
     if delta_date:
@@ -177,6 +180,7 @@ def test_restoration_court_orders(session, test_status, file_number, expected_co
     filing = copy.deepcopy(FILING_HEADER)
     filing['filing']['restoration'] = copy.deepcopy(RESTORATION)
     filing['filing']['header']['name'] = 'restoration'
+    filing['filing']['restoration']['nameRequest']['legalName'] = legal_name
     filing['filing']['restoration']['relationships'] = relationships
 
     if file_number:

--- a/legal-api/tests/unit/services/filings/validations/test_restoration.py
+++ b/legal-api/tests/unit/services/filings/validations/test_restoration.py
@@ -202,14 +202,16 @@ def test_restoration_court_orders(session, test_status, file_number, expected_co
         # full restoration
         ('SUCCESS_NEW_NR', 'fullRestoration', ['BC', 'BEN', 'ULC', 'CC'], 'NR 1234567', 'new name', None, None),
         ('SUCCESS_NAME_ONLY', 'fullRestoration', ['BC', 'BEN', 'ULC', 'CC'], None, 'new name', None, None),
-        ('SUCCESS_NO_NR_AND_NAME', 'fullRestoration', ['BC', 'BEN', 'ULC', 'CC'], None, None, None, None),
+        ('FAIL_NO_NR_AND_NAME', 'fullRestoration', ['BC', 'BEN', 'ULC', 'CC'], None, None, HTTPStatus.BAD_REQUEST,
+         'Legal name is missing in nameRequest.'),
         ('FAIL_NR_AND_NO_NAME', 'fullRestoration', ['BC', 'BEN', 'ULC', 'CC'], 'NR 1234567', None,
          HTTPStatus.BAD_REQUEST, 'Legal name is missing in nameRequest.'),
 
         # limited restoration
         ('SUCCESS_NEW_NR', 'limitedRestoration', ['BC', 'BEN', 'ULC', 'CC'], 'NR 1234567', 'new name', None, None),
         ('SUCCESS_NAME_ONLY', 'limitedRestoration', ['BC', 'BEN', 'ULC', 'CC'], None, 'new name', None, None),
-        ('SUCCESS_NO_NR_AND_NAME', 'limitedRestoration', ['BC', 'BEN', 'ULC', 'CC'], None, None, None, None),
+        ('FAIL_NO_NR_AND_NAME', 'limitedRestoration', ['BC', 'BEN', 'ULC', 'CC'], None, None, HTTPStatus.BAD_REQUEST,
+         'Legal name is missing in nameRequest.'),
         ('FAIL_NR_AND_NO_NAME', 'limitedRestoration', ['BC', 'BEN', 'ULC', 'CC'], 'NR 1234567', None,
          HTTPStatus.BAD_REQUEST, 'Legal name is missing in nameRequest.'),
     ]


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15479

*Description of changes:*

* Update restoration NR validation logic to not validate NR block when there is no `nrNumber` provided in filing json for a NR.  This follows the logic used for corrections.
* Added tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
