### PR TITLE
14642 Update numbered legal name suffix used for restoration application outputs

### DIFF
--- a/legal-api/report-templates/template-parts/restoration-application/nameRequest.html
+++ b/legal-api/report-templates/template-parts/restoration-application/nameRequest.html
@@ -19,7 +19,7 @@
                 <td class="bold pt-2">Name Reserved:</td>
                 <td class="pt-2">
                     {% if not nameRequest.nrNumber %}
-                    The company is to be restored with a name created by adding "{{numbered_legal_type_desc}}" after
+                    The company is to be restored with a name created by adding "{{numberedLegalNameSuffix}}" after
                     the incorporation number.
                     {% else %}
                     {{nameRequest.legalName}}

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -487,14 +487,7 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
         filing['offices'] = filing['restoration']['offices']
         meta_data = self._filing.meta_data or {}
         filing['fromLegalName'] = meta_data.get('restoration', {}).get('fromLegalName')
-
-        legal_type_desc = {
-            Business.LegalTypes.COMP.value: 'B.C. LTD.',
-            Business.LegalTypes.BCOMP.value: 'B.C. LTD.',
-            Business.LegalTypes.BC_ULC_COMPANY.value: 'ULC LTD.',
-            Business.LegalTypes.BC_CCC.value: 'CCC LTD.'
-        }
-        filing['numbered_legal_type_desc'] = legal_type_desc.get(self._business.legal_type)
+        filing['numberedLegalNameSuffix'] = Business.BUSINESSES[self._business.legal_type]['numberedLegalNameSuffix']
 
         if relationships := filing['restoration'].get('relationships'):
             filing['relationshipsDesc'] = ', '.join(relationships)


### PR DESCRIPTION

*Issue #:* /bcgov/entity#14642

*Description of changes:*

* Update numbered legal name suffix to match what filer uses when creating a numbered corp

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
