### PR TITLE
14674 filer extension conversion limited restoration

### DIFF
--- a/queue_services/entity-filer/requirements.txt
+++ b/queue_services/entity-filer/requirements.txt
@@ -23,6 +23,6 @@ urllib3==1.26.4
 minio==7.0.2
 PyPDF2==1.26.0
 reportlab==3.6.1
-git+https://github.com/bcgov/business-schemas.git@2.17.0#egg=registry_schemas
+git+https://github.com/bcgov/business-schemas.git@2.18.5#egg=registry_schemas
 git+https://github.com/bcgov/lear.git#egg=legal_api&subdirectory=legal-api
 git+https://github.com/bcgov/lear.git#egg=entity_queue_common&subdirectory=queue_services/common

--- a/queue_services/entity-filer/requirements/bcregistry-libraries.txt
+++ b/queue_services/entity-filer/requirements/bcregistry-libraries.txt
@@ -1,3 +1,3 @@
-git+https://github.com/bcgov/business-schemas.git@2.17.0#egg=registry_schemas
+git+https://github.com/bcgov/business-schemas.git@2.18.5#egg=registry_schemas
 git+https://github.com/bcgov/lear.git#egg=legal_api&subdirectory=legal-api
 git+https://github.com/bcgov/lear.git#egg=entity_queue_common&subdirectory=queue_services/common

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/restoration.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/restoration.py
@@ -81,10 +81,8 @@ def process(business: Business, filing: Dict, filing_rec: Filing, filing_meta: F
         application_date = restoration_filing.get('applicateDate')
         notice_date = restoration_filing.get('noticeDate')
         if application_date and notice_date:
-            application_date_formatted = datetime.fromisoformat(application_date) + timedelta(hours=8)
-            notice_date_formatted = datetime.fromisoformat(notice_date) + timedelta(hours=8)
-            filing_rec.applicate_date = application_date_formatted #wait for argus
-            filing_rec.notice_date = notice_date_formatted #wait for argus
+            filing_rec.application_date = datetime.fromisoformat(application_date) + timedelta(hours=8)
+            filing_rec.notice_date = datetime.fromisoformat(notice_date) + timedelta(hours=8)
 
 def _update_parties(business: Business, parties: dict, filing_rec: Filing):
     """Create applicant party and cease custodian if exist."""

--- a/queue_services/entity-filer/tests/unit/test_worker/test_restoration.py
+++ b/queue_services/entity-filer/tests/unit/test_worker/test_restoration.py
@@ -221,8 +221,8 @@ async def test_restoration_registrar(app, session, mocker, approval_type):
     final_filing = Filing.find_by_id(filing_id)
     assert filing['filing']['restoration']['approvalType'] == final_filing.approval_type
     if approval_type == 'registrar':
-        assert filing['filing']['restoration']['applicationDate'] == final_filing.application_date  #wait for argus
-        assert filing['filing']['restoration']['noticeDate'] == final_filing.notice_date  #wait for argus
+        assert filing['filing']['restoration']['applicationDate'] == final_filing.application_date
+        assert filing['filing']['restoration']['noticeDate'] == final_filing.notice_date
     else:
         assert final_filing.application_date is None
         assert final_filing.notice_date is None


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14674

*Description of changes:*
- Save `applicationDate` and `noticeDate` to filing when approval type is registrar.
- Save name translations for restorations.
- Add new unit tests for when approval type is registrar.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
