### PR TITLE
14672 Update restoration validation logic

### DIFF
--- a/legal-api/src/legal_api/services/filings/validations/restoration.py
+++ b/legal-api/src/legal_api/services/filings/validations/restoration.py
@@ -47,14 +47,15 @@ def validate(business: Business, restoration: Dict) -> Optional[Error]:
     elif restoration_type in ('fullRestoration', 'limitedRestorationToFull'):
         msg.extend(validate_relationship(restoration))
 
-    name_request = restoration.get('filing', {}).get('restoration', {}).get('nameRequest', {})
-    if name_request.get('nrNumber', None):
-        accepted_request_types = ['RCC', 'RCR', 'BERE', 'RUL']
-        msg.extend(validate_name_request(restoration, business.legal_type, filing_type, accepted_request_types))
-    else:
-        if not name_request.get('legalName', None):
-            msg.append({'error': 'Legal name is missing in nameRequest.',
-                        'path': '/filing/restoration/nameRequest/legalName'})
+    if restoration_type in ('fullRestoration', 'limitedRestoration', 'limitedRestorationToFull'):
+        name_request = restoration.get('filing', {}).get('restoration', {}).get('nameRequest', {})
+        if name_request.get('nrNumber', None):
+            accepted_request_types = ['RCC', 'RCR', 'BERE', 'RUL']
+            msg.extend(validate_name_request(restoration, business.legal_type, filing_type, accepted_request_types))
+        else:
+            if not name_request.get('legalName', None):
+                msg.append({'error': 'Legal name is missing in nameRequest.',
+                            'path': '/filing/restoration/nameRequest/legalName'})
 
     msg.extend(validate_party(restoration))
     msg.extend(validate_offices(restoration, filing_type))


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14672

*Description of changes:*

* Update NR validation logic for restorations to not require a NR block for limited restoration extensions
* Add NR tests for limited restoration extensions and convert limited to full restorations

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
