### PR TITLE
15958 Fix restoration application output bug

### DIFF
--- a/legal-api/report-templates/template-parts/restoration-application/approvalType.html
+++ b/legal-api/report-templates/template-parts/restoration-application/approvalType.html
@@ -20,10 +20,10 @@
         The restoration was approved by Registrar.
       </div>
       <div class="section-data mt-2">
-        BC Gazette published date: <span class="bold">{{noticeDate}}</span>
+        BC Gazette published date: {{noticeDate}}
       </div>
       <div class="section-data mt-2">
-        Notice of Application mailed date: <span class="bold">{{applicationDate}}</span>
+        Notice of Application mailed date: {{applicationDate}}
       </div>
     {% endif %}
   {% endif %}

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -497,8 +497,8 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
         if approval_type == 'courtOrder':
             filing['courtOrder'] = filing['restoration'].get('courtOrder')
         else:
-            filing['applicationDate'] = filing['restoration'].get('applicationDate')
-            filing['noticeDate'] = filing['restoration'].get('noticeDate')
+            filing['applicationDate'] = filing['restoration'].get('applicationDate', 'Not Applicable')
+            filing['noticeDate'] = filing['restoration'].get('noticeDate', 'Not Applicable')
 
         business_dissolution = VersionedBusinessDetailsService.find_last_value_from_business_revision(
             self._filing.transaction_id, self._business.id, is_dissolution_date=True)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15958

*Description of changes:*

* Fix restoration application output for extensions to display "Not Applicable" instead of "None" for the two dates when approval type = "Registrar"
* Remove bold style for two dates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
