### PR TITLE
Add in or '', which gets rid of the scenario where the optional field…

### DIFF
--- a/queue_services/entity-filer/src/entity_filer/filing_processors/special_resolution.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/special_resolution.py
@@ -31,7 +31,7 @@ def process(business: Business, filing: Dict, filing_rec: Filing):
             party = Party(
                 first_name=signatory.get('givenName', '').upper(),
                 last_name=signatory.get('familyName', '').upper(),
-                middle_initial=signatory.get('additionalName', '').upper()
+                middle_initial=(signatory.get('additionalName', '') or '').upper()
             )
             resolution.party = party
 


### PR DESCRIPTION
… is passed None.

```
14:00:33,777-asyncio-DEBUG > special_resolution:special_resolution.py:22-process:Processing Special Resolution : {'specialResolution': {'signatory': {'givenName': 'test', 'familyName': 'tset', 'additionalName': None}, 'resolution': 'test', 'signingDate': '2023-05-24', 'resolutionDate': '2023-05-24', 'resolutionConfirmed': True}}
14:00:33,778-asyncio-ERROR > worker:worker.py:379-cb_subscription_handler:Queue Error: {"filing": {"id": 145193}}
Traceback (most recent call last):
  File "/opt/app-root/src/entity_filer/worker.py", line 367, in cb_subscription_handler
    await process_filing(filing_msg, FLASK_APP)
  File "/opt/app-root/src/entity_filer/worker.py", line 237, in process_filing
    special_resolution.process(business, filing, filing_submission)
  File "/opt/app-root/src/entity_filer/filing_processors/special_resolution.py", line 34, in process
    middle_initial=signatory.get('additionalName', '').upper()
AttributeError: 'NoneType' object has no attribute 'upper'
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
