### PR TITLE
16121 Legal API - List of Outputs - Continuation Out for Corporations

### DIFF
--- a/legal-api/src/legal_api/core/filing.py
+++ b/legal-api/src/legal_api/core/filing.py
@@ -470,6 +470,7 @@ class Filing:
         no_legal_filings_in_paid_status = [
             Filing.FilingTypes.REGISTRATION.value,
             Filing.FilingTypes.CONSENTCONTINUATIONOUT.value,
+            Filing.FilingTypes.CONTINUATIONOUT.value,
         ]
         if filing.status == Filing.Status.PAID and \
             not (filing.filing_type in no_legal_filings_in_paid_status
@@ -496,6 +497,7 @@ class Filing:
 
                 no_legal_filings = [
                     Filing.FilingTypes.CONSENTCONTINUATIONOUT.value,
+                    Filing.FilingTypes.CONTINUATIONOUT.value,
                 ]
                 if filing.filing_type not in no_legal_filings:
                     documents['documents']['legalFilings'] = \

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
@@ -45,6 +45,7 @@ from registry_schemas.example_data import (
     RESTORATION,
     SPECIAL_RESOLUTION,
     TRANSITION_FILING_TEMPLATE,
+    CONTINUATION_OUT,
 )
 from registry_schemas.example_data.schema_data import ALTERATION, INCORPORATION
 
@@ -992,6 +993,69 @@ ALTERATION_MEMORANDUM_RULES_IN_RESOLUTION['rulesInResolution'] = True
                     }
       },
      HTTPStatus.OK, '2017-10-01'
+     ),
+    
+    ('bc_continuationOut_complete', 'BC7654321', Business.LegalTypes.COMP.value,
+     'continuationOut', CONTINUATION_OUT, None, None, Filing.Status.COMPLETED,
+     {'documents': {
+         'receipt': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/receipt'
+        }
+     },
+     HTTPStatus.OK, '2017-10-1'
+     ),
+    ('ulc_continuationOut_complete', 'BC7654321', Business.LegalTypes.BC_ULC_COMPANY.value,
+     'continuationOut', CONTINUATION_OUT, None, None, Filing.Status.COMPLETED,
+     {'documents': {
+         'receipt': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/receipt'
+        }
+     },
+     HTTPStatus.OK, '2017-10-1'
+     ),
+    ('cc_continuationOut_complete', 'BC7654321', Business.LegalTypes.BC_CCC.value,
+     'continuationOut', CONTINUATION_OUT, None, None, Filing.Status.COMPLETED,
+     {'documents': {
+            'receipt': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/receipt'
+        }
+     },
+     HTTPStatus.OK, '2017-10-1'
+     ),
+    ('ben_continuationOut_complete', 'BC7654321', Business.LegalTypes.BCOMP.value, 'continuationOut', CONTINUATION_OUT, None, None, Filing.Status.COMPLETED,
+     {'documents': {
+         'receipt': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/receipt'
+        }
+     },
+     HTTPStatus.OK, '2017-10-1'
+     ),
+    ('bc_continuationOut_paid', 'BC7654321', Business.LegalTypes.COMP.value,
+     'continuationOut', CONTINUATION_OUT, None, None, Filing.Status.PAID,
+     {'documents': {
+         'receipt': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/receipt'
+        }
+     },
+     HTTPStatus.OK, '2017-10-1'
+     ),
+    ('ulc_continuationOut_paid', 'BC7654321', Business.LegalTypes.BC_ULC_COMPANY.value,
+     'continuationOut', CONTINUATION_OUT, None, None, Filing.Status.PAID,
+     {'documents': {
+         'receipt': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/receipt'
+        }
+     },
+     HTTPStatus.OK, '2017-10-1'
+     ),
+    ('cc_continuationOut_paid', 'BC7654321', Business.LegalTypes.BC_CCC.value,
+     'continuationOut', CONTINUATION_OUT, None, None, Filing.Status.PAID,
+     {'documents': {
+            'receipt': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/receipt'
+        }
+     },
+     HTTPStatus.OK, '2017-10-1'
+     ),
+    ('ben_continuationOut_paid', 'BC7654321', Business.LegalTypes.BCOMP.value, 'continuationOut', CONTINUATION_OUT, None, None, Filing.Status.PAID,
+     {'documents': {
+         'receipt': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/receipt'
+        }
+     },
+     HTTPStatus.OK, '2017-10-1'
      )
 ])
 def test_document_list_for_various_filing_states(session, client, jwt,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16121

*Description of changes:*
- the only output document for continuation out for corps is receipt
- add unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
