### PR TITLE
Performance tweaks for retrieving business object

### DIFF
--- a/legal-api/src/legal_api/models/business.py
+++ b/legal-api/src/legal_api/models/business.py
@@ -457,13 +457,8 @@ class Business(db.Model):  # pylint: disable=too-many-instance-attributes,disabl
                 LegislationDatetime.as_legislation_timezone(self.foreign_incorporation_date)
             ).isoformat() if self.foreign_incorporation_date else None
 
-        filings = self.filings.all()
-
-        d['hasCorrections'] = any(x for x in filings if x.filing_type == 'correction' and
-                                  x.status == 'COMPLETED')
-
-        d['hasCourtOrders'] = any(x for x in filings if x.filing_type == 'courtOrder' and
-                                  x.status == 'COMPLETED')
+        d['hasCorrections'] = Filing.has_completed_filing(self.id, 'correction')
+        d['hasCourtOrders'] = Filing.has_completed_filing(self.id, 'courtOrder')
 
     @property
     def compliance_warnings(self):

--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -855,6 +855,17 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
         return None
 
     @staticmethod
+    def has_completed_filing(business_id: int, filing_type: str) -> bool:
+        """Return whether a completed filing of a given filing type exists."""
+        query = db.session.query(Filing). \
+            filter(Filing.business_id == business_id). \
+            filter(Filing._filing_type == filing_type). \
+            filter(Filing._status == Filing.Status.COMPLETED.value)
+        exists_stmt = query.exists()
+        filing_exists = db.session.query(exists_stmt).scalar()
+        return filing_exists
+
+    @staticmethod
     def get_filings_sub_type(filing_type: str, filing_json: dict):
         """Return sub-type from filing json if sub-type exists for filing type."""
         filing_sub_type_key = Filing.FILING_SUB_TYPE_KEYS.get(filing_type)


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*
* Update logic for returning business response json such that logic for determining if corrections or court orders exist does not require pulling back all filings for a given business.  Added a static function to filings model to just perform a query that returns a scalar value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
