### PR TITLE
16202 Add script for migrating data from old to new LEAR data model

### DIFF
--- a/legal-api/migrations/versions/004f7558063f_second.py
+++ b/legal-api/migrations/versions/004f7558063f_second.py
@@ -411,7 +411,7 @@ def upgrade():
     sa.Column('mailing_address_id', sa.Integer(), autoincrement=False, nullable=True),
     sa.Column('naics_key', sa.String(length=50), autoincrement=False, nullable=True),
     sa.Column('naics_code', sa.String(length=10), autoincrement=False, nullable=True),
-    sa.Column('naics_description', sa.String(length=150), autoincrement=False, nullable=True),
+    sa.Column('naics_description', sa.String(length=300), autoincrement=False, nullable=True),
     sa.Column('foreign_jurisdiction', sa.String(length=10), autoincrement=False, nullable=True),
     sa.Column('foreign_jurisdiction_region', sa.String(length=10), autoincrement=False, nullable=True),
     sa.Column('foreign_identifier', sa.String(length=15), autoincrement=False, nullable=True),
@@ -877,7 +877,7 @@ def upgrade():
         batch_op.add_column(sa.Column('mailing_address_id', sa.Integer(), nullable=True))
         batch_op.add_column(sa.Column('naics_key', sa.String(length=50), nullable=True))
         batch_op.add_column(sa.Column('naics_code', sa.String(length=10), nullable=True))
-        batch_op.add_column(sa.Column('naics_description', sa.String(length=150), nullable=True))
+        batch_op.add_column(sa.Column('naics_description', sa.String(length=300), nullable=True))
         batch_op.add_column(sa.Column('foreign_jurisdiction', sa.String(length=10), nullable=True))
         batch_op.add_column(sa.Column('foreign_jurisdiction_region', sa.String(length=10), nullable=True))
         batch_op.add_column(sa.Column('foreign_identifier', sa.String(length=15), nullable=True))

--- a/legal-api/migrations/versions/3d8eb786f4c2_add_coop_firm_sequence.py
+++ b/legal-api/migrations/versions/3d8eb786f4c2_add_coop_firm_sequence.py
@@ -1,4 +1,4 @@
-"""add_coop_sequence
+"""add_coop_firm_sequence
 
 Revision ID: 3d8eb786f4c2
 Revises: b6997f07700a
@@ -17,8 +17,10 @@ depends_on = None
 
 
 def upgrade():
-    op.execute("CREATE SEQUENCE legal_entity_identifier_coop START 1002395")
+    op.execute("CREATE SEQUENCE legal_entity_identifier_coop")
+    op.execute("CREATE SEQUENCE legal_entity_identifier_sp_gp")
 
 
 def downgrade():
     op.execute("DROP SEQUENCE legal_entity_identifier_coop")
+    op.execute("DROP SEQUENCE legal_entity_identifier_sp_gp")

--- a/legal-api/scripts/manual_db_scripts/legal_name_change/README.md
+++ b/legal-api/scripts/manual_db_scripts/legal_name_change/README.md
@@ -1,0 +1,69 @@
+
+## DB Model & Data Migration Steps
+The following will serve as steps required to get the LEAR database model and data up to date to support the [legal name changes](https://app.zenhub.com/workspaces/entities-team-space-6143567664fb320019b81f39/issues/gh/bcgov/entity/15527).  Note that as a part of the legal name changes, the database was updated to no longer use sqlcontinuum as the database versioning mechanism.
+
+### 1. Transfer LEAR data in old data model to new LEAR database model
+1. Create a new empty new LEAR database and apply the new data model using alembic scripts.
+2. Install dbshell -  [DbShell | Free Universal SQL Command-Line Client](https://dbschema.com/dbshell.html)  More general info around configuration and data transfer can be found at [DbShell | Multi-Database SQL Command Line Client](https://dbschema.com/documentation/dbshell.html)
+3. Add `/Applications/DbShell` to path
+4. Register source db by adding db connection in  `~/.DbSchema/dbshell/init.sql`
+   e.g. `connection lear_old PostgreSql "user=postgres password=postgres host=localhost port=5432 db=lear"`
+5. Register target db by adding db connection in  `~/.DbSchema/dbshell/init.sql`
+   e.g. `connection lear_new PostgreSql "user=postgres password=postgres host=localhost port=5432 db=lear_new"`
+6. Prep new LEAR db for data transfer.
+   Run `<lear-repo-base-path>/legal-api/scripts/manual_db_scripts/legal_name_change/transfer_to_new_lear_before.sql` against new LEAR db
+7. Transfer data from old LEAR to new LEAR db
+   `dbshell <lear-repo-base-path>/legal-api/scripts/manual_db_scripts/legal_name_change/transfer_to_new_lear.sql`
+   A successful run will look like the following:
+``` bash
+
+(legal-api-py3.10) argus@Argus-Mac-Studio ~/h3/git/bcreg/lear/legal-api (dev_legal_name_changes) $ dbshell /Users/argus/h3/git/bcreg/lear/legal-api/scripts/manual_db_scripts/legal_name_change/transfer_to_new_lear.sql
+DbShell 1.3.2 Build #210311
+Type 'help' for a list of commands.
+
+Processing file /Users/argus/h3/git/bcreg/lear/legal-api/scripts/manual_db_scripts/legal_name_change/transfer_to_new_lear.sql
+
+...
+
+Transfer using 8 thread(s) users ...                                368 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) users_history ...                        472 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) legal_entities ...                       3707 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) legal_entities_history ...               19232 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) filings ...                              32674 rows in 00:02. Reader waited 00:00, writer 00:09.
+Transfer using 8 thread(s) addresses ...                            28079 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) addresses_history ...                    31928 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) aliases ...                              551 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) aliases_history ...                      756 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) colin_event_ids ...                      27857 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) colin_last_update ...                    34 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) comments ...                             1205 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) dc_connections ...                       28 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) dc_definitions ...                       1 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) dc_issued_credentials ...                13 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) documents ...                            457 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) documents_history ...                    457 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) offices ...                              4347 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) offices_history ...                      5863 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) parties ...                              11901 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) parties_history ...                      12828 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) party_roles ...                          13307 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) party_roles_history ...                  14360 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) registration_bootstrap ...               2722 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) request_tracker ...                      830 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) resolutions ...                          271 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) resolutions_history ...                  271 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) share_classes ...                        1037 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) share_classes_history ...                2166 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) share_series ...                         137 rows in 00:01. Reader waited 00:00, writer 00:08.
+Transfer using 8 thread(s) share_series_history ...                 573 rows in 00:01. Reader waited 00:00, writer 00:08.
+
+...
+
+Done
+
+```
+8. Cleanup temporary artifacts and states created by data transfer scripts.
+   Run `<lear-repo-base-path>/legal-api/scripts/manual_db_scripts/legal_name_change/transfer_to_new_lear_after.sql` against new LEAR db
+
+### 2. FUTURE (Migrate data in new LEAR database for legal name changes)
+

--- a/legal-api/scripts/manual_db_scripts/legal_name_change/transfer_to_new_lear.sql
+++ b/legal-api/scripts/manual_db_scripts/legal_name_change/transfer_to_new_lear.sql
@@ -1,0 +1,692 @@
+-- Description:
+-- Script to migrate existing data in existing LEAR(old) tables to new LEAR tables.
+--
+-- Notes: ensure that lear_old and lear_new connections have been configured before running this script via dbshell.
+
+vset ignore_errors=false
+vset transfer.threads=8
+vset format.date=YYYY-MM-dd'T'hh:mm:ss'Z'
+vset format.timestamp=YYYY-MM-dd'T'hh:mm:ss'Z'
+
+
+-- *****************************************************************************************************************
+-- Prep old LEAR database before transferring of data from old to new LEAR database
+-- *****************************************************************************************************************
+
+connect lear_old;
+
+-- temp table to determine which filing_id to use for transactions that map to more than one filing which is incorrect
+CREATE TABLE public.temp_multiple_filing_transactions AS
+select f.id as filing_id,
+       f.filing_type,
+       change_filing_transaction.transaction_id
+from (select t.id as transaction_id, min(f.id) as filing_id
+      from public.transaction t
+               join filings f on t.id = f.transaction_id
+               join businesses b on f.business_id = b.id
+      where t.id in (select transaction_id
+                     from (select t.id as transaction_id, count(f.id) as filing_count
+                           from filings f
+                                    join transaction t on f.transaction_id = t.id
+                           group by t.id) tblTemp
+                     where filing_count > 1)
+      group by t.id) change_filing_transaction
+         join filings f on change_filing_transaction.filing_id = f.id
+;
+
+
+-- *****************************************************************************************************************
+-- Transfer data from old to new LEAR database
+-- *****************************************************************************************************************
+
+connect lear_new;
+
+
+-- users -> users
+transfer public.users from lear_old using
+select u.id,
+       u.username,
+       u.firstname,
+       u.lastname,
+       u.email,
+       u.sub,
+       u.iss,
+       u.creation_date,
+       u.middlename,
+       u.idp_userid,
+       u.login_source,
+       COALESCE(uv.version, 0) as version
+from public.users u
+         left join (select id, count(transaction_id) - 1 as version
+                    from users_version
+                    group by id) uv on u.id = uv.id;
+
+
+
+-- users_version -> users_history
+transfer public.users_history from lear_old using
+select uv.id,
+       uv.username,
+       uv.firstname,
+       uv.lastname,
+       uv.email,
+       uv.sub,
+       uv.iss,
+       uv.creation_date,
+       uv.middlename,
+       uv.idp_userid,
+       uv.login_source,
+       t.issued_at                                                                            as changed,
+       COALESCE(ROW_NUMBER() OVER (PARTITION BY uv.id ORDER BY uv.transaction_id ASC) - 1, 0) as version
+from public.users_version uv
+         left join transaction t on uv.transaction_id = t.id;
+
+
+
+-- businesses -> legal_entities
+transfer public.legal_entities from lear_old using
+SELECT b.id,
+       b.admin_freeze,
+       b.association_type,
+       b.continuation_out_date,
+       b.dissolution_date,
+       b.fiscal_year_end_date,
+       b.foreign_identifier,
+       b.foreign_incorporation_date,
+       b.foreign_jurisdiction,
+       b.foreign_jurisdiction_region,
+       b.foreign_legal_name,
+       b.foreign_legal_type,
+       b.founding_date,
+       b.identifier,
+       b.last_agm_date,
+       b.last_ar_date,
+       b.last_ar_reminder_year,
+       b.last_ar_year,
+       b.last_coa_date,
+       b.last_cod_date,
+       b.last_ledger_id,
+       b.last_ledger_timestamp,
+       b.last_modified,
+       b.last_remote_ledger_id,
+       b.legal_name,
+       b.legal_type            as entity_type,
+       b.naics_code,
+       b.naics_description,
+       b.naics_key,
+       b.restoration_expiry_date,
+       b.restriction_ind,
+       b.send_ar_ind,
+       b.start_date,
+       b.state                 as state_text,
+       b.state_filing_id,
+       b.submitter_userid,
+       b.tax_id,
+       COALESCE(bv.version, 0) as version
+FROM public.businesses b
+         left join (select id, count(transaction_id) - 1 as version
+                    from businesses_version bv
+                    group by id) bv on b.id = bv.id;
+
+
+-- businesses_version -> legal_entities_history
+transfer public.legal_entities_history from lear_old using
+SELECT bv.id,
+       bv.admin_freeze,
+       bv.association_type,
+       bv.continuation_out_date,
+       bv.dissolution_date,
+       bv.fiscal_year_end_date,
+       bv.foreign_identifier,
+       bv.foreign_incorporation_date,
+       bv.foreign_jurisdiction,
+       bv.foreign_jurisdiction_region,
+       bv.foreign_legal_name,
+       bv.foreign_legal_type,
+       bv.founding_date,
+       bv.identifier,
+       bv.last_agm_date,
+       bv.last_ar_date,
+       bv.last_ar_reminder_year,
+       bv.last_ar_year,
+       bv.last_coa_date,
+       bv.last_cod_date,
+       bv.last_ledger_id,
+       bv.last_ledger_timestamp,
+       bv.last_modified,
+       bv.last_remote_ledger_id,
+       bv.legal_name,
+       bv.legal_type                                                                          as entity_type,
+       bv.naics_code,
+       bv.naics_description,
+       bv.naics_key,
+       bv.restoration_expiry_date,
+       bv.restriction_ind,
+       bv.send_ar_ind,
+       bv.start_date,
+       bv.state                                                                               as state_text,
+       bv.state_filing_id,
+       bv.submitter_userid,
+       bv.tax_id,
+       t.issued_at                                                                            as changed,
+       COALESCE(ROW_NUMBER() OVER (PARTITION BY bv.id ORDER BY bv.transaction_id ASC) - 1, 0) as version
+from public.businesses_version bv
+         join public.transaction t on bv.transaction_id = t.id;
+
+
+-- filings -> filings
+transfer public.filings from lear_old using
+select id,
+       application_date,
+       approval_type,
+       business_id as legal_entity_id,
+       colin_only,
+       completion_date,
+       court_order_date,
+       court_order_effect_of_order,
+       court_order_file_number,
+       deletion_locked,
+       effective_date,
+       filing_date,
+       filing_json,
+       filing_sub_type,
+       filing_type,
+       meta_data,
+       notice_date,
+       order_details,
+       paper_only,
+       parent_filing_id,
+       payment_account,
+       payment_completion_date,
+       payment_id,
+       payment_status_code,
+       source,
+       status,
+       submitter_id,
+       submitter_roles,
+       tech_correction_json,
+       temp_reg,
+       transaction_id
+from public.filings;
+
+
+-- addresses -> addresses
+transfer public.addresses from lear_old using
+SELECT a.id,
+       a.address_type,
+       a.street,
+       a.street_additional,
+       a.city,
+       a.region,
+       a.country,
+       a.postal_code,
+       a.delivery_instructions,
+       a.business_id           as legal_entity_id,
+       a.office_id,
+       (CASE
+            WHEN f.id is not null THEN f.id
+            WHEN tmft.filing_id is not null THEN tmft.filing_id
+            ELSE NULL
+           END)                AS change_filing_id,
+       COALESCE(av.version, 0) as version
+FROM public.addresses a
+         left join (select id, max(transaction_id) as transaction_id, count(transaction_id) - 1 as version
+                    from public.addresses_version
+                    group by id) av on a.id = av.id
+         left join public.filings f
+                   on av.transaction_id not in (select transaction_id from temp_multiple_filing_transactions) and
+                      f.transaction_id = av.transaction_id
+         left join temp_multiple_filing_transactions tmft on av.transaction_id = tmft.transaction_id
+;
+
+
+-- addresses_version -> addresses_history
+transfer public.addresses_history from lear_old using
+SELECT av.id,
+       av.address_type,
+       av.street,
+       av.street_additional,
+       av.city,
+       av.region,
+       av.country,
+       av.postal_code,
+       av.delivery_instructions,
+       av.business_id                                                            as legal_entity_id,
+       av.office_id,
+       (CASE
+            WHEN f.id is not null THEN f.id
+            WHEN tmft.filing_id is not null THEN tmft.filing_id
+            ELSE NULL
+           END)                                                                  AS change_filing_id,
+       t.issued_at                                                               as changed,
+       ROW_NUMBER() OVER (PARTITION BY av.id ORDER BY av.transaction_id ASC) - 1 as version
+from public.addresses_version av
+         left join public.transaction t
+                   on av.transaction_id not in (select transaction_id from temp_multiple_filing_transactions) and
+                      av.transaction_id = t.id
+         left join public.filings f on f.transaction_id = t.id
+         left join temp_multiple_filing_transactions tmft on av.transaction_id = tmft.transaction_id
+;
+
+
+-- aliases -> aliases
+transfer public.aliases from lear_old using
+SELECT a.id,
+       a.alias,
+       a.type,
+       a.business_id           as legal_entity_id,
+       f.id                    as change_filing_id,
+       COALESCE(av.version, 0) as version
+FROM public.aliases a
+         left join (select id, max(transaction_id) as transaction_id, count(transaction_id) - 1 as version
+                    from public.aliases_version
+                    group by id) av on a.id = av.id
+         left join public.filings f on f.transaction_id = av.transaction_id;
+
+
+-- aliases_version -> aliases_history
+transfer public.aliases_history from lear_old using
+SELECT av.id,
+       av.alias,
+       av.type,
+       av.business_id                                                                         as legal_entity_id,
+       f.id                                                                                   as change_filing_id,
+       t.issued_at                                                                            as changed,
+       COALESCE(ROW_NUMBER() OVER (PARTITION BY av.id ORDER BY av.transaction_id ASC) - 1, 0) as version
+from public.aliases_version av
+         left join public.transaction t on av.transaction_id = t.id
+         left join public.filings f on f.transaction_id = t.id;
+
+
+-- colin_event_ids -> colin_event_ids
+transfer public.colin_event_ids from lear_old using
+SELECT colin_event_id,
+       filing_id
+FROM public.colin_event_ids;
+
+
+-- colin_last_update -> colin_last_update
+transfer public.colin_last_update from lear_old using
+SELECT id,
+       last_update,
+       last_event_id
+FROM public.colin_last_update;
+
+
+-- comments -> comments
+transfer public.comments from lear_old using
+SELECT id,
+       comment,
+       timestamp,
+       business_id as legal_entity_id,
+       staff_id,
+       filing_id
+FROM public.comments;
+
+
+-- dc_connections -> dc_connections
+transfer public.dc_connections from lear_old using
+SELECT id,
+       connection_id,
+       invitation_url,
+       is_active,
+       connection_state,
+       business_id as legal_entity_id
+FROM public.dc_connections;
+
+
+-- dc_definitions -> dc_definitions
+transfer public.dc_definitions from lear_old using
+SELECT id,
+       credential_type as credential_type_text,
+       schema_id,
+       schema_name,
+       schema_version,
+       credential_definition_id,
+       is_deleted
+FROM public.dc_definitions;
+
+
+-- dc_issued_credentials -> dc_issued_credentials
+transfer public.dc_issued_credentials from lear_old using
+SELECT id,
+       dc_definition_id,
+       dc_connection_id,
+       credential_exchange_id,
+       credential_id,
+       is_issued,
+       date_of_issue,
+       is_revoked
+FROM public.dc_issued_credentials;
+
+
+-- documents -> documents
+transfer public.documents from lear_old using
+SELECT d.id,
+       d.type,
+       d.file_key,
+       d.business_id           as legal_entity_id,
+       d.filing_id,
+       COALESCE(dv.version, 0) as version
+FROM public.documents d
+         left join (select id, count(transaction_id) - 1 as version
+                    from public.documents_version
+                    group by id) dv on d.id = dv.id;
+
+
+-- documents_version -> documents_history
+transfer public.documents_history from lear_old using
+SELECT dv.id,
+       dv.type,
+       dv.file_key,
+       dv.business_id                                                                         as legal_entity_id,
+       dv.filing_id,
+       t.issued_at                                                                            as changed,
+       COALESCE(ROW_NUMBER() OVER (PARTITION BY dv.id ORDER BY dv.transaction_id ASC) - 1, 0) as version
+from public.documents_version dv
+         left join public.transaction t on dv.transaction_id = t.id;
+
+
+
+
+-- offices -> offices
+transfer public.offices from lear_old using
+SELECT distinct o.id,
+                o.office_type,
+                o.deactivated_date,
+                o.business_id           as legal_entity_id,
+                (CASE
+                     WHEN f.id is not null THEN f.id
+                     WHEN tmft.filing_id is not null THEN tmft.filing_id
+                     ELSE NULL
+                    END)                AS change_filing_id,
+
+                COALESCE(ov.version, 0) as version
+FROM public.offices o
+         left join (select id, max(transaction_id) as transaction_id, count(transaction_id) - 1 as version
+                    from public.offices_version
+                    group by id) ov on o.id = ov.id
+         left join public.filings f
+                   on ov.transaction_id not in (select transaction_id from temp_multiple_filing_transactions) and
+                      f.transaction_id = ov.transaction_id
+         left join temp_multiple_filing_transactions tmft on ov.transaction_id = tmft.transaction_id;
+
+
+-- offices_version -> offices_history
+transfer public.offices_history from lear_old using
+SELECT ov.id,
+       ov.office_type,
+       ov.deactivated_date,
+       ov.business_id                                                                         as legal_entity_id,
+       f.id                                                                                   as change_filing_id,
+       t.issued_at                                                                            as changed,
+       COALESCE(ROW_NUMBER() OVER (PARTITION BY ov.id ORDER BY ov.transaction_id ASC) - 1, 0) as version
+from public.offices_version ov
+         left join public.transaction t
+                   on ov.transaction_id not in (select transaction_id from temp_multiple_filing_transactions) and
+                      ov.transaction_id = t.id
+         left join public.filings f on f.transaction_id = t.id
+         left join temp_multiple_filing_transactions tmft on ov.transaction_id = tmft.transaction_id;
+
+
+-- parties -> parties
+transfer public.parties from lear_old using
+SELECT p.id,
+       p.party_type,
+       p.first_name,
+       p.middle_initial,
+       p.last_name,
+       p.title,
+       p.organization_name,
+       p.delivery_address_id,
+       p.mailing_address_id,
+       p.identifier,
+       p.email,
+       (CASE
+            WHEN f.id is not null THEN f.id
+            WHEN tmft.filing_id is not null THEN tmft.filing_id
+            ELSE NULL
+           END)                AS change_filing_id,
+       COALESCE(pv.version, 0) as version
+FROM public.parties p
+         left join (select id, max(transaction_id) as transaction_id, count(transaction_id) - 1 as version
+                    from public.parties_version
+                    group by id) pv on p.id = pv.id
+         left join public.filings f
+                   on pv.transaction_id not in (select transaction_id from temp_multiple_filing_transactions) and
+                      f.transaction_id = pv.transaction_id
+         left join temp_multiple_filing_transactions tmft on pv.transaction_id = tmft.transaction_id;
+
+
+
+
+-- parties_version -> parties_history
+transfer public.parties_history from lear_old using
+SELECT pv.id,
+       pv.party_type,
+       pv.first_name,
+       pv.middle_initial,
+       pv.last_name,
+       pv.title,
+       pv.organization_name,
+       pv.delivery_address_id,
+       pv.mailing_address_id,
+       pv.identifier,
+       pv.email,
+       f.id                                                                                   as change_filing_id,
+       t.issued_at                                                                            as changed,
+       COALESCE(ROW_NUMBER() OVER (PARTITION BY pv.id ORDER BY pv.transaction_id ASC) - 1, 0) as version
+from public.parties_version pv
+         left join public.transaction t
+                   on pv.transaction_id not in (select transaction_id from temp_multiple_filing_transactions) and
+                      pv.transaction_id = t.id
+         left join public.filings f on f.transaction_id = t.id
+         left join temp_multiple_filing_transactions tmft on pv.transaction_id = tmft.transaction_id;
+
+
+-- party_roles -> party_roles
+transfer public.party_roles from lear_old using
+SELECT pr.id,
+       pr.role,
+       pr.appointment_date,
+       pr.cessation_date,
+       pr.business_id           as legal_entity_id,
+       pr.party_id,
+       pr.filing_id,
+       COALESCE(prv.version, 0) as version
+FROM public.party_roles pr
+         left join (select id, count(transaction_id) - 1 as version
+                    from public.party_roles_version
+                    group by id) prv on pr.id = prv.id;
+
+
+-- party_roles_version -> party_roles_history
+transfer public.party_roles_history from lear_old using
+SELECT prv.id,
+       prv.role,
+       prv.appointment_date,
+       prv.cessation_date,
+       prv.business_id                                                                          as legal_entity_id,
+       prv.party_id,
+       prv.filing_id,
+       t.issued_at                                                                              as changed,
+       COALESCE(ROW_NUMBER() OVER (PARTITION BY prv.id ORDER BY prv.transaction_id ASC) - 1, 0) as version
+from public.party_roles_version prv
+         left join public.transaction t on prv.transaction_id = t.id;
+
+
+-- registration_bootstrap -> registration_bootstrap
+transfer public.registration_bootstrap from lear_old using
+SELECT identifier,
+       account,
+       last_modified
+FROM public.registration_bootstrap;
+
+
+-- request_tracker -> request_tracker
+transfer public.request_tracker from lear_old using
+SELECT id,
+       request_type as request_type_text,
+       is_processed,
+       request_object,
+       response_object,
+       retry_number,
+       service_name as service_name_text,
+       business_id  as legal_entity_id,
+       creation_date,
+       last_modified,
+       filing_id,
+       is_admin,
+       message_id
+FROM public.request_tracker;
+
+
+-- resolutions -> resolutions
+transfer public.resolutions from lear_old using
+SELECT r.id,
+       r.resolution_date,
+       r.type,
+       r.business_id           as legal_entity_id,
+       r.resolution,
+       r.signing_date,
+       r.signing_party_id,
+       r.sub_type,
+       f.id                    as change_filing_id,
+       COALESCE(rv.version, 0) as version
+FROM public.resolutions r
+         left join (select id, max(transaction_id) as transaction_id, count(transaction_id) - 1 as version
+                    from public.resolutions_version
+                    group by id) rv on r.id = rv.id
+         left join public.filings f on f.transaction_id = rv.transaction_id;
+
+
+
+-- resolutions_version -> resolutions_history
+transfer public.resolutions_history from lear_old using
+SELECT rv.id,
+       rv.resolution_date,
+       rv.type,
+       rv.business_id                                                                         as legal_entity_id,
+       rv.resolution,
+       rv.signing_date,
+       rv.signing_party_id,
+       rv.sub_type,
+       f.id                                                                                   as change_filing_id,
+       t.issued_at                                                                            as changed,
+       COALESCE(ROW_NUMBER() OVER (PARTITION BY rv.id ORDER BY rv.transaction_id ASC) - 1, 0) as version
+from public.resolutions_version rv
+         left join public.transaction t on rv.transaction_id = t.id
+         left join public.filings f on f.transaction_id = t.id;
+
+
+-- share_classes -> share_classes
+transfer public.share_classes from lear_old using
+SELECT sc.id,
+       sc.name,
+       sc.priority,
+       sc.max_share_flag,
+       sc.max_shares,
+       sc.par_value_flag,
+       sc.par_value,
+       sc.currency,
+       sc.special_rights_flag,
+       sc.business_id           as legal_entity_id,
+       f.id                     as change_filing_id,
+       COALESCE(scv.version, 0) as version
+FROM public.share_classes sc
+         left join (select id, max(transaction_id) as transaction_id, count(transaction_id) - 1 as version
+                    from public.share_classes_version
+                    group by id) scv on sc.id = scv.id
+         left join public.filings f on f.transaction_id = scv.transaction_id;
+
+
+-- share_classes_version -> share_classes_history
+transfer public.share_classes_history from lear_old using
+SELECT scv.id,
+       scv.name,
+       scv.priority,
+       scv.max_share_flag,
+       scv.max_shares,
+       scv.par_value_flag,
+       scv.par_value,
+       scv.currency,
+       scv.special_rights_flag,
+       scv.business_id                                                                          as legal_entity_id,
+       f.id                                                                                     as change_filing_id,
+       t.issued_at                                                                              as changed,
+       COALESCE(ROW_NUMBER() OVER (PARTITION BY scv.id ORDER BY scv.transaction_id ASC) - 1, 0) as version
+from public.share_classes_version scv
+         left join public.transaction t on scv.transaction_id = t.id
+         left join public.filings f on f.transaction_id = t.id;
+
+
+-- share_series -> share_series
+transfer public.share_series from lear_old using
+SELECT ss.id,
+       ss.name,
+       ss.priority,
+       ss.max_share_flag,
+       ss.max_shares,
+       ss.special_rights_flag,
+       ss.share_class_id,
+       f.id                     as change_filing_id,
+       COALESCE(ssv.version, 0) as version
+FROM public.share_series ss
+         left join (select id, max(transaction_id) as transaction_id, count(transaction_id) - 1 as version
+                    from public.share_series_version ssv
+                    group by id) ssv on ss.id = ssv.id
+         left join public.filings f on f.transaction_id = ssv.transaction_id;
+
+
+-- share_series_version -> share_series_history
+transfer public.share_series_history from lear_old using
+SELECT ssv.id,
+       ssv.name,
+       ssv.priority,
+       ssv.max_share_flag,
+       ssv.max_shares,
+       ssv.special_rights_flag,
+       ssv.share_class_id,
+       f.id                                                                                     as change_filing_id,
+       t.issued_at                                                                              as changed,
+       COALESCE(ROW_NUMBER() OVER (PARTITION BY ssv.id ORDER BY ssv.transaction_id ASC) - 1, 0) as version
+from public.share_series_version ssv
+         left join public.transaction t on ssv.transaction_id = t.id
+         left join public.filings f on f.transaction_id = t.id;
+
+
+-- ensure sequence numbers are updated so collisions with future data does not happen
+SELECT setval('users_id_seq', (SELECT max(id) + 1 FROM public.users));
+SELECT setval('legal_entities_id_seq', (SELECT max(id) + 1 FROM public.legal_entities));
+SELECT setval('legal_entity_identifier_coop', (select MAX(CAST(substring(identifier, '(1[0-9]{6})') AS INTEGER)) + 1
+                                               from legal_entities
+                                               where entity_type = 'CP'));
+SELECT setval('legal_entity_identifier_sp_gp', (select MAX(CAST(substring(identifier, '(1[0-9]{6})') AS INTEGER)) + 1
+                                                from legal_entities
+                                                where entity_type in ('SP', 'GP')));
+SELECT setval('filings_id_seq', (SELECT max(id) + 1 FROM public.filings));
+SELECT setval('addresses_id_seq', (SELECT max(id) + 1 FROM public.addresses));
+SELECT setval('aliases_id_seq', (SELECT max(id) + 1 FROM public.aliases));
+SELECT setval('colin_event_ids_colin_event_id_seq', (SELECT max(colin_event_id) + 1 FROM public.colin_event_ids));
+SELECT setval('colin_last_update_id_seq', (SELECT max(id) + 1 FROM public.colin_last_update));
+SELECT setval('comments_id_seq', (SELECT max(id) + 1 FROM public.comments));
+SELECT setval('dc_definitions_id_seq', (SELECT max(id) + 1 FROM public.dc_definitions));
+SELECT setval('dc_connections_id_seq', (SELECT max(id) + 1 FROM public.dc_connections));
+SELECT setval('dc_issued_credentials_id_seq', (SELECT max(id) + 1 FROM public.dc_issued_credentials));
+SELECT setval('documents_id_seq', (SELECT max(id) + 1 FROM public.documents));
+SELECT setval('offices_id_seq', (SELECT max(id) + 1 FROM public.offices));
+SELECT setval('parties_id_seq', (SELECT max(id) + 1 FROM public.parties));
+SELECT setval('party_roles_id_seq', (SELECT max(id) + 1 FROM public.party_roles));
+SELECT setval('request_tracker_id_seq', (SELECT max(id) + 1 FROM public.request_tracker));
+SELECT setval('resolutions_id_seq', (SELECT max(id) + 1 FROM public.resolutions));
+SELECT setval('share_classes_id_seq', (SELECT max(id) + 1 FROM public.share_classes));
+SELECT setval('share_series_id_seq', (SELECT max(id) + 1 FROM public.share_series));
+
+-- *****************************************************************************************************************
+-- Cleanup of any necessary artifacts/states created as a part of data transfer
+-- *****************************************************************************************************************
+
+connect lear_old;
+
+DROP TABLE public.temp_multiple_filing_transactions;
+

--- a/legal-api/scripts/manual_db_scripts/legal_name_change/transfer_to_new_lear_after.sql
+++ b/legal-api/scripts/manual_db_scripts/legal_name_change/transfer_to_new_lear_after.sql
@@ -1,0 +1,106 @@
+-- ******************************************************************************************************************
+-- Description:
+-- Script that runs after transfer_to_new_lear.sql runs.
+-- This script re-enables triggers and removes temporary triggers/columns/functions used to deal with transferring
+-- enum type data.
+--
+-- Note: it would have been ideal to have the sql in this script in transfer_to_new_lear.sql but the tool(dbshell)
+-- used to transfer data between the source(old LEAR) and target(new LEAR) database has issues with the postgres
+-- enum type.  To workaround this enum issue, temporary triggers/columns/functions are used to populate the enum
+-- fields properly.
+-- ******************************************************************************************************************
+
+-- Re-enable triggers
+ALTER TABLE users
+    ENABLE TRIGGER ALL;
+ALTER TABLE users_history
+    ENABLE TRIGGER ALL;
+ALTER TABLE dc_definitions
+    ENABLE TRIGGER ALL;
+ALTER TABLE legal_entities
+    ENABLE TRIGGER ALL;
+ALTER TABLE legal_entities_history
+    ENABLE TRIGGER ALL;
+ALTER TABLE filings
+    ENABLE TRIGGER ALL;
+ALTER TABLE addresses
+    ENABLE TRIGGER ALL;
+ALTER TABLE addresses_history
+    ENABLE TRIGGER ALL;
+ALTER TABLE aliases
+    ENABLE TRIGGER ALL;
+ALTER TABLE aliases_history
+    ENABLE TRIGGER ALL;
+ALTER TABLE colin_event_ids
+    ENABLE TRIGGER ALL;
+ALTER TABLE colin_last_update
+    ENABLE TRIGGER ALL;
+ALTER TABLE comments
+    ENABLE TRIGGER ALL;
+ALTER TABLE dc_connections
+    ENABLE TRIGGER ALL;
+ALTER TABLE dc_definitions
+    ENABLE TRIGGER ALL;
+ALTER TABLE dc_issued_credentials
+    ENABLE TRIGGER ALL;
+ALTER TABLE documents
+    ENABLE TRIGGER ALL;
+ALTER TABLE documents_history
+    ENABLE TRIGGER ALL;
+ALTER TABLE offices
+    ENABLE TRIGGER ALL;
+ALTER TABLE offices_history
+    ENABLE TRIGGER ALL;
+ALTER TABLE parties
+    ENABLE TRIGGER ALL;
+ALTER TABLE parties_history
+    ENABLE TRIGGER ALL;
+ALTER TABLE party_roles
+    ENABLE TRIGGER ALL;
+ALTER TABLE party_roles_history
+    ENABLE TRIGGER ALL;
+ALTER TABLE registration_bootstrap
+    ENABLE TRIGGER ALL;
+ALTER TABLE request_tracker
+    ENABLE TRIGGER ALL;
+ALTER TABLE resolutions
+    ENABLE TRIGGER ALL;
+ALTER TABLE resolutions_history
+    ENABLE TRIGGER ALL;
+ALTER TABLE share_classes
+    ENABLE TRIGGER ALL;
+ALTER TABLE share_classes_history
+    ENABLE TRIGGER ALL;
+ALTER TABLE share_series
+    ENABLE TRIGGER ALL;
+ALTER TABLE share_series_history
+    ENABLE TRIGGER ALL;
+
+-- Cleanup temporary columns/functions/triggers
+
+-- legal_entities.state & legal_entities_history.state enum
+DROP TRIGGER fill_state_trigger ON legal_entities;
+DROP TRIGGER fill_state_history_trigger ON legal_entities_history;
+ALTER TABLE legal_entities
+    DROP COLUMN state_text;
+ALTER TABLE legal_entities_history
+    DROP COLUMN state_text;
+DROP FUNCTION fill_state;
+
+-- dc_definitions.credential_type enum
+DROP TRIGGER fill_credential_type_trigger ON dc_definitions;
+ALTER TABLE dc_definitions
+    DROP COLUMN credential_type_text;
+DROP FUNCTION fill_credential_type;
+
+-- request_tracker.request_type enum
+DROP TRIGGER fill_request_type_trigger ON request_tracker;
+ALTER TABLE request_tracker
+    DROP COLUMN request_type_text;
+DROP FUNCTION fill_request_type;
+
+-- request_tracker.service_name enum
+DROP TRIGGER fill_service_name_trigger ON request_tracker;
+ALTER TABLE request_tracker
+    DROP COLUMN service_name_text;
+DROP FUNCTION fill_service_name;

--- a/legal-api/scripts/manual_db_scripts/legal_name_change/transfer_to_new_lear_before.sql
+++ b/legal-api/scripts/manual_db_scripts/legal_name_change/transfer_to_new_lear_before.sql
@@ -1,0 +1,161 @@
+-- ******************************************************************************************************************
+-- Description:
+-- Script that runs before transfer_to_new_lear.sql runs.
+-- This script disables triggers and also adds some temporary triggers/columns/functions to deal with transferring
+-- enum type data.
+--
+-- Note: it would have been ideal to have the sql in this script in transfer_to_new_lear.sql but the tool(dbshell)
+-- used to transfer data between the source(old LEAR) and target(new LEAR) database has issues with the postgres
+-- enum type.  To workaround this enum issue, temporary triggers/columns/functions are used to populate the enum
+-- fields properly.
+-- ******************************************************************************************************************
+
+-- Disable triggers
+ALTER TABLE public.users
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.users_history
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.dc_definitions
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.legal_entities
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.legal_entities_history
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.filings
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.addresses
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.addresses_history
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.aliases
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.aliases_history
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.colin_event_ids
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.colin_last_update
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.comments
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.dc_connections
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.dc_definitions
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.dc_issued_credentials
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.documents
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.documents_history
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.offices
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.offices_history
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.parties
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.parties_history
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.party_roles
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.party_roles_history
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.registration_bootstrap
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.request_tracker
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.resolutions
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.resolutions_history
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.share_classes
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.share_classes_history
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.share_series
+    DISABLE TRIGGER ALL;
+ALTER TABLE public.share_series_history
+    DISABLE TRIGGER ALL;
+
+
+-- Temporary columns/functions/triggers for enum workaround
+
+ALTER TABLE public.legal_entities
+    ADD COLUMN state_text text;
+ALTER TABLE public.legal_entities_history
+    ADD COLUMN state_text text;
+ALTER TABLE public.dc_definitions
+    ADD COLUMN credential_type_text text;
+ALTER TABLE request_tracker
+    ADD COLUMN request_type_text text;
+ALTER TABLE public.request_tracker
+    ADD COLUMN service_name_text text;
+
+
+-- legal_entities.state & legal_entities_history.state enum
+CREATE OR REPLACE FUNCTION public.fill_state() RETURNS TRIGGER AS
+$$
+BEGIN
+    NEW.state := NEW.state_text::state;
+    RETURN NEW;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER fill_state_trigger
+    BEFORE INSERT OR UPDATE
+    ON public.legal_entities
+    FOR EACH ROW
+EXECUTE FUNCTION public.fill_state();
+
+CREATE TRIGGER fill_state_history_trigger
+    BEFORE INSERT OR UPDATE
+    ON public.legal_entities_history
+    FOR EACH ROW
+EXECUTE FUNCTION public.fill_state();
+
+
+-- dc_definitions.credential_type enum
+CREATE OR REPLACE FUNCTION public.fill_credential_type() RETURNS TRIGGER AS
+$$
+BEGIN
+    NEW.credential_type := NEW.credential_type_text::credentialtype;
+    RETURN NEW;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER fill_credential_type_trigger
+    BEFORE INSERT OR UPDATE
+    ON public.dc_definitions
+    FOR EACH ROW
+EXECUTE FUNCTION public.fill_credential_type();
+
+
+-- request_tracker.request_type enum
+CREATE OR REPLACE FUNCTION public.fill_request_type() RETURNS TRIGGER AS
+$$
+BEGIN
+    NEW.request_type := NEW.request_type_text::requesttype;
+    RETURN NEW;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER fill_request_type_trigger
+    BEFORE INSERT OR UPDATE
+    ON public.request_tracker
+    FOR EACH ROW
+EXECUTE FUNCTION fill_request_type();
+
+
+-- request_tracker.service_name enum
+CREATE OR REPLACE FUNCTION public.fill_service_name() RETURNS TRIGGER AS
+$$
+BEGIN
+    NEW.service_name := NEW.service_name_text::servicename;
+    RETURN NEW;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER fill_service_name_trigger
+    BEFORE INSERT OR UPDATE
+    ON public.request_tracker
+    FOR EACH ROW
+EXECUTE FUNCTION public.fill_service_name();

--- a/legal-api/src/legal_api/models/legal_entity.py
+++ b/legal-api/src/legal_api/models/legal_entity.py
@@ -267,7 +267,7 @@ class LegalEntity(Versioned, db.Model):  # pylint: disable=too-many-instance-att
                                    db.ForeignKey('addresses.id'))
     naics_key = db.Column(db.String(50))
     naics_code = db.Column(db.String(10))
-    naics_description = db.Column(db.String(150))
+    naics_description = db.Column(db.String(300))
 
     jurisdiction = db.Column('foreign_jurisdiction', db.String(10))
     foreign_jurisdiction_region = db.Column('foreign_jurisdiction_region', db.String(10))


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16202

*Description of changes:*

* Added scripts to transfer data from old to new data model.  The new data model contains the new legal name changes as well as the new versioning approach. 
* Added readme file to provide instructions for migrating data to new model 
* misc alembic and model updates that were required to successfully apply the alembic scripts to a new empty LEAR database

**_Examples of what the data looks like for various tables after being migrated from old to new LEAR db._**

**legal_entities/legal_entities_history**
![image](https://github.com/bcgov/lear/assets/6685223/3f010a7b-2ca8-4680-a02a-9e18f2b15ba3)

**addresses/addresses_history**
![image](https://github.com/bcgov/lear/assets/6685223/2dd3f69e-5158-4460-bed0-247bddefe685)

**share_classes/share_classes_history**
![image](https://github.com/bcgov/lear/assets/6685223/af56228d-11e4-4692-b961-99361e4793ea)

**party_roles/party_roles_history**
![image](https://github.com/bcgov/lear/assets/6685223/b5695b28-a126-4808-8adb-233ab4b82485)


**parties/parties_history**
![image](https://github.com/bcgov/lear/assets/6685223/29390a1e-f1a5-4223-8f71-c3002d908bd3)

**Output from running migration scripts using current Dev db as source database:**

```
(legal-api-py3.10) argus@Argus-Mac-Studio ~/h3/git/bcreg/lear/legal-api (16202_migrate_to_new_lear_script) $ !533
dbshell /Users/argus/h3/git/bcreg/lear/legal-api/scripts/manual_db_scripts/legal_name_change/transfer_to_new_lear.sql
DbShell 1.3.2 Build #210311
Type 'help' for a list of commands.

Processing file /Users/argus/h3/git/bcreg/lear/legal-api/scripts/manual_db_scripts/legal_name_change/transfer_to_new_lear.sql

...

Connected

Transfer using 8 thread(s) users ...                                368 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) users_history ...                        472 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) legal_entities ...                       3707 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) legal_entities_history ...               19232 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) filings ...                              32674 rows in 00:03. Reader waited 00:00, writer 00:09.
Transfer using 8 thread(s) addresses ...                            28079 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) addresses_history ...                    31928 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) aliases ...                              551 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) aliases_history ...                      756 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) colin_event_ids ...                      27857 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) colin_last_update ...                    34 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) comments ...                             1205 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) dc_connections ...                       28 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) dc_definitions ...                       1 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) dc_issued_credentials ...                13 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) documents ...                            457 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) documents_history ...                    457 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) offices ...                              4347 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) offices_history ...                      5863 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) parties ...                              11901 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) parties_history ...                      12828 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) party_roles ...                          13307 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) party_roles_history ...                  14360 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) registration_bootstrap ...               2722 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) request_tracker ...                      830 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) resolutions ...                          271 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) resolutions_history ...                  271 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) share_classes ...                        1037 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) share_classes_history ...                2166 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) share_series ...                         137 rows in 00:01. Reader waited 00:00, writer 00:08.
Transfer using 8 thread(s) share_series_history ...                 573 rows in 00:01. Reader waited 00:00, writer 00:08.
        setval : 679
        setval : 34392
        setval : 1002588
        setval : 1043450
        setval : 555557
        setval : 2708426
        setval : 641
        setval : 104092585
        setval : 78
        setval : 570529
        setval : 2
        setval : 36
        setval : 14
        setval : 480
        setval : 758298
        setval : 573357
        setval : 1137487
        setval : 865
        setval : 261028
        setval : 452672
        setval : 451130
Connected

Done


```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
