### PR TITLE
Fix emailer q_cli

### DIFF
--- a/queue_services/entity-emailer/q_cli.py
+++ b/queue_services/entity-emailer/q_cli.py
@@ -31,10 +31,10 @@ import uuid
 from datetime import datetime, timezone
 from typing import Final
 
-from entity_queue_common.service_utils import error_cb, logger, signal_handler
-
 from nats.aio.client import Client as NATS  # noqa N814; by convention the name is NATS
 from stan.aio.client import Client as STAN  # noqa N814; by convention the name is STAN
+
+from entity_queue_common.service_utils import error_cb, logger, signal_handler
 
 
 affiliation_type: Final = 'bc.registry.affiliation'


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*

* Fix import order issue that was causing emailer `q_cli.py` to error out when called. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
