### PR TITLE
16730 Dynamically configure number of email resending

### DIFF
--- a/queue_services/entity-emailer/src/entity_emailer/config.py
+++ b/queue_services/entity-emailer/src/entity_emailer/config.py
@@ -60,6 +60,8 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
+    MSG_RETRY_NUM = int(os.getenv('MSG_RETRY_NUM', 5))
+
     # urls
     DASHBOARD_URL = os.getenv('DASHBOARD_URL', None)
     NOTIFY_API_URL = os.getenv('NOTIFY_API_URL', None)

--- a/queue_services/entity-emailer/src/entity_emailer/config.py
+++ b/queue_services/entity-emailer/src/entity_emailer/config.py
@@ -60,7 +60,7 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
-    MSG_RETRY_NUM = int(os.getenv('MSG_RETRY_NUM', 5))
+    MSG_RETRY_NUM = int(os.getenv('MSG_RETRY_NUM', '5'))
 
     # urls
     DASHBOARD_URL = os.getenv('DASHBOARD_URL', None)

--- a/queue_services/entity-emailer/src/entity_emailer/message_tracker/tracker.py
+++ b/queue_services/entity-emailer/src/entity_emailer/message_tracker/tracker.py
@@ -14,13 +14,18 @@
 """Functionality for tracking processing of messages in queue."""
 
 import json
+import os
 
 import nats
 
+from entity_emailer import config
 from entity_emailer.email_processors import filing_notification
-from entity_emailer.worker import APP_CONFIG
 from tracker.models import MessageProcessing
 from tracker.services import MessageProcessingService
+
+MSG_RETRY_NUM = config.get_named_config(
+    os.getenv('DEPLOYMENT_ENV', 'production')
+    ).MSG_RETRY_NUM
 
 
 def get_message_context_properties(queue_msg: nats.aio.client.Msg):  # pylint: disable=too-many-return-statements
@@ -142,7 +147,7 @@ def is_processable_message(message_context_properties: dict):
         msg: MessageProcessing = \
             MessageProcessingService.find_message_by_message_id(message_id)
 
-    if msg and msg.message_seen_count > APP_CONFIG.MSG_RETRY_NUM:
+    if msg and msg.message_seen_count > MSG_RETRY_NUM:
         return False, msg
 
     if msg is None or msg.status == MessageProcessing.Status.FAILED.value:

--- a/queue_services/entity-emailer/src/entity_emailer/message_tracker/tracker.py
+++ b/queue_services/entity-emailer/src/entity_emailer/message_tracker/tracker.py
@@ -18,6 +18,7 @@ import json
 import nats
 
 from entity_emailer.email_processors import filing_notification
+from entity_emailer.worker import APP_CONFIG
 from tracker.models import MessageProcessing
 from tracker.services import MessageProcessingService
 
@@ -140,6 +141,9 @@ def is_processable_message(message_context_properties: dict):
             return False, None
         msg: MessageProcessing = \
             MessageProcessingService.find_message_by_message_id(message_id)
+
+    if msg and msg.message_seen_count > APP_CONFIG.MSG_RETRY_NUM:
+        return False, msg
 
     if msg is None or msg.status == MessageProcessing.Status.FAILED.value:
         return True, msg

--- a/queue_services/entity-emailer/src/entity_emailer/message_tracker/tracker.py
+++ b/queue_services/entity-emailer/src/entity_emailer/message_tracker/tracker.py
@@ -147,6 +147,7 @@ def is_processable_message(message_context_properties: dict):
         msg: MessageProcessing = \
             MessageProcessingService.find_message_by_message_id(message_id)
 
+    # limit total number of retries to 1 + MSG_RETRY_NUM
     if msg and msg.message_seen_count > MSG_RETRY_NUM:
         return False, msg
 

--- a/queue_services/entity-emailer/src/entity_emailer/message_tracker/tracker.py
+++ b/queue_services/entity-emailer/src/entity_emailer/message_tracker/tracker.py
@@ -14,19 +14,13 @@
 """Functionality for tracking processing of messages in queue."""
 
 import json
-import os
 
 import nats
 
-from entity_emailer import config
 from entity_emailer.email_processors import filing_notification
+from flask import current_app
 from tracker.models import MessageProcessing
 from tracker.services import MessageProcessingService
-
-
-MSG_RETRY_NUM = config.get_named_config(
-    os.getenv('DEPLOYMENT_ENV', 'production')
-    ).MSG_RETRY_NUM
 
 
 def get_message_context_properties(queue_msg: nats.aio.client.Msg):  # pylint: disable=too-many-return-statements
@@ -149,6 +143,7 @@ def is_processable_message(message_context_properties: dict):
             MessageProcessingService.find_message_by_message_id(message_id)
 
     # limit total number of retries to 1 + MSG_RETRY_NUM
+    MSG_RETRY_NUM = current_app.config.get('MSG_RETRY_NUM')
     if msg and msg.message_seen_count > MSG_RETRY_NUM:
         return False, msg
 

--- a/queue_services/entity-emailer/src/entity_emailer/message_tracker/tracker.py
+++ b/queue_services/entity-emailer/src/entity_emailer/message_tracker/tracker.py
@@ -23,6 +23,7 @@ from entity_emailer.email_processors import filing_notification
 from tracker.models import MessageProcessing
 from tracker.services import MessageProcessingService
 
+
 MSG_RETRY_NUM = config.get_named_config(
     os.getenv('DEPLOYMENT_ENV', 'production')
     ).MSG_RETRY_NUM

--- a/queue_services/entity-emailer/src/entity_emailer/message_tracker/tracker.py
+++ b/queue_services/entity-emailer/src/entity_emailer/message_tracker/tracker.py
@@ -15,10 +15,10 @@
 
 import json
 
+from flask import current_app
 import nats
 
 from entity_emailer.email_processors import filing_notification
-from flask import current_app
 from tracker.models import MessageProcessing
 from tracker.services import MessageProcessingService
 
@@ -142,9 +142,9 @@ def is_processable_message(message_context_properties: dict):
         msg: MessageProcessing = \
             MessageProcessingService.find_message_by_message_id(message_id)
 
-    # limit total number of retries to 1 + MSG_RETRY_NUM
-    MSG_RETRY_NUM = current_app.config.get('MSG_RETRY_NUM')
-    if msg and msg.message_seen_count > MSG_RETRY_NUM:
+    # limit total number of retries to 1 + msg_retry_num
+    msg_retry_num = current_app.config.get('MSG_RETRY_NUM')
+    if msg and msg.message_seen_count > msg_retry_num:
         return False, msg
 
     if msg is None or msg.status == MessageProcessing.Status.FAILED.value:

--- a/queue_services/entity-emailer/src/entity_emailer/message_tracker/tracker.py
+++ b/queue_services/entity-emailer/src/entity_emailer/message_tracker/tracker.py
@@ -15,8 +15,8 @@
 
 import json
 
-from flask import current_app
 import nats
+from flask import current_app
 
 from entity_emailer.email_processors import filing_notification
 from tracker.models import MessageProcessing

--- a/queue_services/entity-emailer/src/entity_emailer/worker.py
+++ b/queue_services/entity-emailer/src/entity_emailer/worker.py
@@ -57,8 +57,6 @@ from entity_emailer.email_processors import (
     restoration_notification,
 )
 
-from .message_tracker import tracker as tracker_util
-
 
 qsm = QueueServiceManager()  # pylint: disable=invalid-name
 APP_CONFIG = config.get_named_config(os.getenv('DEPLOYMENT_ENV', 'production'))
@@ -66,6 +64,7 @@ FLASK_APP = Flask(__name__)
 FLASK_APP.config.from_object(APP_CONFIG)
 db.init_app(FLASK_APP)
 
+from .message_tracker import tracker as tracker_util
 
 async def publish_event(payload: dict):
     """Publish the email message onto the NATS event subject."""

--- a/queue_services/entity-emailer/src/entity_emailer/worker.py
+++ b/queue_services/entity-emailer/src/entity_emailer/worker.py
@@ -59,6 +59,7 @@ from entity_emailer.email_processors import (
 
 from .message_tracker import tracker as tracker_util
 
+
 qsm = QueueServiceManager()  # pylint: disable=invalid-name
 APP_CONFIG = config.get_named_config(os.getenv('DEPLOYMENT_ENV', 'production'))
 FLASK_APP = Flask(__name__)

--- a/queue_services/entity-emailer/src/entity_emailer/worker.py
+++ b/queue_services/entity-emailer/src/entity_emailer/worker.py
@@ -57,6 +57,7 @@ from entity_emailer.email_processors import (
     restoration_notification,
 )
 
+from .message_tracker import tracker as tracker_util
 
 qsm = QueueServiceManager()  # pylint: disable=invalid-name
 APP_CONFIG = config.get_named_config(os.getenv('DEPLOYMENT_ENV', 'production'))
@@ -64,7 +65,6 @@ FLASK_APP = Flask(__name__)
 FLASK_APP.config.from_object(APP_CONFIG)
 db.init_app(FLASK_APP)
 
-from .message_tracker import tracker as tracker_util
 
 async def publish_event(payload: dict):
     """Publish the email message onto the NATS event subject."""

--- a/queue_services/entity-emailer/tests/unit/test_tracker.py
+++ b/queue_services/entity-emailer/tests/unit/test_tracker.py
@@ -430,11 +430,11 @@ async def test_should_correctly_track_retries_for_failed_processing(tracker_app,
 
     # mock out process_email function to throw exception to simulate failed scenario
     with patch.object(worker, 'process_email', side_effect=QueueException('Queue Error.')):
-        for x in range(5):
+        for x in range(10):
             await worker.cb_subscription_handler(mock_msg)
 
     result = MessageProcessing.find_message_by_message_id(message_id=message_id)
     assert result
     assert result.status == 'FAILED'
-    assert result.message_seen_count == 5
+    assert result.message_seen_count == 6
     assert result.last_error == 'QueueException, Exception - Queue Error.'

--- a/queue_services/entity-emailer/tests/unit/test_tracker.py
+++ b/queue_services/entity-emailer/tests/unit/test_tracker.py
@@ -15,10 +15,12 @@
 from unittest.mock import patch
 
 import pytest
+from entity_queue_common.service_utils import EmailException, QueueException  # noqa: I001
+from sqlalchemy.exc import OperationalError
 
 from entity_emailer import worker
-from entity_queue_common.service_utils import EmailException, QueueException  # noqa: I001
 from tracker.models import MessageProcessing
+
 from . import create_mock_message  # noqa: I003
 
 
@@ -409,9 +411,15 @@ async def test_should_process_previously_failed_message_successfully(tracker_app
 
 
 @pytest.mark.asyncio
-async def test_should_correctly_track_retries_for_failed_processing(tracker_app, tracker_db, session):
+@pytest.mark.parametrize(['message_id', 'exception', 'args', 'expected_last_error'], [
+    ('16fd2111-8baf-433b-82eb-8c7fada84eea', OperationalError, [None, None, None], 'OperationalError'),
+    ('16fd2111-8baf-433b-82eb-8c7fada84eeb', EmailException, ['Unsucessful response when sending email.'], 'EmailException'),
+    ('16fd2111-8baf-433b-82eb-8c7fada84eec', QueueException, ['Queue error.'], 'QueueException, Exception'),
+    ('16fd2111-8baf-433b-82eb-8c7fada84eed', Exception, ['Other error.'], 'QueueException, Exception')
+])
+async def test_should_correctly_track_retries_for_failed_processing(tracker_app, tracker_db, session,
+                                                                    message_id, exception, args, expected_last_error):
     """Assert that message processing retries are properly tracked."""
-    message_id = '16fd2111-8baf-433b-82eb-8c7fada84eee'
     message_payload = {
         'specversion': '1.x-wip',
         'type': 'bc.registry.names.request',
@@ -429,13 +437,16 @@ async def test_should_correctly_track_retries_for_failed_processing(tracker_app,
     mock_msg = create_mock_message(message_payload)
 
     # mock out process_email function to throw exception to simulate failed scenario
-    with patch.object(worker, 'process_email', side_effect=EmailException('Queue Error.')):
+    with patch.object(worker, 'process_email', side_effect=exception(*args)):
         for _ in range(6):
-            with pytest.raises(EmailException):
+            if exception in [OperationalError, EmailException]:
+                with pytest.raises(exception):
+                    await worker.cb_subscription_handler(mock_msg)
+            else:
                 await worker.cb_subscription_handler(mock_msg)
 
     # mock out process_email function not to process since message reaches max retries
-    with patch.object(worker, 'process_email', side_effect=EmailException('Queue Error.')):
+    with patch.object(worker, 'process_email', side_effect=exception(*args)):
         for _ in range(5):
             await worker.cb_subscription_handler(mock_msg)
 
@@ -444,4 +455,4 @@ async def test_should_correctly_track_retries_for_failed_processing(tracker_app,
     assert result.status == 'FAILED'
     # check email retries not exceed the max retry limit
     assert result.message_seen_count == 6
-    assert result.last_error == 'EmailException - Queue Error.'
+    assert expected_last_error in result.last_error

--- a/queue_services/entity-emailer/tests/unit/test_tracker.py
+++ b/queue_services/entity-emailer/tests/unit/test_tracker.py
@@ -413,7 +413,8 @@ async def test_should_process_previously_failed_message_successfully(tracker_app
 @pytest.mark.asyncio
 @pytest.mark.parametrize(['message_id', 'exception', 'args', 'expected_last_error'], [
     ('16fd2111-8baf-433b-82eb-8c7fada84eea', OperationalError, [None, None, None], 'OperationalError'),
-    ('16fd2111-8baf-433b-82eb-8c7fada84eeb', EmailException, ['Unsucessful response when sending email.'], 'EmailException'),
+    ('16fd2111-8baf-433b-82eb-8c7fada84eeb', EmailException,
+     ['Unsucessful response when sending email.'], 'EmailException'),
     ('16fd2111-8baf-433b-82eb-8c7fada84eec', QueueException, ['Queue error.'], 'QueueException, Exception'),
     ('16fd2111-8baf-433b-82eb-8c7fada84eed', Exception, ['Other error.'], 'QueueException, Exception')
 ])

--- a/queue_services/entity-emailer/tests/unit/test_tracker.py
+++ b/queue_services/entity-emailer/tests/unit/test_tracker.py
@@ -433,7 +433,7 @@ async def test_should_correctly_track_retries_for_failed_processing(tracker_app,
         for _ in range(6):
             with pytest.raises(EmailException):
                 await worker.cb_subscription_handler(mock_msg)
-        
+
     # mock out process_email function not to process since message reaches max retries
     with patch.object(worker, 'process_email', side_effect=EmailException('Queue Error.')):
         for _ in range(5):


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16730

*Description of changes:*
-  Add a way to dynamically configure number of retries for emailer. It need to add a new variable `MSG_RETRY_NUM` at `.env`. Note that the default number of retries is 5.
- Update unit test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
