### PR TITLE
16901 Update db migration scripts to work with GCP loads

### DIFF
--- a/legal-api/scripts/manual_db_scripts/legal_name_change/README.md
+++ b/legal-api/scripts/manual_db_scripts/legal_name_change/README.md
@@ -65,10 +65,10 @@ Transfer using 8 thread(s) sent_to_gazette ...                      1038 rows in
 Done
 
 ```
-8. Cleanup temporary artifacts and states created by data transfer scripts.
-   Run `<lear-repo-base-path>/legal-api/scripts/manual_db_scripts/legal_name_change/transfer_to_new_lear_after.sql` against new LEAR db
 
 ### 2. Migrate data in new LEAR database for legal name changes
 
 1. Run `<lear-repo-base-path>/legal-api/scripts/manual_db_scripts/legal_name_change/legal_name_updates.sql` against new LEAR db
+2. Cleanup temporary artifacts and states created by data transfer scripts.
+   Run `<lear-repo-base-path>/legal-api/scripts/manual_db_scripts/legal_name_change/transfer_to_new_lear_after.sql` against new LEAR db
 

--- a/legal-api/scripts/manual_db_scripts/legal_name_change/legal_name_updates.sql
+++ b/legal-api/scripts/manual_db_scripts/legal_name_change/legal_name_updates.sql
@@ -15,26 +15,6 @@
 --    changeOfRegistration and conversion) that contain references to party ids.
 
 
--- disable triggers to deal with existing bad data scenarios
-ALTER table legal_entities_history
-    disable trigger all;
-ALTER table legal_entities
-    disable trigger all;
-ALTER table entity_roles_history
-    disable trigger all;
-ALTER table entity_roles
-    disable trigger all;
-ALTER table addresses_history
-    disable trigger all;
-ALTER table addresses
-    disable trigger all;
-
--- temporarily remove primary keys for versioning tables as there are scenarios where version numbers need
--- to be updated.  in these scenarios, some version numbers are repeated until the full update has completed
-ALTER TABLE public.legal_entities_history
-    DROP CONSTRAINT legal_entities_history_pkey;
-
-
 -- temp columns used to provide a way of joining newly created entries with previous party/party_roles data
 ALTER TABLE legal_entities
     ADD COLUMN temp_party_id INTEGER;
@@ -613,23 +593,5 @@ ALTER TABLE entity_roles
 ALTER TABLE entity_roles
     DROP COLUMN temp_party_id;
 
--- restore required constraints that were previously dropped
-ALTER TABLE public.legal_entities_history
-    ADD CONSTRAINT legal_entities_history_pkey PRIMARY KEY (id, version);
-
-
--- re-enable triggers
-ALTER table legal_entities_history
-    enable trigger all;
-ALTER table legal_entities
-    enable trigger all;
-ALTER table entity_roles_history
-    enable trigger all;
-ALTER table entity_roles
-    enable trigger all;
-ALTER table addresses_history
-    enable trigger all;
-ALTER table addresses
-    enable trigger all;
 
 VACUUM FULL;

--- a/legal-api/scripts/manual_db_scripts/legal_name_change/transfer_to_new_lear_after.sql
+++ b/legal-api/scripts/manual_db_scripts/legal_name_change/transfer_to_new_lear_after.sql
@@ -10,75 +10,115 @@
 -- fields properly.
 -- ******************************************************************************************************************
 
--- Re-enable triggers
-ALTER TABLE users
-    ENABLE TRIGGER ALL;
-ALTER TABLE users_history
-    ENABLE TRIGGER ALL;
-ALTER TABLE dc_definitions
-    ENABLE TRIGGER ALL;
-ALTER TABLE legal_entities
-    ENABLE TRIGGER ALL;
-ALTER TABLE legal_entities_history
-    ENABLE TRIGGER ALL;
-ALTER TABLE filings
-    ENABLE TRIGGER ALL;
-ALTER TABLE addresses
-    ENABLE TRIGGER ALL;
-ALTER TABLE addresses_history
-    ENABLE TRIGGER ALL;
-ALTER TABLE aliases
-    ENABLE TRIGGER ALL;
-ALTER TABLE aliases_history
-    ENABLE TRIGGER ALL;
-ALTER TABLE colin_event_ids
-    ENABLE TRIGGER ALL;
-ALTER TABLE colin_last_update
-    ENABLE TRIGGER ALL;
-ALTER TABLE comments
-    ENABLE TRIGGER ALL;
-ALTER TABLE dc_connections
-    ENABLE TRIGGER ALL;
-ALTER TABLE dc_definitions
-    ENABLE TRIGGER ALL;
-ALTER TABLE dc_issued_credentials
-    ENABLE TRIGGER ALL;
-ALTER TABLE documents
-    ENABLE TRIGGER ALL;
-ALTER TABLE documents_history
-    ENABLE TRIGGER ALL;
-ALTER TABLE offices
-    ENABLE TRIGGER ALL;
-ALTER TABLE offices_history
-    ENABLE TRIGGER ALL;
-ALTER TABLE parties
-    ENABLE TRIGGER ALL;
-ALTER TABLE parties_history
-    ENABLE TRIGGER ALL;
-ALTER TABLE party_roles
-    ENABLE TRIGGER ALL;
-ALTER TABLE party_roles_history
-    ENABLE TRIGGER ALL;
-ALTER TABLE registration_bootstrap
-    ENABLE TRIGGER ALL;
-ALTER TABLE request_tracker
-    ENABLE TRIGGER ALL;
-ALTER TABLE resolutions
-    ENABLE TRIGGER ALL;
-ALTER TABLE resolutions_history
-    ENABLE TRIGGER ALL;
-ALTER TABLE share_classes
-    ENABLE TRIGGER ALL;
-ALTER TABLE share_classes_history
-    ENABLE TRIGGER ALL;
-ALTER TABLE share_series
-    ENABLE TRIGGER ALL;
-ALTER TABLE share_series_history
-    ENABLE TRIGGER ALL;
-ALTER TABLE consent_continuation_outs
-    ENABLE TRIGGER ALL;
-ALTER TABLE sent_to_gazette
-    ENABLE TRIGGER ALL;
+
+-- RESTORE CONSTRAINTS
+
+-- legal_entities/legal_entities_history
+ALTER TABLE public.legal_entities_history
+    ADD CONSTRAINT legal_entities_history_pkey PRIMARY KEY (id, version);
+
+ALTER TABLE public.legal_entities
+    ADD CONSTRAINT legal_entities_delivery_address_id_fkey FOREIGN KEY (delivery_address_id) REFERENCES public.addresses (id);
+ALTER TABLE public.legal_entities
+    ADD CONSTRAINT legal_entities_mailing_address_id_fkey FOREIGN KEY (mailing_address_id) REFERENCES public.addresses (id);
+
+ALTER TABLE public.legal_entities_history
+    ADD CONSTRAINT legal_entities_history_delivery_address_id_fkey FOREIGN KEY (delivery_address_id) REFERENCES public.addresses (id);
+ALTER TABLE public.legal_entities_history
+    ADD CONSTRAINT legal_entities_history_mailing_address_id_fkey FOREIGN KEY (mailing_address_id) REFERENCES public.addresses (id);
+
+
+-- addresses/addresses_history
+ALTER TABLE public.addresses_history
+    ADD CONSTRAINT addresses_history_pkey PRIMARY KEY (id, version);
+
+ALTER TABLE public.addresses
+    ADD CONSTRAINT addresses_legal_entity_id_fkey FOREIGN KEY (legal_entity_id) REFERENCES public.legal_entities (id);
+ALTER TABLE public.addresses
+    ADD CONSTRAINT addresses_office_id_fkey FOREIGN KEY (office_id) REFERENCES public.offices (id) ON DELETE CASCADE;
+
+ALTER TABLE public.addresses_history
+    ADD CONSTRAINT addresses_history_legal_entity_id_fkey FOREIGN KEY (legal_entity_id) REFERENCES public.legal_entities (id);
+ALTER TABLE public.addresses_history
+    ADD CONSTRAINT addresses_history_office_id_fkey FOREIGN KEY (office_id) REFERENCES public.offices (id) ON DELETE CASCADE;
+
+
+-- aliases/aliases_history
+ALTER TABLE public.aliases_history
+    ADD CONSTRAINT aliases_history_pkey PRIMARY KEY (id, version);
+
+ALTER TABLE public.aliases
+    ADD CONSTRAINT aliases_legal_entity_id_fkey FOREIGN KEY (legal_entity_id) REFERENCES public.legal_entities (id);
+
+ALTER TABLE public.aliases_history
+    ADD CONSTRAINT aliases_history_legal_entity_id_fkey FOREIGN KEY (legal_entity_id) REFERENCES public.legal_entities (id);
+
+
+-- offices/offices_history
+ALTER TABLE public.offices_history
+    ADD CONSTRAINT offices_history_pkey PRIMARY KEY (id, version);
+
+ALTER TABLE public.offices_history
+    ADD CONSTRAINT offices_history_legal_entity_id_fkey FOREIGN KEY (legal_entity_id) REFERENCES public.legal_entities (id);
+
+
+-- parties/parties_history
+ALTER TABLE public.parties_history
+    ADD CONSTRAINT parties_history_pkey PRIMARY KEY (id, version);
+
+ALTER TABLE public.parties_history
+    ADD CONSTRAINT parties_history_delivery_address_id_fkey FOREIGN KEY (delivery_address_id) REFERENCES public.addresses (id);
+ALTER TABLE public.parties_history
+    ADD CONSTRAINT parties_history_mailing_address_id_fkey FOREIGN KEY (mailing_address_id) REFERENCES public.addresses (id);
+
+
+-- party_roles/party_roles_history
+ALTER TABLE public.party_roles_history
+    ADD CONSTRAINT party_roles_history_pkey PRIMARY KEY (id, version);
+
+ALTER TABLE public.party_roles_history
+    ADD CONSTRAINT party_roles_history_filing_id_fkey FOREIGN KEY (filing_id) REFERENCES public.filings (id);
+ALTER TABLE public.party_roles_history
+    ADD CONSTRAINT party_roles_history_legal_entity_id_fkey FOREIGN KEY (legal_entity_id) REFERENCES public.legal_entities (id);
+ALTER TABLE public.party_roles_history
+    ADD CONSTRAINT party_roles_history_party_id_fkey FOREIGN KEY (party_id) REFERENCES public.parties (id);
+
+
+-- share_series/share_series_history
+ALTER TABLE public.share_series_history
+    ADD CONSTRAINT share_series_history_pkey PRIMARY KEY (id, version);
+
+ALTER TABLE public.share_series_history
+    ADD CONSTRAINT share_series_history_share_class_id_fkey FOREIGN KEY (share_class_id) REFERENCES public.share_classes (id);
+
+
+-- entity_roles/entity_roles_history
+ALTER TABLE public.entity_roles_history
+    ADD CONSTRAINT entity_roles_history_pkey PRIMARY KEY (id, version);
+
+ALTER TABLE public.entity_roles
+    ADD CONSTRAINT entity_roles_related_colin_entity_id_fkey FOREIGN KEY (related_colin_entity_id) REFERENCES public.colin_entities (id);
+ALTER TABLE public.entity_roles
+    ADD CONSTRAINT entity_roles_filing_id_fkey FOREIGN KEY (filing_id) REFERENCES public.filings (id);
+ALTER TABLE public.entity_roles
+    ADD CONSTRAINT entity_roles_legal_entity_id_fkey FOREIGN KEY (legal_entity_id) REFERENCES public.legal_entities (id);
+ALTER TABLE public.entity_roles
+    ADD CONSTRAINT entity_roles_related_entity_id_fkey FOREIGN KEY (related_entity_id) REFERENCES public.legal_entities (id);
+
+ALTER TABLE public.entity_roles_history
+    ADD CONSTRAINT entity_roles_history_filing_id_fkey FOREIGN KEY (filing_id) REFERENCES public.filings (id);
+ALTER TABLE public.entity_roles_history
+    ADD CONSTRAINT entity_roles_history_legal_entity_id_fkey FOREIGN KEY (legal_entity_id) REFERENCES public.legal_entities (id);
+ALTER TABLE public.entity_roles_history
+    ADD CONSTRAINT entity_roles_history_related_entity_id_fkey FOREIGN KEY (related_entity_id) REFERENCES public.legal_entities (id);
+
+
+-- filings
+ALTER TABLE public.filings
+    ADD CONSTRAINT filings_parent_filing_id_fkey FOREIGN KEY (parent_filing_id) REFERENCES public.filings (id);
+ALTER TABLE public.filings
+    ADD CONSTRAINT filings_legal_entity_id_fkey FOREIGN KEY (legal_entity_id) REFERENCES public.legal_entities (id);
+
 
 -- Cleanup temporary columns/functions/triggers
 

--- a/legal-api/scripts/manual_db_scripts/legal_name_change/transfer_to_new_lear_before.sql
+++ b/legal-api/scripts/manual_db_scripts/legal_name_change/transfer_to_new_lear_before.sql
@@ -10,75 +10,115 @@
 -- fields properly.
 -- ******************************************************************************************************************
 
--- Disable triggers
-ALTER TABLE public.users
-    DISABLE TRIGGER ALL;
-ALTER TABLE public.users_history
-    DISABLE TRIGGER ALL;
-ALTER TABLE public.dc_definitions
-    DISABLE TRIGGER ALL;
-ALTER TABLE public.legal_entities
-    DISABLE TRIGGER ALL;
+
+-- DISABLE CONSTRAINTS
+-- Note: Initially, the approach of disabling triggers was used to help with the data migration.  This was
+-- changed as Google Cloud SQL databases do not allow disabling of triggers easily.  It was possible to disable triggers
+-- on a session basis using `SET session_replication_role = 'replica';` but this did not play well with dbshell.
+
+-- legal_entities/legal_entities_history
 ALTER TABLE public.legal_entities_history
-    DISABLE TRIGGER ALL;
-ALTER TABLE public.filings
-    DISABLE TRIGGER ALL;
-ALTER TABLE public.addresses
-    DISABLE TRIGGER ALL;
+    DROP CONSTRAINT legal_entities_history_pkey;
+
+ALTER TABLE public.legal_entities
+    DROP CONSTRAINT legal_entities_delivery_address_id_fkey;
+ALTER TABLE public.legal_entities
+    DROP CONSTRAINT legal_entities_mailing_address_id_fkey;
+
+ALTER TABLE public.legal_entities_history
+    DROP CONSTRAINT legal_entities_history_delivery_address_id_fkey;
+ALTER TABLE public.legal_entities_history
+    DROP CONSTRAINT legal_entities_history_mailing_address_id_fkey;
+
+
+-- addresses/addresses_history
 ALTER TABLE public.addresses_history
-    DISABLE TRIGGER ALL;
-ALTER TABLE public.aliases
-    DISABLE TRIGGER ALL;
+    DROP CONSTRAINT addresses_history_pkey;
+
+ALTER TABLE public.addresses
+    DROP CONSTRAINT addresses_legal_entity_id_fkey;
+ALTER TABLE public.addresses
+    DROP CONSTRAINT addresses_office_id_fkey;
+
+ALTER TABLE public.addresses_history
+    DROP CONSTRAINT addresses_history_legal_entity_id_fkey;
+ALTER TABLE public.addresses_history
+    DROP CONSTRAINT addresses_history_office_id_fkey;
+
+
+-- aliases/aliases_history
 ALTER TABLE public.aliases_history
-    DISABLE TRIGGER ALL;
-ALTER TABLE public.colin_event_ids
-    DISABLE TRIGGER ALL;
-ALTER TABLE public.colin_last_update
-    DISABLE TRIGGER ALL;
-ALTER TABLE public.comments
-    DISABLE TRIGGER ALL;
-ALTER TABLE public.dc_connections
-    DISABLE TRIGGER ALL;
-ALTER TABLE public.dc_definitions
-    DISABLE TRIGGER ALL;
-ALTER TABLE public.dc_issued_credentials
-    DISABLE TRIGGER ALL;
-ALTER TABLE public.documents
-    DISABLE TRIGGER ALL;
-ALTER TABLE public.documents_history
-    DISABLE TRIGGER ALL;
-ALTER TABLE public.offices
-    DISABLE TRIGGER ALL;
+    DROP CONSTRAINT aliases_history_pkey;
+
+ALTER TABLE public.aliases
+    DROP CONSTRAINT aliases_legal_entity_id_fkey;
+
+ALTER TABLE public.aliases_history
+    DROP CONSTRAINT aliases_history_legal_entity_id_fkey;
+
+
+-- offices/offices_history
 ALTER TABLE public.offices_history
-    DISABLE TRIGGER ALL;
-ALTER TABLE public.parties
-    DISABLE TRIGGER ALL;
+    DROP CONSTRAINT offices_history_pkey;
+
+ALTER TABLE public.offices_history
+    DROP CONSTRAINT offices_history_legal_entity_id_fkey;
+
+
+-- parties/parties_history
 ALTER TABLE public.parties_history
-    DISABLE TRIGGER ALL;
-ALTER TABLE public.party_roles
-    DISABLE TRIGGER ALL;
+    DROP CONSTRAINT parties_history_pkey;
+
+ALTER TABLE public.parties_history
+    DROP CONSTRAINT parties_history_delivery_address_id_fkey;
+ALTER TABLE public.parties_history
+    DROP CONSTRAINT parties_history_mailing_address_id_fkey;
+
+
+-- party_roles/party_roles_history
 ALTER TABLE public.party_roles_history
-    DISABLE TRIGGER ALL;
-ALTER TABLE public.registration_bootstrap
-    DISABLE TRIGGER ALL;
-ALTER TABLE public.request_tracker
-    DISABLE TRIGGER ALL;
-ALTER TABLE public.resolutions
-    DISABLE TRIGGER ALL;
-ALTER TABLE public.resolutions_history
-    DISABLE TRIGGER ALL;
-ALTER TABLE public.share_classes
-    DISABLE TRIGGER ALL;
-ALTER TABLE public.share_classes_history
-    DISABLE TRIGGER ALL;
-ALTER TABLE public.share_series
-    DISABLE TRIGGER ALL;
+    DROP CONSTRAINT party_roles_history_pkey;
+
+ALTER TABLE public.party_roles_history
+    DROP CONSTRAINT party_roles_history_filing_id_fkey;
+ALTER TABLE public.party_roles_history
+    DROP CONSTRAINT party_roles_history_legal_entity_id_fkey;
+ALTER TABLE public.party_roles_history
+    DROP CONSTRAINT party_roles_history_party_id_fkey;
+
+
+-- share_series/share_series_history
 ALTER TABLE public.share_series_history
-    DISABLE TRIGGER ALL;
-ALTER TABLE public.consent_continuation_outs
-    DISABLE TRIGGER ALL;
-ALTER TABLE public.sent_to_gazette
-    DISABLE TRIGGER ALL;
+    DROP CONSTRAINT share_series_history_pkey;
+
+ALTER TABLE public.share_series_history
+    DROP CONSTRAINT share_series_history_share_class_id_fkey;
+
+
+-- entity_roles/entity_roles_history
+ALTER TABLE public.entity_roles_history
+    DROP CONSTRAINT entity_roles_history_pkey;
+
+ALTER TABLE public.entity_roles
+    DROP CONSTRAINT entity_roles_filing_id_fkey;
+ALTER TABLE public.entity_roles
+    DROP CONSTRAINT entity_roles_legal_entity_id_fkey;
+ALTER TABLE public.entity_roles
+    DROP CONSTRAINT entity_roles_related_entity_id_fkey;
+
+ALTER TABLE public.entity_roles_history
+    DROP CONSTRAINT entity_roles_history_filing_id_fkey;
+ALTER TABLE public.entity_roles_history
+    DROP CONSTRAINT entity_roles_history_legal_entity_id_fkey;
+ALTER TABLE public.entity_roles_history
+    DROP CONSTRAINT entity_roles_history_related_entity_id_fkey;
+
+
+-- filings
+ALTER TABLE public.filings
+    DROP CONSTRAINT filings_parent_filing_id_fkey;
+ALTER TABLE public.filings
+    DROP CONSTRAINT filings_legal_entity_id_fkey;
 
 
 -- Temporary columns/functions/triggers for enum workaround


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16901

*Description of changes:*

* Updated scripts to add/drop constraints instead of disabling/enabling triggers.  Google Cloud SQL databases do not allow disabling of triggers easily.  
* Updated README such that `transfer_to_near_lear_after.sql` is run as last step.
* Changed ordering of table transfers in `transfer_to_new_lear.sql` to reduce adding/removal of constraints.
* Added additional tables to sequence updates as well as updated sequence updating logic to handle edge case.

Note that due to there being orphaned data in dev/test/prod databases, not all dropped constraints could be added back in the `transfer_to_new_lear_after.sql` script.  This issue will go away once the cleanup orphaned data script is created and applied via the work in #16902.  

As an example of the constraint issue, a successful test data load to GCP using a recent DEV LEAR db dump resulted in the following constraints remaining dropped.
![image](https://github.com/bcgov/lear/assets/6685223/881d0e08-188c-4582-80a2-b18ac7a651f2)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
