### PR TITLE
17162 Add warnings in code to flag obsolete corrections code

### DIFF
--- a/data-tool/flows/custom_filer/filing_processors/correction.py
+++ b/data-tool/flows/custom_filer/filing_processors/correction.py
@@ -30,7 +30,8 @@ def process(correction_filing: Filing, filing: Dict, filing_meta: FilingMeta, bu
 
     # link to original filing
     original_filing = Filing.find_by_id(filing['correction']['correctedFilingId'])
-    original_filing.parent_filing = correction_filing
+    # FUTURE: parent_filing should no longer be used for correction filings and will be removed
+    original_filing.parent_filing = correction_filing 
 
     # add comment to the original filing
     original_filing.comments.append(

--- a/legal-api/src/legal_api/core/filing.py
+++ b/legal-api/src/legal_api/core/filing.py
@@ -380,6 +380,7 @@ class Filing:
                 ledger_filing['filingSubType'] = filing.filing_sub_type
 
             # correction
+            # FUTURE: parent_filing should no longer be used for correction filings and will be removed
             if filing.parent_filing:
                 ledger_filing['correctionFilingId'] = filing.parent_filing.id
                 ledger_filing['correctionLink'] = \

--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -338,7 +338,7 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
             'notice_date',
             'order_details',
             'paper_only',
-            'parent_filing_id',
+            'parent_filing_id', # FUTURE: parent_filing_id should no longer be used for correction filings and will be removed
             'payment_account',
             'submitter_id',
             'submitter_roles',
@@ -396,6 +396,7 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
     documents = db.relationship('Document', lazy='dynamic')
     filing_entity_roles = db.relationship('EntityRole', lazy='dynamic', primaryjoin="(Filing.id==EntityRole.filing_id)")
 
+    # FUTURE: parent_filing_id and parent_filing should no longer be used for correction filings and will be removed
     parent_filing_id = db.Column(db.Integer, db.ForeignKey('filings.id'))
     parent_filing = db.relationship('Filing', remote_side=[id], backref=backref('children'))
 
@@ -472,6 +473,7 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
     def status(self):
         """Property containing the filing status."""
         # pylint: disable=W0212; prevent infinite loop
+        # FUTURE: parent_filing_id and parent_filing should no longer be used for correction filings and will be removed
         if self._status == Filing.Status.COMPLETED \
             and self.parent_filing_id \
                 and self.parent_filing._status == Filing.Status.COMPLETED:
@@ -595,6 +597,7 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
     def is_corrected(self):
         """Has this filing been corrected."""
         if (
+                # FUTURE: parent_filing should no longer be used for correction filings and will be removed
                 self.parent_filing and
                 self.parent_filing.filing_type == Filing.FILINGS['correction'].get('name') and
                 self.parent_filing.status == Filing.Status.COMPLETED.value
@@ -606,6 +609,7 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
     def is_correction_pending(self):
         """Is there a pending correction for this filing."""
         if (
+                # FUTURE: parent_filing should no longer be used for correction filings and will be removed
                 self.parent_filing and
                 self.parent_filing.filing_type == Filing.FILINGS['correction'].get('name') and
                 self.parent_filing.status == Filing.Status.PENDING_CORRECTION.value

--- a/legal-api/src/legal_api/services/document_meta.py
+++ b/legal-api/src/legal_api/services/document_meta.py
@@ -330,6 +330,7 @@ class DocumentMetaService():
             ]
 
         filing_data = Filing.find_by_id(filing['filing']['header']['filingId'])
+        # FUTURE: parent_filing_id should no longer be used for correction filings and will be removed
         has_corrected = filing_data.parent_filing_id is not None  # Identify whether it is corrected
         label_original = ' (Original)' if has_corrected else ''
         label_certificate_original = ' (Original)' if has_corrected and NameXService.\

--- a/legal-api/tests/unit/models/test_filing.py
+++ b/legal-api/tests/unit/models/test_filing.py
@@ -593,6 +593,7 @@ def test_is_corrected_filing(session):
     b = factory_legal_entity('CP1234567')
     filing2 = factory_completed_filing(b, CORRECTION_AR)
 
+    # FUTURE: parent_filing should no longer be used for correction filings and will be removed
     filing1.parent_filing = filing2
     filing1.save()
 
@@ -621,6 +622,7 @@ def test_is_pending_correction_filing(session):
     setattr(filing2, 'skip_status_listener', True)
     filing2.save()
 
+    # FUTURE: parent_filing should no longer be used for correction filings and will be removed
     filing1.parent_filing = filing2
     filing1.save()
 
@@ -646,6 +648,7 @@ def test_linked_not_correction(session):
     filing2.filing_json = f
     filing2.save()
 
+    # FUTURE: parent_filing should no longer be used for correction filings and will be removed
     filing1.parent_filing = filing2
     filing1.save()
 

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filings_ledger.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filings_ledger.py
@@ -394,6 +394,7 @@ def test_ledger_display_corrected_incorporation(session, client, jwt):
         identifier = 'BC1234567'
         legal_entity, original = ledger_element_setup_help(identifier, 'incorporationApplication')
         correction = ledger_element_setup_filing(legal_entity, 'correction', filing_date=legal_entity.founding_date + datedelta.datedelta(months=3))
+        # FUTURE: parent_filing_id should no longer be used for correction filings and will be removed
         original.parent_filing_id = correction.id
         original.save()
 
@@ -425,6 +426,7 @@ def test_ledger_display_corrected_annual_report(session, client, jwt):
             'correction',
             filing_date=legal_entity.founding_date + datedelta.datedelta(months=3),
             filing_dict=ar_correction)
+        # FUTURE: parent_filing_id should no longer be used for correction filings and will be removed
         original.parent_filing_id = correction.id
         original.save()
 
@@ -516,6 +518,7 @@ def test_ledger_display_special_resolution_correction(session, client, jwt):
         'correction',
         filing_date=business.founding_date + datedelta.datedelta(months=3),
         filing_dict=sr_correction)
+    # FUTURE: parent_filing_id should no longer be used for correction filings and will be removed
     original.parent_filing_id = correction.id
     original.save()
 
@@ -534,6 +537,7 @@ def test_ledger_display_special_resolution_correction(session, client, jwt):
         'correction',
         filing_date=business.founding_date + datedelta.datedelta(months=3),
         filing_dict=sr_correction_2)
+    # FUTURE: parent_filing_id should no longer be used for correction filings and will be removed
     correction.parent_filing_id = correction_2.id
     correction.save()
 
@@ -570,6 +574,7 @@ def test_ledger_display_non_special_resolution_correction_name(session, client, 
         'correction',
         filing_date=business.founding_date + datedelta.datedelta(months=3),
         filing_dict=correction)
+    # FUTURE: parent_filing_id should no longer be used for correction filings and will be removed
     original.parent_filing_id = correction.id
     original.save()
 

--- a/legal-api/tests/unit/services/test_document_meta.py
+++ b/legal-api/tests/unit/services/test_document_meta.py
@@ -901,6 +901,7 @@ def test_ia_completed_bcomp_original(session, app):
                     }
                 }
             }
+            # FUTURE: parent_filing_id should no longer be used for correction filings and will be removed
             original_filing.parent_filing_id = corrected_filing.id
             original_filing.save()
             documents = document_meta.get_documents(filing)

--- a/python/common/business-registry-model/src/business_model/models/filing.py
+++ b/python/common/business-registry-model/src/business_model/models/filing.py
@@ -338,7 +338,7 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
             'notice_date',
             'order_details',
             'paper_only',
-            'parent_filing_id',
+            'parent_filing_id', # FUTURE: parent_filing_id should no longer be used for correction filings and will be removed
             'payment_account',
             'submitter_id',
             'submitter_roles',
@@ -396,6 +396,7 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
     documents = db.relationship('Document', lazy='dynamic')
     filing_entity_roles = db.relationship('EntityRole', lazy='dynamic', primaryjoin="(Filing.id==EntityRole.filing_id)")
 
+    # FUTURE: parent_filing_id and parent_filing should no longer be used for correction filings and will be removed
     parent_filing_id = db.Column(db.Integer, db.ForeignKey('filings.id'))
     parent_filing = db.relationship('Filing', remote_side=[id], backref=backref('children'))
 
@@ -472,6 +473,7 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
     def status(self):
         """Property containing the filing status."""
         # pylint: disable=W0212; prevent infinite loop
+        # FUTURE: parent_filing_id and parent_filing should no longer be used for correction filings and will be removed
         if self._status == Filing.Status.COMPLETED \
             and self.parent_filing_id \
                 and self.parent_filing._status == Filing.Status.COMPLETED:
@@ -595,6 +597,7 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
     def is_corrected(self):
         """Has this filing been corrected."""
         if (
+                # FUTURE: parent_filing should no longer be used for correction filings and will be removed
                 self.parent_filing and
                 self.parent_filing.filing_type == Filing.FILINGS['correction'].get('name') and
                 self.parent_filing.status == Filing.Status.COMPLETED.value
@@ -606,6 +609,7 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
     def is_correction_pending(self):
         """Is there a pending correction for this filing."""
         if (
+                # FUTURE: parent_filing should no longer be used for correction filings and will be removed
                 self.parent_filing and
                 self.parent_filing.filing_type == Filing.FILINGS['correction'].get('name') and
                 self.parent_filing.status == Filing.Status.PENDING_CORRECTION.value

--- a/python/common/business-registry-model/tests/models/test_filing.py
+++ b/python/common/business-registry-model/tests/models/test_filing.py
@@ -599,7 +599,8 @@ def test_is_corrected_filing(session):
 
     b = factory_legal_entity('CP1234567')
     filing2 = factory_completed_filing(b, CORRECTION_AR)
-
+    
+    # FUTURE: parent_filing should no longer be used for correction filings and will be removed
     filing1.parent_filing = filing2
     filing1.save()
 
@@ -628,6 +629,7 @@ def test_is_pending_correction_filing(session):
     setattr(filing2, 'skip_status_listener', True)
     filing2.save()
 
+    # FUTURE: parent_filing should no longer be used for correction filings and will be removed
     filing1.parent_filing = filing2
     filing1.save()
 
@@ -653,6 +655,7 @@ def test_linked_not_correction(session):
     filing2.filing_json = f
     filing2.save()
 
+    # FUTURE: parent_filing should no longer be used for correction filings and will be removed
     filing1.parent_filing = filing2
     filing1.save()
 

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/correction.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/correction.py
@@ -31,6 +31,7 @@ def process(correction_filing: Filing, filing: Dict, filing_meta: FilingMeta, bu
 
     # link to original filing
     original_filing = Filing.find_by_id(filing['correction']['correctedFilingId'])
+    # FUTURE: parent_filing should no longer be used for correction filings and will be removed
     original_filing.parent_filing = correction_filing
 
     # add comment to the original filing

--- a/queue_services/entity-filer/tests/unit/test_worker/test_worker.py
+++ b/queue_services/entity-filer/tests/unit/test_worker/test_worker.py
@@ -460,6 +460,7 @@ async def test_correction_filing(app, session):
     staff_user = User.find_by_username('staff_user')
 
     # check that the correction filing is linked to the original filing
+    # FUTURE: parent_filing should no longer be used for correction filings and will be removed
     assert original_filing.parent_filing
     assert original_filing.parent_filing == correction_filing
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17162

*Description of changes:*
 - Added a comment to `parent_filing_id` column in filings model to indicate that this should no longer be used for correction filings.
- Added comments for all references to `parent_filing` indicating that corrections should no longer use this and it should be removed in the future.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
