### PR TITLE
16978 Added extra validation to special resolution correction

### DIFF
--- a/legal-api/requirements.txt
+++ b/legal-api/requirements.txt
@@ -59,4 +59,4 @@ minio==7.0.2
 PyPDF2==1.26.0
 reportlab==3.6.12
 html-sanitizer==1.9.3
-git+https://github.com/bcgov/business-schemas.git@2.18.10#egg=registry_schemas
+git+https://github.com/bcgov/business-schemas.git@2.18.11#egg=registry_schemas

--- a/legal-api/requirements.txt
+++ b/legal-api/requirements.txt
@@ -34,7 +34,7 @@ flask-restx==0.3.0
 gunicorn==20.1.0
 idna==2.10
 itsdangerous==1.1.0
-jsonschema==4.16.0
+jsonschema==4.19.0
 launchdarkly-server-sdk==7.1.0
 protobuf==3.15.8
 psycopg2-binary==2.8.6

--- a/legal-api/requirements.txt
+++ b/legal-api/requirements.txt
@@ -19,7 +19,7 @@ alembic==1.7.5
 aniso8601==9.0.1
 asyncio-nats-client==0.11.4
 asyncio-nats-streaming==0.4.0
-attrs==20.3.0
+attrs==23.1.0
 blinker==1.4
 cachelib==0.1.1
 certifi==2020.12.5

--- a/legal-api/src/legal_api/services/filings/validations/correction.py
+++ b/legal-api/src/legal_api/services/filings/validations/correction.py
@@ -132,7 +132,7 @@ def _validate_special_resolution_correction(filing_dict, legal_type, msg):
         msg.extend(court_order_validation(filing_dict))
     if filing_dict.get('filing', {}).get(filing_type, {}).get('correction', {}).get('rulesFileKey', None):
         msg.extend(rules_change_validation(filing_dict))
-    if is_special_resolution_correction_by_filing_json(filing_dict):
+    if is_special_resolution_correction_by_filing_json(filing_dict.get('filing', {})):
         if filing_dict.get('filing', {}).get('correction', {}).get('parties', None):
             err = validate_roles(filing_dict, legal_type, filing_type)
             if err:

--- a/legal-api/src/legal_api/services/filings/validations/correction.py
+++ b/legal-api/src/legal_api/services/filings/validations/correction.py
@@ -19,6 +19,7 @@ from typing import Dict, Final
 from dateutil.relativedelta import relativedelta
 from flask_babel import _
 
+from legal_api.core.filing_helper import is_special_resolution_correction_by_filing_json
 from legal_api.errors import Error
 from legal_api.models import Business, Filing, PartyRole
 from legal_api.services import STAFF_ROLE, NaicsService
@@ -131,6 +132,22 @@ def _validate_special_resolution_correction(filing_dict, legal_type, msg):
         msg.extend(court_order_validation(filing_dict))
     if filing_dict.get('filing', {}).get(filing_type, {}).get('correction', {}).get('rulesFileKey', None):
         msg.extend(rules_change_validation(filing_dict))
+    if is_special_resolution_correction_by_filing_json(filing_dict):
+        if filing_dict.get('filing', {}).get('correction', {}).get('parties', None):
+            err = validate_roles(filing_dict, legal_type, filing_type)
+            if err:
+                msg.extend(err)
+            # FUTURE: this should be removed when COLIN sync back is no longer required.
+            err = validate_parties_names(filing_dict, legal_type, filing_type)
+            if err:
+                msg.extend(err)
+
+            err = validate_parties_mailing_address(filing_dict, legal_type, filing_type)
+            if err:
+                msg.extend(err)
+        else:
+            err_path = f'/filing/{filing_type}/parties/roles'
+            msg.append({'error': 'Parties list cannot be empty or null', 'path': err_path})
 
 
 def validate_party(filing: Dict, legal_type: str) -> list:

--- a/legal-api/tests/unit/services/filings/validations/test_correction_special_resolution.py
+++ b/legal-api/tests/unit/services/filings/validations/test_correction_special_resolution.py
@@ -95,9 +95,9 @@ def test_parties_special_resolution_correction(session, test_name, legal_type, c
     elif test_name == "empty_parties":
         f['filing']['correction']['parties'] = []
     elif test_name == "only_completing":
-        del f['filing']['correction']['parties'][0]['roles'][1]
-        del f['filing']['correction']['parties'][1]
         del f['filing']['correction']['parties'][2]
+        del f['filing']['correction']['parties'][1]
+        del f['filing']['correction']['parties'][0]['roles'][1]
     elif test_name == 'valid_parties':
         if correction_type == 'STAFF':
             del f['filing']['correction']['parties'][0]['roles'][0]  # completing party

--- a/legal-api/tests/unit/services/filings/validations/test_correction_special_resolution.py
+++ b/legal-api/tests/unit/services/filings/validations/test_correction_special_resolution.py
@@ -67,7 +67,8 @@ def test_valid_special_resolution_correction(session):
     ('only_completing', 'CP', 'CLIENT', 
      [{'error': 'Must have a minimum of three Directors', 'path': '/filing/correction/parties/roles'}]),
     ('only_completing', 'CP', 'STAFF', 
-     [{'error': 'Should not provide completing party when correction type is STAFF', 'path': '/filing/correction/parties/roles'}]),
+     [{'error': 'Should not provide completing party when correction type is STAFF', 'path': '/filing/correction/parties/roles'},
+      {'error': 'Must have a minimum of three Directors', 'path': '/filing/correction/parties/roles'}]),
 ])
 def test_parties_special_resolution_correction(session, test_name, legal_type, correction_type, err_msg):
     """Test parties for SPECIAL_RESOLUTION correction."""
@@ -96,12 +97,6 @@ def test_parties_special_resolution_correction(session, test_name, legal_type, c
         del f['filing']['correction']['parties'][1]
         del f['filing']['correction']['parties'][2]
     elif test_name == 'valid_parties':
-        if legal_type == 'CP':
-            director = copy.deepcopy(f['filing']['correction']['parties'][0])
-            del director['roles'][0]  # completing party
-            f['filing']['correction']['parties'].append(director)
-            f['filing']['correction']['parties'].append(director)
-
         if correction_type == 'STAFF':
             del f['filing']['correction']['parties'][0]['roles'][0]  # completing party
 

--- a/legal-api/tests/unit/services/filings/validations/test_correction_special_resolution.py
+++ b/legal-api/tests/unit/services/filings/validations/test_correction_special_resolution.py
@@ -70,7 +70,7 @@ def test_valid_special_resolution_correction(session):
      [{'error': 'Should not provide completing party when correction type is STAFF', 'path': '/filing/correction/parties/roles'}]),
 ])
 def test_parties_special_resolution_correction(session, test_name, legal_type, correction_type, err_msg):
-    """Test that a valid NR correction passes validation."""
+    """Test parties for SPECIAL_RESOLUTION correction."""
     # setup
     identifier = 'BC1234567'
     business = factory_business(identifier)

--- a/legal-api/tests/unit/services/filings/validations/test_correction_special_resolution.py
+++ b/legal-api/tests/unit/services/filings/validations/test_correction_special_resolution.py
@@ -80,9 +80,11 @@ def test_parties_special_resolution_correction(session, test_name, legal_type, c
     correction_data = copy.deepcopy(FILING_HEADER)
     correction_data['filing']['correction'] = copy.deepcopy(CORRECTION_CP_SPECIAL_RESOLUTION)
     correction_data['filing']['header']['name'] = 'correction'
+    
     f = copy.deepcopy(correction_data)
     f['filing']['header']['identifier'] = identifier
     f['filing']['correction']['correctedFilingId'] = corrected_filing.id
+    f['filing']['correction']['type'] = correction_type
 
     if test_name == 'no_roles':
         f['filing']['correction']['parties'][0]['roles'] = []


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16978

*Description of changes:*
- Updated to include validation for special resolution corrections.
- Added tests to ensure:
  - if no parties list is provided, validation fails
  - if parties is an empty list, validation fails
  - if only completing party is included in parties list, validation fails indicating at least 3 directors are req'd
  - if less than 3 directors is included in parties list, validation fails

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
