### PR TITLE
17443 Update error handling to work properly for auth exceptions and other unhandled exceptions

### DIFF
--- a/colin-api/src/colin_api/__init__.py
+++ b/colin-api/src/colin_api/__init__.py
@@ -23,7 +23,7 @@ from legal_api.services import flags
 from sentry_sdk.integrations.flask import FlaskIntegration  # noqa: I001
 
 from colin_api import config, errorhandlers
-from colin_api.resources import API_BLUEPRINT, OPS_BLUEPRINT
+from colin_api.resources import API, API_BLUEPRINT, OPS_BLUEPRINT
 from colin_api.utils.auth import jwt
 from colin_api.utils.logging import setup_logging
 from colin_api.utils.run_version import get_run_version
@@ -44,7 +44,7 @@ def create_app(run_mode=os.getenv('FLASK_ENV', 'production')):
         )
 
     flags.init_app(app)
-    errorhandlers.init_app(app)
+    errorhandlers.init_app(API)
     app.register_blueprint(API_BLUEPRINT)
     app.register_blueprint(OPS_BLUEPRINT)
     setup_jwt_manager(app, jwt)

--- a/colin-api/src/colin_api/resources/__init__.py
+++ b/colin-api/src/colin_api/resources/__init__.py
@@ -35,7 +35,7 @@ from .reset import API as RESET_API
 from .share_struct import API as SHARES_API
 
 
-__all__ = ('API_BLUEPRINT', 'OPS_BLUEPRINT')
+__all__ = ('API', 'API_BLUEPRINT', 'OPS_BLUEPRINT')
 
 # This will add the Authorize button to the swagger docs
 AUTHORIZATIONS = {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17443

*Description of changes:*
* Register error handlers directly against flask restx api object.  Registering against flask app resulted in errors not being picked up and a generic 500 internal server error would be returned for things like auth errors.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
