### PR TITLE
sftp-icbc-report and sftp-nuans-report broken on PROD#17739

### DIFF
--- a/jobs/sftp-icbc-report/requirements.txt
+++ b/jobs/sftp-icbc-report/requirements.txt
@@ -36,7 +36,7 @@ pylint
 pylint-flask
 pep8
 autopep8
-paramiko==2.7.2
+paramiko==3.3.1
 pysftp==0.2.9
 
 git+https://github.com/bcgov/business-schemas.git@2.5.0#egg=registry_schemas

--- a/jobs/sftp-nuans-report/requirements.txt
+++ b/jobs/sftp-nuans-report/requirements.txt
@@ -36,7 +36,7 @@ pylint
 pylint-flask
 pep8
 autopep8
-paramiko==2.7.2
+paramiko==3.3.1
 pysftp==0.2.9
 
 git+https://github.com/bcgov/business-schemas.git@2.5.0#egg=registry_schemas


### PR DESCRIPTION
*Issue #:* /bcgov/entity: 17739

*Description of changes:*
Both sftp-icbc-report and sftp-nuans-report were broken after Pimento patched last weekend. Fixed the broken 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
