### PR TITLE
17447 Remove unnecessary logging

### DIFF
--- a/jobs/update-legal-filings/update_legal_filings.py
+++ b/jobs/update-legal-filings/update_legal_filings.py
@@ -88,7 +88,6 @@ def check_for_manual_filings(application: Flask = None, token: dict = None):
         application.logger.error(f'Error getting last updated colin id from \
             legal: {response.status_code} {response.json()}')
     else:
-        application.logger.debug(f'response.status_code, response json: {response.status_code}, {response.json()}')
         if response.status_code == 404:
             last_event_id = 'earliest'
         else:
@@ -100,26 +99,20 @@ def check_for_manual_filings(application: Flask = None, token: dict = None):
             try:
                 for corp_type in corp_types:
                     application.logger.debug(f'corp_type: {corp_type}')
-                    headers = {**AccountService.CONTENT_TYPE_JSON,
-                               'Authorization': AccountService.BEARER + token}
-                    application.logger.debug(f'headers, timeout: {headers}, {AccountService.timeout}')
                     url = f'{colin_url}/event/{corp_type}/{last_event_id}'
                     application.logger.debug(f'url: {url}')
                     # call colin api for ids + filing types list
                     response = requests.get(url,
-                                            headers=headers,
+                                            headers={**AccountService.CONTENT_TYPE_JSON,
+                                                     'Authorization': AccountService.BEARER + token},
                                             timeout=AccountService.timeout)
-                    application.logger.debug(f'r.status_code, r.json: {response.status_code}, {response.json()}')
                     event_info = dict(response.json())
                     events = event_info.get('events')
                     if corp_type in no_corp_num_prefix_in_colin:
-                        application.logger.debug('no_corp_num_prefix_in_colin flow')
                         append_corp_num_prefixes(events, 'BC')
                     if colin_events:
-                        application.logger.debug('colin_events extend')
                         colin_events.get('events').extend(events)
                     else:
-                        application.logger.debug('colin_events no extend')
                         colin_events = event_info
 
             except Exception as err:  # noqa: B902


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17447

*Description of changes:*

* Remove most of the logging that was added/used to determine why calls to colin api with auth turned on was not working.  Issue turned out the  image pull policies in the cronjob.yaml files in update-colin-filings and update-colin-legal filings job were not set to "always".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
