### PR TITLE
18026 Add allowable actions for AGM location change

### DIFF
--- a/legal-api/requirements.txt
+++ b/legal-api/requirements.txt
@@ -60,3 +60,4 @@ PyPDF2==1.26.0
 reportlab==3.6.12
 html-sanitizer==1.9.3
 git+https://github.com/bcgov/business-schemas.git@2.18.13#egg=registry_schemas
+

--- a/legal-api/src/legal_api/core/meta/filing.py
+++ b/legal-api/src/legal_api/core/meta/filing.py
@@ -84,9 +84,13 @@ FILINGS: Final = {
     },
     'agmLocationChange': {
         'name': 'agmLocationChange',
-        'title': 'agmLocationChange',
+        'title': 'AGM Location Change',
+        'displayName': 'AGM Location Change',
         'codes': {
-
+            'BC': 'AGMLC',
+            'BEN': 'AGMLC',
+            'ULC': 'AGMLC',
+            'CC': 'AGMLC'
         }
     },
     'alteration': {

--- a/legal-api/src/legal_api/services/authz.py
+++ b/legal-api/src/legal_api/services/authz.py
@@ -118,6 +118,17 @@ ALLOWABLE_FILINGS: Final = {
             'adminFreeze': {
                 'legalTypes': ['SP', 'GP', 'CP', 'BC', 'BEN', 'CC', 'ULC'],
             },
+            'agmLocationChange': {
+                'legalTypes': ['BC', 'BEN', 'ULC', 'CC'],
+                'blockerChecks': {
+                    'business': [
+                        BusinessBlocker.DEFAULT,
+                        BusinessBlocker.BUSINESS_FROZEN,
+                        BusinessBlocker.DRAFT_PENDING,
+                        BusinessBlocker.NOT_IN_GOOD_STANDING
+                    ]
+                }
+            },
             'alteration': {
                 'legalTypes': ['BC', 'BEN', 'ULC', 'CC'],
                 'blockerChecks': {
@@ -267,6 +278,17 @@ ALLOWABLE_FILINGS: Final = {
     },
     'general': {
         Business.State.ACTIVE: {
+            'agmLocationChange': {
+                'legalTypes': ['BC', 'BEN', 'ULC', 'CC'],
+                'blockerChecks': {
+                    'business': [
+                        BusinessBlocker.DEFAULT,
+                        BusinessBlocker.BUSINESS_FROZEN,
+                        BusinessBlocker.DRAFT_PENDING,
+                        BusinessBlocker.NOT_IN_GOOD_STANDING
+                    ]
+                }
+            },
             'alteration': {
                 'legalTypes': ['BC', 'BEN', 'ULC', 'CC'],
                 'blockerChecks': {

--- a/legal-api/src/legal_api/services/authz.py
+++ b/legal-api/src/legal_api/services/authz.py
@@ -121,12 +121,7 @@ ALLOWABLE_FILINGS: Final = {
             'agmLocationChange': {
                 'legalTypes': ['BC', 'BEN', 'ULC', 'CC'],
                 'blockerChecks': {
-                    'business': [
-                        BusinessBlocker.DEFAULT,
-                        BusinessBlocker.BUSINESS_FROZEN,
-                        BusinessBlocker.DRAFT_PENDING,
-                        BusinessBlocker.NOT_IN_GOOD_STANDING
-                    ]
+                    'business': [BusinessBlocker.DEFAULT, BusinessBlocker.NOT_IN_GOOD_STANDING]
                 }
             },
             'alteration': {
@@ -281,12 +276,7 @@ ALLOWABLE_FILINGS: Final = {
             'agmLocationChange': {
                 'legalTypes': ['BC', 'BEN', 'ULC', 'CC'],
                 'blockerChecks': {
-                    'business': [
-                        BusinessBlocker.DEFAULT,
-                        BusinessBlocker.BUSINESS_FROZEN,
-                        BusinessBlocker.DRAFT_PENDING,
-                        BusinessBlocker.NOT_IN_GOOD_STANDING
-                    ]
+                    'business': [BusinessBlocker.DEFAULT, BusinessBlocker.NOT_IN_GOOD_STANDING]
                 }
             },
             'alteration': {

--- a/legal-api/tests/unit/services/test_authorization.py
+++ b/legal-api/tests/unit/services/test_authorization.py
@@ -1082,8 +1082,8 @@ def test_get_allowed_filings_blocker_admin_freeze(monkeypatch, app, session, jwt
                                             admin_freeze=True)
             filing_types = get_allowed_filings(business, state, legal_type, jwt)
             assert filing_types == expected
-            
 
+            
 @pytest.mark.parametrize(
     'test_name,state,legal_types,username,roles,filing_statuses,expected',
     [
@@ -1414,6 +1414,7 @@ def test_allowed_filings_warnings(monkeypatch, app, session, jwt, test_name, sta
         ('staff_active_corps_valid_state_filing_fail', Business.State.ACTIVE, ['BC', 'BEN', 'CC', 'ULC'], 'staff',
          [STAFF_ROLE], [None, 'restoration'], [None, 'fullRestoration'],
          expected_lookup([FilingKey.ADMN_FRZE,
+                          FilingKey.AGM_LOCATION_CHANGE,
                           FilingKey.ALTERATION,
                           FilingKey.AR_CORPS,
                           FilingKey.COA_CORPS,
@@ -1630,6 +1631,7 @@ def test_is_allowed_ignore_draft_filing(monkeypatch, app, session, jwt, test_nam
         ('staff_active_corps_completed_filing_fail', Business.State.ACTIVE, ['BC', 'BEN', 'CC', 'ULC'], 'staff',
          [STAFF_ROLE], [None, None], [None, None], [False, False],
          expected_lookup([FilingKey.ADMN_FRZE,
+                          FilingKey.AGM_LOCATION_CHANGE,
                           FilingKey.ALTERATION,
                           FilingKey.AR_CORPS,
                           FilingKey.COA_CORPS,

--- a/legal-api/tests/unit/services/test_authorization.py
+++ b/legal-api/tests/unit/services/test_authorization.py
@@ -1084,6 +1084,60 @@ def test_get_allowed_filings_blocker_admin_freeze(monkeypatch, app, session, jwt
 
 
 @pytest.mark.parametrize(
+    'test_name,business_exists,state,legal_types,username,roles,expected',
+    [
+        # active business - staff user
+        ('staff_active_cp', True, Business.State.ACTIVE, ['CP'], 'staff', [STAFF_ROLE],[]),
+        ('staff_active_corps', True, Business.State.ACTIVE, ['BC', 'BEN', 'CC', 'ULC'], 'staff', [STAFF_ROLE],[]),
+        ('staff_active_llc', True, Business.State.ACTIVE, ['LLC'], 'staff', [STAFF_ROLE], []),
+        ('staff_active_firms', True, Business.State.ACTIVE, ['SP', 'GP'], 'staff', [STAFF_ROLE],[]),
+
+        # active business - general user
+        ('general_user_cp', True, Business.State.ACTIVE, ['CP'], 'general', [BASIC_USER], []),
+        ('general_user_corps', True, Business.State.ACTIVE, ['BC', 'BEN', 'CC', 'ULC'], 'general', [BASIC_USER],[]),
+        ('general_user_llc', True, Business.State.ACTIVE, ['LLC'], 'general', [BASIC_USER], []),
+        ('general_user_firms', True, Business.State.ACTIVE, ['SP', 'GP'], 'general', [BASIC_USER], []),
+
+        # historical business - staff user
+        ('staff_historical_cp', True, Business.State.HISTORICAL, ['CP'], 'staff', [STAFF_ROLE],[]),
+        ('staff_historical_corps', True, Business.State.HISTORICAL, ['BC', 'BEN', 'CC', 'ULC'], 'staff', [STAFF_ROLE],[]),
+        ('staff_historical_llc', True, Business.State.HISTORICAL, ['LLC'], 'staff', [STAFF_ROLE], []),
+        ('staff_historical_firms', True, Business.State.HISTORICAL, ['SP', 'GP'], 'staff', [STAFF_ROLE],[]),
+
+        # historical business - general user
+        ('general_user_historical_cp', True, Business.State.HISTORICAL, ['CP'], 'general', [BASIC_USER], []),
+        ('general_user_historical_corps', True, Business.State.HISTORICAL, ['BC', 'BEN', 'CC', 'ULC'], 'general',
+         [BASIC_USER], []),
+        ('general_user_historical_llc', True, Business.State.HISTORICAL, ['LLC'], 'general', [BASIC_USER], []),
+        ('general_user_historical_firms', True, Business.State.HISTORICAL, ['SP', 'GP'], 'general', [BASIC_USER], []),
+    ]
+)
+def test_get_allowed_filings_blocker_not_in_good_standing(monkeypatch, app, session, jwt, test_name, business_exists, state,
+                                                  legal_types, username, roles, expected):
+    """Assert that get allowed returns valid filings when business is not in good standing."""
+    token = helper_create_jwt(jwt, roles=roles, username=username)
+    headers = {'Authorization': 'Bearer ' + token}
+
+    def mock_auth(one, two):  # pylint: disable=unused-argument; mocks of library methods
+        return headers[one]
+
+    with app.test_request_context():
+        monkeypatch.setattr('flask.request.headers.get', mock_auth)
+
+        for legal_type in legal_types:
+            business = None
+            if business_exists:
+                identifier = (f'BC{random.SystemRandom().getrandbits(0x58)}')[:9]
+                business = factory_business(identifier=identifier,
+                                            entity_type=legal_type,
+                                            state=state)
+                business.good_standing = False
+            filing_types = get_allowed_filings(business, state, legal_type, jwt)
+            print("test:")
+            print(filing_types)
+            assert filing_types == expected
+
+@pytest.mark.parametrize(
     'test_name,state,legal_types,username,roles,filing_statuses,expected',
     [
         # active business - staff user

--- a/legal-api/tests/unit/services/test_authorization.py
+++ b/legal-api/tests/unit/services/test_authorization.py
@@ -160,7 +160,7 @@ EXPECTED_DATA = {
                                     'name': 'registrarsNotation'},
     FilingKey.REGISTRARS_ORDER: {'displayName': "Registrar's Order", 'feeCode': 'NOFEE', 'name': 'registrarsOrder'},
     FilingKey.SPECIAL_RESOLUTION: {'displayName': 'Special Resolution', 'feeCode': 'SPRLN', 'name': 'specialResolution'},
-    FilingKey.AGM_LOCATION_CHANGE: {'displayName': 'agmLocationChange', 'feeCode': 'AGMLC', 'name': 'AGM Location Change'},
+    FilingKey.AGM_LOCATION_CHANGE: {'displayName': 'AGM Location Change', 'feeCode': 'AGMLC', 'name': 'agmLocationChange'},
     FilingKey.ALTERATION: {'displayName': 'Alteration', 'feeCode': 'ALTER', 'name': 'alteration'},
     FilingKey.CONSENT_CONTINUATION_OUT: {'displayName': '6-Month Consent to Continue Out', 'feeCode': 'CONTO',
                                  'name': 'consentContinuationOut'},

--- a/legal-api/tests/unit/services/test_authorization.py
+++ b/legal-api/tests/unit/services/test_authorization.py
@@ -24,6 +24,7 @@ from enum import Enum
 from http import HTTPStatus
 
 import pytest
+from unittest.mock import patch
 from flask import jsonify
 from registry_schemas.example_data import AGM_LOCATION_CHANGE, ALTERATION_FILING_TEMPLATE, ANNUAL_REPORT, \
     CORRECTION_AR, CHANGE_OF_REGISTRATION_TEMPLATE, RESTORATION, FILING_TEMPLATE, DISSOLUTION, PUT_BACK_ON, \
@@ -1081,61 +1082,7 @@ def test_get_allowed_filings_blocker_admin_freeze(monkeypatch, app, session, jwt
                                             admin_freeze=True)
             filing_types = get_allowed_filings(business, state, legal_type, jwt)
             assert filing_types == expected
-
-
-@pytest.mark.parametrize(
-    'test_name,business_exists,state,legal_types,username,roles,expected',
-    [
-        # active business - staff user
-        ('staff_active_cp', True, Business.State.ACTIVE, ['CP'], 'staff', [STAFF_ROLE],[]),
-        ('staff_active_corps', True, Business.State.ACTIVE, ['BC', 'BEN', 'CC', 'ULC'], 'staff', [STAFF_ROLE],[]),
-        ('staff_active_llc', True, Business.State.ACTIVE, ['LLC'], 'staff', [STAFF_ROLE], []),
-        ('staff_active_firms', True, Business.State.ACTIVE, ['SP', 'GP'], 'staff', [STAFF_ROLE],[]),
-
-        # active business - general user
-        ('general_user_cp', True, Business.State.ACTIVE, ['CP'], 'general', [BASIC_USER], []),
-        ('general_user_corps', True, Business.State.ACTIVE, ['BC', 'BEN', 'CC', 'ULC'], 'general', [BASIC_USER],[]),
-        ('general_user_llc', True, Business.State.ACTIVE, ['LLC'], 'general', [BASIC_USER], []),
-        ('general_user_firms', True, Business.State.ACTIVE, ['SP', 'GP'], 'general', [BASIC_USER], []),
-
-        # historical business - staff user
-        ('staff_historical_cp', True, Business.State.HISTORICAL, ['CP'], 'staff', [STAFF_ROLE],[]),
-        ('staff_historical_corps', True, Business.State.HISTORICAL, ['BC', 'BEN', 'CC', 'ULC'], 'staff', [STAFF_ROLE],[]),
-        ('staff_historical_llc', True, Business.State.HISTORICAL, ['LLC'], 'staff', [STAFF_ROLE], []),
-        ('staff_historical_firms', True, Business.State.HISTORICAL, ['SP', 'GP'], 'staff', [STAFF_ROLE],[]),
-
-        # historical business - general user
-        ('general_user_historical_cp', True, Business.State.HISTORICAL, ['CP'], 'general', [BASIC_USER], []),
-        ('general_user_historical_corps', True, Business.State.HISTORICAL, ['BC', 'BEN', 'CC', 'ULC'], 'general',
-         [BASIC_USER], []),
-        ('general_user_historical_llc', True, Business.State.HISTORICAL, ['LLC'], 'general', [BASIC_USER], []),
-        ('general_user_historical_firms', True, Business.State.HISTORICAL, ['SP', 'GP'], 'general', [BASIC_USER], []),
-    ]
-)
-def test_get_allowed_filings_blocker_not_in_good_standing(monkeypatch, app, session, jwt, test_name, business_exists, state,
-                                                  legal_types, username, roles, expected):
-    """Assert that get allowed returns valid filings when business is not in good standing."""
-    token = helper_create_jwt(jwt, roles=roles, username=username)
-    headers = {'Authorization': 'Bearer ' + token}
-
-    def mock_auth(one, two):  # pylint: disable=unused-argument; mocks of library methods
-        return headers[one]
-
-    with app.test_request_context():
-        monkeypatch.setattr('flask.request.headers.get', mock_auth)
-
-        for legal_type in legal_types:
-            business = None
-            if business_exists:
-                identifier = (f'BC{random.SystemRandom().getrandbits(0x58)}')[:9]
-                business = factory_business(identifier=identifier,
-                                            entity_type=legal_type,
-                                            state=state)
-                business.good_standing = False
-            filing_types = get_allowed_filings(business, state, legal_type, jwt)
-            print("test:")
-            print(filing_types)
-            assert filing_types == expected
+            
 
 @pytest.mark.parametrize(
     'test_name,state,legal_types,username,roles,filing_statuses,expected',

--- a/legal-api/tests/unit/services/test_authorization.py
+++ b/legal-api/tests/unit/services/test_authorization.py
@@ -25,9 +25,9 @@ from http import HTTPStatus
 
 import pytest
 from flask import jsonify
-from registry_schemas.example_data import ALTERATION_FILING_TEMPLATE, ANNUAL_REPORT, CORRECTION_AR, \
-    CHANGE_OF_REGISTRATION_TEMPLATE, RESTORATION, FILING_TEMPLATE, DISSOLUTION, PUT_BACK_ON, CONTINUATION_IN, \
-    CONSENT_CONTINUATION_OUT, CONTINUATION_OUT
+from registry_schemas.example_data import AGM_LOCATION_CHANGE, ALTERATION_FILING_TEMPLATE, ANNUAL_REPORT, \
+    CORRECTION_AR, CHANGE_OF_REGISTRATION_TEMPLATE, RESTORATION, FILING_TEMPLATE, DISSOLUTION, PUT_BACK_ON, \
+    CONTINUATION_IN, CONSENT_CONTINUATION_OUT, CONTINUATION_OUT
 
 from legal_api.models import Filing
 from legal_api.models.business import Business
@@ -120,6 +120,7 @@ class FilingKey(str, Enum):
     REGISTRARS_NOTATION = 'REGISTRARS_NOTATION'
     REGISTRARS_ORDER = 'REGISTRARS_ORDER'
     SPECIAL_RESOLUTION = 'SPECIAL_RESOLUTION'
+    AGM_LOCATION_CHANGE = 'AGM_LOCATION_CHANGE'
     ALTERATION = 'ALTERATION'
     CONSENT_CONTINUATION_OUT = 'CONSENT_CONTINUATION_OUT'
     CONTINUATION_OUT = 'CONTINUATION_OUT'
@@ -159,6 +160,7 @@ EXPECTED_DATA = {
                                     'name': 'registrarsNotation'},
     FilingKey.REGISTRARS_ORDER: {'displayName': "Registrar's Order", 'feeCode': 'NOFEE', 'name': 'registrarsOrder'},
     FilingKey.SPECIAL_RESOLUTION: {'displayName': 'Special Resolution', 'feeCode': 'SPRLN', 'name': 'specialResolution'},
+    FilingKey.AGM_LOCATION_CHANGE: {'displayName': '', 'feeCode': '', 'name': ''},
     FilingKey.ALTERATION: {'displayName': 'Alteration', 'feeCode': 'ALTER', 'name': 'alteration'},
     FilingKey.CONSENT_CONTINUATION_OUT: {'displayName': '6-Month Consent to Continue Out', 'feeCode': 'CONTO',
                                  'name': 'consentContinuationOut'},
@@ -201,6 +203,9 @@ BLOCKER_FILING_STATUSES_AND_ADDITIONAL = factory_incomplete_statuses(['unknown_s
                                                                       'unknown_status_2'])
 BLOCKER_FILING_TYPES = ['alteration', 'correction']
 
+AGM_LOCATION_CHANGE_FILING_TEMPLATE = copy.deepcopy(FILING_TEMPLATE)
+AGM_LOCATION_CHANGE_FILING_TEMPLATE['filing']['agmLocationChange'] = AGM_LOCATION_CHANGE
+
 RESTORATION_FILING_TEMPLATE = copy.deepcopy(FILING_TEMPLATE)
 RESTORATION_FILING_TEMPLATE['filing']['restoration'] = RESTORATION
 
@@ -220,6 +225,7 @@ CONSENT_CONTINUATION_OUT_TEMPLATE = copy.deepcopy(FILING_TEMPLATE)
 CONSENT_CONTINUATION_OUT_TEMPLATE['filing']['consentContinuationOut'] = CONSENT_CONTINUATION_OUT
 
 FILING_DATA = {
+    'agmLocationChange': AGM_LOCATION_CHANGE_FILING_TEMPLATE,
     'alteration': ALTERATION_FILING_TEMPLATE,
     'correction': CORRECTION_AR,
     'changeOfRegistration': CHANGE_OF_REGISTRATION_TEMPLATE,
@@ -401,9 +407,11 @@ def test_authorized_invalid_roles(monkeypatch, app, jwt):
           {'dissolution': ['voluntary', 'administrative']}, 'incorporationApplication',
           'registrarsNotation', 'registrarsOrder', 'specialResolution']),
         ('staff_active_corps', Business.State.ACTIVE, ['BC', 'BEN', 'CC', 'ULC'], 'staff', [STAFF_ROLE],
-         ['adminFreeze', 'alteration', 'annualReport', 'changeOfAddress', 'changeOfDirectors', 'consentContinuationOut', 'continuationOut',
-          'correction', 'courtOrder', {'dissolution': ['voluntary', 'administrative']}, 'incorporationApplication',
-          'registrarsNotation', 'registrarsOrder', 'transition', {'restoration': ['limitedRestorationExtension', 'limitedRestorationToFull']}]),
+         ['adminFreeze', 'agmLocationChange', 'alteration', 'annualReport', 'changeOfAddress', 'changeOfDirectors',
+          'consentContinuationOut', 'continuationOut', 'correction', 'courtOrder',
+          {'dissolution': ['voluntary', 'administrative']}, 'incorporationApplication',
+          'registrarsNotation', 'registrarsOrder', 'transition',
+          {'restoration': ['limitedRestorationExtension', 'limitedRestorationToFull']}]),
         ('staff_active_llc', Business.State.ACTIVE, ['LLC'], 'staff', [STAFF_ROLE], []),
         ('staff_active_firms', Business.State.ACTIVE, ['SP', 'GP'], 'staff', [STAFF_ROLE],
          ['adminFreeze', 'changeOfRegistration', 'conversion', 'correction', 'courtOrder',
@@ -414,8 +422,8 @@ def test_authorized_invalid_roles(monkeypatch, app, jwt):
          ['annualReport', 'changeOfAddress', 'changeOfDirectors',
           {'dissolution': ['voluntary']}, 'incorporationApplication', 'specialResolution']),
         ('user_active_corps', Business.State.ACTIVE, ['BC', 'BEN', 'CC', 'ULC'], 'general', [BASIC_USER],
-         ['alteration', 'annualReport', 'changeOfAddress', 'changeOfDirectors', 'consentContinuationOut',
-          {'dissolution': ['voluntary']}, 'incorporationApplication', 'transition']),
+         ['agmLocationChange', 'alteration', 'annualReport', 'changeOfAddress', 'changeOfDirectors',
+          'consentContinuationOut', {'dissolution': ['voluntary']}, 'incorporationApplication', 'transition']),
         ('user_active_llc', Business.State.ACTIVE, ['LLC'], 'general', [BASIC_USER], []),
         ('user_active_firms', Business.State.ACTIVE, ['SP', 'GP'], 'general', [BASIC_USER],
          ['changeOfRegistration', {'dissolution': ['voluntary']}, 'registration']),
@@ -452,6 +460,11 @@ def test_get_allowed(monkeypatch, app, jwt, test_name, state, legal_types, usern
     'test_name,state,filing_type,sub_filing_type,legal_types,username,roles,expected',
     [
         # active business
+        ('staff_active_allowed', Business.State.ACTIVE, 'agmLocationChange', None,
+         ['BC', 'BEN', 'ULC', 'CC'], 'staff', [STAFF_ROLE], True),
+        ('staff_active', Business.State.ACTIVE, 'agmLocationChange', None,
+         ['CP', 'LLC'], 'staff', [STAFF_ROLE], False),
+
         ('staff_active_allowed', Business.State.ACTIVE, 'alteration', None,
          ['BC', 'BEN', 'ULC', 'CC'], 'staff', [STAFF_ROLE], True),
         ('staff_active', Business.State.ACTIVE, 'alteration', None,
@@ -533,6 +546,10 @@ def test_get_allowed(monkeypatch, app, jwt, test_name, state, legal_types, usern
         ('staff_active_allowed', Business.State.ACTIVE, 'changeOfRegistration', None,
          ['SP', 'GP'], 'staff', [STAFF_ROLE], True),
 
+        ('user_active_allowed', Business.State.ACTIVE, 'agmLocationChange', None,
+         ['BC', 'BEN', 'ULC', 'CC'], 'general', [BASIC_USER], True),
+        ('user_active', Business.State.ACTIVE, 'agmLocationChange', None,
+         ['CP', 'LLC'], 'general', [BASIC_USER], False),
 
         ('user_active_allowed', Business.State.ACTIVE, 'alteration', None,
          ['BC', 'BEN', 'ULC', 'CC'], 'general', [BASIC_USER], True),
@@ -749,6 +766,7 @@ def test_is_allowed(monkeypatch, app, session, jwt, test_name, state, filing_typ
                           FilingKey.SPECIAL_RESOLUTION])),
         ('staff_active_corps', True, Business.State.ACTIVE, ['BC', 'BEN', 'CC', 'ULC'], 'staff', [STAFF_ROLE],
          expected_lookup([FilingKey.ADMN_FRZE,
+                          FilingKey.AGM_LOCATION_CHANGE,
                           FilingKey.ALTERATION,
                           FilingKey.AR_CORPS,
                           FilingKey.COA_CORPS,
@@ -781,7 +799,8 @@ def test_is_allowed(monkeypatch, app, session, jwt, test_name, state, filing_typ
                           FilingKey.VOL_DISS,
                           FilingKey.SPECIAL_RESOLUTION])),
         ('general_user_corps', True, Business.State.ACTIVE, ['BC', 'BEN', 'CC', 'ULC'], 'general', [BASIC_USER],
-         expected_lookup([FilingKey.ALTERATION,
+         expected_lookup([FilingKey.AGM_LOCATION_CHANGE,
+                          FilingKey.ALTERATION,
                           FilingKey.AR_CORPS,
                           FilingKey.COA_CORPS,
                           FilingKey.COD_CORPS,
@@ -892,6 +911,7 @@ def test_get_allowed_actions(monkeypatch, app, session, jwt, test_name, business
                           FilingKey.SPECIAL_RESOLUTION])),
         ('staff_active_corps', True, Business.State.ACTIVE, ['BC', 'BEN', 'CC', 'ULC'], 'staff', [STAFF_ROLE],
          expected_lookup([FilingKey.ADMN_FRZE,
+                          FilingKey.AGM_LOCATION_CHANGE,
                           FilingKey.ALTERATION,
                           FilingKey.AR_CORPS,
                           FilingKey.COA_CORPS,
@@ -924,7 +944,8 @@ def test_get_allowed_actions(monkeypatch, app, session, jwt, test_name, business
                           FilingKey.VOL_DISS,
                           FilingKey.SPECIAL_RESOLUTION])),
         ('general_user_corps', True, Business.State.ACTIVE, ['BC', 'BEN', 'CC', 'ULC'], 'general', [BASIC_USER],
-         expected_lookup([FilingKey.ALTERATION,
+         expected_lookup([FilingKey.AGM_LOCATION_CHANGE,
+                          FilingKey.ALTERATION,
                           FilingKey.AR_CORPS,
                           FilingKey.COA_CORPS,
                           FilingKey.COD_CORPS,
@@ -1269,6 +1290,7 @@ def test_allowed_filings_blocker_filing_specific_incomplete(monkeypatch, app, se
                           FilingKey.SPECIAL_RESOLUTION])),
         ('staff_active_corps', Business.State.ACTIVE, ['BC', 'BEN', 'CC', 'ULC'], 'staff', [STAFF_ROLE],
          expected_lookup([FilingKey.ADMN_FRZE,
+                          FilingKey.AGM_LOCATION_CHANGE,
                           FilingKey.ALTERATION,
                           FilingKey.AR_CORPS,
                           FilingKey.COA_CORPS,
@@ -1297,7 +1319,8 @@ def test_allowed_filings_blocker_filing_specific_incomplete(monkeypatch, app, se
                           FilingKey.VOL_DISS,
                           FilingKey.SPECIAL_RESOLUTION])),
         ('general_user_corps', Business.State.ACTIVE, ['BC', 'BEN', 'CC', 'ULC'], 'general', [BASIC_USER],
-         expected_lookup([FilingKey.ALTERATION,
+         expected_lookup([FilingKey.AGM_LOCATION_CHANGE,
+                          FilingKey.ALTERATION,
                           FilingKey.AR_CORPS,
                           FilingKey.COA_CORPS,
                           FilingKey.COD_CORPS,
@@ -1372,6 +1395,7 @@ def test_allowed_filings_warnings(monkeypatch, app, session, jwt, test_name, sta
         ('staff_active_corps_valid_state_filing_success', Business.State.ACTIVE, ['BC', 'BEN', 'CC', 'ULC'], 'staff',
          [STAFF_ROLE], ['restoration', 'restoration'], ['limitedRestoration', 'limitedRestorationExtension'],
          expected_lookup([FilingKey.ADMN_FRZE,
+                          FilingKey.AGM_LOCATION_CHANGE,
                           FilingKey.ALTERATION,
                           FilingKey.AR_CORPS,
                           FilingKey.COA_CORPS,
@@ -1430,7 +1454,8 @@ def test_allowed_filings_warnings(monkeypatch, app, session, jwt, test_name, sta
         ('general_user_corps_unaffected', Business.State.ACTIVE, ['BC', 'BEN', 'CC', 'ULC'], 'general', [BASIC_USER],
          ['restoration', 'restoration', None, 'restoration'],
          ['limitedRestoration', 'limitedRestorationExtension', None, 'fullRestoration'],
-         expected_lookup([FilingKey.ALTERATION,
+         expected_lookup([FilingKey.AGM_LOCATION_CHANGE,
+                          FilingKey.ALTERATION,
                           FilingKey.AR_CORPS,
                           FilingKey.COA_CORPS,
                           FilingKey.COD_CORPS,
@@ -1572,6 +1597,7 @@ def test_is_allowed_ignore_draft_filing(monkeypatch, app, session, jwt, test_nam
         ('staff_active_corps_completed_filing_success', Business.State.ACTIVE, ['BC', 'BEN', 'CC', 'ULC'], 'staff',
          [STAFF_ROLE], ['consentContinuationOut', 'consentContinuationOut'], [None, None], [True, True],
          expected_lookup([FilingKey.ADMN_FRZE,
+                          FilingKey.AGM_LOCATION_CHANGE,
                           FilingKey.ALTERATION,
                           FilingKey.AR_CORPS,
                           FilingKey.COA_CORPS,

--- a/legal-api/tests/unit/services/test_authorization.py
+++ b/legal-api/tests/unit/services/test_authorization.py
@@ -160,7 +160,7 @@ EXPECTED_DATA = {
                                     'name': 'registrarsNotation'},
     FilingKey.REGISTRARS_ORDER: {'displayName': "Registrar's Order", 'feeCode': 'NOFEE', 'name': 'registrarsOrder'},
     FilingKey.SPECIAL_RESOLUTION: {'displayName': 'Special Resolution', 'feeCode': 'SPRLN', 'name': 'specialResolution'},
-    FilingKey.AGM_LOCATION_CHANGE: {'displayName': '', 'feeCode': '', 'name': ''},
+    FilingKey.AGM_LOCATION_CHANGE: {'displayName': 'agmLocationChange', 'feeCode': 'AGMLC', 'name': 'AGM Location Change'},
     FilingKey.ALTERATION: {'displayName': 'Alteration', 'feeCode': 'ALTER', 'name': 'alteration'},
     FilingKey.CONSENT_CONTINUATION_OUT: {'displayName': '6-Month Consent to Continue Out', 'feeCode': 'CONTO',
                                  'name': 'consentContinuationOut'},


### PR DESCRIPTION
*Issue #:* /bcgov/entity#18026

*Description of changes:*
-  Added Allowable Change item for filing type = `agmLocationChange`
- Applicable only to company types - BC Ltd., BEN, ULC, CCC
- Filing is not allowed when one or more of following is true for business
  - Business is in "Not in Good Standing" state
  - Business is frozen
  - Business has a pending or draft filing
- Created Unit Tests

Note: The unit tests are currently blocked by tickets in progress.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
