### PR TITLE
display name properly on pdf when last name only

### DIFF
--- a/legal-api/report-templates/template-parts/registration/completingParty.html
+++ b/legal-api/report-templates/template-parts/registration/completingParty.html
@@ -12,10 +12,19 @@
                         {% if party.officer.partyType == 'organization' %}
                            <span class="capitalize-text">{{ party.officer.organizationName }}</span>
                         {% else %}
-                           <span class="capitalize-text">{{ party.officer.lastName }}</span>,
-                           <span class="capitalize-text">{{ party.officer.firstName }}</span>
-                           {% if party.officer.middleName %}
-                              <span class="capitalize-text">{{ party.officer.middleName }}</span>
+                           {% if party.officer.firstName %}
+                              <span class="capitalize-text">{{ party.officer.lastName }}</span>,
+                              <span class="capitalize-text">{{ party.officer.firstName }}</span>
+                              {% if party.officer.middleName %}
+                                 <span class="capitalize-text">{{ party.officer.middleName }}</span>
+                              {% endif %}
+                           {% else %}
+                              {% if party.officer.middleName %}
+                                 <span class="capitalize-text">{{ party.officer.lastName }}</span>,
+                                 <span class="capitalize-text">{{ party.officer.middleName }}</span>
+                              {% else %}
+                                 <span class="capitalize-text">{{ party.officer.lastName }}</span>
+                              {% endif %}
                            {% endif %}
                         {% endif %}
                      </div>


### PR DESCRIPTION
*Issue #:* /bcgov/entity#18034

*Description of changes:*
Add if else statement to display first name, middle name, and last name properly on pdf when both middle name and first name are optional

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
