### PR TITLE
17214 -add 3 versions of expiry email: modernized, colin, neither

### DIFF
--- a/queue_services/entity-emailer/src/entity_emailer/config.py
+++ b/queue_services/entity-emailer/src/entity_emailer/config.py
@@ -140,6 +140,8 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     NAME_REQUEST_URL = os.getenv('NAME_REQUEST_URL', '')
     DECIDE_BUSINESS_URL = os.getenv('DECIDE_BUSINESS_URL', '')
+    COLIN_URL = os.getenv('COLIN_URL', '')
+    CORP_FORMS_URL = os.getenv('CORP_FORMS_URL', '')
 
 
 class DevConfig(_Config):  # pylint: disable=too-few-public-methods

--- a/queue_services/entity-emailer/src/entity_emailer/email_processors/nr_notification.py
+++ b/queue_services/entity-emailer/src/entity_emailer/email_processors/nr_notification.py
@@ -37,6 +37,26 @@ class Option(Enum):
     UPGRADE = 'upgrade'
     REFUND = 'refund'
 
+def is_modernized(legal_type):
+    modernized_list = ['GP', 'DBA', 'FR', 'CP', 'BC']
+    if legal_type in modernized_list:
+        return True
+
+
+def is_colin(legal_type):
+    colin_list = ['CR', 'UL', 'CC', 'XCR', 'XUL', 'RLC']
+    if legal_type in colin_list:
+        return True
+
+
+def get_instruction_group(legal_type):
+    if is_modernized(legal_type):
+        return 'modernized'
+    elif is_colin(legal_type):
+        return 'colin'
+    else:
+        return ''
+
 
 def process(email_info: dict, option) -> dict:  # pylint: disable-msg=too-many-locals
     """
@@ -46,8 +66,6 @@ def process(email_info: dict, option) -> dict:  # pylint: disable-msg=too-many-l
     """
     logger.debug('NR %s notification: %s', option, email_info)
     nr_number = email_info['identifier']
-    template = Path(f'{current_app.config.get("TEMPLATE_PATH")}/NR-{option.upper()}.html').read_text()
-    filled_template = substitute_template_parts(template)
 
     nr_response = NameXService.query_nr_number(nr_number)
     if nr_response.status_code != HTTPStatus.OK:
@@ -74,6 +92,17 @@ def process(email_info: dict, option) -> dict:  # pylint: disable-msg=too-many-l
 
     name_request_url = current_app.config.get('NAME_REQUEST_URL')
     decide_business_url = current_app.config.get('DECIDE_BUSINESS_URL')
+    corp_online_url = current_app.config.get('COLIN_URL')
+    form_page_url = current_app.config.get('CORP_FORMS_URL')
+
+    file_name_suffix = option.upper()
+    if option == Option.BEFORE_EXPIRY.value:
+        legal_type = nr_data['legalType']
+        instruction_group = '-' + get_instruction_group(legal_type)
+        file_name_suffix += instruction_group.upper()
+
+    template = Path(f'{current_app.config.get("TEMPLATE_PATH")}/NR-{file_name_suffix}.html').read_text()
+    filled_template = substitute_template_parts(template)
 
     # render template with vars
     mail_template = Template(filled_template, autoescape=True)
@@ -83,7 +112,9 @@ def process(email_info: dict, option) -> dict:  # pylint: disable-msg=too-many-l
         legal_name=legal_name,
         refund_value=refund_value,
         name_request_url=name_request_url,
-        decide_business_url=decide_business_url
+        decide_business_url=decide_business_url,
+        corp_online_url=corp_online_url,
+        form_page_url=form_page_url
     )
 
     # get recipients

--- a/queue_services/entity-emailer/src/entity_emailer/email_processors/nr_notification.py
+++ b/queue_services/entity-emailer/src/entity_emailer/email_processors/nr_notification.py
@@ -37,25 +37,23 @@ class Option(Enum):
     UPGRADE = 'upgrade'
     REFUND = 'refund'
 
-def is_modernized(legal_type):
+
+def __is_modernized(legal_type):
     modernized_list = ['GP', 'DBA', 'FR', 'CP', 'BC']
-    if legal_type in modernized_list:
-        return True
+    return legal_type in modernized_list
 
 
-def is_colin(legal_type):
+def __is_colin(legal_type):
     colin_list = ['CR', 'UL', 'CC', 'XCR', 'XUL', 'RLC']
-    if legal_type in colin_list:
-        return True
+    return legal_type in colin_list
 
 
-def get_instruction_group(legal_type):
-    if is_modernized(legal_type):
+def __get_instruction_group(legal_type):
+    if __is_modernized(legal_type):
         return 'modernized'
-    elif is_colin(legal_type):
+    if __is_colin(legal_type):
         return 'colin'
-    else:
-        return ''
+    return ''
 
 
 def process(email_info: dict, option) -> dict:  # pylint: disable-msg=too-many-locals
@@ -97,10 +95,12 @@ def process(email_info: dict, option) -> dict:  # pylint: disable-msg=too-many-l
 
     file_name_suffix = option.upper()
     if option == Option.BEFORE_EXPIRY.value:
-        legal_type = nr_data['legalType']
-        if get_instruction_group(legal_type):
-            instruction_group = '-' + get_instruction_group(legal_type)
-            file_name_suffix += instruction_group.upper()
+        if 'legalType' in nr_data:
+            legal_type = nr_data['legalType']
+            group = __get_instruction_group(legal_type)
+            if group:
+                instruction_group = '-' + group
+                file_name_suffix += instruction_group.upper()
 
     template = Path(f'{current_app.config.get("TEMPLATE_PATH")}/NR-{file_name_suffix}.html').read_text()
     filled_template = substitute_template_parts(template)

--- a/queue_services/entity-emailer/src/entity_emailer/email_processors/nr_notification.py
+++ b/queue_services/entity-emailer/src/entity_emailer/email_processors/nr_notification.py
@@ -98,8 +98,9 @@ def process(email_info: dict, option) -> dict:  # pylint: disable-msg=too-many-l
     file_name_suffix = option.upper()
     if option == Option.BEFORE_EXPIRY.value:
         legal_type = nr_data['legalType']
-        instruction_group = '-' + get_instruction_group(legal_type)
-        file_name_suffix += instruction_group.upper()
+        if get_instruction_group(legal_type):
+            instruction_group = '-' + get_instruction_group(legal_type)
+            file_name_suffix += instruction_group.upper()
 
     template = Path(f'{current_app.config.get("TEMPLATE_PATH")}/NR-{file_name_suffix}.html').read_text()
     filled_template = substitute_template_parts(template)

--- a/queue_services/entity-emailer/src/entity_emailer/email_templates/NR-BEFORE-EXPIRY-COLIN.html
+++ b/queue_services/entity-emailer/src/entity_emailer/email_templates/NR-BEFORE-EXPIRY-COLIN.html
@@ -15,9 +15,8 @@ Finish registering a business with this name before it expires. If you are not r
 
 Follow these steps to register your business using the approved name:
 
-1.Visit [Forms, fees and information packages page]({{ form_page_url }})
-2. Download the appropriate form
-3. Complete and submit the form along with any required documentation and payment
+1. Visit [BC Corporate Online]( {{ corp_online_url }})
+2. Register the business with this name by filing an Incorporation Application
 
 If you don't have a BC Registries Account, [create one here]({{ decide_business_url }})
 

--- a/queue_services/entity-emailer/src/entity_emailer/email_templates/NR-BEFORE-EXPIRY-MODERNIZED.html
+++ b/queue_services/entity-emailer/src/entity_emailer/email_templates/NR-BEFORE-EXPIRY-MODERNIZED.html
@@ -15,9 +15,10 @@ Finish registering a business with this name before it expires. If you are not r
 
 Follow these steps to register your business using the approved name:
 
-1.Visit [Forms, fees and information packages page]({{ form_page_url }})
-2. Download the appropriate form
-3. Complete and submit the form along with any required documentation and payment
+1. Visit [BC Registries and Online Services]({{ name_request_url }})
+2. Log in with your BC Registries Account
+3. Look up your Name Request
+4. Register the business with this name by following the instructions
 
 If you don't have a BC Registries Account, [create one here]({{ decide_business_url }})
 

--- a/queue_services/entity-emailer/tests/unit/email_processors/test_nr_notification.py
+++ b/queue_services/entity-emailer/tests/unit/email_processors/test_nr_notification.py
@@ -45,6 +45,7 @@ def test_nr_notification(app, session, option, nr_number, subject, expiration_da
     nr_json = {
         'expirationDate': expiration_date,
         'names': names,
+        'legalType': 'BC',
         'applicants': {
             'emailAddress': 'test@test.com'
         }

--- a/queue_services/entity-emailer/tests/unit/test_worker.py
+++ b/queue_services/entity-emailer/tests/unit/test_worker.py
@@ -318,6 +318,7 @@ def test_nr_notification(app, session, option, nr_number, subject, expiration_da
     nr_json = {
         'expirationDate': expiration_date,
         'names': names,
+        'legalType': 'BC',
         'applicants': {
             'emailAddress': 'test@test.com'
         }


### PR DESCRIPTION
*Issue #:* https://github.com/bcgov/entity/issues/17214

*Description of changes:* Most recent uxpin design splits email contents into 3 groups: modernized/colin/neither(paper form workflow). Need to provide users with different instructions for 'expiring soon' NRs depending on which type of legal entity NR is for (i.e., which group it is in)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
