### PR TITLE
17340 - Revert remove mailingAddress for directors for CP.

### DIFF
--- a/legal-api/src/legal_api/resources/v2/business/business_directors.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_directors.py
@@ -55,8 +55,6 @@ def get_directors(identifier, director_id=None):
     active_directors = PartyRole.get_active_directors(business.id, end_date)
     for director in active_directors:
         director_json = director.json
-        if business.legal_type == Business.LegalTypes.COOP.value:
-            del director_json['mailingAddress']
         party_list.append(director_json)
 
     return jsonify(directors=party_list)

--- a/legal-api/tests/unit/resources/v2/test_business_director.py
+++ b/legal-api/tests/unit/resources/v2/test_business_director.py
@@ -248,41 +248,6 @@ def test_directors_mailing_address(session, client, jwt):
     assert rv.json['directors'][0]['mailingAddress']['addressCity'] == 'Test Mailing City'
 
 
-def test_directors_coop_no_mailing_address(session, client, jwt):
-    """Assert that coop directors have a mailing and delivery address."""
-    # setup
-    identifier = 'CP7654321'
-    business = factory_business(identifier)
-    delivery_address = Address(city='Test Delivery City', address_type=Address.DELIVERY)
-    officer = {
-        'firstName': 'Michael',
-        'lastName': 'Crane',
-        'middleInitial': 'Joe',
-        'partyType': 'person',
-        'organizationName': ''
-    }
-    party_role = factory_party_role(
-        delivery_address,
-        None,
-        officer,
-        datetime.datetime(2017, 5, 17),
-        None,
-        PartyRole.RoleTypes.DIRECTOR
-    )
-    business.party_roles.append(party_role)
-    business.save()
-
-    # test
-    rv = client.get(f'/api/v2/businesses/{identifier}/directors',
-                    headers=create_header(jwt, [STAFF_ROLE], identifier)
-                    )
-    # check
-    assert rv.status_code == HTTPStatus.OK
-    assert 'directors' in rv.json
-    assert rv.json['directors'][0]['deliveryAddress']['addressCity'] == 'Test Delivery City'
-    assert 'mailingAddress' not in rv.json['directors'][0]
-
-
 def test_directors_unauthorized(app, session, client, jwt, requests_mock):
     """Assert that directors are not returned for an unauthorized user."""
     # setup


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17340

*Description of changes:*
Revert remove mailingAddress for directors for CP.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
