### PR TITLE
18284 Add pre-fork server hook to gunicorn config

### DIFF
--- a/legal-api/gunicorn_config.py
+++ b/legal-api/gunicorn_config.py
@@ -16,9 +16,13 @@
 """
 
 import os
+import gunicorn_server
 
 workers = int(os.environ.get('GUNICORN_PROCESSES', '1'))  # pylint: disable=invalid-name
 threads = int(os.environ.get('GUNICORN_THREADS', '1'))  # pylint: disable=invalid-name
 
 forwarded_allow_ips = '*'  # pylint: disable=invalid-name
 secure_scheme_headers = {'X-Forwarded-Proto': 'https'}  # pylint: disable=invalid-name
+
+# Server Hooks
+pre_fork = gunicorn_server.pre_fork

--- a/legal-api/gunicorn_server.py
+++ b/legal-api/gunicorn_server.py
@@ -1,0 +1,10 @@
+
+import time
+
+
+def pre_fork(server, worker):
+    # Delay loading of each worker by 5 seconds
+    # This is done to work around an issue where the Traction API is returning an invalid token. The issue happens
+    # when successive token retrieval calls are made with less than 2-3 seconds between the calls.
+    time.sleep(5)
+


### PR DESCRIPTION
*Issue #:* /bcgov/entity#18284

*Description of changes:*

* Add pre-fork server hook to gunicorn config such that loading of each worker process is staggered by 5 seconds.  This works around a traction api token retrieval issue where back to back token retrievals with less than 2 seconds produces invalid tokens.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
