### PR TITLE
18394 Update NAICS validation to be internal for legal api validation

### DIFF
--- a/legal-api/src/legal_api/services/filings/validations/correction.py
+++ b/legal-api/src/legal_api/services/filings/validations/correction.py
@@ -21,8 +21,8 @@ from flask_babel import _
 
 from legal_api.core.filing_helper import is_special_resolution_correction_by_filing_json
 from legal_api.errors import Error
-from legal_api.models import Business, Filing, PartyRole
-from legal_api.services import STAFF_ROLE, NaicsService
+from legal_api.models import Business, Filing, NaicsStructure, PartyRole
+from legal_api.services import STAFF_ROLE
 from legal_api.services.filings.validations.common_validations import (
     validate_court_order,
     validate_name_request,
@@ -193,8 +193,8 @@ def validate_naics(business: Business, filing: Dict, filing_type: str) -> list:
 
     # Note: if existing naics code and description has not changed, no NAICS validation is required
     if naics_code and (business.naics_code != naics_code or business.naics_description != naics_desc):
-        naics = NaicsService.find_by_code(naics_code)
-        if not naics or naics['classTitle'] != naics_desc:
+        naics = NaicsStructure.find_by_code(naics_code)
+        if not naics or naics.class_title != naics_desc:
             msg.append({'error': 'Invalid naics code or description.', 'path': naics_code_path})
 
     return msg

--- a/legal-api/src/legal_api/services/filings/validations/registration.py
+++ b/legal-api/src/legal_api/services/filings/validations/registration.py
@@ -21,8 +21,8 @@ from dateutil.relativedelta import relativedelta
 from flask_babel import _ as babel  # noqa: N813, I004, I001, I003
 
 from legal_api.errors import Error
-from legal_api.models import Business, PartyRole
-from legal_api.services import STAFF_ROLE, NaicsService
+from legal_api.models import Business, NaicsStructure, PartyRole
+from legal_api.services import STAFF_ROLE
 from legal_api.utils.auth import jwt
 from legal_api.utils.legislation_datetime import LegislationDatetime
 
@@ -84,8 +84,8 @@ def validate_naics(filing: Dict, filing_type='registration') -> list:
     naics_code_path = f'/filing/{filing_type}/business/naics/naicsCode'
     naics_desc = get_str(filing, f'/filing/{filing_type}/business/naics/naicsDescription')
     if naics_code := get_str(filing, naics_code_path):
-        naics = NaicsService.find_by_code(naics_code)
-        if not naics or naics['classTitle'] != naics_desc:
+        naics = NaicsStructure.find_by_code(naics_code)
+        if not naics or naics.class_title != naics_desc:
             msg.append({'error': 'Invalid naics code or description.', 'path': naics_code_path})
 
     return msg

--- a/legal-api/tests/unit/services/filings/validations/test_change_of_registration.py
+++ b/legal-api/tests/unit/services/filings/validations/test_change_of_registration.py
@@ -20,6 +20,7 @@ from http import HTTPStatus
 import pytest
 from registry_schemas.example_data import CHANGE_OF_REGISTRATION_TEMPLATE, REGISTRATION
 
+from legal_api.models import NaicsStructure
 from legal_api.services import NaicsService, NameXService
 from legal_api.services.filings.validations.change_of_registration import validate
 
@@ -72,10 +73,10 @@ nr_response = {
     }]
 }
 
-naics_response = {
-    'code': REGISTRATION['business']['naics']['naicsCode'],
-    'classTitle': REGISTRATION['business']['naics']['naicsDescription']
-}
+
+mock_naics_structure = NaicsStructure(code=REGISTRATION['business']['naics']['naicsCode'],
+                                      class_title=REGISTRATION['business']['naics']['naicsDescription'])
+
 
 
 class MockResponse:
@@ -93,7 +94,7 @@ class MockResponse:
 def test_gp_change_of_registration(session):
     """Assert that the general partnership change of registration is valid."""
     with patch.object(NameXService, 'query_nr_number', return_value=MockResponse(nr_response)):
-        with patch.object(NaicsService, 'find_by_code', return_value=naics_response):
+        with patch.object(NaicsStructure, 'find_by_code', return_value=mock_naics_structure):
             err = validate(GP_CHANGE_OF_REGISTRATION)
     assert not err
 
@@ -103,7 +104,7 @@ def test_sp_change_of_registration(session):
     nr_res = copy.deepcopy(nr_response)
     nr_res['legalType'] = 'SP'
     with patch.object(NameXService, 'query_nr_number', return_value=MockResponse(nr_res)):
-        with patch.object(NaicsService, 'find_by_code', return_value=naics_response):
+        with patch.object(NaicsStructure, 'find_by_code', return_value=mock_naics_structure):
             err = validate(SP_CHANGE_OF_REGISTRATION)
 
     assert not err
@@ -114,7 +115,7 @@ def test_dba_change_of_registration(session):
     nr_res = copy.deepcopy(nr_response)
     nr_res['legalType'] = 'SP'
     with patch.object(NameXService, 'query_nr_number', return_value=MockResponse(nr_res)):
-        with patch.object(NaicsService, 'find_by_code', return_value=naics_response):
+        with patch.object(NaicsStructure, 'find_by_code', return_value=mock_naics_structure):
             err = validate(DBA_CHANGE_OF_REGISTRATION)
 
     assert not err
@@ -133,7 +134,7 @@ def test_invalid_nr_change_of_registration(session):
         }]
     }
     with patch.object(NameXService, 'query_nr_number', return_value=MockResponse(invalid_nr_response)):
-        with patch.object(NaicsService, 'find_by_code', return_value=naics_response):
+        with patch.object(NaicsStructure, 'find_by_code', return_value=mock_naics_structure):
             err = validate(filing)
 
     assert err
@@ -157,7 +158,7 @@ def test_invalid_party(session, test_name, filing, expected_msg):
     nr_res = copy.deepcopy(nr_response)
     nr_res['legalType'] = filing['filing']['changeOfRegistration']['nameRequest']['legalType']
     with patch.object(NameXService, 'query_nr_number', return_value=MockResponse(nr_res)):
-        with patch.object(NaicsService, 'find_by_code', return_value=naics_response):
+        with patch.object(NaicsStructure, 'find_by_code', return_value=mock_naics_structure):
             err = validate(filing)
 
     assert err
@@ -182,7 +183,7 @@ def test_invalid_business_address(session, test_name, filing):
     nr_res = copy.deepcopy(nr_response)
     nr_res['legalType'] = filing['filing']['changeOfRegistration']['nameRequest']['legalType']
     with patch.object(NameXService, 'query_nr_number', return_value=MockResponse(nr_res)):
-        with patch.object(NaicsService, 'find_by_code', return_value=naics_response):
+        with patch.object(NaicsStructure, 'find_by_code', return_value=mock_naics_structure):
             err = validate(filing)
 
     assert err
@@ -209,7 +210,7 @@ def test_change_of_registration_court_orders(session, test_status, file_number, 
     filing['filing']['changeOfRegistration']['courtOrder'] = court_order
 
     with patch.object(NameXService, 'query_nr_number', return_value=MockResponse(nr_response)):
-        with patch.object(NaicsService, 'find_by_code', return_value=naics_response):
+        with patch.object(NaicsStructure, 'find_by_code', return_value=mock_naics_structure):
             err = validate(filing)
 
     # validate outcomes


### PR DESCRIPTION
*Issue #:* /bcgov/entity#18394

Making this update such that it is possible for the legal api to run with 1 Gunicorn worker process.  Previously, this was not possible as self calls to the legal api for NAICS validation would cause the legal api to block itself until a response came back.

*Description of changes:*
* Update all NAICS validation logic in legal api to be internal.  
Note: the service class is still in place such that if we ever want to do self calls or standup NAICS as a standalone API, we can easily re-wire things to do that.
* Update unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
