### PR TITLE
fix: 404 errors from Traction when revoking or replacing a credential

### DIFF
--- a/legal-api/src/legal_api/decorators.py
+++ b/legal-api/src/legal_api/decorators.py
@@ -27,18 +27,14 @@ def requires_traction_auth(f):
     """Check for a valid Traction token and refresh if needed."""
     @wraps(f)
     def decorated_function(*args, **kwargs):
-        traction_api_url = current_app.config['TRACTION_API_URL']
-        traction_tenant_id = current_app.config['TRACTION_TENANT_ID']
-        traction_api_key = current_app.config['TRACTION_API_KEY']
+        if not (traction_api_url := current_app.config['TRACTION_API_URL']):
+            raise EnvironmentError('TRACTION_API_URL environment variable is not set')
 
-        if traction_api_url is None:
-            raise EnvironmentError('TRACTION_API_URL environment vairable is not set')
+        if not (traction_tenant_id := current_app.config['TRACTION_TENANT_ID']):
+            raise EnvironmentError('TRACTION_TENANT_ID environment variable is not set')
 
-        if traction_tenant_id is None:
-            raise EnvironmentError('TRACTION_TENANT_ID environment vairable is not set')
-
-        if traction_api_key is None:
-            raise EnvironmentError('TRACTION_API_KEY environment vairable is not set')
+        if not (traction_api_key := current_app.config['TRACTION_API_KEY']):
+            raise EnvironmentError('TRACTION_API_KEY environment variable is not set')
 
         try:
             if not hasattr(current_app, 'api_token'):

--- a/legal-api/src/legal_api/models/__init__.py
+++ b/legal-api/src/legal_api/models/__init__.py
@@ -25,6 +25,7 @@ from .dc_connection import DCConnection
 from .dc_definition import DCDefinition
 from .dc_issued_business_user_credential import DCIssuedBusinessUserCredential
 from .dc_issued_credential import DCIssuedCredential
+from .dc_revocation_reason import DCRevocationReason
 from .document import Document, DocumentType
 from .filing import Filing
 from .naics_element import NaicsElement
@@ -40,8 +41,8 @@ from .user import User, UserRoles
 
 
 __all__ = ('db',
-           'Address', 'Alias', 'Business', 'ColinLastUpdate', 'Comment', 'ConsentContinuationOut', 'CorpType',
-           'DCConnection', 'DCDefinition', 'DCIssuedCredential', 'DCIssuedBusinessUserCredential', 'Document',
-           'DocumentType', 'Filing', 'Office', 'OfficeType', 'Party', 'RegistrationBootstrap', 'RequestTracker',
-           'Resolution', 'PartyRole', 'ShareClass', 'ShareSeries', 'User', 'UserRoles', 'NaicsStructure',
-           'NaicsElement')
+           'Address', 'Alias', 'Business', 'ColinLastUpdate', 'Comment', 'ConsentContinuationOut',
+           'CorpType', 'DCConnection', 'DCDefinition', 'DCIssuedCredential', 'DCIssuedBusinessUserCredential',
+           'DCRevocationReason', 'Document', 'DocumentType', 'Filing', 'Office', 'OfficeType', 'Party',
+           'RegistrationBootstrap', 'RequestTracker', 'Resolution', 'PartyRole', 'ShareClass', 'ShareSeries',
+           'User', 'UserRoles', 'NaicsStructure', 'NaicsElement')

--- a/legal-api/src/legal_api/models/dc_connection.py
+++ b/legal-api/src/legal_api/models/dc_connection.py
@@ -14,6 +14,7 @@
 """This module holds data for digital credentials connection."""
 from __future__ import annotations
 
+from enum import Enum
 from typing import List
 
 from .db import db
@@ -21,6 +22,18 @@ from .db import db
 
 class DCConnection(db.Model):  # pylint: disable=too-many-instance-attributes
     """This class manages the digital credentials connection."""
+
+    class State(Enum):
+        """Enum of the connection states."""
+
+        INIT = 'init'
+        INVITATION = 'invitation'
+        REQUEST = 'request'
+        RESPONSE = 'response'
+        ACTIVE = 'active'
+        COMPLETED = 'completed'
+        INACTIVE = 'inactive'
+        ERROR = 'error'
 
     __tablename__ = 'dc_connections'
 

--- a/legal-api/src/legal_api/models/dc_issued_business_user_credential.py
+++ b/legal-api/src/legal_api/models/dc_issued_business_user_credential.py
@@ -35,6 +35,14 @@ class DCIssuedBusinessUserCredential(db.Model):  # pylint: disable=too-many-inst
         db.session.commit()
 
     @classmethod
+    def find_by_id(cls, dc_issued_business_user_id: str) -> DCIssuedBusinessUserCredential:
+        """Return the issued business user credential matching the id."""
+        dc_issued_business_user = None
+        if dc_issued_business_user_id:
+            dc_issued_business_user = cls.query.filter_by(id=dc_issued_business_user_id).one_or_none()
+        return dc_issued_business_user
+
+    @classmethod
     def find_by(cls,
                 business_id: int = None,
                 user_id: int = None) -> List[DCIssuedBusinessUserCredential]:

--- a/legal-api/src/legal_api/models/dc_revocation_reason.py
+++ b/legal-api/src/legal_api/models/dc_revocation_reason.py
@@ -1,0 +1,28 @@
+# Copyright © 2023 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This module holds revocation reasons for issued credential."""
+from enum import Enum
+
+
+class DCRevocationReason(Enum):
+    """Digital Credential Revocation Reasons."""
+
+    UPDATED_INFORMATION = 'You were offered a new credential with updated information ' \
+        'and that revoked all previous copies.'
+    VOLUNTARY_DISSOLUTION = 'You chose to dissolve your business. ' \
+        'A new credential was offered that reflects the new company status and that revoked all previous copies.'
+    ADMINISTRATIVE_DISSOLUTION = 'Your business was dissolved by the Registrar.'
+    PUT_BACK_ON = 'Your business was put back on the Registry. '
+    SELF_REISSUANCE = 'You chose to issue yourself a new credential and that revoked all previous copies.'
+    SELF_REVOCATION = 'You chose to revoke your own credential.'


### PR DESCRIPTION
*Issue #:* /bcgov/entity#18474

*Description of changes:*

* Will only try to delete a record in Traction if it exists (prevents 404 and subsequent 500 errors from Traction)
* Adds connection state enums (following DRY pattern)
* Adds ability to vary revocation reason
* Adds helper class to be re-used with queueing service in #2299 
* Uses walrus operator for code legibility

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
