### PR TITLE
refactor: use models to detrmine access to digital credentials

### DIFF
--- a/legal-api/src/legal_api/services/authz.py
+++ b/legal-api/src/legal_api/services/authz.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """This manages all of the authentication and authorization service."""
+from datetime import datetime
 from enum import Enum
 from http import HTTPStatus
 from typing import Final, List
@@ -25,7 +26,7 @@ from requests import Session, exceptions
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from legal_api.models import Business, Filing, User
+from legal_api.models import Business, Filing, PartyRole, User
 from legal_api.services.warnings.business.business_checks import WarningType
 
 
@@ -697,38 +698,32 @@ def is_self_registered_owner_operator(business, user):
     if not (registration_filing := get_registration_filing(business)):
         return False
 
-    if not (filing_json := registration_filing.filing_json.get('filing', {}).get('registration', None)):
+    if not len(proprietors := PartyRole.get_parties_by_role(
+            business.id, PartyRole.RoleTypes.PROPRIETOR.value)) > 0:
         return False
 
-    if not (parties := filing_json.get('parties', None)):
+    if not len(completing_parties := PartyRole.get_party_roles_by_filing(
+            registration_filing.id, datetime.utcnow(), PartyRole.RoleTypes.COMPLETING_PARTY.value)) > 0:
         return False
 
-    completing_party = (next((party for party in parties if party.get('roles', None) and (
-        any(role for role in party.get('roles') if role.get('roleType') == 'Completing Party'))), None)
-    ).get('officer', None)
-    proprietor = (next((party for party in parties if party.get('roles', None) and (
-        any(role for role in party.get('roles') if role.get('roleType') == 'Proprietor'))), None)
-    ).get('officer', None)
-    if (not completing_party) or (not proprietor):
+    if not (proprietor := proprietors[0].party):
+        return False
+
+    if not (completing_party := completing_parties[0].party):
         return False
 
     return (
         registration_filing.submitter_id == user.id and
-        completing_party.get('firstName') == proprietor.get('firstName') and
-        completing_party.get('lastName') == proprietor.get('lastName') and
-        proprietor.get('firstName') == user.firstname and
-        proprietor.get('lastName') == user.lastname
+        completing_party.first_name == proprietor.first_name and
+        completing_party.last_name == proprietor.last_name and
+        proprietor.first_name == user.firstname and
+        proprietor.last_name == user.lastname
     )
 
 
 def get_registration_filing(business):
     """Return the registration filing for the business."""
-    filings = Filing.get_filings_by_types(business.id, ['registration'])
+    if not len(registration_filings := Filing.get_filings_by_types(business.id, ['registration'])) > 0:
+        return None
 
-    registration_filing = None
-    for filing in filings:
-        if filing.filing_json.get('filing', {}).get('registration', None):
-            registration_filing = filing
-            break
-
-    return registration_filing
+    return registration_filings[0]

--- a/legal-api/tests/unit/services/test_authorization.py
+++ b/legal-api/tests/unit/services/test_authorization.py
@@ -31,14 +31,16 @@ from registry_schemas.example_data import AGM_EXTENSION, AGM_LOCATION_CHANGE, AL
     CORRECTION_AR, CHANGE_OF_REGISTRATION_TEMPLATE, RESTORATION, FILING_TEMPLATE, DISSOLUTION, PUT_BACK_ON, \
     CONTINUATION_IN, CONSENT_CONTINUATION_OUT, CONTINUATION_OUT
 
-from legal_api.models import Filing
-from legal_api.models.business import Business, User
+from legal_api.models import Address, Filing
+from legal_api.models.business import Business, PartyRole, User
 
 from legal_api.services.authz import BASIC_USER, COLIN_SVC_ROLE, STAFF_ROLE, PUBLIC_USER, \
-    are_digital_credentials_allowed, authorized, get_allowed, is_allowed, get_allowed_filings, get_allowable_actions
+    are_digital_credentials_allowed, authorized, is_allowed, is_self_registered_owner_operator, \
+        get_allowed, get_allowed_filings, get_allowable_actions
 from legal_api.services.warnings.business.business_checks import WarningType
 from tests import integration_authorization, not_github_ci
-from tests.unit.models import factory_business, factory_filing, factory_incomplete_statuses, factory_completed_filing
+from tests.unit.models import factory_business, factory_filing, factory_incomplete_statuses, factory_completed_filing, \
+    factory_party_role, factory_user
 
 from .utils import helper_create_jwt
 
@@ -1946,6 +1948,181 @@ def test_are_digital_credentials_allowed_true(monkeypatch, app, session, jwt):
         assert are_digital_credentials_allowed(business, jwt) is True
 
 
+@patch('legal_api.services.authz.get_registration_filing', return_value=None)
+def test_is_self_registered_owner_operator_false_when_no_registration_filing(app, session):
+    user = factory_user(username='test', firstname='Test', lastname='User')
+    business = create_business('SP', Business.State.ACTIVE)
+
+    assert is_self_registered_owner_operator(business, user) is False
+
+
+def test_is_self_registered_owner_operator_false_when_no_proprietors(app, session):
+    user = factory_user(username='test', firstname='Test', lastname='User')
+    business = create_business('SP', Business.State.ACTIVE)
+    completing_party_role = create_party_role(
+        PartyRole.RoleTypes.COMPLETING_PARTY,
+        firstName='Test',
+        lastName='User',
+        middleInitial='TU'
+    )
+    filing = factory_completed_filing(
+        business=business,
+        data_dict={'filing': {'header': {'name': 'registration'}}},
+        filing_date=_datetime.utcnow(), filing_type='registration'
+    )
+    filing.filing_party_roles.append(completing_party_role)
+    filing.submitter_id = user.id
+    filing.save()
+
+    assert is_self_registered_owner_operator(business, user) is False
+
+
+@patch('legal_api.models.PartyRole.get_parties_by_role',
+       return_value=[PartyRole(role=PartyRole.RoleTypes.PROPRIETOR.value)])
+def test_is_self_registered_owner_operator_false_when_no_proprietor(app, session):
+    user = factory_user(username='test', firstname='Test', lastname='User')
+    business = create_business('SP', Business.State.ACTIVE)
+    completing_party_role = create_party_role(
+        PartyRole.RoleTypes.COMPLETING_PARTY,
+        firstName='Test',
+        lastName='User',
+        middleInitial='TU'
+    )
+    filing = factory_completed_filing(
+        business=business,
+        data_dict={'filing': {'header': {'name': 'registration'}}},
+        filing_date=_datetime.utcnow(), filing_type='registration'
+    )
+    filing.filing_party_roles.append(completing_party_role)
+    filing.submitter_id = user.id
+    filing.save()
+
+    assert is_self_registered_owner_operator(business, user) is False
+
+
+@patch('legal_api.models.PartyRole.get_party_roles_by_filing', return_value=None)
+def test_is_self_registered_owner_operator_false_when_no_completing_parties(app, session):
+    user = factory_user(username='test', firstname='Test', lastname='User')
+    business = create_business('SP', Business.State.ACTIVE)
+    proprietor_party_role = create_party_role(
+        PartyRole.RoleTypes.PROPRIETOR,
+        firstName='Test',
+        lastName='User',
+        middleInitial='TU'
+    )    
+    proprietor_party_role.business_id = business.id
+    proprietor_party_role.save()
+
+    assert is_self_registered_owner_operator(business, user) is False
+
+
+@patch('legal_api.models.PartyRole.get_party_roles_by_filing',
+        return_value=[PartyRole(role=PartyRole.RoleTypes.COMPLETING_PARTY.value)])
+def test_is_self_registered_owner_operator_false_when_no_completing_party(app, session):
+    user = factory_user(username='test', firstname='Test', lastname='User')
+    business = create_business('SP', Business.State.ACTIVE)
+    proprietor_party_role = create_party_role(
+        PartyRole.RoleTypes.PROPRIETOR,
+        firstName='Test',
+        lastName='User',
+        middleInitial='TU'
+    )    
+    proprietor_party_role.business_id = business.id
+    proprietor_party_role.save()
+
+    assert is_self_registered_owner_operator(business, user) is False
+
+
+def test_is_self_registered_owner_operator_false_when_parties_not_matching(app, session):
+    user = factory_user(username='test', firstname='Test1', lastname='User1')
+    business = create_business('SP', Business.State.ACTIVE)
+    completing_party_role = create_party_role(
+        PartyRole.RoleTypes.COMPLETING_PARTY,
+        firstName='Test1',
+        lastName='User1',
+        middleInitial='TU1'
+    )
+    filing = factory_completed_filing(
+        business=business,
+        data_dict={'filing': {'header': {'name': 'registration'}}},
+        filing_date=_datetime.utcnow(), filing_type='registration'
+    )
+    filing.filing_party_roles.append(completing_party_role)
+    filing.submitter_id = user.id
+    filing.save()
+
+    proprietor_party_role = create_party_role(
+        PartyRole.RoleTypes.PROPRIETOR,
+        firstName='Test2',
+        lastName='User2',
+        middleInitial='TU2'
+    )    
+    proprietor_party_role.business_id = business.id
+    proprietor_party_role.save()
+
+    assert is_self_registered_owner_operator(business, user) is False
+
+    
+def test_is_self_registered_owner_operator_false_when_user_not_matching(app, session):
+    user = factory_user(username='test', firstname='Test1', lastname='User1')
+    business = create_business('SP', Business.State.ACTIVE)
+    completing_party_role = create_party_role(
+        PartyRole.RoleTypes.COMPLETING_PARTY,
+        firstName='Test2',
+        lastName='User2',
+        middleInitial='TU2'
+    )
+    filing = factory_completed_filing(
+        business=business,
+        data_dict={'filing': {'header': {'name': 'registration'}}},
+        filing_date=_datetime.utcnow(), filing_type='registration'
+    )
+    filing.filing_party_roles.append(completing_party_role)
+    filing.submitter_id = user.id
+    filing.save()
+
+    proprietor_party_role = create_party_role(
+        PartyRole.RoleTypes.PROPRIETOR,
+        firstName='Test2',
+        lastName='User2',
+        middleInitial='TU2'
+    )    
+    proprietor_party_role.business_id = business.id
+    proprietor_party_role.save()
+
+    assert is_self_registered_owner_operator(business, user) is False
+
+
+def test_is_self_registered_owner_operator_true(app, session):
+    user = factory_user(username='test', firstname='Test', lastname='User')
+    business = create_business('SP', Business.State.ACTIVE)
+    completing_party_role = create_party_role(
+        PartyRole.RoleTypes.COMPLETING_PARTY,
+        firstName='Test',
+        lastName='User',
+        middleInitial='TU'
+    )
+    filing = factory_completed_filing(
+        business=business,
+        data_dict={'filing': {'header': {'name': 'registration'}}},
+        filing_date=_datetime.utcnow(), filing_type='registration'
+    )
+    filing.filing_party_roles.append(completing_party_role)
+    filing.submitter_id = user.id
+    filing.save()
+
+    proprietor_party_role = create_party_role(
+        PartyRole.RoleTypes.PROPRIETOR,
+        firstName='Test',
+        lastName='User',
+        middleInitial='TU'
+    )    
+    proprietor_party_role.business_id = business.id
+    proprietor_party_role.save()
+
+    assert is_self_registered_owner_operator(business, user) is True
+
+
 def create_business(legal_type, state):
     """Create a business."""
     identifier = (f'BC{random.SystemRandom().getrandbits(0x58)}')[:9]
@@ -1984,7 +2161,28 @@ def create_filing(business, filing_type, filing_sub_type=None):
         filing_sub_type_key = Filing.FILING_SUB_TYPE_KEYS.get(filing_type, None)
         filing_dict['filing'][filing_type][filing_sub_type_key] = filing_sub_type
     filing = factory_completed_filing(business=business,
-                                            data_dict=filing_dict,
-                                            filing_type=filing_type,
-                                            filing_sub_type=filing_sub_type)
+                                      data_dict=filing_dict,
+                                      filing_type=filing_type,
+                                      filing_sub_type=filing_sub_type)
     return filing
+
+
+def create_party_role(role=PartyRole.RoleTypes.COMPLETING_PARTY,
+                      firstName=None, lastName=None, middleInitial=None):
+    completing_party_address = Address(city='Test Mailing City', address_type=Address.DELIVERY)
+    officer = {
+        'firstName': firstName or 'Test',
+        'middleInitial': middleInitial or 'TU',
+        'lastName': lastName or 'User',
+        'partyType': 'person',
+        'organizationName': ''
+    }
+    party_role = factory_party_role(
+        completing_party_address,
+        None,
+        officer,
+        _datetime.utcnow(),
+        None,
+        role
+    )
+    return party_role


### PR DESCRIPTION
*Issue #:* /bcgov/entity#18688

*Description of changes:*

* refactor logic to use models directly rather than filing and party json data
* adds unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
