### PR TITLE
18784 Include PAID status in allowable actions blocker check for FED pending dissolution filings

### DIFF
--- a/legal-api/src/legal_api/core/filing.py
+++ b/legal-api/src/legal_api/core/filing.py
@@ -88,6 +88,19 @@ class Filing:
         SPECIALRESOLUTION = 'specialResolution'
         TRANSITION = 'transition'
 
+    class FilingTypesCompact(str, Enum):
+        """Render enum for filing types with sub-types."""
+
+        DISSOLUTION_VOLUNTARY = 'dissolution.voluntary'
+        DISSOLUTION_ADMINISTRATIVE = 'dissolution.administrative'
+        RESTORATION_FULL_RESTORATION = 'restoration.fullRestoration'
+        RESTORATION_LIMITED_RESTORATION = 'restoration.limitedRestoration'
+        RESTORATION_LIMITED_RESTORATION_EXT = 'restoration.limitedRestorationExtension'
+        RESTORATION_LIMITED_RESTORATION_TO_FULL = 'restoration.limitedRestorationToFull'
+        AMALGAMATION_APPLICATION_REGULAR = 'amalgamationApplication.regular'
+        AMALGAMATION_APPLICATION_VERTICAL = 'amalgamationApplication.vertical'
+        AMALGAMATION_APPLICATION_HORIZONTAL = 'amalgamationApplication.horizontal'
+
     def __init__(self):
         """Create the Filing."""
         self._storage: Optional[FilingStorage] = None

--- a/legal-api/src/legal_api/services/authz.py
+++ b/legal-api/src/legal_api/services/authz.py
@@ -15,7 +15,7 @@
 from datetime import datetime, timezone
 from enum import Enum
 from http import HTTPStatus
-from typing import Final, List
+from typing import List
 from urllib.parse import urljoin
 
 import jwt as pyjwt
@@ -122,304 +122,318 @@ def has_roles(jwt: JwtManager, roles: List[str]) -> bool:
     return False
 
 
-ALLOWABLE_FILINGS: Final = {
-    'staff': {
-        Business.State.ACTIVE: {
-            'adminFreeze': {
-                'legalTypes': ['SP', 'GP', 'CP', 'BC', 'BEN', 'CC', 'ULC'],
-            },
-            'agmExtension': {
-                'legalTypes': ['BC', 'BEN', 'ULC', 'CC'],
-                'blockerChecks': {
-                    'business': [BusinessBlocker.DEFAULT, BusinessBlocker.NOT_IN_GOOD_STANDING]
-                }
-            },
-            'agmLocationChange': {
-                'legalTypes': ['BC', 'BEN', 'ULC', 'CC'],
-                'blockerChecks': {
-                    'business': [BusinessBlocker.DEFAULT, BusinessBlocker.NOT_IN_GOOD_STANDING]
-                }
-            },
-            'alteration': {
-                'legalTypes': ['BC', 'BEN', 'ULC', 'CC'],
-                'blockerChecks': {
-                    'business': [BusinessBlocker.DEFAULT]
-                }
-            },
-            'amalgamationApplication': {
-                'businessRequirement': BusinessRequirement.NO_RESTRICTION,
-                'regular': {
-                    'legalTypes': ['BEN', 'BC', 'ULC', 'CC'],
-                    'blockerChecks': {
-                        'business': [BusinessBlocker.BUSINESS_FROZEN],
-                        'futureEffectiveFilings': ['dissolution']
-                    }
+def get_allowable_filings_dict():
+    """Return dictionary containing rules for when filings are allowed."""
+    # importing here to avoid circular dependencies
+    # pylint: disable=import-outside-toplevel
+    from legal_api.core.filing import Filing as CoreFiling
+
+    filing_types_compact = CoreFiling.FilingTypesCompact
+
+    return {
+        'staff': {
+            Business.State.ACTIVE: {
+                'adminFreeze': {
+                    'legalTypes': ['SP', 'GP', 'CP', 'BC', 'BEN', 'CC', 'ULC'],
                 },
-                'vertical': {
-                    'legalTypes': ['BEN', 'BC', 'ULC', 'CC'],
+                'agmExtension': {
+                    'legalTypes': ['BC', 'BEN', 'ULC', 'CC'],
                     'blockerChecks': {
-                        'business': [BusinessBlocker.BUSINESS_FROZEN],
-                        'futureEffectiveFilings': ['dissolution']
-                    }
-                },
-                'horizontal': {
-                    'legalTypes': ['BEN', 'BC', 'ULC', 'CC'],
-                    'blockerChecks': {
-                        'business': [BusinessBlocker.BUSINESS_FROZEN],
-                        'futureEffectiveFilings': ['dissolution']
-                    }
-                }
-            },
-            'annualReport': {
-                'legalTypes': ['CP', 'BEN', 'BC', 'ULC', 'CC'],
-                'blockerChecks': {
-                    'business': [BusinessBlocker.DEFAULT]
-                }
-            },
-            'changeOfAddress': {
-                'legalTypes': ['CP', 'BEN', 'BC', 'ULC', 'CC'],
-                'blockerChecks': {
-                    'business': [BusinessBlocker.DEFAULT]
-                }
-            },
-            'changeOfDirectors': {
-                'legalTypes': ['CP', 'BEN', 'BC', 'ULC', 'CC'],
-                'blockerChecks': {
-                    'business': [BusinessBlocker.DEFAULT]
-                }
-            },
-            'changeOfRegistration': {
-                'legalTypes': ['SP', 'GP'],
-                'blockerChecks': {
-                    'warningTypes': [WarningType.MISSING_REQUIRED_BUSINESS_INFO],
-                    'business': [BusinessBlocker.DEFAULT]
-                }
-            },
-            'consentContinuationOut': {
-                'legalTypes': ['BC', 'BEN', 'CC', 'ULC'],
-                'blockerChecks': {
-                    'business': [BusinessBlocker.DEFAULT, BusinessBlocker.NOT_IN_GOOD_STANDING]
-                }
-            },
-            'continuationOut': {
-                'legalTypes': ['BC', 'BEN', 'CC', 'ULC'],
-                'blockerChecks': {
-                    'business': [BusinessBlocker.NOT_IN_GOOD_STANDING],
-                    'completedFilings': ['consentContinuationOut']
-                }
-            },
-            'conversion': {
-                'legalTypes': ['SP', 'GP']
-            },
-            'correction': {
-                'legalTypes': ['CP', 'BEN', 'SP', 'GP', 'BC', 'ULC', 'CC'],
-                'blockerChecks': {
-                    'warningTypes': [WarningType.MISSING_REQUIRED_BUSINESS_INFO],
-                    'business': [BusinessBlocker.DEFAULT]
-                }
-            },
-            'courtOrder': {
-                'legalTypes': ['SP', 'GP', 'CP', 'BC', 'BEN', 'CC', 'ULC']
-            },
-            'dissolution': {
-                'voluntary': {
-                    'legalTypes': ['CP', 'BC', 'BEN', 'CC', 'ULC', 'SP', 'GP'],
-                    'blockerChecks': {
-                        'warningTypes': [WarningType.MISSING_REQUIRED_BUSINESS_INFO],
                         'business': [BusinessBlocker.DEFAULT, BusinessBlocker.NOT_IN_GOOD_STANDING]
                     }
                 },
-                'administrative': {
-                    'legalTypes': ['CP', 'BC', 'BEN', 'CC', 'ULC', 'SP', 'GP'],
+                'agmLocationChange': {
+                    'legalTypes': ['BC', 'BEN', 'ULC', 'CC'],
                     'blockerChecks': {
-                        'warningTypes': [WarningType.MISSING_REQUIRED_BUSINESS_INFO],
-                        'business': [BusinessBlocker.DRAFT_PENDING]
+                        'business': [BusinessBlocker.DEFAULT, BusinessBlocker.NOT_IN_GOOD_STANDING]
                     }
-                }
-            },
-            'incorporationApplication': {
-                'legalTypes': ['CP', 'BC', 'BEN', 'ULC', 'CC'],
-                # only show filing when providing allowable filings not specific to a business
-                'businessRequirement': BusinessRequirement.NOT_EXIST
-            },
-            'registrarsNotation': {
-                'legalTypes': ['SP', 'GP', 'CP', 'BC', 'BEN', 'CC', 'ULC']
-            },
-            'registrarsOrder': {
-                'legalTypes': ['SP', 'GP', 'CP', 'BC', 'BEN', 'CC', 'ULC']
-            },
-            'registration': {
-                'legalTypes': ['SP', 'GP'],
-                # only show filing when providing allowable filings not specific to a business
-                'businessRequirement': BusinessRequirement.NOT_EXIST
-            },
-            'specialResolution': {
-                'legalTypes': ['CP'],
-                'blockerChecks': {
-                    'business': [BusinessBlocker.DEFAULT]
-                }
-            },
-            'transition': {
-                'legalTypes': ['BC', 'BEN', 'CC', 'ULC']
-            },
-            'restoration': {
-                'limitedRestorationExtension': {
-                    'legalTypes': ['BC', 'BEN', 'CC', 'ULC'],
+                },
+                'alteration': {
+                    'legalTypes': ['BC', 'BEN', 'ULC', 'CC'],
                     'blockerChecks': {
-                        'validStateFilings': ['restoration.limitedRestoration',
-                                              'restoration.limitedRestorationExtension'],
                         'business': [BusinessBlocker.DEFAULT]
                     }
                 },
-                'limitedRestorationToFull': {
+                'amalgamationApplication': {
+                    'businessRequirement': BusinessRequirement.NO_RESTRICTION,
+                    'regular': {
+                        'legalTypes': ['BEN', 'BC', 'ULC', 'CC'],
+                        'blockerChecks': {
+                            'business': [BusinessBlocker.BUSINESS_FROZEN],
+                            'futureEffectiveFilings': [filing_types_compact.DISSOLUTION_VOLUNTARY,
+                                                       filing_types_compact.DISSOLUTION_ADMINISTRATIVE]
+                        }
+                    },
+                    'vertical': {
+                        'legalTypes': ['BEN', 'BC', 'ULC', 'CC'],
+                        'blockerChecks': {
+                            'business': [BusinessBlocker.BUSINESS_FROZEN],
+                            'futureEffectiveFilings': [filing_types_compact.DISSOLUTION_VOLUNTARY,
+                                                       filing_types_compact.DISSOLUTION_ADMINISTRATIVE]
+                        }
+                    },
+                    'horizontal': {
+                        'legalTypes': ['BEN', 'BC', 'ULC', 'CC'],
+                        'blockerChecks': {
+                            'business': [BusinessBlocker.BUSINESS_FROZEN],
+                            'futureEffectiveFilings': [filing_types_compact.DISSOLUTION_VOLUNTARY,
+                                                       filing_types_compact.DISSOLUTION_ADMINISTRATIVE]
+                        }
+                    }
+                },
+                'annualReport': {
+                    'legalTypes': ['CP', 'BEN', 'BC', 'ULC', 'CC'],
+                    'blockerChecks': {
+                        'business': [BusinessBlocker.DEFAULT]
+                    }
+                },
+                'changeOfAddress': {
+                    'legalTypes': ['CP', 'BEN', 'BC', 'ULC', 'CC'],
+                    'blockerChecks': {
+                        'business': [BusinessBlocker.DEFAULT]
+                    }
+                },
+                'changeOfDirectors': {
+                    'legalTypes': ['CP', 'BEN', 'BC', 'ULC', 'CC'],
+                    'blockerChecks': {
+                        'business': [BusinessBlocker.DEFAULT]
+                    }
+                },
+                'changeOfRegistration': {
+                    'legalTypes': ['SP', 'GP'],
+                    'blockerChecks': {
+                        'warningTypes': [WarningType.MISSING_REQUIRED_BUSINESS_INFO],
+                        'business': [BusinessBlocker.DEFAULT]
+                    }
+                },
+                'consentContinuationOut': {
                     'legalTypes': ['BC', 'BEN', 'CC', 'ULC'],
                     'blockerChecks': {
-                        'validStateFilings': ['restoration.limitedRestoration',
-                                              'restoration.limitedRestorationExtension'],
+                        'business': [BusinessBlocker.DEFAULT, BusinessBlocker.NOT_IN_GOOD_STANDING]
+                    }
+                },
+                'continuationOut': {
+                    'legalTypes': ['BC', 'BEN', 'CC', 'ULC'],
+                    'blockerChecks': {
+                        'business': [BusinessBlocker.NOT_IN_GOOD_STANDING],
+                        'completedFilings': ['consentContinuationOut']
+                    }
+                },
+                'conversion': {
+                    'legalTypes': ['SP', 'GP']
+                },
+                'correction': {
+                    'legalTypes': ['CP', 'BEN', 'SP', 'GP', 'BC', 'ULC', 'CC'],
+                    'blockerChecks': {
+                        'warningTypes': [WarningType.MISSING_REQUIRED_BUSINESS_INFO],
                         'business': [BusinessBlocker.DEFAULT]
+                    }
+                },
+                'courtOrder': {
+                    'legalTypes': ['SP', 'GP', 'CP', 'BC', 'BEN', 'CC', 'ULC']
+                },
+                'dissolution': {
+                    'voluntary': {
+                        'legalTypes': ['CP', 'BC', 'BEN', 'CC', 'ULC', 'SP', 'GP'],
+                        'blockerChecks': {
+                            'warningTypes': [WarningType.MISSING_REQUIRED_BUSINESS_INFO],
+                            'business': [BusinessBlocker.DEFAULT, BusinessBlocker.NOT_IN_GOOD_STANDING]
+                        }
+                    },
+                    'administrative': {
+                        'legalTypes': ['CP', 'BC', 'BEN', 'CC', 'ULC', 'SP', 'GP'],
+                        'blockerChecks': {
+                            'warningTypes': [WarningType.MISSING_REQUIRED_BUSINESS_INFO],
+                            'business': [BusinessBlocker.DRAFT_PENDING]
+                        }
+                    }
+                },
+                'incorporationApplication': {
+                    'legalTypes': ['CP', 'BC', 'BEN', 'ULC', 'CC'],
+                    # only show filing when providing allowable filings not specific to a business
+                    'businessRequirement': BusinessRequirement.NOT_EXIST
+                },
+                'registrarsNotation': {
+                    'legalTypes': ['SP', 'GP', 'CP', 'BC', 'BEN', 'CC', 'ULC']
+                },
+                'registrarsOrder': {
+                    'legalTypes': ['SP', 'GP', 'CP', 'BC', 'BEN', 'CC', 'ULC']
+                },
+                'registration': {
+                    'legalTypes': ['SP', 'GP'],
+                    # only show filing when providing allowable filings not specific to a business
+                    'businessRequirement': BusinessRequirement.NOT_EXIST
+                },
+                'specialResolution': {
+                    'legalTypes': ['CP'],
+                    'blockerChecks': {
+                        'business': [BusinessBlocker.DEFAULT]
+                    }
+                },
+                'transition': {
+                    'legalTypes': ['BC', 'BEN', 'CC', 'ULC']
+                },
+                'restoration': {
+                    'limitedRestorationExtension': {
+                        'legalTypes': ['BC', 'BEN', 'CC', 'ULC'],
+                        'blockerChecks': {
+                            'validStateFilings': [filing_types_compact.RESTORATION_LIMITED_RESTORATION,
+                                                  filing_types_compact.RESTORATION_LIMITED_RESTORATION_EXT],
+                            'business': [BusinessBlocker.DEFAULT]
+                        }
+                    },
+                    'limitedRestorationToFull': {
+                        'legalTypes': ['BC', 'BEN', 'CC', 'ULC'],
+                        'blockerChecks': {
+                            'validStateFilings': [filing_types_compact.RESTORATION_LIMITED_RESTORATION,
+                                                  filing_types_compact.RESTORATION_LIMITED_RESTORATION_EXT],
+                            'business': [BusinessBlocker.DEFAULT]
+                        }
+                    }
+                }
+            },
+            Business.State.HISTORICAL: {
+                'courtOrder': {
+                    'legalTypes': ['SP', 'GP', 'CP', 'BC', 'BEN', 'CC', 'ULC'],
+                },
+                'putBackOn': {
+                    'legalTypes': ['SP', 'GP', 'BEN', 'CP', 'BC', 'CC', 'ULC'],
+                    'blockerChecks': {
+                        'validStateFilings': [filing_types_compact.DISSOLUTION_ADMINISTRATIVE]
+                    }
+                },
+                'registrarsNotation': {
+                    'legalTypes': ['SP', 'GP', 'CP', 'BC', 'BEN', 'CC', 'ULC']
+                },
+                'registrarsOrder': {
+                    'legalTypes': ['SP', 'GP', 'CP', 'BC', 'BEN', 'CC', 'ULC']
+                },
+                'restoration': {
+                    'fullRestoration': {
+                        'legalTypes': ['BC', 'BEN', 'CC', 'ULC'],
+                        'blockerChecks': {
+                            'invalidStateFilings': ['continuationIn', 'continuationOut']
+                        }
+                    },
+                    'limitedRestoration': {
+                        'legalTypes': ['BC', 'BEN', 'CC', 'ULC'],
+                        'blockerChecks': {
+                            'invalidStateFilings': ['continuationIn', 'continuationOut']
+                        }
                     }
                 }
             }
         },
-        Business.State.HISTORICAL: {
-            'courtOrder': {
-                'legalTypes': ['SP', 'GP', 'CP', 'BC', 'BEN', 'CC', 'ULC'],
-            },
-            'putBackOn': {
-                'legalTypes': ['SP', 'GP', 'BEN', 'CP', 'BC', 'CC', 'ULC'],
-                'blockerChecks': {
-                    'validStateFilings': ['dissolution.administrative']
-                }
-            },
-            'registrarsNotation': {
-                'legalTypes': ['SP', 'GP', 'CP', 'BC', 'BEN', 'CC', 'ULC']
-            },
-            'registrarsOrder': {
-                'legalTypes': ['SP', 'GP', 'CP', 'BC', 'BEN', 'CC', 'ULC']
-            },
-            'restoration': {
-                'fullRestoration': {
-                    'legalTypes': ['BC', 'BEN', 'CC', 'ULC'],
+        'general': {
+            Business.State.ACTIVE: {
+                'agmExtension': {
+                    'legalTypes': ['BC', 'BEN', 'ULC', 'CC'],
                     'blockerChecks': {
-                        'invalidStateFilings': ['continuationIn', 'continuationOut']
+                        'business': [BusinessBlocker.DEFAULT, BusinessBlocker.NOT_IN_GOOD_STANDING]
                     }
                 },
-                'limitedRestoration': {
+                'agmLocationChange': {
+                    'legalTypes': ['BC', 'BEN', 'ULC', 'CC'],
+                    'blockerChecks': {
+                        'business': [BusinessBlocker.DEFAULT, BusinessBlocker.NOT_IN_GOOD_STANDING]
+                    }
+                },
+                'alteration': {
+                    'legalTypes': ['BC', 'BEN', 'ULC', 'CC'],
+                    'blockerChecks': {
+                        'business': [BusinessBlocker.DEFAULT]
+                    }
+                },
+                'amalgamationApplication': {
+                    'businessRequirement': BusinessRequirement.NO_RESTRICTION,
+                    'regular': {
+                        'legalTypes': ['BEN', 'BC', 'ULC', 'CC'],
+                        'blockerChecks': {
+                            'business': [BusinessBlocker.BUSINESS_FROZEN],
+                            'futureEffectiveFilings': [filing_types_compact.DISSOLUTION_VOLUNTARY,
+                                                       filing_types_compact.DISSOLUTION_ADMINISTRATIVE]
+                        }
+                    },
+                    'vertical': {
+                        'legalTypes': ['BEN', 'BC', 'ULC', 'CC'],
+                        'blockerChecks': {
+                            'business': [BusinessBlocker.BUSINESS_FROZEN],
+                            'futureEffectiveFilings': [filing_types_compact.DISSOLUTION_VOLUNTARY,
+                                                       filing_types_compact.DISSOLUTION_ADMINISTRATIVE]
+                        }
+                    },
+                    'horizontal': {
+                        'legalTypes': ['BEN', 'BC', 'ULC', 'CC'],
+                        'blockerChecks': {
+                            'business': [BusinessBlocker.BUSINESS_FROZEN],
+                            'futureEffectiveFilings': [filing_types_compact.DISSOLUTION_VOLUNTARY,
+                                                       filing_types_compact.DISSOLUTION_ADMINISTRATIVE]
+                        }
+                    }
+                },
+                'annualReport': {
+                    'legalTypes': ['CP', 'BEN', 'BC', 'ULC', 'CC'],
+                    'blockerChecks': {
+                        'business': [BusinessBlocker.DEFAULT]
+                    }
+                },
+                'changeOfAddress': {
+                    'legalTypes': ['CP', 'BEN', 'BC', 'ULC', 'CC'],
+                    'blockerChecks': {
+                        'business': [BusinessBlocker.DEFAULT],
+                    }
+                },
+                'changeOfDirectors': {
+                    'legalTypes': ['CP', 'BEN', 'BC', 'ULC', 'CC'],
+                    'blockerChecks': {
+                        'business': [BusinessBlocker.DEFAULT]
+                    }
+                },
+                'changeOfRegistration': {
+                    'legalTypes': ['SP', 'GP'],
+                    'blockerChecks': {
+                        'warningTypes': [WarningType.MISSING_REQUIRED_BUSINESS_INFO],
+                        'business': [BusinessBlocker.DEFAULT]
+                    }
+                },
+                'consentContinuationOut': {
                     'legalTypes': ['BC', 'BEN', 'CC', 'ULC'],
                     'blockerChecks': {
-                        'invalidStateFilings': ['continuationIn', 'continuationOut']
+                        'business': [BusinessBlocker.DEFAULT, BusinessBlocker.NOT_IN_GOOD_STANDING]
                     }
+                },
+                'dissolution': {
+                    'voluntary': {
+                        'legalTypes': ['CP', 'BC', 'BEN', 'CC', 'ULC', 'SP', 'GP'],
+                        'blockerChecks': {
+                            'warningTypes': [WarningType.MISSING_REQUIRED_BUSINESS_INFO],
+                            'business': [BusinessBlocker.DEFAULT, BusinessBlocker.NOT_IN_GOOD_STANDING]
+                        }
+                    },
+                },
+                'incorporationApplication': {
+                    'legalTypes': ['CP', 'BC', 'BEN', 'ULC', 'CC'],
+                    # only show filing when providing allowable filings not specific to a business
+                    'businessRequirement': BusinessRequirement.NOT_EXIST
+                },
+                'registration': {
+                    'legalTypes': ['SP', 'GP'],
+                    # only show filing when providing allowable filings not specific to a business
+                    'businessRequirement': BusinessRequirement.NOT_EXIST
+                },
+                'specialResolution': {
+                    'legalTypes': ['CP'],
+                    'blockerChecks': {
+                        'business': [BusinessBlocker.DEFAULT]
+                    }
+                },
+                'transition': {
+                    'legalTypes': ['BC', 'BEN', 'CC', 'ULC']
                 }
-            }
+            },
+            Business.State.HISTORICAL: {}
         }
-    },
-    'general': {
-        Business.State.ACTIVE: {
-            'agmExtension': {
-                'legalTypes': ['BC', 'BEN', 'ULC', 'CC'],
-                'blockerChecks': {
-                    'business': [BusinessBlocker.DEFAULT, BusinessBlocker.NOT_IN_GOOD_STANDING]
-                }
-            },
-            'agmLocationChange': {
-                'legalTypes': ['BC', 'BEN', 'ULC', 'CC'],
-                'blockerChecks': {
-                    'business': [BusinessBlocker.DEFAULT, BusinessBlocker.NOT_IN_GOOD_STANDING]
-                }
-            },
-            'alteration': {
-                'legalTypes': ['BC', 'BEN', 'ULC', 'CC'],
-                'blockerChecks': {
-                    'business': [BusinessBlocker.DEFAULT]
-                }
-            },
-            'amalgamationApplication': {
-                'businessRequirement': BusinessRequirement.NO_RESTRICTION,
-                'regular': {
-                    'legalTypes': ['BEN', 'BC', 'ULC', 'CC'],
-                    'blockerChecks': {
-                        'business': [BusinessBlocker.BUSINESS_FROZEN],
-                        'futureEffectiveFilings': ['dissolution']
-                    }
-                },
-                'vertical': {
-                    'legalTypes': ['BEN', 'BC', 'ULC', 'CC'],
-                    'blockerChecks': {
-                        'business': [BusinessBlocker.BUSINESS_FROZEN],
-                        'futureEffectiveFilings': ['dissolution']
-                    }
-                },
-                'horizontal': {
-                    'legalTypes': ['BEN', 'BC', 'ULC', 'CC'],
-                    'blockerChecks': {
-                        'business': [BusinessBlocker.BUSINESS_FROZEN],
-                        'futureEffectiveFilings': ['dissolution']
-                    }
-                }
-            },
-            'annualReport': {
-                'legalTypes': ['CP', 'BEN', 'BC', 'ULC', 'CC'],
-                'blockerChecks': {
-                    'business': [BusinessBlocker.DEFAULT]
-                }
-            },
-            'changeOfAddress': {
-                'legalTypes': ['CP', 'BEN', 'BC', 'ULC', 'CC'],
-                'blockerChecks': {
-                    'business': [BusinessBlocker.DEFAULT],
-                }
-            },
-            'changeOfDirectors': {
-                'legalTypes': ['CP', 'BEN', 'BC', 'ULC', 'CC'],
-                'blockerChecks': {
-                    'business': [BusinessBlocker.DEFAULT]
-                }
-            },
-            'changeOfRegistration': {
-                'legalTypes': ['SP', 'GP'],
-                'blockerChecks': {
-                    'warningTypes': [WarningType.MISSING_REQUIRED_BUSINESS_INFO],
-                    'business': [BusinessBlocker.DEFAULT]
-                }
-            },
-            'consentContinuationOut': {
-                'legalTypes': ['BC', 'BEN', 'CC', 'ULC'],
-                'blockerChecks': {
-                    'business': [BusinessBlocker.DEFAULT, BusinessBlocker.NOT_IN_GOOD_STANDING]
-                }
-            },
-            'dissolution': {
-                'voluntary': {
-                    'legalTypes': ['CP', 'BC', 'BEN', 'CC', 'ULC', 'SP', 'GP'],
-                    'blockerChecks': {
-                        'warningTypes': [WarningType.MISSING_REQUIRED_BUSINESS_INFO],
-                        'business': [BusinessBlocker.DEFAULT, BusinessBlocker.NOT_IN_GOOD_STANDING]
-                    }
-                },
-            },
-            'incorporationApplication': {
-                'legalTypes': ['CP', 'BC', 'BEN', 'ULC', 'CC'],
-                # only show filing when providing allowable filings not specific to a business
-                'businessRequirement': BusinessRequirement.NOT_EXIST
-            },
-            'registration': {
-                'legalTypes': ['SP', 'GP'],
-                # only show filing when providing allowable filings not specific to a business
-                'businessRequirement': BusinessRequirement.NOT_EXIST
-            },
-            'specialResolution': {
-                'legalTypes': ['CP'],
-                'blockerChecks': {
-                    'business': [BusinessBlocker.DEFAULT]
-                }
-            },
-            'transition': {
-                'legalTypes': ['BC', 'BEN', 'CC', 'ULC']
-            }
-        },
-        Business.State.HISTORICAL: {}
     }
-}
 
 
 # pylint: disable=(too-many-arguments,too-many-locals
@@ -483,7 +497,7 @@ def get_allowed_filings(business: Business,
 
     # doing this check up front to cache result
     business_blocker_dict: dict = business_blocker_check(business, is_ignore_draft_blockers)
-    allowable_filings = ALLOWABLE_FILINGS.get(user_role, {}).get(state, {})
+    allowable_filings = get_allowable_filings_dict().get(user_role, {}).get(state, {})
     allowable_filing_types = []
 
     for allowable_filing_key, allowable_filing_value in allowable_filings.items():
@@ -669,7 +683,7 @@ def has_blocker_future_effective_filing(business: Business, blocker_checks: dict
 
     pending_filings = Filing.get_filings_by_type_pairs(business.id,
                                                        filing_type_pairs,
-                                                       [Filing.Status.PENDING.value],
+                                                       [Filing.Status.PENDING.value, Filing.Status.PAID.value],
                                                        True)
 
     now = datetime.utcnow().replace(tzinfo=timezone.utc)
@@ -722,7 +736,7 @@ def get_allowed(state: Business.State, legal_type: str, jwt: JwtManager):
     if jwt.contains_role([STAFF_ROLE, SYSTEM_ROLE, COLIN_SVC_ROLE]):
         user_role = 'staff'
 
-    allowable_filings = ALLOWABLE_FILINGS.get(user_role, {}).get(state, {})
+    allowable_filings = get_allowable_filings_dict().get(user_role, {}).get(state, {})
     allowable_filing_types = []
     for allowable_filing_key, allowable_filing_value in allowable_filings.items():
         if legal_types := allowable_filing_value.get('legalTypes', None):


### PR DESCRIPTION
*Issue #:* /bcgov/entity#18784

*Description of changes:*

* Add PAID status to allowable actions blocker check for FED pending dissolution filings
* Update allowable actions config for amalgamation to explicitly pass in dissolution sub-type.  If this was't passed in, the underlying db query filters dissolutions out entirely
* Update unit tests to include dissolution sub-type and PAID status
* Created `FilingTypesCompact` in core filing to reduce code duplication that was being flagged by sonarcloud
* Updated `ALLOWABLE_FILINGS` to be returned in a function to access `FilingTypesCompact`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
