### PR TITLE
fix absolute path for requirement.txt in makefile

### DIFF
--- a/legal-api/Makefile
+++ b/legal-api/Makefile
@@ -49,11 +49,11 @@ install: clean ## Install python virtrual environment
 	test -f venv/bin/activate || python3 -m venv  $(CURRENT_ABS_DIR)/venv ;\
 	. venv/bin/activate ;\
 	pip install --upgrade pip ;\
-	pip install -Ur requirements.txt
+	pip install -Ur $(CURRENT_ABS_DIR)/requirements.txt
 
 install-dev: ## Install local application
 	. venv/bin/activate ; \
-	pip install -Ur requirements/dev.txt; \
+	pip install -Ur $(CURRENT_ABS_DIR)/requirements/dev.txt; \
 	pip install -e .
 
 #################################################################################


### PR DESCRIPTION
currently linting/tests are failing in gtihub actions due to makefie  failing to find requirements.txt in relative path

*Issue #:* /bcgov/entity###

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
