### PR TITLE
11550 - remove amalgamating information section for TING

### DIFF
--- a/legal-api/src/legal_api/reports/business_document.py
+++ b/legal-api/src/legal_api/reports/business_document.py
@@ -464,8 +464,11 @@ class BusinessDocument:
 
     def _set_amalgamating_details(self, business: dict):
         amalgamating_info = business.get('business', {}).get('amalgamatedInto')
+        amalgamated_entity = business.get('business', {}).get('amalgamatedEntity')
         if amalgamating_info:
             business['business']['isAmalgamating'] = True
+            if amalgamated_entity:
+                business['business']['amalgamatedEntity'] = False
 
     def _set_liquidation_details(self, business: dict):
         """Set partial liquidation filing data."""


### PR DESCRIPTION
*Issue #:* /bcgov/entity#11550

*Description of changes:*

Back to Yui's comment, remove "Amalgamating Corporations Information" section, only keep "Amalgamated Into" section for a business that is previously TED and then TING now
# now
<img width="1025" alt="MicrosoftTeams-image (6)" src="https://github.com/bcgov/lear/assets/144159934/0f46d106-815d-46a9-905f-37cd0a42d56f">

# previously 

<img width="1029" alt="MicrosoftTeams-image (7)" src="https://github.com/bcgov/lear/assets/144159934/6e38fe85-8d7e-4e1e-b04c-46b665a5e448">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
