### PR TITLE
18802 added spacing to amalgamating corp information

### DIFF
--- a/legal-api/report-templates/template-parts/amalgamation/amalgamatingCorp.html
+++ b/legal-api/report-templates/template-parts/amalgamation/amalgamatingCorp.html
@@ -15,12 +15,12 @@
     {% for entity in amalgamatingBusinesses %}
         <tr class="no-page-break">
         <td class="col-50">
-            <div class="{{'upper-text' if entity.legalName!='Not Available'}}">
+            <div class="{{'upper-text' if entity.legalName!='Not Available'}} pt-2">
                 {{ entity.name }}
             </div>
         </td>
         <td class="col-50">
-            <div class="{{'upper-text' if entity.identifier!='Not Available'}}">
+            <div class="{{'upper-text' if entity.identifier!='Not Available'}} pt-2">
                 {{ entity.identifier }}
             </div>
         </td>


### PR DESCRIPTION
*Issue #:* /bcgov/entity#18802

*Description of changes:*

- Similar to Shaoyun's previous PR, applied the changes that spaced out the amalgamating corp information correctly according to UX.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
