### PR TITLE
19346 Update alternate_names and other tables + misc script updates

### DIFF
--- a/legal-api/scripts/manual_db_scripts/legal_name_change/legal_name_updates.sql
+++ b/legal-api/scripts/manual_db_scripts/legal_name_change/legal_name_updates.sql
@@ -1498,6 +1498,10 @@ DROP FUNCTION has_non_legal_name_change;
 DROP FUNCTION update_filing_json_party_ids;
 DROP FUNCTION rename_jsonb_key;
 DROP FUNCTION update_legal_name;
+DROP FUNCTION cast_le_to_leh;
+DROP FUNCTION get_previous_le_history_entry;
+DROP FUNCTION insert_into_leh;
+DROP EXTENSION hstore;
 ALTER TABLE legal_entities
     DROP COLUMN temp_party_id;
 ALTER TABLE colin_entities


### PR DESCRIPTION
*Issue #:* /bcgov/entity#19346

*Description of changes:*

* Addition of following columns to alternate_names/alternate_names_history tables
  * business_start_date
  * dissolution_date
  * state
  * state_filing_id
  * admin_freeze
  * last_modified
* Addition of required FKs and indexes to  alternate_names/alternate_names_history tables
*  Add alternate_name_id column to following tables and corresponding FK entry
  * comments
  * request_tracker
  * filings
  * dc_connections
  * dc_issued_business_user_credentials
  * documents/document_versions
 * Misc cleanup of temp functions + extensions created by migrations scripts

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
