### PR TITLE
19453 added legalName field to draft_results to link with auth-api

### DIFF
--- a/legal-api/src/legal_api/resources/v2/business/business.py
+++ b/legal-api/src/legal_api/resources/v2/business/business.py
@@ -173,7 +173,9 @@ def search_businesses():
             {
                 'identifier': x.temp_reg,
                 'legalType': x.json_legal_type,
-                **({'nrNumber': x.json_nr} if x.json_nr else {})
+                **({'nrNumber': x.json_nr} if x.json_nr else {}),
+                **({'legalName': x.filing_json.get('filing', {}).get(x.filing_type).get('nameRequest', {}).get('legalName')}
+                   if x.filing_type == 'amalgamationApplication' else {})
             } for x in draft_query.all()]
 
         return jsonify({'businessEntities': bus_results, 'draftEntities': draft_results}), HTTPStatus.OK

--- a/legal-api/src/legal_api/resources/v2/business/business.py
+++ b/legal-api/src/legal_api/resources/v2/business/business.py
@@ -174,7 +174,9 @@ def search_businesses():
                 'identifier': x.temp_reg,
                 'legalType': x.json_legal_type,
                 **({'nrNumber': x.json_nr} if x.json_nr else {}),
-                **({'legalName': x.filing_json.get('filing', {}).get(x.filing_type).get('nameRequest', {}).get('legalName')}
+                **({'legalName': x.filing_json.get('filing', {})
+                    .get(x.filing_type).get('nameRequest', {})
+                    .get('legalName')}
                    if x.filing_type == 'amalgamationApplication' else {})
             } for x in draft_query.all()]
 

--- a/legal-api/src/legal_api/resources/v2/business/business.py
+++ b/legal-api/src/legal_api/resources/v2/business/business.py
@@ -175,9 +175,8 @@ def search_businesses():
                 'legalType': x.json_legal_type,
                 **({'nrNumber': x.json_nr} if x.json_nr else {}),
                 **({'legalName': x.filing_json.get('filing', {})
-                    .get(x.filing_type).get('nameRequest', {})
-                    .get('legalName')}
-                   if x.filing_type == 'amalgamationApplication' else {})
+                    .get('nameRequest', {})
+                    .get('legalName')})
             } for x in draft_query.all()]
 
         return jsonify({'businessEntities': bus_results, 'draftEntities': draft_results}), HTTPStatus.OK

--- a/legal-api/src/legal_api/resources/v2/business/business.py
+++ b/legal-api/src/legal_api/resources/v2/business/business.py
@@ -175,6 +175,7 @@ def search_businesses():
                 'legalType': x.json_legal_type,
                 **({'nrNumber': x.json_nr} if x.json_nr else {}),
                 **({'legalName': x.filing_json.get('filing', {})
+                    .get(x.filing_type, {})
                     .get('nameRequest', {})
                     .get('legalName')})
             } for x in draft_query.all()]

--- a/legal-api/tests/unit/resources/v2/test_business.py
+++ b/legal-api/tests/unit/resources/v2/test_business.py
@@ -376,7 +376,8 @@ def test_post_affiliated_businesses(session, client, jwt):
         json_data['filing']['header']['legalType'] = draft_business[2]
         if draft_business[3]:
             json_data['filing'][filing_name] = {
-                'nameRequest': {'nrNumber': draft_business[3]}
+                'nameRequest': {'nrNumber': draft_business[3],
+                                'legalName': 'name example'}
             }
         if filing_name == 'amalgamationApplication':
             json_data['filing'][filing_name] = {
@@ -399,6 +400,16 @@ def test_post_affiliated_businesses(session, client, jwt):
     assert len(rv.json['businessEntities']) == len(businesses)
     assert len(rv.json['draftEntities']) == len(draft_businesses) - len(old_draft_businesses)
 
+    # verify 'legalName' for each draft entity
+    for draft_entity in rv.json['draftEntities']:
+        identifier = draft_entity['identifier']
+        expected_draft_business = next((draftb for draftb in draft_businesses if draftb[0] == identifier), None)
+        if expected_draft_business and expected_draft_business[3]:
+            # if NR number is present, assert 'legalName' is also expected to be present
+            assert 'legalName' in draft_entity
+        else:
+            # assert 'legalName' is None or empty if no NR number is provided
+            assert draft_entity.get('legalName') is None or draft_entity.get('legalName') == ''
 
 def test_post_affiliated_businesses_unathorized(session, client, jwt):
     """Assert that the affiliated businesses endpoint unauthorized if not a system token."""


### PR DESCRIPTION
*Issue #:* /bcgov/entity#19453

*Description of changes:*

- added legalName field to draft_results to link with auth-api

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
