### PR TITLE
19360 Update migration scripts to populate person identifiers

### DIFF
--- a/legal-api/migrations/versions/3d8eb786f4c2_add_sequences.py
+++ b/legal-api/migrations/versions/3d8eb786f4c2_add_sequences.py
@@ -19,8 +19,10 @@ depends_on = None
 def upgrade():
     op.execute("CREATE SEQUENCE legal_entity_identifier_coop START 1002395")
     op.execute("CREATE SEQUENCE legal_entity_identifier_sp_gp START 1002395")
+    op.execute("CREATE SEQUENCE legal_entity_identifier_person START 1002395")
 
 
 def downgrade():
     op.execute("DROP SEQUENCE legal_entity_identifier_coop")
     op.execute("DROP SEQUENCE legal_entity_identifier_sp_gp")
+    op.execute("DROP SEQUENCE legal_entity_identifier_person")

--- a/legal-api/scripts/manual_db_scripts/legal_name_change/transfer_to_new_lear.sql
+++ b/legal-api/scripts/manual_db_scripts/legal_name_change/transfer_to_new_lear.sql
@@ -963,6 +963,9 @@ SELECT setval('legal_entity_identifier_coop', (select MAX(CAST(substring(identif
 SELECT setval('legal_entity_identifier_sp_gp', (select MAX(CAST(substring(identifier, '(1[0-9]{6})') AS INTEGER)) + 1
                                                 from legal_entities
                                                 where entity_type in ('SP', 'GP')));
+SELECT setval('legal_entity_identifier_person', (select MAX(CAST(substring(identifier, '(1[0-9]{6})') AS INTEGER)) + 1
+                                                from legal_entities
+                                                where lower(entity_type) = 'person'));
 SELECT setval('filings_id_seq', (select coalesce(max(id) + 1, 1) FROM public.filings));
 SELECT setval('addresses_id_seq', (select coalesce(max(id) + 1, 1) FROM public.addresses));
 SELECT setval('aliases_id_seq', (select coalesce(max(id) + 1, 1) FROM public.aliases));


### PR DESCRIPTION
*Issue #:* /bcgov/entity#19360

*Description of changes:*
- add sequence `legal_entity_identifier_person`
- populate person identifiers for tables `legal_entities` and `legal_entities_history`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
