### PR TITLE
19193 - Bumped legal api version to test GCP CD

### DIFF
--- a/legal-api/src/legal_api/version.py
+++ b/legal-api/src/legal_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = "2.99.0"  # pylint: disable=invalid-name
+__version__ = "2.100.0"  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:* /bcgov/entity#19193

*Description of changes:*
Currently, the meta endpoint for the GCP endpoint returns the following: 
![legal api v2](https://github.com/bcgov/lear/assets/122301442/e67159e7-ecbc-4478-8e93-b5bb1dc22352)

We're hoping that after this PR is merged, the CD will automatically run and the meta endpoint will return 2.100.0 for the legal-api version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
