### PR TITLE
Updated migration script to fix unmatched firm owner data

### DIFF
--- a/legal-api/scripts/manual_db_scripts/legal_name_change/legal_name_updates.sql
+++ b/legal-api/scripts/manual_db_scripts/legal_name_change/legal_name_updates.sql
@@ -403,17 +403,10 @@ select distinct ph.id                                                           
                     and ph.party_type = 'organization'
                     and
                  le.id is not null)                                                             is_business_party_org_match,
-                ((r.id is null
+                (r.id is null
                     and pr.filing_id is null
                     and le.id is null
-                    and ph.party_type = 'organization'
-                    and (ph.identifier is not null and ph.identifier != '' and ph.identifier not like 'FM%')
-                    ) or (r.id is null
-                      and pr.filing_id is null
-                      and ph.party_type = 'organization'
-                      and le.id is null
-                      and (ph.identifier is null or ph.identifier = '' or ph.identifier like 'FM%')
-                    ))                                                                          is_business_party_colin_entity,
+                    and ph.party_type = 'organization')                                         is_business_party_colin_entity,
                 (r.id is null and pr.filing_id is not null)                                     is_filing_party,
                 (r.id is not null and pr.id is null)                                            is_resolution_party,
                 ph.version,
@@ -471,17 +464,10 @@ select distinct p.id                                                            
                     and p.party_type = 'organization'
                     and
                  le.id is not null)                                                            is_business_party_org_match,
-                ((r.id is null
+                (r.id is null
                     and pr.filing_id is null
                     and le.id is null
-                    and p.party_type = 'organization'
-                    and (p.identifier is not null and p.identifier != '' and p.identifier not like 'FM%')
-                    ) or (r.id is null
-                      and pr.filing_id is null
-                      and p.party_type = 'organization'
-                      and le.id is null
-                      and (p.identifier is null or p.identifier = '' or p.identifier like 'FM%')
-                    ))                                                                         is_business_party_colin_entity,
+                    and p.party_type = 'organization')                                         is_business_party_colin_entity,
                 (r.id is null and pr.filing_id is not null)                                    is_filing_party,
                 (r.id is not null and pr.id is null)                                           is_resolution_party,
                 p.version,

--- a/legal-api/scripts/manual_db_scripts/legal_name_change/legal_name_updates.sql
+++ b/legal-api/scripts/manual_db_scripts/legal_name_change/legal_name_updates.sql
@@ -413,7 +413,7 @@ select distinct ph.id                                                           
                       and ph.party_type = 'organization'
                       and le.id is null
                       and (ph.identifier is null or ph.identifier = '' or ph.identifier like 'FM%')
-                    ))                                                                           is_business_party_colin_entity,
+                    ))                                                                          is_business_party_colin_entity,
                 (r.id is null and pr.filing_id is not null)                                     is_filing_party,
                 (r.id is not null and pr.id is null)                                            is_resolution_party,
                 ph.version,

--- a/legal-api/scripts/manual_db_scripts/legal_name_change/legal_name_updates.sql
+++ b/legal-api/scripts/manual_db_scripts/legal_name_change/legal_name_updates.sql
@@ -403,12 +403,17 @@ select distinct ph.id                                                           
                     and ph.party_type = 'organization'
                     and
                  le.id is not null)                                                             is_business_party_org_match,
-                (r.id is null
+                ((r.id is null
                     and pr.filing_id is null
                     and le.id is null
                     and ph.party_type = 'organization'
                     and (ph.identifier is not null and ph.identifier != '' and ph.identifier not like 'FM%')
-                    )                                                                           is_business_party_colin_entity,
+                    ) or (r.id is null
+                      and pr.filing_id is null
+                      and ph.party_type = 'organization'
+                      and le.id is null
+                      and (ph.identifier is null or ph.identifier = '' or ph.identifier like 'FM%')
+                    ))                                                                           is_business_party_colin_entity,
                 (r.id is null and pr.filing_id is not null)                                     is_filing_party,
                 (r.id is not null and pr.id is null)                                            is_resolution_party,
                 ph.version,
@@ -466,12 +471,17 @@ select distinct p.id                                                            
                     and p.party_type = 'organization'
                     and
                  le.id is not null)                                                            is_business_party_org_match,
-                (r.id is null
+                ((r.id is null
                     and pr.filing_id is null
                     and le.id is null
                     and p.party_type = 'organization'
                     and (p.identifier is not null and p.identifier != '' and p.identifier not like 'FM%')
-                    )                                                                          is_business_party_colin_entity,
+                    ) or (r.id is null
+                      and pr.filing_id is null
+                      and p.party_type = 'organization'
+                      and le.id is null
+                      and (p.identifier is null or p.identifier = '' or p.identifier like 'FM%')
+                    ))                                                                         is_business_party_colin_entity,
                 (r.id is null and pr.filing_id is not null)                                    is_filing_party,
                 (r.id is not null and pr.id is null)                                           is_resolution_party,
                 p.version,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#19685

*Description of changes:*
- If owner of SP DBA does not match a LEAR business, a colin entity is now created and the DBA is owned by the colin entity
- If a non-person partner entry for a GP does not match a LEAR business, a colin entity is now created and the entity role correctly references the colin entity id.
- Verified changes (below). Please let me know if I'm missing something.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
