### PR TITLE
19826 Update remaining business endpoints to work with alternate name

### DIFF
--- a/legal-api/src/legal_api/resources/v2/business/business.py
+++ b/legal-api/src/legal_api/resources/v2/business/business.py
@@ -163,13 +163,11 @@ def search_businesses():
 
         # base legal entity query
         bus_le_query = db.session.query(LegalEntity).filter(
-            LegalEntity._identifier.in_(identifiers)
-        )  # noqa: E501; pylint: disable=protected-access
+            LegalEntity._identifier.in_(identifiers)  # noqa: E501; pylint: disable=protected-access
+        )
 
         # base alternate name query
-        bus_an_query = db.session.query(AlternateName).filter(
-            AlternateName.identifier.in_(identifiers)
-        )  # noqa: E501; pylint: disable=protected-access
+        bus_an_query = db.session.query(AlternateName).filter(AlternateName.identifier.in_(identifiers))
 
         # base filings query (for draft incorporation/registration filings -- treated as 'draft' business in auth-web)
         draft_query = db.session.query(Filing).filter(


### PR DESCRIPTION
*Issue #:* /bcgov/entity#19816

*Description of changes:*
- Updated POST /search endpoint to work with alternate names.
- For the POST /businesses endpoint:
  - It does not appear to use `LegalEntity` or `AlternateName` specific code (and neither does the `RegistrationBootstrapService` which is used in this endpoint), so no updates were made. 
  - When testing it seems to work fine up until the `auth_url` POSTs in [`create_affiliation`](https://github.com/bcgov/lear/blob/feature-legal-name/legal-api/src/legal_api/services/bootstrap.py#L137). It probably fails here because I do not have an accountId and access token combo that work together for the auth requests. It should be fine anyway since that is the last step before saving the filing (which is already updated).

**Tests**
POST
{{url}}/api/v2/businesses/search

Body:
```
{
    // Identifiers can be commented out to test individual scenarios, or can search all at once.
    "identifiers": [
        // COOP
        "CP1002603",
        // BEN - no DBAs
        "BC0871269",
        // BEN - multiple DBAs
        "BC1230010",
        // SP - individual
        "FM1028594",
        // SP - LEAR DBA
        "FM1054864",
        // SP - COLIN DBA
        "FM1061225",
        // GP - 2 partners - 2 persons
        "FM1018902",
        // GP - 2 partners - 1 person + 1 LEAR org, 1 DBA
        "FM1044962",
        // GP - 2 partners - 1 person + 1 COLIN org
        "FM1000001",
        // draft incorporation application
        "TgsaSsV3mZ",
        // draft registration
        "TkFajOEnfU"
    ]
}
```

Results: Each identifier above returns an entry.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
