### PR TITLE
19934 - bring in latest amalgamation table changes

### DIFF
--- a/legal-api/migrations/versions/5238dd8fb805_.py
+++ b/legal-api/migrations/versions/5238dd8fb805_.py
@@ -16,18 +16,18 @@ down_revision = '60d9c14c2b7f'
 branch_labels = None
 depends_on = None
 
-role_enum = postgresql.ENUM('amalgamating', 'holding', 'primary', name='amalgamating_businesses_role')
-amalgamations_type_enum = postgresql.ENUM('regular',
+role_enum = postgresql.ENUM('amalgamating', 'holding', 'primary', name='amalgamating_business_role')
+amalgamation_type_enum = postgresql.ENUM('regular',
                                          'vertical',
                                          'horizontal',
-                                         name='amalgamations_type')
+                                         name='amalgamation_type')
 
 
 def upgrade():
 
     # add enum values
     role_enum.create(op.get_bind(), checkfirst=True)
-    amalgamations_type_enum.create(op.get_bind(), checkfirst=True)
+    amalgamation_type_enum.create(op.get_bind(), checkfirst=True)
 
     # ==========================================================================================
     # amalgamating_businesses/amalgamations tables
@@ -38,26 +38,26 @@ def upgrade():
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('legal_entity_id', sa.Integer(), nullable=False),
         sa.Column('filing_id', sa.Integer(), nullable=False),
-        sa.Column('amalgamations_date', sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column('amalgamation_date', sa.TIMESTAMP(timezone=True), nullable=False),
         sa.Column('court_approval', sa.Boolean(), nullable=False),
         sa.ForeignKeyConstraint(['filing_id'], ['filings.id']),
         sa.ForeignKeyConstraint(['legal_entity_id'], ['legal_entities.id']),
         sa.PrimaryKeyConstraint('id'))
 
     # enum added after creating table as DuplicateObject error would be thrown otherwise
-    op.add_column('amalgamations', sa.Column('amalgamations_type', amalgamations_type_enum, nullable=False))
+    op.add_column('amalgamations', sa.Column('amalgamation_type', amalgamation_type_enum, nullable=False))
 
     op.create_table(
         'amalgamating_businesses',
         sa.Column('id', sa.Integer(), primary_key=False),
         sa.Column('legal_entity_id', sa.Integer(), nullable=True),
-        sa.Column('amalgamations_id', sa.Integer(), nullable=False),
+        sa.Column('amalgamation_id', sa.Integer(), nullable=False),
         sa.Column('foreign_jurisdiction', sa.String(length=10), nullable=True),
         sa.Column('foreign_jurisdiction_region', sa.String(length=10), nullable=True),
         sa.Column('foreign_name', sa.String(length=100), nullable=True),
         sa.Column('foreign_identifier', sa.String(length=50), nullable=True),
         sa.ForeignKeyConstraint(['legal_entity_id'], ['legal_entities.id']),
-        sa.ForeignKeyConstraint(['amalgamations_id'], ['amalgamations.id']),
+        sa.ForeignKeyConstraint(['amalgamation_id'], ['amalgamations.id']),
         sa.PrimaryKeyConstraint('id'))
 
     # enum added after creating table as DuplicateObject error would be thrown otherwise
@@ -69,5 +69,5 @@ def downgrade():
     op.drop_table('amalgamations')
 
     # Drop enum types from the database
-    amalgamations_type_enum.drop(op.get_bind(), checkfirst=True)
+    amalgamation_type_enum.drop(op.get_bind(), checkfirst=True)
     role_enum.drop(op.get_bind(), checkfirst=True)

--- a/legal-api/migrations/versions/5238dd8fb805_.py
+++ b/legal-api/migrations/versions/5238dd8fb805_.py
@@ -16,21 +16,21 @@ down_revision = '60d9c14c2b7f'
 branch_labels = None
 depends_on = None
 
-role_enum = postgresql.ENUM('amalgamating', 'holding', 'primary', name='amalgamating_business_role')
-amalgamation_type_enum = postgresql.ENUM('regular',
+role_enum = postgresql.ENUM('amalgamating', 'holding', 'primary', name='amalgamating_businesses_role')
+amalgamations_type_enum = postgresql.ENUM('regular',
                                          'vertical',
                                          'horizontal',
-                                         name='amalgamation_type')
+                                         name='amalgamations_type')
 
 
 def upgrade():
 
     # add enum values
     role_enum.create(op.get_bind(), checkfirst=True)
-    amalgamation_type_enum.create(op.get_bind(), checkfirst=True)
+    amalgamations_type_enum.create(op.get_bind(), checkfirst=True)
 
     # ==========================================================================================
-    # amalgamating_business/amalgamation tables
+    # amalgamating_businesses/amalgamations tables
     # ==========================================================================================
 
     op.create_table(
@@ -38,26 +38,26 @@ def upgrade():
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('legal_entity_id', sa.Integer(), nullable=False),
         sa.Column('filing_id', sa.Integer(), nullable=False),
-        sa.Column('amalgamation_date', sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column('amalgamations_date', sa.TIMESTAMP(timezone=True), nullable=False),
         sa.Column('court_approval', sa.Boolean(), nullable=False),
         sa.ForeignKeyConstraint(['filing_id'], ['filings.id']),
         sa.ForeignKeyConstraint(['legal_entity_id'], ['legal_entities.id']),
         sa.PrimaryKeyConstraint('id'))
 
     # enum added after creating table as DuplicateObject error would be thrown otherwise
-    op.add_column('amalgamations', sa.Column('amalgamation_type', amalgamation_type_enum, nullable=False))
+    op.add_column('amalgamations', sa.Column('amalgamations_type', amalgamations_type_enum, nullable=False))
 
     op.create_table(
         'amalgamating_businesses',
         sa.Column('id', sa.Integer(), primary_key=False),
         sa.Column('legal_entity_id', sa.Integer(), nullable=True),
-        sa.Column('amalgamation_id', sa.Integer(), nullable=False),
+        sa.Column('amalgamations_id', sa.Integer(), nullable=False),
         sa.Column('foreign_jurisdiction', sa.String(length=10), nullable=True),
         sa.Column('foreign_jurisdiction_region', sa.String(length=10), nullable=True),
         sa.Column('foreign_name', sa.String(length=100), nullable=True),
         sa.Column('foreign_identifier', sa.String(length=50), nullable=True),
         sa.ForeignKeyConstraint(['legal_entity_id'], ['legal_entities.id']),
-        sa.ForeignKeyConstraint(['amalgamation_id'], ['amalgamation.id']),
+        sa.ForeignKeyConstraint(['amalgamations_id'], ['amalgamations.id']),
         sa.PrimaryKeyConstraint('id'))
 
     # enum added after creating table as DuplicateObject error would be thrown otherwise
@@ -69,5 +69,5 @@ def downgrade():
     op.drop_table('amalgamations')
 
     # Drop enum types from the database
-    amalgamation_type_enum.drop(op.get_bind(), checkfirst=True)
+    amalgamations_type_enum.drop(op.get_bind(), checkfirst=True)
     role_enum.drop(op.get_bind(), checkfirst=True)

--- a/legal-api/migrations/versions/5238dd8fb805_.py
+++ b/legal-api/migrations/versions/5238dd8fb805_.py
@@ -34,7 +34,7 @@ def upgrade():
     # ==========================================================================================
 
     op.create_table(
-        'amalgamation',
+        'amalgamations',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('legal_entity_id', sa.Integer(), nullable=False),
         sa.Column('filing_id', sa.Integer(), nullable=False),
@@ -45,28 +45,28 @@ def upgrade():
         sa.PrimaryKeyConstraint('id'))
 
     # enum added after creating table as DuplicateObject error would be thrown otherwise
-    op.add_column('amalgamation', sa.Column('amalgamation_type', amalgamation_type_enum, nullable=False))
+    op.add_column('amalgamations', sa.Column('amalgamation_type', amalgamation_type_enum, nullable=False))
 
     op.create_table(
-        'amalgamating_business',
+        'amalgamating_businesses',
         sa.Column('id', sa.Integer(), primary_key=False),
         sa.Column('legal_entity_id', sa.Integer(), nullable=True),
         sa.Column('amalgamation_id', sa.Integer(), nullable=False),
         sa.Column('foreign_jurisdiction', sa.String(length=10), nullable=True),
         sa.Column('foreign_jurisdiction_region', sa.String(length=10), nullable=True),
         sa.Column('foreign_name', sa.String(length=100), nullable=True),
-        sa.Column('foreign_corp_num', sa.String(length=50), nullable=True),
+        sa.Column('foreign_identifier', sa.String(length=50), nullable=True),
         sa.ForeignKeyConstraint(['legal_entity_id'], ['legal_entities.id']),
         sa.ForeignKeyConstraint(['amalgamation_id'], ['amalgamation.id']),
         sa.PrimaryKeyConstraint('id'))
 
     # enum added after creating table as DuplicateObject error would be thrown otherwise
-    op.add_column('amalgamating_business', sa.Column('role', role_enum, nullable=False))
+    op.add_column('amalgamating_businesses', sa.Column('role', role_enum, nullable=False))
 
 
 def downgrade():
-    op.drop_table('amalgamating_business')
-    op.drop_table('amalgamation')
+    op.drop_table('amalgamating_businesses')
+    op.drop_table('amalgamations')
 
     # Drop enum types from the database
     amalgamation_type_enum.drop(op.get_bind(), checkfirst=True)

--- a/legal-api/scripts/manual_db_scripts/legal_name_change/transfer_to_new_lear.sql
+++ b/legal-api/scripts/manual_db_scripts/legal_name_change/transfer_to_new_lear.sql
@@ -925,25 +925,25 @@ FROM public.sent_to_gazette stg;
 
 
 -- amalgamation -> amalgamations
-CREATE CAST (varchar AS amalgamations_type) WITH INOUT AS IMPLICIT;
+CREATE CAST (varchar AS amalgamation_type) WITH INOUT AS IMPLICIT;
 
 transfer public.amalgamations from lear_old using
 SELECT  id,
         business_id as legal_entity_id,
         filing_id,
-        amalgamation_date as amalgamations_date,
-        amalgamation_type as amalgamations_type,
+        amalgamation_date,
+        amalgamation_type,
         court_approval
 FROM public.amalgamation;
 
 
 -- amalgamating_business -> amalgamating_businesses
-CREATE CAST (varchar AS amalgamating_businesses_role) WITH INOUT AS IMPLICIT;
+CREATE CAST (varchar AS amalgamating_business_role) WITH INOUT AS IMPLICIT;
 
 transfer public.amalgamating_businesses from lear_old using
 SELECT id,
        business_id as legal_entity_id,
-       amalgamation_id as amalgamations_id,
+       amalgamation_id,
        foreign_jurisdiction,
        foreign_jurisdiction_region,
        foreign_name,
@@ -1001,8 +1001,8 @@ DROP CAST (varchar AS state);
 DROP CAST (varchar AS credentialtype);
 DROP CAST (varchar AS requesttype);
 DROP CAST (varchar AS servicename);
-DROP CAST (varchar AS amalgamations_type);
-DROP CAST (varchar AS amalgamating_businesses_role);
+DROP CAST (varchar AS amalgamation_type);
+DROP CAST (varchar AS amalgamating_business_role);
 
 
 -- *****************************************************************************************************************

--- a/legal-api/scripts/manual_db_scripts/legal_name_change/transfer_to_new_lear.sql
+++ b/legal-api/scripts/manual_db_scripts/legal_name_change/transfer_to_new_lear.sql
@@ -924,10 +924,10 @@ SELECT stg.filing_id,
 FROM public.sent_to_gazette stg;
 
 
--- amalgamation -> amalgamation
+-- amalgamation -> amalgamations
 CREATE CAST (varchar AS amalgamation_type) WITH INOUT AS IMPLICIT;
 
-transfer public.amalgamation from lear_old using
+transfer public.amalgamations from lear_old using
 SELECT  id,
         business_id as legal_entity_id,
         filing_id,
@@ -937,17 +937,17 @@ SELECT  id,
 FROM public.amalgamation;
 
 
--- amalgamating_business -> amalgamating_business
+-- amalgamating_business -> amalgamating_businesses
 CREATE CAST (varchar AS amalgamating_business_role) WITH INOUT AS IMPLICIT;
 
-transfer public.amalgamating_business from lear_old using
+transfer public.amalgamating_businesses from lear_old using
 SELECT id,
        business_id as legal_entity_id,
        amalgamation_id,
        foreign_jurisdiction,
        foreign_jurisdiction_region,
        foreign_name,
-       foreign_corp_num,
+       foreign_corp_num as foreign_identifier,
        role :: amalgamating_business_role
 FROM public.amalgamating_business;
 

--- a/legal-api/scripts/manual_db_scripts/legal_name_change/transfer_to_new_lear.sql
+++ b/legal-api/scripts/manual_db_scripts/legal_name_change/transfer_to_new_lear.sql
@@ -925,25 +925,25 @@ FROM public.sent_to_gazette stg;
 
 
 -- amalgamation -> amalgamations
-CREATE CAST (varchar AS amalgamation_type) WITH INOUT AS IMPLICIT;
+CREATE CAST (varchar AS amalgamations_type) WITH INOUT AS IMPLICIT;
 
 transfer public.amalgamations from lear_old using
 SELECT  id,
         business_id as legal_entity_id,
         filing_id,
-        amalgamation_date,
-        amalgamation_type,
+        amalgamation_date as amalgamations_date,
+        amalgamation_type as amalgamations_type,
         court_approval
 FROM public.amalgamation;
 
 
 -- amalgamating_business -> amalgamating_businesses
-CREATE CAST (varchar AS amalgamating_business_role) WITH INOUT AS IMPLICIT;
+CREATE CAST (varchar AS amalgamating_businesses_role) WITH INOUT AS IMPLICIT;
 
 transfer public.amalgamating_businesses from lear_old using
 SELECT id,
        business_id as legal_entity_id,
-       amalgamation_id,
+       amalgamation_id as amalgamations_id,
        foreign_jurisdiction,
        foreign_jurisdiction_region,
        foreign_name,
@@ -990,8 +990,8 @@ SELECT setval('colin_entities_id_seq', (select coalesce(max(id) + 1, 1) FROM pub
 SELECT setval('alternate_names_id_seq', (select coalesce(max(id) + 1, 1) FROM public.alternate_names));
 SELECT setval('users_id_seq', (select coalesce(max(id) + 1, 1) FROM public.users));
 SELECT setval('consent_continuation_outs_id_seq', (select coalesce(max(id) + 1, 1) FROM public.consent_continuation_outs));
-SELECT setval('amalgamating_business_id_seq', (select coalesce(max(id) + 1, 1) FROM public.amalgamating_business));
-SELECT setval('amalgamation_id_seq', (select coalesce(max(id) + 1, 1) FROM public.amalgamation));
+SELECT setval('amalgamating_businesses_id_seq', (select coalesce(max(id) + 1, 1) FROM public.amalgamating_businesses));
+SELECT setval('amalgamations_id_seq', (select coalesce(max(id) + 1, 1) FROM public.amalgamations));
 SELECT setval('naics_elements_id_seq', (select coalesce(max(id) + 1, 1) FROM public.naics_elements));
 SELECT setval('naics_structures_id_seq', (select coalesce(max(id) + 1, 1) FROM public.naics_structures));
 SELECT setval('sent_to_gazette_filing_id_seq', (select coalesce(max(filing_id) + 1, 1) FROM public.sent_to_gazette));
@@ -1001,8 +1001,8 @@ DROP CAST (varchar AS state);
 DROP CAST (varchar AS credentialtype);
 DROP CAST (varchar AS requesttype);
 DROP CAST (varchar AS servicename);
-DROP CAST (varchar AS amalgamation_type);
-DROP CAST (varchar AS amalgamating_business_role);
+DROP CAST (varchar AS amalgamations_type);
+DROP CAST (varchar AS amalgamating_businesses_role);
 
 
 -- *****************************************************************************************************************

--- a/legal-api/src/legal_api/models/amalgamating_business.py
+++ b/legal-api/src/legal_api/models/amalgamating_business.py
@@ -34,7 +34,7 @@ class AmalgamatingBusiness(db.Model):  # pylint: disable=too-many-instance-attri
         primary = auto()
 
     # __versioned__ = {}
-    __tablename__ = "amalgamating_business"
+    __tablename__ = "amalgamating_businesses"
 
     id = db.Column(db.Integer, primary_key=True)
     role = db.Column("role", db.Enum(Role), nullable=False)

--- a/legal-api/src/legal_api/models/amalgamation.py
+++ b/legal-api/src/legal_api/models/amalgamation.py
@@ -35,7 +35,7 @@ class Amalgamation(db.Model):  # pylint: disable=too-many-instance-attributes
         horizontal = auto()
 
     # __versioned__ = {}
-    __tablename__ = "amalgamation"
+    __tablename__ = "amalgamations"
 
     id = db.Column(db.Integer, primary_key=True)
     amalgamation_type = db.Column("amalgamation_type", db.Enum(AmalgamationTypes), nullable=False)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#19934

*Description of changes:*

- change `foreign_corp_num` column name to `foreign_identifier` in `amalgamating_businesses` table
- change `amalgamating_business` table name to `amalgamating_businesses` and `amalgamation` to `amalgamations` and corresponding columns in those two tables
- update `transfer_to_new_lear.sql`


For now `amalgamations` table looks like 
<img width="789" alt="image" src="https://github.com/bcgov/lear/assets/144159934/d0044596-5b13-48c2-80ea-9cf54cf31647">
`amalgamating_businesses` table looks like 
<img width="1223" alt="image" src="https://github.com/bcgov/lear/assets/144159934/1a123dfa-88c0-4d51-9d0f-b75f8941873d">




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
