### PR TITLE
15285 update state filing id in putbackon

### DIFF
--- a/queue_services/entity-filer/src/entity_filer/filing_processors/put_back_on.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/put_back_on.py
@@ -41,4 +41,4 @@ def process(business: Business,  filing: Dict, filing_rec: Filing, filing_meta: 
 
     business.state = Business.State.ACTIVE
     business.dissolution_date = None
-    business.state_filing_id = None
+    business.state_filing_id = filing_rec.id

--- a/queue_services/entity-filer/tests/unit/filing_processors/test_put_back_on.py
+++ b/queue_services/entity-filer/tests/unit/filing_processors/test_put_back_on.py
@@ -49,6 +49,6 @@ def test_worker_put_back_on(app, session):
     final_filing = Filing.find_by_id(filing.id)
 
     assert business.state == Business.State.ACTIVE
-    assert business.state_filing_id is None
+    assert business.state_filing_id == final_filing.id
     assert business.dissolution_date is None
     assert filing_json['filing']['putBackOn']['details'] == final_filing.order_details


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15285

*Description of changes:*

Post deployment script to update existing business with state_filing_id:
```
with business_with_pbo as (
	select f.business_id from public.filings f
	join public.businesses b on b.id = f.business_id
	where f.filing_type='putBackOn' and b.state = 'ACTIVE' and b.state_filing_id is null
),
last_pbo_filing as (
	select f.business_id, f.id, f.filing_type, rank() over (partition by f.business_id order by f.filing_date desc, f.effective_date desc) as r
	from public.filings f 
	where f.business_id in (select business_id from business_with_pbo) and f.filing_type='putBackOn'
)

update public.businesses b set state_filing_id = f.id
from public.filings f
where f.id in (select id from last_pbo_filing where r = 1) and f.business_id = b.id;
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
