### PR TITLE
19429 update migration scripts to populate SP addresses and other related stuff

### DIFF
--- a/legal-api/scripts/manual_db_scripts/legal_name_change/legal_name_updates.sql
+++ b/legal-api/scripts/manual_db_scripts/legal_name_change/legal_name_updates.sql
@@ -1618,7 +1618,7 @@ WITH subquery AS (
         o.alternate_name_id
     FROM addresses a
     JOIN offices o 
-        ON a.office_id = o.id AND COALESCE(a.change_filing_id, 1) = COALESCE(o.change_filing_id, 1) 
+        ON a.office_id = o.id
     WHERE a.office_id IS NOT NULL AND o.office_type = 'custodialOffice'
 )
 UPDATE addresses a
@@ -1633,7 +1633,7 @@ WITH subquery AS (
         oh.alternate_name_id
     FROM addresses_history ah
     JOIN offices_history oh 
-        ON ah.office_id = oh.id AND COALESCE(ah.change_filing_id, 1) = COALESCE(oh.change_filing_id, 1)
+        ON ah.office_id = oh.id
     WHERE ah.office_id IS NOT NULL AND oh.office_type = 'custodialOffice'
 )
 UPDATE addresses_history ah


### PR DESCRIPTION
*Issue #:* /bcgov/entity#19429

*Description of changes:*
- populate SP proprietor addresses & email for SP DBA LEAR & SP DBA COLIN
- link `offices/offices_history` to alternate names through `althernate_name_id`
- link custodial addresses in `addresses/addresses_history` to alternate names through `alternate_name_id` , for compatibility with old method (please refer to `addresses.legal_entity_id`)
- update TO-DOs for future reference

## Notes
1. No changes to populate SP addresses & email to `alternate_names_history` in this PR, this complex scenario will be carefully considered in bcgov/entity#19349
2. Here is the explanation for different scenarios of SP proprietors' addresses
   - SP individual: use LE person address fields 
   - SP DBA LEAR & SP DBA COLIN: use alternate name address fields

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
