### PR TITLE
19667 Legal API - update to use correct SP addresses

### DIFF
--- a/legal-api/src/legal_api/services/warnings/business/business_checks/firms.py
+++ b/legal-api/src/legal_api/services/warnings/business/business_checks/firms.py
@@ -53,8 +53,7 @@ def check_office(business: any) -> list:
     result = []
     business_office = None
 
-    if business.is_legal_entity:
-        business_office = business.offices.filter(Office.office_type == "businessOffice").one_or_none()
+    business_office = business.offices.filter(Office.office_type == "businessOffice").one_or_none()
 
     if not business_office:
         result.append(
@@ -190,7 +189,7 @@ def check_sp_party(alternate_name: AlternateName):
         if not colin_entity.organization_name:
             no_org_name_warning = True
         result.extend(
-            check_address(colin_entity.mailing_address, Address.MAILING, BusinessWarningReferers.BUSINESS_PARTY)
+            check_address(alternate_name.owner_mailing_address, Address.MAILING, BusinessWarningReferers.BUSINESS_PARTY)
         )
     elif alternate_name.is_owned_by_legal_entity_person:
         legal_entity = alternate_name.legal_entity
@@ -204,7 +203,7 @@ def check_sp_party(alternate_name: AlternateName):
         if not legal_entity.legal_name:
             no_org_name_warning = True
         result.extend(
-            check_address(legal_entity.entity_mailing_address, Address.MAILING, BusinessWarningReferers.BUSINESS_PARTY)
+            check_address(alternate_name.owner_mailing_address, Address.MAILING, BusinessWarningReferers.BUSINESS_PARTY)
         )
 
     if no_person_name_check_warning:

--- a/legal-api/tests/unit/resources/v2/test_business_parties.py
+++ b/legal-api/tests/unit/resources/v2/test_business_parties.py
@@ -16,7 +16,7 @@
 
 Test-Suite to ensure that the /businesses../parties endpoint is working as expected.
 """
-from datetime import datetime
+import datetime
 from http import HTTPStatus
 
 import pytest
@@ -317,6 +317,7 @@ def test_get_parties_unauthorized(app, session, client, jwt, requests_mock):
         assert rv.status_code == HTTPStatus.UNAUTHORIZED
         assert rv.json == {"message": f"You are not authorized to view parties for {identifier}."}
 
+
 def test_get_business_parties_sp_proprietor(app, session, client, jwt):
     """Assert that SP proprietor is returned."""
     with nested_session(session):
@@ -327,7 +328,7 @@ def test_get_business_parties_sp_proprietor(app, session, client, jwt):
         alternate_name = factory_alternate_name(
             identifier=identifier,
             name='TEST OPERATING NAME',
-            start_date=datetime.utcnow(),
+            start_date=datetime.datetime.utcnow(),
             legal_entity_id=legal_entity.id
         )
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#19667

*Description of changes:*
- update alternate name model so that the parties endpoint can use correct SP addresses
- add unit test for parties endpoint
- other related updates

### Test results
- SP Individual - FM1028594
![image](https://github.com/bcgov/lear/assets/60866283/1162da58-77cd-4be7-aac2-2493ad432583)

- SP LEAR DBA - FM1054864

![image](https://github.com/bcgov/lear/assets/60866283/0bd4ab6f-9c6a-4cc3-a4d3-c8adaecbcb9c)


- SP COLIN DBA - FM1061225

![image](https://github.com/bcgov/lear/assets/60866283/81e3b048-0c42-462f-bebb-d4d58405e6f3)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
