### PR TITLE
20129 fix broken alternate name related tests

### DIFF
--- a/legal-api/tests/unit/models/__init__.py
+++ b/legal-api/tests/unit/models/__init__.py
@@ -123,7 +123,7 @@ def factory_user(username: str, firstname: str = None, lastname: str = None):
 def factory_alternate_name(
     identifier=None,
     name=None,
-    name_type=AlternateName.NameType.OPERATING,
+    name_type=AlternateName.NameType.DBA,
     bn15=None,
     legal_entity_id=None,
     start_date=None,

--- a/legal-api/tests/unit/models/test_alternate_name.py
+++ b/legal-api/tests/unit/models/test_alternate_name.py
@@ -32,7 +32,7 @@ def test_valid_alternate_name_save(session):
 
     alternate_name_1 = AlternateName(
         identifier=identifier,
-        name_type=AlternateName.NameType.OPERATING,
+        name_type=AlternateName.NameType.DBA,
         name="XYZ Test BC LTD",
         bn15="111111100BC1111",
         start_date=datetime.utcnow(),
@@ -42,7 +42,7 @@ def test_valid_alternate_name_save(session):
 
     alternate_name_2 = AlternateName(
         identifier=identifier,
-        name_type=AlternateName.NameType.OPERATING,
+        name_type=AlternateName.NameType.DBA,
         name="ABC Test BC LTD",
         bn15="222222200BC2222",
         start_date=datetime.utcnow(),
@@ -55,7 +55,7 @@ def test_valid_alternate_name_save(session):
     assert alternate_name_2.id
     alternate_names = legal_entity.alternate_names.all()
     assert len(alternate_names) == 2
-    assert all(alternate_name.name_type == AlternateName.NameType.OPERATING for alternate_name in alternate_names)
+    assert all(alternate_name.name_type == AlternateName.NameType.DBA for alternate_name in alternate_names)
     assert any(alternate_name.name == "XYZ Test BC LTD" for alternate_name in alternate_names)
     assert any(alternate_name.name == "ABC Test BC LTD" for alternate_name in alternate_names)
 
@@ -76,7 +76,7 @@ def test_business_name(session, entity_type, operating_name, expected_business_n
         alternate_name = factory_alternate_name(
             identifier=identifier,
             name=operating_name,
-            name_type=AlternateName.NameType.OPERATING,
+            name_type=AlternateName.NameType.DBA,
             bn15="111111100BC1111",
             start_date=datetime.utcnow(),
             legal_entity_id=legal_entity.id,

--- a/legal-api/tests/unit/models/test_legal_entity.py
+++ b/legal-api/tests/unit/models/test_legal_entity.py
@@ -665,7 +665,7 @@ def test_legal_name_firms_SP(session, test_name, partner_info, expected_legal_na
 
         sp_firm = AlternateName(
             identifier="FM1234567",
-            name_type=AlternateName.NameType.OPERATING,
+            name_type=AlternateName.NameType.DBA,
             name="OPERATING NAME",
             start_date=datetime.utcnow(),
             state=AlternateName.State.ACTIVE,
@@ -915,7 +915,7 @@ def test_alternate_names(session, test_name, legal_entities_info, alternate_name
 
                 alternate_name = AlternateName(
                     identifier=alternate_name_identifier,
-                    name_type=AlternateName.NameType.OPERATING,
+                    name_type=AlternateName.NameType.DBA,
                     name=alternate_name_info["operatingName"],
                     bn15="111111100BC1111",
                     start_date=start_date,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#20129

*Description of changes:*

* Update `AlternateName.OPERATING` references to use `AlternateName.DBA`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
