### PR TITLE
20121 Fix db data not being reset properly between test runs

### DIFF
--- a/legal-api/src/legal_api/models/business_common.py
+++ b/legal-api/src/legal_api/models/business_common.py
@@ -247,7 +247,7 @@ class BusinessCommon:
                 return last_ar_date + datedelta.datedelta(years=1, months=2, days=1) > datetime.utcnow()
         return True
 
-    def get_filing_by_id(self, filing_id: str):
+    def get_filing_by_id(self, filing_id: int):
         """Return the filings for a specific business and filing_id."""
         from legal_api.models import AlternateName, Filing, LegalEntity
 

--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
@@ -189,10 +189,11 @@ def delete_filings(identifier, filing_id=None):
             HTTPStatus.UNAUTHORIZED,
         )
 
+    business = business_service.fetch_business(identifier)
     if identifier.startswith("T"):
         filing = Filing.get_temp_reg_filing(identifier, filing_id)
     else:
-        filing = LegalEntity.get_filing_by_id(identifier, filing_id)
+        filing = business.get_filing_by_id(filing_id)
 
     if not filing:
         return jsonify({"message": _("Filing Not Found.")}), HTTPStatus.NOT_FOUND
@@ -241,12 +242,13 @@ def patch_filings(identifier, filing_id=None):
             HTTPStatus.UNAUTHORIZED,
         )
 
+    business = business_service.fetch_business(identifier)
     if identifier.startswith("T"):
         q = db.session.query(Filing).filter(Filing.temp_reg == identifier).filter(Filing.id == filing_id)
 
         filing = q.one_or_none()
     else:
-        filing = LegalEntity.get_filing_by_id(identifier, filing_id)
+        filing = business.get_filing_by_id(identifier, filing_id)
 
     if not filing:
         return jsonify({"message": ("Filing Not Found.")}), HTTPStatus.NOT_FOUND
@@ -341,7 +343,7 @@ class ListFilingResource:
                 effective_date = _datetime.fromisoformat(datetime_str)
 
         business = business_service.fetch_business(identifier)
-
+        
         if not business:
             return jsonify(filings=[]), HTTPStatus.NOT_FOUND
 

--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
@@ -343,7 +343,7 @@ class ListFilingResource:
                 effective_date = _datetime.fromisoformat(datetime_str)
 
         business = business_service.fetch_business(identifier)
-        
+
         if not business:
             return jsonify(filings=[]), HTTPStatus.NOT_FOUND
 

--- a/legal-api/tests/conftest.py
+++ b/legal-api/tests/conftest.py
@@ -24,9 +24,8 @@ import sqlalchemy
 from flask_migrate import Migrate, upgrade
 from ldclient.integrations.test_data import TestData
 from sqlalchemy import event, inspect, text
-from sqlalchemy.schema import DropConstraint, MetaData
 from sqlalchemy.orm import scoped_session, sessionmaker
-
+from sqlalchemy.schema import DropConstraint, MetaData
 
 from legal_api import create_app
 from legal_api import jwt as _jwt

--- a/legal-api/tests/unit/__init__.py
+++ b/legal-api/tests/unit/__init__.py
@@ -47,10 +47,8 @@ def nested_session(session):
         sess.rollback()
     except AssertionError as err:
         raise err
-    except exc.ResourceClosedError:
+    except exc.ResourceClosedError as err:
         # mean the close out of the transaction got fouled in pytest
         pass
-    except Exception as err:
-        raise err
     finally:
         pass

--- a/legal-api/tests/unit/__init__.py
+++ b/legal-api/tests/unit/__init__.py
@@ -47,7 +47,7 @@ def nested_session(session):
         sess.rollback()
     except AssertionError as err:
         raise err
-    except exc.ResourceClosedError as err:
+    except exc.ResourceClosedError:
         # mean the close out of the transaction got fouled in pytest
         pass
     finally:

--- a/legal-api/tests/unit/resources/v2/test_business.py
+++ b/legal-api/tests/unit/resources/v2/test_business.py
@@ -152,19 +152,19 @@ def test_get_temp_business_info(session, client, jwt):
     assert rv.status_code == HTTPStatus.OK
 
 
-# TODO: Works with unique identifiers but DB reset fix will resolve the randomly failing tests (ticket# 20121)
 @pytest.mark.parametrize(
-    "test_name, role, calls_auth, identifier",
+    "test_name,role,calls_auth",
     [
-        ("public-user", PUBLIC_USER, True, "CP7654321"),
-        ("account-identity", ACCOUNT_IDENTITY, False, "CP7654322"),
-        ("staff", STAFF_ROLE, False, "CP7654323"),
-        ("system", SYSTEM_ROLE, False, "CP7654324"),
+        ("public-user", PUBLIC_USER, True),
+        ("account-identity", ACCOUNT_IDENTITY, False),
+        ("staff", STAFF_ROLE, False),
+        ("system", SYSTEM_ROLE, False),
     ],
 )
-def test_get_business_info(app, session, client, jwt, requests_mock, test_name, role, calls_auth, identifier):
+def test_get_business_info(app, session, client, jwt, requests_mock, test_name, role, calls_auth):
     """Assert that the business info can be received in a valid JSONSchema format."""
     with nested_session(session):
+        identifier = "CP7654321"
         legal_name = identifier + " legal name"
         factory_legal_entity_model(
             entity_type="CP",
@@ -289,7 +289,6 @@ def test_get_business_with_allowed_filings(session, client, jwt):
         assert rv.json["business"]["allowedFilings"]
 
 
-# TODO: Works with unique identifiers but DB reset fix will resolve the randomly failing tests (ticket# 20121)
 @pytest.mark.parametrize(
     "test_name, legal_type, owner_legal_type, identifier, owner_identifier, has_missing_business_info,"
     + "missing_business_info_warning_expected",
@@ -299,8 +298,8 @@ def test_get_business_with_allowed_filings(session, client, jwt):
         ("NO_WARNINGS_EXIST_NO_MISSING_DATA", "SP", "BEN", "FM0000003", "BC0000003", False, False),
         ("NO_WARNINGS_EXIST_NO_MISSING_DATA", "GP", None, "FM0000004", None, False, False),
         ("NO_WARNINGS_NON_FIRM", "CP", None, "CP7654321", None, True, False),
-        ("NO_WARNINGS_NON_FIRM", "BEN", None, "CP7654322", None, True, False),
-        ("NO_WARNINGS_NON_FIRM", "BC", None, "BC7654323", None, True, False),
+        ("NO_WARNINGS_NON_FIRM", "BEN", None, "CP7654321", None, True, False),
+        ("NO_WARNINGS_NON_FIRM", "BC", None, "BC7654321", None, True, False),
     ],
 )
 def test_get_business_with_incomplete_info(

--- a/legal-api/tests/unit/resources/v2/test_business_address.py
+++ b/legal-api/tests/unit/resources/v2/test_business_address.py
@@ -26,20 +26,20 @@ from tests.unit.models import Address, Office, factory_legal_entity
 from tests.unit.services.utils import create_header
 
 
-# TODO: Works with unique identifiers but DB reset fix will resolve the randomly failing tests (ticket# 20121)
 @pytest.mark.parametrize(
-    "test_name,role,identifier",
+    "test_name,role",
     [
-        ("public-user", PUBLIC_USER, "CP7654321"),
-        ("account-identity", ACCOUNT_IDENTITY, "CP7654322"),
-        ("staff", STAFF_ROLE, "CP7654323"),
-        ("system", SYSTEM_ROLE, "CP7654324"),
+        ("public-user", PUBLIC_USER),
+        ("account-identity", ACCOUNT_IDENTITY),
+        ("staff", STAFF_ROLE),
+        ("system", SYSTEM_ROLE),
     ],
 )
-def test_get_business_addresses(app, session, client, jwt, requests_mock, test_name, role, identifier):
+def test_get_business_addresses(app, session, client, jwt, requests_mock, test_name, role):
     """Assert that business addresses are returned."""
     # setup
     with nested_session(session):
+        identifier = "CP7654321"
         legal_entity = factory_legal_entity(identifier)
         mailing_address = Address(city="Test Mailing City", address_type=Address.MAILING)
         delivery_address = Address(city="Test Delivery City", address_type=Address.DELIVERY)

--- a/legal-api/tests/unit/resources/v2/test_business_director.py
+++ b/legal-api/tests/unit/resources/v2/test_business_director.py
@@ -28,20 +28,20 @@ from tests.unit.models import Address, factory_legal_entity, factory_party_role
 from tests.unit.services.utils import create_header
 
 
-# TODO: Works with unique identifiers but DB reset fix will resolve the randomly failing tests (ticket# 20121)
 @pytest.mark.parametrize(
-    "test_name,role,identifier",
+    "test_name,role",
     [
-        ("public-user", PUBLIC_USER, "CP7654321"),
-        ("account-identity", ACCOUNT_IDENTITY, "CP7654322"),
-        ("staff", STAFF_ROLE, "CP7654323"),
-        ("system", SYSTEM_ROLE, "CP7654324"),
+        ("public-user", PUBLIC_USER),
+        ("account-identity", ACCOUNT_IDENTITY),
+        ("staff", STAFF_ROLE),
+        ("system", SYSTEM_ROLE),
     ],
 )
-def test_get_business_directors(app, session, client, jwt, requests_mock, test_name, role, identifier):
+def test_get_business_directors(app, session, client, jwt, requests_mock, test_name, role):
     """Assert that business directors are returned."""
     with nested_session(session):
         # setup
+        identifier = "CP7654321"
         legal_entity = factory_legal_entity(identifier)
         director_address = Address(city="Test Mailing City", address_type=Address.DELIVERY)
         officer = {

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
@@ -2007,7 +2007,7 @@ def test_document_list_for_various_filing_states(
     with nested_session(session):
         # Setup
         # identifier = 'CP7654321'
-        legal_entity = factory_legal_entity(identifier, _entity_type=entity_type)
+        legal_entity = factory_legal_entity(identifier, entity_type=entity_type)
 
         filing_json = copy.deepcopy(FILING_HEADER)
         filing_json["filing"]["header"]["name"] = filing_name_1
@@ -2025,6 +2025,8 @@ def test_document_list_for_various_filing_states(
         filing._status = status
         filing._payment_completion_date = payment_completion_date
         filing.save()
+
+        meta_data = {}
 
         if status == "COMPLETED":
             lf = [list(x.keys()) for x in filing.legal_filings()]

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filings_ledger.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filings_ledger.py
@@ -126,7 +126,7 @@ def test_ledger_search(session, client, jwt):
             identifier=identifier,
             founding_date=founding_date,
             last_ar_date=None,
-            _entity_type=LegalEntity.EntityTypes.BCOMP.value,
+            entity_type=LegalEntity.EntityTypes.BCOMP.value,
         )
         num_of_files = load_ledger(legal_entity, founding_date)
 
@@ -171,7 +171,7 @@ def ledger_element_setup_help(identifier: str, filing_name: str = "brokenFiling"
         identifier=identifier,
         founding_date=founding_date,
         last_ar_date=None,
-        _entity_type=LegalEntity.EntityTypes.BCOMP.value,
+        entity_type=LegalEntity.EntityTypes.BCOMP.value,
     )
     return legal_entity, ledger_element_setup_filing(
         legal_entity, filing_name, filing_date=founding_date + datedelta.datedelta(months=1)
@@ -354,7 +354,7 @@ def test_ledger_display_restoration(session, client, jwt, restoration_type, expe
         business_name = "Skinners Fine Saves"
 
         legal_entity = factory_legal_entity(
-            identifier=identifier, founding_date=founding_date, last_ar_date=None, _entity_type="BC"
+            identifier=identifier, founding_date=founding_date, last_ar_date=None, entity_type="BC"
         )
         legal_entity._legal_name = business_name
         legal_entity.save()
@@ -409,7 +409,7 @@ def test_ledger_display_incorporation(session, client, jwt, test_name, identifie
         business_name = "The Truffle House"
 
         legal_entity = factory_legal_entity(
-            identifier=identifier, founding_date=founding_date, last_ar_date=None, _entity_type=entity_type
+            identifier=identifier, founding_date=founding_date, last_ar_date=None, entity_type=entity_type
         )
         legal_entity._legal_name = business_name
         legal_entity.save()
@@ -609,7 +609,7 @@ def test_ledger_redaction(
             entity_type = LegalEntity.EntityTypes.BCOMP.value
 
             legal_entity = factory_legal_entity(
-                identifier=identifier, founding_date=founding_date, last_ar_date=None, _entity_type=entity_type
+                identifier=identifier, founding_date=founding_date, last_ar_date=None, entity_type=entity_type
             )
             legal_entity._legal_name = business_name
             legal_entity.save()

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filings_ledger.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filings_ledger.py
@@ -207,32 +207,31 @@ def test_ledger_comment_count(session, client, jwt):
         assert rv.json["filings"][0]["commentsCount"] == number_of_comments
 
 
-# TODO: Works with unique identifiers but DB reset fix will resolve the randomly failing tests (ticket# 20121)
 @pytest.mark.parametrize(
-    "test_name, identifier, file_number, order_date, effect_of_order, order_details, expected",
+    "test_name, file_number, order_date, effect_of_order, order_details, expected",
     [
         (
             "all_elements",
-            "BC1234561",
             "ABC123",
             datetime.utcnow(),
             "effect",
             "details",
             ["effectOfOrder", "fileNumber", "orderDate", "orderDetails"],
         ),
-        ("no_elements", "BC1234562", None, None, None, None, []),
-        ("no-file-number-or-details", "BC1234563", None, datetime.utcnow(), None, None, []),
-        ("date", "BC1234564", "ABC123", datetime.utcnow(), None, None, ["fileNumber", "orderDate"]),
-        ("effect", "BC1234565", "ABC123", None, "effect", None, ["effectOfOrder", "fileNumber"]),
-        ("details", "BC1234566", "ABC123", None, None, "details", ["fileNumber", "orderDetails"]),
+        ("no_elements", None, None, None, None, []),
+        ("no-file-number-or-details", None, datetime.utcnow(), None, None, []),
+        ("date", "ABC123", datetime.utcnow(), None, None, ["fileNumber", "orderDate"]),
+        ("effect", "ABC123", None, "effect", None, ["effectOfOrder", "fileNumber"]),
+        ("details", "ABC123", None, None, "details", ["fileNumber", "orderDetails"]),
     ],
 )
 def test_ledger_court_order(
-    session, client, jwt, test_name, identifier, file_number, order_date, effect_of_order, order_details, expected
+    session, client, jwt, test_name, file_number, order_date, effect_of_order, order_details, expected
 ):
     """Assert that the ledger returns court_order values."""
     with nested_session(session):
         # setup
+        identifier = "BC1234567"
         _, filing_storage = ledger_element_setup_help(identifier)
 
         filing_storage.court_order_file_number = file_number

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_internal.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_internal.py
@@ -46,6 +46,7 @@ from tests.unit.models import (  # noqa:E501,I001
     factory_legal_entity_mailing_address,
 )
 from tests.unit.services.utils import create_header
+from sqlalchemy import text
 
 
 def test_post_pre_load_colin_filing(session, client, jwt):
@@ -374,10 +375,10 @@ def test_get_colin_last_update(session, client, jwt):
         # setup
         colin_id = 1234
         db.session.execute(
-            f"""
+            text(f"""
             insert into colin_last_update (last_update, last_event_id)
             values (current_timestamp, {colin_id})
-            """
+            """)
         )
 
         rv = client.get("/api/v2/businesses/internal/filings/colin_id")

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_internal.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_internal.py
@@ -32,6 +32,7 @@ from registry_schemas.example_data import (
     FILING_HEADER,
     INCORPORATION_FILING_TEMPLATE,
 )
+from sqlalchemy import text
 
 from legal_api.models import Filing, LegalEntity
 from legal_api.services import QueueService
@@ -46,7 +47,6 @@ from tests.unit.models import (  # noqa:E501,I001
     factory_legal_entity_mailing_address,
 )
 from tests.unit.services.utils import create_header
-from sqlalchemy import text
 
 
 def test_post_pre_load_colin_filing(session, client, jwt):
@@ -375,10 +375,12 @@ def test_get_colin_last_update(session, client, jwt):
         # setup
         colin_id = 1234
         db.session.execute(
-            text(f"""
+            text(
+                f"""
             insert into colin_last_update (last_update, last_event_id)
             values (current_timestamp, {colin_id})
-            """)
+            """
+            )
         )
 
         rv = client.get("/api/v2/businesses/internal/filings/colin_id")

--- a/legal-api/tests/unit/resources/v2/test_business_resolutions.py
+++ b/legal-api/tests/unit/resources/v2/test_business_resolutions.py
@@ -28,19 +28,19 @@ from tests.unit.models import factory_legal_entity
 from tests.unit.services.utils import create_header
 
 
-# TODO: Works with unique identifiers but DB reset fix will resolve the randomly failing tests (ticket# 20121)
 @pytest.mark.parametrize(
-    "test_name,role,identifier",
+    "test_name,role",
     [
-        ("public-user", PUBLIC_USER, "CP1234561"),
-        ("account-identity", ACCOUNT_IDENTITY, "CP1234562"),
-        ("staff", STAFF_ROLE, "CP1234563"),
-        ("system", SYSTEM_ROLE, "CP1234564"),
+        ("public-user", PUBLIC_USER),
+        ("account-identity", ACCOUNT_IDENTITY),
+        ("staff", STAFF_ROLE),
+        ("system", SYSTEM_ROLE),
     ],
 )
-def test_get_business_resolutions(app, session, client, jwt, requests_mock, test_name, role, identifier):
+def test_get_business_resolutions(app, session, client, jwt, requests_mock, test_name, role):
     """Assert that business resolutions are returned."""
     with nested_session(session):
+        identifier = "CP1234561"
         resolution_text = "bla bla"
         legal_entity = factory_legal_entity(identifier)
         signing_party = LegalEntity(

--- a/legal-api/tests/unit/resources/v2/test_business_share_classes.py
+++ b/legal-api/tests/unit/resources/v2/test_business_share_classes.py
@@ -26,19 +26,19 @@ from tests.unit.models import factory_legal_entity, factory_share_class
 from tests.unit.services.utils import create_header
 
 
-# TODO: Works with unique identifiers but DB reset fix will resolve the randomly failing tests (ticket# 20121)
 @pytest.mark.parametrize(
-    "test_name,role,identifier",
+    "test_name,role",
     [
-        ("public-user", PUBLIC_USER, "CP1234561"),
-        ("account-identity", ACCOUNT_IDENTITY, "CP1234562"),
-        ("staff", STAFF_ROLE, "CP1234563"),
-        ("system", SYSTEM_ROLE, "CP1234564"),
+        ("public-user", PUBLIC_USER),
+        ("account-identity", ACCOUNT_IDENTITY),
+        ("staff", STAFF_ROLE),
+        ("system", SYSTEM_ROLE),
     ],
 )
-def test_get_business_share_classes(app, session, client, jwt, requests_mock, test_name, role, identifier):
+def test_get_business_share_classes(app, session, client, jwt, requests_mock, test_name, role):
     """Assert that business share classes are returned."""
     with nested_session(session):
+        identifier = "CP1234561"
         share_class = factory_share_class(identifier)
 
         # mock response from auth to give view access (not needed if staff / system)

--- a/legal-api/tests/unit/resources/v2/test_business_tasks.py
+++ b/legal-api/tests/unit/resources/v2/test_business_tasks.py
@@ -281,22 +281,21 @@ def test_get_tasks_pending_correction_filings(session, client, jwt):
             assert rv.json["tasks"][0]["task"]["filing"]["header"]["filingId"] == filing.id
 
 
-# TODO: Works with unique identifiers but DB reset fix will resolve the randomly failing tests (ticket# 20121)
 @freeze_time("Jul 2nd, 2022")
 @pytest.mark.parametrize(
     "test_name, identifier, founding_date, previous_ar_date, entity_type, tasks_length",
     [
-        ("BEN first AR to be issued", "BC1234501", "2021-07-02", None, LegalEntity.EntityTypes.BCOMP.value, 1),
-        ("BEN no AR due yet", "BC1234502", "2021-07-03", None, LegalEntity.EntityTypes.BCOMP.value, 0),
-        ("BEN 3 ARs overdue", "BC1234503", "2019-05-15", None, LegalEntity.EntityTypes.BCOMP.value, 3),
-        ("BEN current AR year issued", "BC1234504", "1900-07-01", "2022-03-03", LegalEntity.EntityTypes.BCOMP.value, 0),
-        ("BC first AR to be issued", "BC1234505", "2021-07-02", None, LegalEntity.EntityTypes.COMP.value, 1),
-        ("BC no AR due yet", "BC1234506", "2021-07-03", None, LegalEntity.EntityTypes.COMP.value, 0),
-        ("BC 3 ARs overdue", "BC1234507", "2019-05-15", None, LegalEntity.EntityTypes.COMP.value, 3),
-        ("BC current AR year issued", "BC1234508", "1900-07-01", "2022-03-03", LegalEntity.EntityTypes.COMP.value, 0),
-        ("ULC first AR to be issued", "BC1234509", "2021-07-02", None, LegalEntity.EntityTypes.BC_ULC_COMPANY.value, 1),
-        ("ULC no AR due yet", "BC1234510", "2021-07-03", None, LegalEntity.EntityTypes.BC_ULC_COMPANY.value, 0),
-        ("ULC 3 ARs overdue", "BC1234511", "2019-05-15", None, LegalEntity.EntityTypes.BC_ULC_COMPANY.value, 3),
+        ("BEN first AR to be issued", "BC1234567", "2021-07-02", None, LegalEntity.EntityTypes.BCOMP.value, 1),
+        ("BEN no AR due yet", "BC1234567", "2021-07-03", None, LegalEntity.EntityTypes.BCOMP.value, 0),
+        ("BEN 3 ARs overdue", "BC1234567", "2019-05-15", None, LegalEntity.EntityTypes.BCOMP.value, 3),
+        ("BEN current AR year issued", "BC1234567", "1900-07-01", "2022-03-03", LegalEntity.EntityTypes.BCOMP.value, 0),
+        ("BC first AR to be issued", "BC1234567", "2021-07-02", None, LegalEntity.EntityTypes.COMP.value, 1),
+        ("BC no AR due yet", "BC1234567", "2021-07-03", None, LegalEntity.EntityTypes.COMP.value, 0),
+        ("BC 3 ARs overdue", "BC1234567", "2019-05-15", None, LegalEntity.EntityTypes.COMP.value, 3),
+        ("BC current AR year issued", "BC1234567", "1900-07-01", "2022-03-03", LegalEntity.EntityTypes.COMP.value, 0),
+        ("ULC first AR to be issued", "BC1234567", "2021-07-02", None, LegalEntity.EntityTypes.BC_ULC_COMPANY.value, 1),
+        ("ULC no AR due yet", "BC1234567", "2021-07-03", None, LegalEntity.EntityTypes.BC_ULC_COMPANY.value, 0),
+        ("ULC 3 ARs overdue", "BC1234567", "2019-05-15", None, LegalEntity.EntityTypes.BC_ULC_COMPANY.value, 3),
         (
             "ULC current AR year issued",
             "BC1234567",
@@ -305,15 +304,15 @@ def test_get_tasks_pending_correction_filings(session, client, jwt):
             LegalEntity.EntityTypes.BC_ULC_COMPANY.value,
             0,
         ),
-        ("CC first AR to be issued", "BC1234512", "2021-07-02", None, LegalEntity.EntityTypes.BC_CCC.value, 1),
-        ("CC no AR due yet", "BC1234513", "2021-07-03", None, LegalEntity.EntityTypes.BC_CCC.value, 0),
-        ("CC 3 ARs overdue", "BC1234514", "2019-05-15", None, LegalEntity.EntityTypes.BC_CCC.value, 3),
-        ("CC current AR year issued", "BC1234515", "1900-07-01", "2022-03-03", LegalEntity.EntityTypes.BC_CCC.value, 0),
-        ("CP founded in the end of the year", "CP1234561", "2021-12-31", None, LegalEntity.EntityTypes.COOP.value, 1),
-        ("CP current year AR pending", "CP1234562", "1900-07-01", "2021-03-03", LegalEntity.EntityTypes.COOP.value, 1),
-        ("CP 3 ARs overdue", "CP1234563", "2019-05-15", None, LegalEntity.EntityTypes.COOP.value, 3),
-        ("SP no AR", "FM1234561", "2019-05-15", None, LegalEntity.EntityTypes.SOLE_PROP.value, 0),
-        ("GP no AR", "FM1234562", "2019-05-15", None, LegalEntity.EntityTypes.PARTNERSHIP.value, 0),
+        ("CC first AR to be issued", "BC1234567", "2021-07-02", None, LegalEntity.EntityTypes.BC_CCC.value, 1),
+        ("CC no AR due yet", "BC1234567", "2021-07-03", None, LegalEntity.EntityTypes.BC_CCC.value, 0),
+        ("CC 3 ARs overdue", "BC1234567", "2019-05-15", None, LegalEntity.EntityTypes.BC_CCC.value, 3),
+        ("CC current AR year issued", "BC1234567", "1900-07-01", "2022-03-03", LegalEntity.EntityTypes.BC_CCC.value, 0),
+        ("CP founded in the end of the year", "CP1234567", "2021-12-31", None, LegalEntity.EntityTypes.COOP.value, 1),
+        ("CP current year AR pending", "CP1234567", "1900-07-01", "2021-03-03", LegalEntity.EntityTypes.COOP.value, 1),
+        ("CP 3 ARs overdue", "CP1234567", "2019-05-15", None, LegalEntity.EntityTypes.COOP.value, 3),
+        ("SP no AR", "FM1234567", "2019-05-15", None, LegalEntity.EntityTypes.SOLE_PROP.value, 0),
+        ("GP no AR", "FM1234567", "2019-05-15", None, LegalEntity.EntityTypes.PARTNERSHIP.value, 0),
     ],
 )
 def test_construct_task_list(


### PR DESCRIPTION
*Issue #:* /bcgov/entity#20121

*Description of changes:*
- Update conftest to work with flask-sqlalchemy 3.x
- A couple small fixes to some of the unit tests
- This update improves the unit test success:
```
Latest test run on feature-legal-name == 382 failed, 1466 passed, 44 skipped in 303.10s (0:05:03)
Current test run in this PR: =========== 182 failed, 1666 passed, 44 skipped in 308.61s (0:05:08)
```
- There's still failing unit tests but from a cursory look the failing tests are due to different issues unrelated to improper transaction rollbacks. 

### What caused the bug
In the legal name feature branch, we upgraded the `flask-sqlalchemy` package from 2.5.1 to ^3.0.3. Part of this upgrade means moving from SqlAlchemy 1.x to SqlAlchemy 2.x (confirmed in [poetry.lock](https://github.com/bcgov/lear/blob/feature-legal-name/legal-api/poetry.lock#L799)). This seems to have [caused issues with rollback in pytest](https://github.com/pallets-eco/flask-sqlalchemy/discussions/1179). 

I think what is happening is that when we commit to the nested session, the SAVEPOINT is not getting restarted correctly. We end up with pending changes getting commited to the outermost transaction, and are not getting rolled back within the scope of the savepoint. This can cause queries that expect `one_or_none()` to fail, like in [`legal_entity.find_by_identifier`](https://github.com/bcgov/lear/blob/feature-legal-name/legal-api/src/legal_api/models/legal_entity.py#L575-L579) since there are multiple legal entities created within the outermost transaction with the same identifier.


### Proposed solution
The SQLAlchemy 2.x docs outlines a new approach to [joining a session into an external transaction](https://docs.sqlalchemy.org/en/20/orm/session_transaction.html#session-external-transaction). This uses the new [Session.join_transaction_mode](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session.params.join_transaction_mode) parameter with the setting "create_savepoint", which "_indicates that new SAVEPOINTs should be created in order to implement BEGIN/COMMIT/ROLLBACK for the [Session](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session), which will leave the external transaction in the same state in which it was passed._"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
