### PR TITLE
20119 fix alternate name json issues when business start date is null

### DIFF
--- a/legal-api/src/legal_api/models/legal_entity.py
+++ b/legal-api/src/legal_api/models/legal_entity.py
@@ -374,7 +374,9 @@ class LegalEntity(
                             "nameRegisteredDate": alternate_name.start_date.isoformat(),
                             "nameStartDate": LegislationDatetime.format_as_legislation_date(
                                 alternate_name.business_start_date
-                            ),
+                            )
+                            if alternate_name.business_start_date
+                            else None,
                             "nameType": alternate_name.name_type.name,
                             "operatingName": alternate_name.name,  # will be removed in the future
                         }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#20119

*Description of changes:*

* Fix issue with generating alternate name json for GP when start date is null


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
