### PR TITLE
20119 fix alternate name json issues when business start date is null

### DIFF
--- a/legal-api/src/legal_api/models/alternate_name.py
+++ b/legal-api/src/legal_api/models/alternate_name.py
@@ -318,7 +318,9 @@ class AlternateName(Versioned, db.Model, BusinessCommon):
                     "identifier": self.identifier,
                     "name": self.name,
                     "nameRegisteredDate": self.start_date.isoformat(),
-                    "nameStartDate": LegislationDatetime.format_as_legislation_date(self.business_start_date),
+                    "nameStartDate": LegislationDatetime.format_as_legislation_date(self.business_start_date)
+                    if self.business_start_date
+                    else None,
                     "nameType": self.name_type.name,
                     "operatingName": self.name,  # will be removed in the future
                 }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#20119

*Description of changes:*

* Fix business start date null issue for alternate names model

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
