### PR TITLE
20148 remove operating name

### DIFF
--- a/legal-api/src/legal_api/models/alternate_name.py
+++ b/legal-api/src/legal_api/models/alternate_name.py
@@ -333,7 +333,7 @@ class AlternateName(Versioned, db.Model, BusinessCommon):
                         if self.business_start_date
                         else None
                     ),
-                    "nameType": self.name_type.name
+                    "nameType": self.name_type.name,
                 }
             ],
         }

--- a/legal-api/src/legal_api/models/alternate_name.py
+++ b/legal-api/src/legal_api/models/alternate_name.py
@@ -333,8 +333,7 @@ class AlternateName(Versioned, db.Model, BusinessCommon):
                         if self.business_start_date
                         else None
                     ),
-                    "nameType": self.name_type.name,
-                    "operatingName": self.name,  # will be removed in the future
+                    "nameType": self.name_type.name
                 }
             ],
         }

--- a/legal-api/src/legal_api/models/legal_entity.py
+++ b/legal-api/src/legal_api/models/legal_entity.py
@@ -377,7 +377,7 @@ class LegalEntity(
                             )
                             if alternate_name.business_start_date
                             else None,
-                            "nameType": alternate_name.name_type.name
+                            "nameType": alternate_name.name_type.name,
                         }
                     )
                 else:

--- a/legal-api/src/legal_api/models/legal_entity.py
+++ b/legal-api/src/legal_api/models/legal_entity.py
@@ -377,8 +377,7 @@ class LegalEntity(
                             )
                             if alternate_name.business_start_date
                             else None,
-                            "nameType": alternate_name.name_type.name,
-                            "operatingName": alternate_name.name,  # will be removed in the future
+                            "nameType": alternate_name.name_type.name
                         }
                     )
                 else:

--- a/legal-api/src/legal_api/resources/v2/internal_services.py
+++ b/legal-api/src/legal_api/resources/v2/internal_services.py
@@ -79,7 +79,7 @@ def create_registrars_notation_filing(business: any, user: User, old_bn: str):
             "header": {"name": "registrarsNotation", "date": date.today().isoformat(), "certifiedBy": "system"},
             "business": {"identifier": business.identifier, "legalType": business.entity_type},
             "registrarsNotation": {
-                "orderDetails": f"Business Number changed from {old_bn} to {new_bn }"
+                "orderDetails": f"Business Number changed from {old_bn} to {new_bn}"
                 + " based on a request from the CRA."
             },
         }

--- a/legal-api/tests/unit/models/test_legal_entity.py
+++ b/legal-api/tests/unit/models/test_legal_entity.py
@@ -761,7 +761,7 @@ def test_business_name(session, entity_type, legal_name, expected_business_name)
             # expected_alternate_names
             [
                 {
-                    "identifier": ALTERNATE_NAME_1_IDENTIFIER
+                    "identifier": ALTERNATE_NAME_1_IDENTIFIER,
                     "entityType": "SP",
                     "nameRegisteredDate": ALTERNATE_NAME_1_REGISTERED_DATE,
                     "nameStartDate": ALTERNATE_NAME_1_START_DATE,

--- a/legal-api/tests/unit/models/test_legal_entity.py
+++ b/legal-api/tests/unit/models/test_legal_entity.py
@@ -746,14 +746,14 @@ def test_business_name(session, entity_type, legal_name, expected_business_name)
                 {
                     "identifier": ALTERNATE_NAME_1_IDENTIFIER,
                     "entityType": "SP",
-                    "operatingName": ALTERNATE_NAME_1,
+                    "name": ALTERNATE_NAME_1,
                     "businessStartDate": ALTERNATE_NAME_1_START_DATE_ISO,
                     "startDate": ALTERNATE_NAME_1_REGISTERED_DATE,
                 },
                 {
                     "identifier": ALTERNATE_NAME_2_IDENTIFIER,
                     "entityType": "GP",
-                    "operatingName": ALTERNATE_NAME_2,
+                    "name": ALTERNATE_NAME_2,
                     "businessStartDate": ALTERNATE_NAME_2_START_DATE_ISO,
                     "startDate": ALTERNATE_NAME_2_REGISTERED_DATE,
                 },
@@ -761,8 +761,7 @@ def test_business_name(session, entity_type, legal_name, expected_business_name)
             # expected_alternate_names
             [
                 {
-                    "identifier": ALTERNATE_NAME_1_IDENTIFIER,
-                    "operatingName": ALTERNATE_NAME_1,
+                    "identifier": ALTERNATE_NAME_1_IDENTIFIER
                     "entityType": "SP",
                     "nameRegisteredDate": ALTERNATE_NAME_1_REGISTERED_DATE,
                     "nameStartDate": ALTERNATE_NAME_1_START_DATE,
@@ -771,7 +770,6 @@ def test_business_name(session, entity_type, legal_name, expected_business_name)
                 },
                 {
                     "identifier": ALTERNATE_NAME_2_IDENTIFIER,
-                    "operatingName": ALTERNATE_NAME_2,
                     "entityType": "GP",
                     "nameRegisteredDate": ALTERNATE_NAME_2_REGISTERED_DATE,
                     "nameStartDate": ALTERNATE_NAME_2_START_DATE,
@@ -796,7 +794,7 @@ def test_business_name(session, entity_type, legal_name, expected_business_name)
                 {
                     "identifier": ALTERNATE_NAME_1_IDENTIFIER,
                     "entityType": "SP",
-                    "operatingName": ALTERNATE_NAME_1,
+                    "name": ALTERNATE_NAME_1,
                     "businessStartDate": ALTERNATE_NAME_1_START_DATE_ISO,
                     "startDate": ALTERNATE_NAME_1_REGISTERED_DATE,
                 }
@@ -805,7 +803,6 @@ def test_business_name(session, entity_type, legal_name, expected_business_name)
             [
                 {
                     "identifier": ALTERNATE_NAME_1_IDENTIFIER,
-                    "operatingName": ALTERNATE_NAME_1,
                     "entityType": "SP",
                     "nameRegisteredDate": ALTERNATE_NAME_1_REGISTERED_DATE,
                     "nameStartDate": ALTERNATE_NAME_1_START_DATE,
@@ -830,7 +827,7 @@ def test_business_name(session, entity_type, legal_name, expected_business_name)
                 {
                     "identifier": ALTERNATE_NAME_2_IDENTIFIER,
                     "entityType": "GP",
-                    "operatingName": ALTERNATE_NAME_2,
+                    "name": ALTERNATE_NAME_2,
                     "businessStartDate": ALTERNATE_NAME_2_START_DATE_ISO,
                     "startDate": ALTERNATE_NAME_2_REGISTERED_DATE,
                 }
@@ -839,7 +836,6 @@ def test_business_name(session, entity_type, legal_name, expected_business_name)
             [
                 {
                     "identifier": ALTERNATE_NAME_2_IDENTIFIER,
-                    "operatingName": ALTERNATE_NAME_2,
                     "entityType": "GP",
                     "nameRegisteredDate": ALTERNATE_NAME_2_REGISTERED_DATE,
                     "nameStartDate": ALTERNATE_NAME_2_START_DATE,
@@ -867,14 +863,14 @@ def test_business_name(session, entity_type, legal_name, expected_business_name)
                 {
                     "identifier": ALTERNATE_NAME_1_IDENTIFIER,
                     "entityType": "GP",
-                    "operatingName": ALTERNATE_NAME_1,
+                    "name": ALTERNATE_NAME_1,
                     "businessStartDate": ALTERNATE_NAME_1_START_DATE_ISO,
                     "startDate": ALTERNATE_NAME_1_REGISTERED_DATE,
                 },
                 {
                     "identifier": ALTERNATE_NAME_2_IDENTIFIER,
                     "entityType": "SP",
-                    "operatingName": ALTERNATE_NAME_2,
+                    "name": ALTERNATE_NAME_2,
                     "businessStartDate": ALTERNATE_NAME_2_START_DATE_ISO,
                     "startDate": ALTERNATE_NAME_2_REGISTERED_DATE,
                 },
@@ -883,7 +879,6 @@ def test_business_name(session, entity_type, legal_name, expected_business_name)
             [
                 {
                     "identifier": ALTERNATE_NAME_1_IDENTIFIER,
-                    "operatingName": ALTERNATE_NAME_1,
                     "entityType": "GP",
                     "nameRegisteredDate": ALTERNATE_NAME_1_REGISTERED_DATE,
                     "nameStartDate": ALTERNATE_NAME_1_START_DATE,
@@ -892,7 +887,6 @@ def test_business_name(session, entity_type, legal_name, expected_business_name)
                 },
                 {
                     "identifier": ALTERNATE_NAME_2_IDENTIFIER,
-                    "operatingName": ALTERNATE_NAME_2,
                     "entityType": "SP",
                     "nameRegisteredDate": ALTERNATE_NAME_2_REGISTERED_DATE,
                     "nameStartDate": ALTERNATE_NAME_2_START_DATE,
@@ -939,7 +933,7 @@ def test_alternate_names(session, test_name, legal_entities_info, alternate_name
                 alternate_name = AlternateName(
                     identifier=alternate_name_identifier,
                     name_type=AlternateName.NameType.DBA,
-                    name=alternate_name_info["operatingName"],
+                    name=alternate_name_info["name"],
                     bn15="111111100BC1111",
                     start_date=start_date,
                     business_start_date=business_start_date,

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filings.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filings.py
@@ -964,7 +964,7 @@ def test_update_ar_with_a_missing_filing_id_fails(session, client, jwt):
         filings = factory_completed_filing(legal_entity, ar)
 
         rv = client.put(
-            f"/api/v2/businesses/{identifier}/filings/{filings.id+1}",
+            f"/api/v2/businesses/{identifier}/filings/{filings.id + 1}",
             json=ar,
             headers=create_header(jwt, [STAFF_ROLE], identifier),
         )
@@ -989,7 +989,7 @@ def test_update_ar_with_a_missing_business_id_fails(session, client, jwt):
         identifier = "CP0000001"
 
         rv = client.put(
-            f"/api/v2/businesses/{identifier}/filings/{filings.id+1}",
+            f"/api/v2/businesses/{identifier}/filings/{filings.id + 1}",
             json=ar,
             headers=create_header(jwt, [STAFF_ROLE], identifier),
         )
@@ -1006,7 +1006,7 @@ def test_update_ar_with_missing_json_body_fails(session, client, jwt):
         filings = factory_filing(b, ANNUAL_REPORT)
 
         rv = client.put(
-            f"/api/v2/businesses/{identifier}/filings/{filings.id+1}",
+            f"/api/v2/businesses/{identifier}/filings/{filings.id + 1}",
             json=None,
             headers=create_header(jwt, [STAFF_ROLE], identifier),
         )

--- a/python/common/business-registry-model/src/business_model/models/alternate_name.py
+++ b/python/common/business-registry-model/src/business_model/models/alternate_name.py
@@ -333,8 +333,7 @@ class AlternateName(Versioned, db.Model, BusinessCommon):
                         if self.business_start_date
                         else None
                     ),
-                    "nameType": self.name_type.name,
-                    "operatingName": self.name,  # will be removed in the future
+                    "nameType": self.name_type.name
                 }
             ],
         }

--- a/python/common/business-registry-model/src/business_model/models/legal_entity.py
+++ b/python/common/business-registry-model/src/business_model/models/legal_entity.py
@@ -377,8 +377,7 @@ class LegalEntity(
                             )
                             if alternate_name.business_start_date
                             else None,
-                            "nameType": alternate_name.name_type.name,
-                            "operatingName": alternate_name.name,  # will be removed in the future
+                            "nameType": alternate_name.name_type.name
                         }
                     )
                 else:

--- a/python/common/business-registry-model/tests/models/test_legal_entity.py
+++ b/python/common/business-registry-model/tests/models/test_legal_entity.py
@@ -956,14 +956,14 @@ def test_business_name(
                 {
                     "identifier": ALTERNATE_NAME_1_IDENTIFIER,
                     "entityType": "SP",
-                    "operatingName": ALTERNATE_NAME_1,
+                    "name": ALTERNATE_NAME_1,
                     "nameRegisteredDate": ALTERNATE_NAME_1_REGISTERED_DATE,
                     "startDate": ALTERNATE_NAME_1_START_DATE,
                 },
                 {
                     "identifier": ALTERNATE_NAME_2_IDENTIFIER,
                     "entityType": "GP",
-                    "operatingName": ALTERNATE_NAME_2,
+                    "name": ALTERNATE_NAME_2,
                     "nameRegisteredDate": ALTERNATE_NAME_2_REGISTERED_DATE,
                     "startDate": ALTERNATE_NAME_2_START_DATE,
                 },
@@ -975,14 +975,14 @@ def test_business_name(
                     "identifier": ALTERNATE_NAME_1_IDENTIFIER,
                     "nameRegisteredDate": ALTERNATE_NAME_1_REGISTERED_DATE,
                     "nameStartDate": ALTERNATE_NAME_1_START_DATE,
-                    "operatingName": ALTERNATE_NAME_1,
+                    "name": ALTERNATE_NAME_1,
                 },
                 {
                     "entityType": "GP",
                     "identifier": ALTERNATE_NAME_2_IDENTIFIER,
                     "nameRegisteredDate": ALTERNATE_NAME_2_REGISTERED_DATE,
                     "nameStartDate": ALTERNATE_NAME_2_START_DATE,
-                    "operatingName": ALTERNATE_NAME_2,
+                    "name": ALTERNATE_NAME_2,
                 },
             ],
         ),
@@ -1002,7 +1002,7 @@ def test_business_name(
                 {
                     "identifier": ALTERNATE_NAME_1_IDENTIFIER,
                     "entityType": "SP",
-                    "operatingName": ALTERNATE_NAME_1,
+                    "name": ALTERNATE_NAME_1,
                     "nameRegisteredDate": ALTERNATE_NAME_1_REGISTERED_DATE,
                     "startDate": ALTERNATE_NAME_1_START_DATE,
                 }
@@ -1014,7 +1014,7 @@ def test_business_name(
                     "identifier": ALTERNATE_NAME_1_IDENTIFIER,
                     "nameRegisteredDate": ALTERNATE_NAME_1_REGISTERED_DATE,
                     "nameStartDate": ALTERNATE_NAME_1_START_DATE,
-                    "operatingName": ALTERNATE_NAME_1,
+                    "name": ALTERNATE_NAME_1,
                 }
             ],
         ),
@@ -1034,7 +1034,7 @@ def test_business_name(
                 {
                     "identifier": ALTERNATE_NAME_2_IDENTIFIER,
                     "entityType": "GP",
-                    "operatingName": ALTERNATE_NAME_2,
+                    "name": ALTERNATE_NAME_2,
                     "nameRegisteredDate": ALTERNATE_NAME_2_REGISTERED_DATE,
                     "startDate": ALTERNATE_NAME_2_START_DATE,
                 }
@@ -1046,7 +1046,7 @@ def test_business_name(
                     "identifier": ALTERNATE_NAME_2_IDENTIFIER,
                     "nameRegisteredDate": ALTERNATE_NAME_2_REGISTERED_DATE,
                     "nameStartDate": ALTERNATE_NAME_2_START_DATE,
-                    "operatingName": ALTERNATE_NAME_2,
+                    "name": ALTERNATE_NAME_2,
                 }
             ],
         ),
@@ -1069,14 +1069,14 @@ def test_business_name(
                 {
                     "identifier": ALTERNATE_NAME_1_IDENTIFIER,
                     "entityType": "GP",
-                    "operatingName": ALTERNATE_NAME_1,
+                    "name": ALTERNATE_NAME_1,
                     "nameRegisteredDate": ALTERNATE_NAME_1_REGISTERED_DATE,
                     "startDate": ALTERNATE_NAME_1_START_DATE,
                 },
                 {
                     "identifier": ALTERNATE_NAME_2_IDENTIFIER,
                     "entityType": "SP",
-                    "operatingName": ALTERNATE_NAME_2,
+                    "name": ALTERNATE_NAME_2,
                     "nameRegisteredDate": ALTERNATE_NAME_2_REGISTERED_DATE,
                     "startDate": ALTERNATE_NAME_2_START_DATE,
                 },
@@ -1088,14 +1088,14 @@ def test_business_name(
                     "identifier": ALTERNATE_NAME_1_IDENTIFIER,
                     "nameRegisteredDate": ALTERNATE_NAME_1_REGISTERED_DATE,
                     "nameStartDate": ALTERNATE_NAME_1_START_DATE,
-                    "operatingName": ALTERNATE_NAME_1,
+                    "name": ALTERNATE_NAME_1,
                 },
                 {
                     "entityType": "SP",
                     "identifier": ALTERNATE_NAME_2_IDENTIFIER,
                     "nameRegisteredDate": ALTERNATE_NAME_2_REGISTERED_DATE,
                     "nameStartDate": ALTERNATE_NAME_2_START_DATE,
-                    "operatingName": ALTERNATE_NAME_2,
+                    "name": ALTERNATE_NAME_2,
                 },
             ],
         ),
@@ -1151,7 +1151,7 @@ def test_alternate_names(
                 alternate_name = AlternateName(
                     identifier=alternate_name_identifier,
                     name_type=AlternateName.NameType.OPERATING,
-                    name=alternate_name_info["operatingName"],
+                    name=alternate_name_info["name"],
                     bn15="111111100BC1111",
                     start_date=start_date,
                     legal_entity_id=le.id,
@@ -1270,7 +1270,7 @@ def test_sole_proprietor(
 
         name_dict = {
             "identifier": "FM1234567",
-            "operatingName": "Harry Lime Questionable Goods Broker",
+            "name": "Harry Lime Questionable Goods Broker",
             "entityType": "person",
             "nameStartDate": "2023-10-29",
         }
@@ -1339,7 +1339,7 @@ def test_find_by_FM_identifier(
 
         name_dict = {
             "identifier": "FM1234567",
-            "operatingName": "Harry Lime Questionable Goods Broker",
+            "name": "Harry Lime Questionable Goods Broker",
             "entityType": "person",
             "nameStartDate": "2023-10-29",
         }
@@ -1409,7 +1409,7 @@ def test_find_by_FM_name(
 
         name_dict = {
             "identifier": "FM1234567",
-            "operatingName": "Harry Lime Questionable Goods Broker",
+            "name": "Harry Lime Questionable Goods Broker",
             "entityType": "person",
             "nameStartDate": "2023-10-29",
         }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#20148

*Description of changes:*
- Removed `operatingName` from everywhere because we're using `name` now.

Verification/Testing:
![removed operatingname](https://github.com/bcgov/lear/assets/122301442/162d328a-0114-448b-a04d-fcbdad6b76f4)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
