### PR TITLE
Fix issue where none was being returned for DBAs where owner is GP

### DIFF
--- a/legal-api/src/legal_api/services/business_service.py
+++ b/legal-api/src/legal_api/services/business_service.py
@@ -30,17 +30,8 @@ class BusinessService:
             return None
         if legal_entity := LegalEntity.find_by_identifier(identifier):
             return legal_entity
-
         if identifier.startswith("FM") and (alternate_name := AlternateName.find_by_identifier(identifier)):
-            if alternate_name.is_owned_by_colin_entity:
-                return alternate_name
-
-            legal_entity = LegalEntity.find_by_id(alternate_name.legal_entity_id)
-            alternate_name_entity = (
-                alternate_name if legal_entity.entity_type != BusinessCommon.EntityTypes.PARTNERSHIP.value else None
-            )
-            return alternate_name_entity
-
+            return alternate_name
         return None
 
     @staticmethod
@@ -57,14 +48,7 @@ class BusinessService:
         if (alternate_name_id := filing.alternate_name_id) and (
             alternate_name := AlternateName.find_by_internal_id(alternate_name_id)
         ):
-            if alternate_name.is_owned_by_colin_entity:
-                return alternate_name
-
-            legal_entity = LegalEntity.find_by_id(alternate_name.legal_entity_id)
-            alternate_name_entity = (
-                alternate_name if legal_entity.entity_type != BusinessCommon.EntityTypes.PARTNERSHIP.value else None
-            )
-            return alternate_name_entity
+            return alternate_name
 
         return None
 

--- a/legal-api/src/legal_api/services/business_service.py
+++ b/legal-api/src/legal_api/services/business_service.py
@@ -14,7 +14,6 @@
 
 """This provides the service for businesses(legal entities and alternate name entities."""
 from legal_api.models import AlternateName, LegalEntity
-from legal_api.models.business_common import BusinessCommon
 
 
 class BusinessService:


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*
* Updated business_service class functions for returning a business to work for scenario where GP is owner of a SP.  Previously, I believe we had to do some hacky logic when `alternate_name.entity_type` wasn't an actual column in the table.  Don't think we need this anymore.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
