### PR TITLE
fixed business pay payload to the filer

### DIFF
--- a/queue_services/entity-pay/src/entity_pay/resources/worker.py
+++ b/queue_services/entity-pay/src/entity_pay/resources/worker.py
@@ -106,13 +106,13 @@ def worker():
 
     # None of these should bail as the filing has been marked PAID
     cloud_event = SimpleCloudEvent(
-        source=__name__[: __name__.find(".")],
+        source="business_pay",
         subject="filing",
-        type="Filing",
+        type="filingMessage",
         data={
-            "filingId": filing.id,
-            "filingType": filing.filing_type,
-            "filingEffectiveDate": filing.effective_date.isoformat(),
+            "filingMessage": {
+                "filingIdentifier": filing.id
+            }
         },
     )
     # None of these should bail as the filing has been marked PAID
@@ -129,6 +129,8 @@ def worker():
     with suppress(Exception):
         if filing.effective_date <= filing.payment_completion_date:
             filer_topic = current_app.config.get("BUSINESS_FILER_TOPIC", "filer")
+            print("JOJO")
+            print(queue.to_queue_message(cloud_event))
             ret = queue.publish(topic=filer_topic, payload=queue.to_queue_message(cloud_event))  # noqa: F841
             structured_log(request, "INFO", f"publish to filer for pay-id: {payment_token.id}")
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#19808

*Description of changes:*
The payload that Filer expects:
```json
{
  "specversion": "1.0",
  "datacontenttype": "application/json",
  "source": "business_pay",
  "subject": "filing",
  "type": "filingMessage",
  "data": {
    "filingMessage": {
      "filingIdentifier": 123
    }
  }
}
````

The payload that's being published to the filer:
![payload sent by pay](https://github.com/bcgov/lear/assets/122301442/98c17ca7-2192-4ced-a16d-6a13fd24b267)
I got the above via debugging code.
 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
