### PR TITLE
20328 Filer - Update change of registration filing processor to work with alternate name changes

### DIFF
--- a/python/common/business-registry-model/src/business_model/models/address.py
+++ b/python/common/business-registry-model/src/business_model/models/address.py
@@ -44,6 +44,7 @@ class Address(Versioned, db.Model):  # pylint: disable=too-many-instance-attribu
             "id",
             "address_type",
             "legal_entity_id",
+            "alternate_name_id",
             "city",
             "change_filing_id",
             "country",
@@ -69,6 +70,7 @@ class Address(Versioned, db.Model):  # pylint: disable=too-many-instance-attribu
     # parent keys
     legal_entity_id = db.Column("legal_entity_id", db.Integer, db.ForeignKey("legal_entities.id"), index=True)
     change_filing_id = db.Column("change_filing_id", db.Integer, db.ForeignKey("filings.id"), index=True)
+    alternate_name_id = db.Column("alternate_name_id", db.Integer, db.ForeignKey("alternate_names.id"), nullable=True)
     office_id = db.Column(
         "office_id",
         db.Integer,

--- a/queue_services/entity-filer/poetry.lock
+++ b/queue_services/entity-filer/poetry.lock
@@ -192,7 +192,7 @@ sql-versioning = {git = "https://github.com/bcgov/lear.git", branch = "feature-l
 type = "git"
 url = "https://github.com/bcgov/lear.git"
 reference = "feature-legal-name"
-resolved_reference = "f0c26b2b43004f76bf3180cb30bd21efb0129c6a"
+resolved_reference = "9543a0a1d676f70ee3ad4bbbc85ff526ff84116b"
 subdirectory = "python/common/business-registry-model"
 
 [[package]]

--- a/queue_services/entity-filer/poetry.lock
+++ b/queue_services/entity-filer/poetry.lock
@@ -192,7 +192,7 @@ sql-versioning = {git = "https://github.com/bcgov/lear.git", branch = "feature-l
 type = "git"
 url = "https://github.com/bcgov/lear.git"
 reference = "feature-legal-name"
-resolved_reference = "76fe8d1d73951a400a6db552321bfc1703e8496a"
+resolved_reference = "f0c26b2b43004f76bf3180cb30bd21efb0129c6a"
 subdirectory = "python/common/business-registry-model"
 
 [[package]]
@@ -648,13 +648,13 @@ requests = ["requests (>=2.20.0,<3.0.0.dev0)"]
 
 [[package]]
 name = "google-cloud-pubsub"
-version = "2.21.0"
+version = "2.21.1"
 description = "Google Cloud Pub/Sub API client library"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "google-cloud-pubsub-2.21.0.tar.gz", hash = "sha256:94017f0bc9a85fa3f4d913f312e930a0fe21775bd68dde5c666e2f1b1addf811"},
-    {file = "google_cloud_pubsub-2.21.0-py2.py3-none-any.whl", hash = "sha256:fabd19e08faa1f70081b0e5ea003a3c031a1d2c1b798cf1be5ded2dbf1d1dbef"},
+    {file = "google-cloud-pubsub-2.21.1.tar.gz", hash = "sha256:31fcf07444b7f813a616c4b650e1fbf1dc998a088fe0059a76164855ac17f05c"},
+    {file = "google_cloud_pubsub-2.21.1-py2.py3-none-any.whl", hash = "sha256:55a3602ec45bc09626604d712032288a8ee3566145cb83523cff908938f69a4b"},
 ]
 
 [package.dependencies]
@@ -1820,13 +1820,13 @@ asn1crypto = ">=1.5.1"
 
 [[package]]
 name = "sentry-sdk"
-version = "1.44.0"
+version = "1.44.1"
 description = "Python client for Sentry (https://sentry.io)"
 optional = false
 python-versions = "*"
 files = [
-    {file = "sentry-sdk-1.44.0.tar.gz", hash = "sha256:f7125a9235795811962d52ff796dc032cd1d0dd98b59beaced8380371cd9c13c"},
-    {file = "sentry_sdk-1.44.0-py2.py3-none-any.whl", hash = "sha256:eb65289da013ca92fad2694851ad2f086aa3825e808dc285bd7dcaf63602bb18"},
+    {file = "sentry-sdk-1.44.1.tar.gz", hash = "sha256:24e6a53eeabffd2f95d952aa35ca52f0f4201d17f820ac9d3ff7244c665aaf68"},
+    {file = "sentry_sdk-1.44.1-py2.py3-none-any.whl", hash = "sha256:5f75eb91d8ab6037c754a87b8501cc581b2827e923682f593bed3539ce5b3999"},
 ]
 
 [package.dependencies]
@@ -1923,7 +1923,7 @@ develop = false
 type = "git"
 url = "https://github.com/bcgov/lear.git"
 reference = "feature-legal-name"
-resolved_reference = "abc274397627f6542f7821c4d276492b01c36c21"
+resolved_reference = "b8278f5f7832ab58f65792b40ed99ec8cd81e6b6"
 subdirectory = "python/common/sql-versioning"
 
 [[package]]

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/change_of_registration.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/change_of_registration.py
@@ -63,9 +63,10 @@ def process(
     # Update business office if present
     with suppress(IndexError, KeyError, TypeError):
         offices = dpath.util.get(change_filing, "/changeOfRegistration/offices")
-        update_offices(alternate_name, offices)
         if entity_type == BusinessCommon.EntityTypes.PARTNERSHIP:
             update_offices(business, offices)
+        else:
+            update_offices(alternate_name, offices)
 
     # Update parties
     with suppress(IndexError, KeyError, TypeError):

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/change_of_registration.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/change_of_registration.py
@@ -17,7 +17,7 @@ from contextlib import suppress
 from typing import Dict
 
 import dpath
-from business_model import Address, AlternateName, Filing, LegalEntity, db
+from business_model import Address, AlternateName, BusinessCommon, Filing, LegalEntity, db
 
 from entity_filer.exceptions.default_exception import DefaultException
 from entity_filer.filing_meta import FilingMeta
@@ -31,29 +31,32 @@ from entity_filer.filing_processors.registration import get_partnership_name
 
 
 def process(
-    legal_entity: LegalEntity,
+    business: any,
     change_filing_rec: Filing,
     change_filing: Dict,
     filing_meta: FilingMeta,
 ):
     """Render the change of registration filing onto the business model objects."""
     filing_meta.change_of_registration = {}
-    match legal_entity.entity_type:
-        case LegalEntity.EntityTypes.PARTNERSHIP:
-            update_partner_change(
-                legal_entity=legal_entity,
+    match business.entity_type:
+        case BusinessCommon.EntityTypes.PARTNERSHIP:
+            business, alternate_name = update_partner_change(
+                legal_entity=business,
                 filing_type="changeOfRegistration",
                 change_filing_rec=change_filing_rec,
                 change_filing=change_filing,
                 filing_meta=filing_meta.change_of_registration,
             )
-        case _:  # LegalEntity.EntityTypes.SOLE_PROP: # legal_entity might be a proprietor?
-            update_proprietor_change(
+        case BusinessCommon.EntityTypes.SOLE_PROP:
+            business, alternate_name = update_proprietor_change(
                 filing_type="changeOfRegistration",
                 change_filing_rec=change_filing_rec,
                 change_filing=change_filing,
                 filing_meta=filing_meta.change_of_registration,
             )
+        case _:
+            # Default and failed
+            raise DefaultException(f"change of registration {change_filing_rec.id} had no valid Firm type.")
 
     # Update business office if present
     with suppress(IndexError, KeyError, TypeError):
@@ -67,12 +70,14 @@ def process(
     # Update parties
     with suppress(IndexError, KeyError, TypeError):
         parties = dpath.util.get(change_filing, "/changeOfRegistration/parties")
-        merge_all_parties(legal_entity, change_filing_rec, {"parties": parties})
+        merge_all_parties(business, change_filing_rec, {"parties": parties})
 
     # update court order, if any is present
     with suppress(IndexError, KeyError, TypeError):
         court_order_json = dpath.util.get(change_filing, "/changeOfRegistration/courtOrder")
         filings.update_filing_court_order(change_filing_rec, court_order_json)
+
+    return business, alternate_name
 
 
 def post_process(business: LegalEntity, filing: Filing):

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/alternate_name.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/alternate_name.py
@@ -75,10 +75,12 @@ def update_partner_change(
         )
         legal_entity.alternate_names.append(new_alternate_name)
 
-        filing_meta.update({
-            "fromLegalName": alternate_name.name,
-            "toLegalName": to_legal_name,
-        })
+        filing_meta.update(
+            {
+                "fromLegalName": alternate_name.name,
+                "toLegalName": to_legal_name,
+            }
+        )
 
     # Update nature of business for LegalEntity and AlternateName
     current_alternate_name = AlternateName.find_by_identifier(legal_entity.identifier)
@@ -86,11 +88,13 @@ def update_partner_change(
         naics_code := naics.get("naicsCode")
     ):
         if legal_entity.naics_code != naics_code:
-            filing_meta.update({
-                "fromNaicsCode": legal_entity.naics_code,
-                "toNaicsCode": naics_code,
-                "naicsDescription": naics.get("naicsDescription"),
-            })
+            filing_meta.update(
+                {
+                    "fromNaicsCode": legal_entity.naics_code,
+                    "toNaicsCode": naics_code,
+                    "naicsDescription": naics.get("naicsDescription"),
+                }
+            )
             legal_entity_info.update_naics_info(legal_entity, naics)
             legal_entity_info.update_naics_info(current_alternate_name, naics)
 
@@ -123,13 +127,17 @@ def update_proprietor_change(
 
         if not proprietor:
             raise DefaultException(f"No Proprietor in the SP {filing_type} for filing:{change_filing_rec.id}")
-    
+
     # Update operating name
     name_request = dpath.util.get(change_filing, f"/{filing_type}/nameRequest", default=None)
     identifier = dpath.util.get(change_filing_rec.filing_json, "filing/business/identifier")
     if name_request and (to_legal_name := name_request.get("legalName")):
         alternate_name = AlternateName.find_by_identifier(identifier)
-        proprietor = LegalEntity.find_by_id(alternate_name.legal_entity_id) if alternate_name.legal_entity_id else ColinEntity.find_by_id(alternate_name.colin_entity_id)
+        proprietor = (
+            LegalEntity.find_by_id(alternate_name.legal_entity_id)
+            if alternate_name.legal_entity_id
+            else ColinEntity.find_by_id(alternate_name.colin_entity_id)
+        )
 
         if start := change_filing.get("filing", {}).get(f"{filing_type}", {}).get("startDate"):
             business_start_date = LegislationDatetime.as_utc_timezone_from_legislation_date_str(start)
@@ -172,26 +180,31 @@ def update_proprietor_change(
         )
         proprietor.alternate_names.append(new_alternate_name)
 
-        filing_meta.update({
-            "fromLegalName": alternate_name.name,
-            "toLegalName": to_legal_name,
-        })
+        filing_meta.update(
+            {
+                "fromLegalName": alternate_name.name,
+                "toLegalName": to_legal_name,
+            }
+        )
 
         # Update nature of business for AlternateName
         if (naics := change_filing.get(f"{filing_type}", {}).get("business", {}).get("naics")) and (
             naics_code := naics.get("naicsCode")
         ):
             if new_alternate_name.naics_code != naics_code:
-                filing_meta.update({
-                    "fromNaicsCode": new_alternate_name.naics_code,
-                    "toNaicsCode": naics_code,
-                    "naicsDescription": naics.get("naicsDescription"),
-                })
+                filing_meta.update(
+                    {
+                        "fromNaicsCode": new_alternate_name.naics_code,
+                        "toNaicsCode": naics_code,
+                        "naicsDescription": naics.get("naicsDescription"),
+                    }
+                )
                 legal_entity_info.update_naics_info(new_alternate_name, naics)
 
         return proprietor, new_alternate_name
 
     return None, None
+
 
 def get_partnership_name(parties_dict: dict):
     """Set the legal_name of the partnership."""

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/alternate_name.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/alternate_name.py
@@ -53,8 +53,6 @@ def update_partner_change(
         else:
             business_start_date = alternate_name.business_start_date
 
-        existing_offices = delete_existing_offices(alternate_name)
-
         # alternate_name.delete()
         db.session.add(alternate_name)
         db.session.commit()
@@ -70,15 +68,9 @@ def update_partner_change(
             name_type=AlternateName.NameType.DBA,
             start_date=alternate_name.start_date,
             business_start_date=business_start_date,
-            state=BusinessCommon.State.ACTIVE,
             entity_type=BusinessCommon.EntityTypes.PARTNERSHIP,
-            naics_key=alternate_name.naics_key,
-            naics_code=alternate_name.naics_code,
-            naics_description=alternate_name.naics_description,
         )
         legal_entity.alternate_names.append(new_alternate_name)
-        for office in existing_offices:
-            new_alternate_name.append(office)
 
         filing_meta.update(
             {
@@ -87,7 +79,7 @@ def update_partner_change(
             }
         )
 
-    # Update nature of business for LegalEntity and AlternateName
+    # Update nature of business for LegalEntity
     current_alternate_name = AlternateName.find_by_identifier(legal_entity.identifier)
     if (naics := change_filing.get(f"{filing_type}", {}).get("business", {}).get("naics")) and (
         naics_code := naics.get("naicsCode")
@@ -101,7 +93,6 @@ def update_partner_change(
                 }
             )
             legal_entity_info.update_naics_info(legal_entity, naics)
-            legal_entity_info.update_naics_info(current_alternate_name, naics)
 
     return legal_entity, current_alternate_name
 

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/alternate_name.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/alternate_name.py
@@ -24,6 +24,7 @@ from entity_filer import db
 from entity_filer.exceptions import DefaultException
 from entity_filer.filing_meta import FilingMeta
 from entity_filer.filing_processors.filing_components import legal_entity_info
+from entity_filer.filing_processors.filing_components.offices import delete_existing_offices
 from entity_filer.filing_processors.filing_components.parties import get_or_create_party
 from entity_filer.utils.legislation_datetime import LegislationDatetime
 
@@ -52,6 +53,8 @@ def update_partner_change(
         else:
             business_start_date = alternate_name.business_start_date
 
+        existing_offices = delete_existing_offices(alternate_name)
+
         # alternate_name.delete()
         db.session.add(alternate_name)
         db.session.commit()
@@ -74,6 +77,8 @@ def update_partner_change(
             naics_description=alternate_name.naics_description,
         )
         legal_entity.alternate_names.append(new_alternate_name)
+        for office in existing_offices:
+            new_alternate_name.append(office)
 
         filing_meta.update(
             {
@@ -154,6 +159,8 @@ def update_proprietor_change(
         alternate_name.end_date = change_filing_rec.effective_date
         alternate_name.change_filing_id = change_filing_rec.id
 
+        existing_offices = delete_existing_offices(alternate_name)
+
         # alternate_name.delete()
         db.session.add(alternate_name)
         db.session.commit()
@@ -179,6 +186,8 @@ def update_proprietor_change(
             naics_description=alternate_name.naics_description,
         )
         proprietor.alternate_names.append(new_alternate_name)
+        for office in existing_offices:
+            new_alternate_name.append(office)
 
         filing_meta.update(
             {

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/alternate_name.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/alternate_name.py
@@ -18,7 +18,7 @@ import datetime
 from typing import Dict, List, Optional, Tuple
 
 import dpath
-from business_model import AlternateName, Filing, LegalEntity
+from business_model import AlternateName, BusinessCommon, ColinEntity, Filing, LegalEntity
 
 from entity_filer import db
 from entity_filer.exceptions import DefaultException
@@ -47,9 +47,11 @@ def update_partner_change(
         alternate_name.change_filing_id = change_filing_rec.id
 
         if start := change_filing.get("filing", {}).get(f"{filing_type}", {}).get("startDate"):
-            start_date = LegislationDatetime.as_utc_timezone_from_legislation_date_str(start)
+            business_start_date = LegislationDatetime.as_utc_timezone_from_legislation_date_str(start)
+            legal_entity.start_date = business_start_date
         else:
-            start_date = alternate_name.start_date
+            business_start_date = alternate_name.business_start_date
+
         # alternate_name.delete()
         db.session.add(alternate_name)
         db.session.commit()
@@ -62,32 +64,37 @@ def update_partner_change(
             end_date=None,
             identifier=legal_entity.identifier,
             name=to_legal_name,
-            name_type=AlternateName.NameType.OPERATING,
-            start_date=start_date,
-            registration_date=change_filing_rec.effective_date,
+            name_type=AlternateName.NameType.DBA,
+            start_date=alternate_name.start_date,
+            business_start_date=business_start_date,
+            state=BusinessCommon.State.ACTIVE,
+            entity_type=BusinessCommon.EntityTypes.PARTNERSHIP,
+            naics_key=alternate_name.naics_key,
+            naics_code=alternate_name.naics_code,
+            naics_description=alternate_name.naics_description,
         )
         legal_entity.alternate_names.append(new_alternate_name)
 
-        filing_meta = {
-            **filing_meta,
+        filing_meta.update({
             "fromLegalName": alternate_name.name,
             "toLegalName": to_legal_name,
-        }
+        })
 
-    # Update Nature of LegalEntity
+    # Update nature of business for LegalEntity and AlternateName
+    current_alternate_name = AlternateName.find_by_identifier(legal_entity.identifier)
     if (naics := change_filing.get(f"{filing_type}", {}).get("business", {}).get("naics")) and (
         naics_code := naics.get("naicsCode")
     ):
         if legal_entity.naics_code != naics_code:
-            filing_meta = {
-                **filing_meta,
-                **{
-                    "fromNaicsCode": legal_entity.naics_code,
-                    "toNaicsCode": naics_code,
-                    "naicsDescription": naics.get("naicsDescription"),
-                },
-            }
+            filing_meta.update({
+                "fromNaicsCode": legal_entity.naics_code,
+                "toNaicsCode": naics_code,
+                "naicsDescription": naics.get("naicsDescription"),
+            })
             legal_entity_info.update_naics_info(legal_entity, naics)
+            legal_entity_info.update_naics_info(current_alternate_name, naics)
+
+    return legal_entity, current_alternate_name
 
 
 def update_proprietor_change(
@@ -96,14 +103,11 @@ def update_proprietor_change(
     change_filing: Dict,
     filing_meta: Dict,
 ):
-    name_request = dpath.util.get(change_filing, f"/{filing_type}/nameRequest", default=None)
-    identifier = dpath.util.get(change_filing_rec.filing_json, "filing/business/identifier")
-    if name_request and (to_legal_name := name_request.get("legalName")):
-        alternate_name = AlternateName.find_by_identifier(identifier)
-        parties_dict = dpath.util.get(change_filing, f"/{filing_type}/parties")
-
+    # Update proprietor information
+    if parties_dict := dpath.util.get(change_filing, f"/{filing_type}/parties", default=None):
         # Find the Proprietor
         proprietor = None
+        proprietor_dict = None
         for party in parties_dict:
             for role in party.get("roles"):
                 if role.get("roleType") == "Proprietor":
@@ -116,16 +120,32 @@ def update_proprietor_change(
             raise DefaultException(f"No Proprietor in the SP {filing_type} for filing:{change_filing_rec.id}")
 
         proprietor, delivery_address, mailing_address = get_or_create_party(proprietor_dict, change_filing_rec)
+
         if not proprietor:
             raise DefaultException(f"No Proprietor in the SP {filing_type} for filing:{change_filing_rec.id}")
+    
+    # Update operating name
+    name_request = dpath.util.get(change_filing, f"/{filing_type}/nameRequest", default=None)
+    identifier = dpath.util.get(change_filing_rec.filing_json, "filing/business/identifier")
+    if name_request and (to_legal_name := name_request.get("legalName")):
+        alternate_name = AlternateName.find_by_identifier(identifier)
+        proprietor = LegalEntity.find_by_id(alternate_name.legal_entity_id) if alternate_name.legal_entity_id else ColinEntity.find_by_id(alternate_name.colin_entity_id)
 
         if start := change_filing.get("filing", {}).get(f"{filing_type}", {}).get("startDate"):
-            start_date = LegislationDatetime.as_utc_timezone_from_legislation_date_str(start)
+            business_start_date = LegislationDatetime.as_utc_timezone_from_legislation_date_str(start)
         else:
-            start_date = alternate_name.start_date
+            business_start_date = alternate_name.business_start_date
+
+        if isinstance(proprietor, LegalEntity) and proprietor.entity_type == BusinessCommon.EntityTypes.PERSON:
+            delivery_address_id = None
+            mailing_address_id = None
+        else:
+            delivery_address_id = delivery_address.id if delivery_address else None
+            mailing_address_id = mailing_address.id if mailing_address else None
 
         alternate_name.end_date = change_filing_rec.effective_date
         alternate_name.change_filing_id = change_filing_rec.id
+
         # alternate_name.delete()
         db.session.add(alternate_name)
         db.session.commit()
@@ -134,21 +154,44 @@ def update_proprietor_change(
 
         new_alternate_name = AlternateName(
             identifier=identifier,
-            name_type=AlternateName.NameType.OPERATING,
+            name_type=AlternateName.NameType.DBA,
             change_filing_id=change_filing_rec.id,
             end_date=None,
             name=to_legal_name,
-            start_date=start_date,
-            registration_date=change_filing_rec.effective_date,
+            start_date=alternate_name.start_date,
+            business_start_date=business_start_date,
+            delivery_address_id=delivery_address_id,
+            mailing_address_id=mailing_address_id,
+            bn15=alternate_name.bn15,
+            email=proprietor.email,
+            state=BusinessCommon.State.ACTIVE,
+            entity_type=BusinessCommon.EntityTypes.SOLE_PROP,
+            naics_key=alternate_name.naics_key,
+            naics_code=alternate_name.naics_code,
+            naics_description=alternate_name.naics_description,
         )
         proprietor.alternate_names.append(new_alternate_name)
 
-        filing_meta = {
-            **filing_meta,
+        filing_meta.update({
             "fromLegalName": alternate_name.name,
             "toLegalName": to_legal_name,
-        }
+        })
 
+        # Update nature of business for AlternateName
+        if (naics := change_filing.get(f"{filing_type}", {}).get("business", {}).get("naics")) and (
+            naics_code := naics.get("naicsCode")
+        ):
+            if new_alternate_name.naics_code != naics_code:
+                filing_meta.update({
+                    "fromNaicsCode": new_alternate_name.naics_code,
+                    "toNaicsCode": naics_code,
+                    "naicsDescription": naics.get("naicsDescription"),
+                })
+                legal_entity_info.update_naics_info(new_alternate_name, naics)
+
+        return proprietor, new_alternate_name
+
+    return None, None
 
 def get_partnership_name(parties_dict: dict):
     """Set the legal_name of the partnership."""

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/legal_entity_info.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/legal_entity_info.py
@@ -18,9 +18,10 @@ from typing import Dict
 
 import requests
 from business_model import EntityRole, Filing, LegalEntity, LegalEntityIdentifier, LegalEntityType
-from entity_filer.services.naics import NaicsService
 from flask import current_app
 from flask_babel import _ as babel  # noqa: N813
+
+from entity_filer.services.naics import NaicsService
 
 
 def set_corp_type(legal_entity: LegalEntity, legal_entity_info: Dict) -> Dict:
@@ -80,7 +81,7 @@ def update_naics_info(business: any, naics: Dict):
     """Update naics info."""
     # TODO update NAICS info
     business.naics_code = naics.get("naicsCode")
-    if business.naics_code and (naics_structure:=NaicsService.find_by_code(business.naics_code)):
+    if business.naics_code and (naics_structure := NaicsService.find_by_code(business.naics_code)):
         business.naics_key = naics_structure["naicsKey"]
     else:
         business.naics_code = None

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/legal_entity_info.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/legal_entity_info.py
@@ -18,16 +18,9 @@ from typing import Dict
 
 import requests
 from business_model import EntityRole, Filing, LegalEntity, LegalEntityIdentifier, LegalEntityType
+from entity_filer.services.naics import NaicsService
 from flask import current_app
 from flask_babel import _ as babel  # noqa: N813
-
-# from legal_api.services import NaicsService
-
-
-class NaicsService:
-    @staticmethod
-    def find_by_code(naics_code: str):
-        return None
 
 
 def set_corp_type(legal_entity: LegalEntity, legal_entity_info: Dict) -> Dict:
@@ -83,19 +76,16 @@ def update_legal_entity_info(corp_num: str, legal_entity: LegalEntity, legal_ent
     return None
 
 
-def update_naics_info(legal_entity: LegalEntity, naics: Dict):
+def update_naics_info(business: any, naics: Dict):
     """Update naics info."""
     # TODO update NAICS info
-    legal_entity.naics_code = naics.get("naicsCode")
-    if legal_entity.naics_code:
-        # TODO: Uncomment next 2 lines when find_by_code implemented and delete "pass"
-        # naics_structure = NaicsService.find_by_code(legal_entity.naics_code)
-        # legal_entity.naics_key = naics_structure["naicsKey"]
-        pass
+    business.naics_code = naics.get("naicsCode")
+    if business.naics_code and (naics_structure:=NaicsService.find_by_code(business.naics_code)):
+        business.naics_key = naics_structure["naicsKey"]
     else:
-        legal_entity.naics_code = None
-        legal_entity.naics_key = None
-    legal_entity.naics_description = naics.get("naicsDescription")
+        business.naics_code = None
+        business.naics_key = None
+    business.naics_description = naics.get("naicsDescription")
 
 
 def get_next_corp_num(entity_type: str):

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/offices.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/offices.py
@@ -65,3 +65,5 @@ def delete_existing_offices(business: any):
     if existing_offices := business.offices.all():
         for office in existing_offices:
             business.offices.remove(office)
+        return existing_offices
+    return []

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/parties.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/parties.py
@@ -468,6 +468,7 @@ def delete_non_memoized_entity_role(
 
         candidate.cessation_date = filing.effective_date
         candidate.change_filing_id = filing.id
+        candidate.delete()
 
     return None
 

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/parties.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/parties.py
@@ -455,6 +455,7 @@ def get_address_for_filing(party_address: Address, address_dict: dict) -> Addres
 
     return None
 
+
 def delete_non_memoized_entity_role(
     legal_entity: LegalEntity, filing: Filing, keep_list, role: EntityRole.RoleTypes
 ) -> []:

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/parties.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/parties.py
@@ -162,6 +162,8 @@ def merge_all_parties(legal_entity: LegalEntity, filing: Filing, parties: dict) 
                 party_le.entity_delivery_address, party_dict.get("deliveryAddress")
             )
             mailing_address = get_address_for_filing(party_le.entity_mailing_address, party_dict.get("mailingAddress"))
+            party_le.entity_delivery_address = delivery_address
+            party_le.entity_mailing_address = mailing_address
         else:
             # New People and Orgs use the attached addresses
             if isinstance(party_le, ColinEntity):
@@ -439,17 +441,19 @@ def get_address_for_filing(party_address: Address, address_dict: dict) -> Addres
     ):
         return party_address
 
-    new_address = Address(
-        street=address_dict["streetAddress"],
-        city=address_dict["addressCity"],
-        country=address_dict["addressCountry"],
-        postal_code=address_dict["postalCode"],
-        region=address_dict["addressRegion"],
-        delivery_instructions=address_dict.get("deliveryInstructions", ""),
-    )
-    # new_address.save()
-    return new_address
+    if address_dict:
+        new_address = Address(
+            street=address_dict["streetAddress"],
+            city=address_dict["addressCity"],
+            country=address_dict["addressCountry"],
+            postal_code=address_dict["postalCode"],
+            region=address_dict["addressRegion"],
+            delivery_instructions=address_dict.get("deliveryInstructions", ""),
+        )
+        # new_address.save()
+        return new_address
 
+    return None
 
 def delete_non_memoized_entity_role(
     legal_entity: LegalEntity, filing: Filing, keep_list, role: EntityRole.RoleTypes
@@ -463,7 +467,6 @@ def delete_non_memoized_entity_role(
 
         candidate.cessation_date = filing.effective_date
         candidate.change_filing_id = filing.id
-        candidate.delete()
 
     return None
 
@@ -504,6 +507,8 @@ def get_or_create_party(party_dict: dict, filing: Filing):
         update_person_info(party_le, party_dict)
         delivery_address = get_address_for_filing(party_le.entity_delivery_address, party_dict.get("deliveryAddress"))
         mailing_address = get_address_for_filing(party_le.entity_mailing_address, party_dict.get("mailingAddress"))
+        party_le.entity_delivery_address = delivery_address
+        party_le.entity_mailing_address = mailing_address
     else:
         # New People and Orgs use the attached addresses
         if isinstance(party_le, ColinEntity):

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/registration.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/registration.py
@@ -139,9 +139,10 @@ def process(
         }
 
     if offices := registration_filing["offices"]:
-        update_offices(alternate_name, offices)
         if entity_type == BusinessCommon.EntityTypes.PARTNERSHIP:
             update_offices(business, offices)
+        else:
+            update_offices(alternate_name, offices)
 
     if parties := registration_filing.get("parties"):
         merge_all_parties(business, filing_rec, {"parties": parties})
@@ -198,13 +199,11 @@ def merge_partnership_registration(
         name_type=AlternateName.NameType.DBA,
         start_date=filing_rec.effective_date,
         business_start_date=business.start_date,
-        state=BusinessCommon.State.ACTIVE,
         entity_type=BusinessCommon.EntityTypes.PARTNERSHIP,
     )
 
     if naics_dict := registration_filing.get("business", {}).get("naics"):
         set_naics(business, naics_dict)
-        set_naics(alternate_name, naics_dict)
 
     business.alternate_names.append(alternate_name)
 

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/registration.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/registration.py
@@ -199,6 +199,7 @@ def merge_partnership_registration(
         start_date=filing_rec.effective_date,
         business_start_date=business.start_date,
         state=BusinessCommon.State.ACTIVE,
+        entity_type=BusinessCommon.EntityTypes.PARTNERSHIP,
     )
 
     if naics_dict := registration_filing.get("business", {}).get("naics"):
@@ -276,6 +277,7 @@ def merge_sp_registration(registration_num: str, filing: Dict, filing_rec: Filin
         bn15=tax_id,
         email=proprietor.email,
         state=BusinessCommon.State.ACTIVE,
+        entity_type=BusinessCommon.EntityTypes.SOLE_PROP,
     )
 
     if naics_dict := filing.get("filing", {}).get("registration", {}).get("business", {}).get("naics"):

--- a/queue_services/entity-filer/src/entity_filer/resources/worker.py
+++ b/queue_services/entity-filer/src/entity_filer/resources/worker.py
@@ -285,7 +285,7 @@ def process_filing(
                 change_of_name.process(business, {filing_type: filing}, filing_meta)
 
             case "changeOfRegistration":
-                change_of_registration.process(business, filing_submission, {filing_type: filing}, filing_meta)
+                business, alternate_name = change_of_registration.process(business, filing_submission, {filing_type: filing}, filing_meta)
 
             case "consentContinuationOut":
                 consent_continuation_out.process(business, filing_submission, {filing_type: filing}, filing_meta)
@@ -341,7 +341,7 @@ def process_filing(
     if alternate_name:
         business_type = alternate_name.entity_type
     else:
-        business_type = business.entity_type if business else filing_submission["business"]["legal_type"]
+        business_type = business.entity_type if business else filing_submission.json_legal_type
 
     filing_submission.set_processed(business_type)
 
@@ -349,7 +349,8 @@ def process_filing(
         json.dumps(filing_meta.asjson, default=json_serial)
     )
 
-    db.session.add(business)
+    if business:
+        db.session.add(business)
     if alternate_name:
         db.session.add(alternate_name)
     db.session.add(filing_submission)
@@ -407,7 +408,7 @@ def process_filing(
         #     corp_type_code=business.legal_type
         # )
 
-    if business.entity_type in ["SP", "GP", "BC", "BEN", "CC", "ULC", "CP"] and any(
+    if business and business.entity_type in ["SP", "GP", "BC", "BEN", "CC", "ULC", "CP"] and any(
         "correction" in x for x in legal_filings
     ):
         # TODO

--- a/queue_services/entity-filer/src/entity_filer/resources/worker.py
+++ b/queue_services/entity-filer/src/entity_filer/resources/worker.py
@@ -285,7 +285,9 @@ def process_filing(
                 change_of_name.process(business, {filing_type: filing}, filing_meta)
 
             case "changeOfRegistration":
-                business, alternate_name = change_of_registration.process(business, filing_submission, {filing_type: filing}, filing_meta)
+                business, alternate_name = change_of_registration.process(
+                    business, filing_submission, {filing_type: filing}, filing_meta
+                )
 
             case "consentContinuationOut":
                 consent_continuation_out.process(business, filing_submission, {filing_type: filing}, filing_meta)
@@ -408,8 +410,10 @@ def process_filing(
         #     corp_type_code=business.legal_type
         # )
 
-    if business and business.entity_type in ["SP", "GP", "BC", "BEN", "CC", "ULC", "CP"] and any(
-        "correction" in x for x in legal_filings
+    if (
+        business
+        and business.entity_type in ["SP", "GP", "BC", "BEN", "CC", "ULC", "CP"]
+        and any("correction" in x for x in legal_filings)
     ):
         # TODO
         pass

--- a/queue_services/entity-filer/src/entity_filer/services/bootstrap.py
+++ b/queue_services/entity-filer/src/entity_filer/services/bootstrap.py
@@ -1,0 +1,276 @@
+# Copyright © 2020 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TODO: remove this file once filer refers to common module
+"""This is a service to bootstrap the Incorporation Application process."""
+
+import contextlib
+import json
+import secrets
+import string
+from http import HTTPStatus
+from typing import Dict, Union
+
+import requests
+from flask import current_app
+from flask_babel import _ as babel  # noqa: N813, I001, I003 casting _ to babel
+from sqlalchemy.orm.exc import FlushError  # noqa: I001
+
+from business_model import RegistrationBootstrap  # noqa: D204, I003, I001;# due to babel cast above
+
+
+class RegistrationBootstrapService:
+    """Provides services to bootstrap the IA registration and account affiliation."""
+
+    @staticmethod
+    def create_bootstrap(account: int) -> Union[Dict, RegistrationBootstrap]:
+        """Return either a new bootstrap registration or an error struct."""
+        if not account:
+            return {"error": babel("An account number must be provided.")}
+
+        bootstrap = RegistrationBootstrap(account=account)
+
+        # try to create a bootstrap registration with a unique ID
+        for _ in range(5):
+            try:
+                bootstrap.identifier = RegistrationBootstrapService._generate_temp_identifier()
+                bootstrap.save()
+                return bootstrap
+            except FlushError:
+                pass  # we try again
+            except Exception:
+                break
+
+        return {"error": babel("Unable to create bootstrap registration.")}
+
+    @staticmethod
+    def _generate_temp_identifier():
+        """Generate a 10 character string which starts with `T` and have at least 1 digit."""
+        allowed_encoded = string.ascii_letters + string.digits
+        identifier = None
+        while True:
+            identifier = "T" + "".join(secrets.choice(allowed_encoded) for _ in range(9))
+            if any(c.isdigit() for c in identifier):  # identifier requires at least 1 digit (as per auth-api)
+                break
+        return identifier
+
+    @staticmethod
+    def delete_bootstrap(bootstrap: RegistrationBootstrap):
+        """Delete the bootstrap registration."""
+        with contextlib.suppress(Exception):
+            bootstrap.delete()
+        return HTTPStatus.OK
+
+    @staticmethod
+    def register_bootstrap(
+        bootstrap: RegistrationBootstrap,
+        business_name: str,
+        corp_type_code: str = "TMP",
+        corp_sub_type_code: str = None,
+    ) -> Union[HTTPStatus, Dict]:
+        """Return either a new bootstrap registration or an error struct."""
+        if not bootstrap:
+            return {"error": babel("An account number must be provided.")}
+
+        rv = AccountService.create_affiliation(
+            account=bootstrap.account,
+            business_registration=bootstrap.identifier,
+            business_name=business_name,
+            corp_type_code=corp_type_code,
+            corp_sub_type_code=corp_sub_type_code,
+        )
+
+        if rv == HTTPStatus.OK:
+            return HTTPStatus.OK
+
+        with contextlib.suppress(Exception):
+            AccountService.delete_affiliation(account=bootstrap.account, business_registration=bootstrap.identifier)
+        return {"error": babel("Unable to create bootstrap registration.")}
+
+    @staticmethod
+    def deregister_bootstrap(bootstrap: RegistrationBootstrap) -> HTTPStatus:
+        """Remove the bootstrap registration."""
+        affiliation_status = AccountService.delete_affiliation(
+            account=bootstrap.account, business_registration=bootstrap.identifier
+        )
+        return affiliation_status
+
+
+class AccountService:
+    """Wrapper to call Authentication Services.
+
+    @TODO Cache and refresh / retry token as needed to reduce calls.
+    """
+
+    BEARER: str = "Bearer "
+    CONTENT_TYPE_JSON = {"Content-Type": "application/json"}
+
+    try:
+        timeout = int(current_app.config.get("ACCOUNT_SVC_TIMEOUT", 20))
+    except Exception:
+        timeout = 20
+
+    @classmethod
+    def get_bearer_token(cls):
+        """Get a valid Bearer token for the service to use."""
+        token_url = current_app.config.get("ACCOUNT_SVC_AUTH_URL")
+        client_id = current_app.config.get("ACCOUNT_SVC_CLIENT_ID")
+        client_secret = current_app.config.get("ACCOUNT_SVC_CLIENT_SECRET")
+
+        data = "grant_type=client_credentials"
+
+        # get service account token
+        res = requests.post(
+            url=token_url,
+            data=data,
+            headers={"content-type": "application/x-www-form-urlencoded"},
+            auth=(client_id, client_secret),
+            timeout=cls.timeout,
+        )
+
+        try:
+            return res.json().get("access_token")
+        except Exception:
+            return None
+
+    @classmethod
+    # pylint: disable=too-many-arguments, too-many-locals disable=invalid-name;
+    def create_affiliation(
+        cls,
+        account: int,
+        business_registration: str,
+        business_name: str = None,
+        corp_type_code: str = "TMP",
+        corp_sub_type_code: str = None,
+        pass_code: str = "",
+        details: dict = None,
+    ):
+        """Affiliate a business to an account."""
+        auth_url = current_app.config.get("AUTH_SVC_URL")
+        account_svc_entity_url = f"{auth_url}/entities"
+        account_svc_affiliate_url = f"{auth_url}/orgs/{account}/affiliations"
+
+        token = cls.get_bearer_token()
+
+        if not token:
+            return HTTPStatus.UNAUTHORIZED
+
+        # Create an entity record
+        entity_data = {
+            "businessIdentifier": business_registration,
+            "corpTypeCode": corp_type_code,
+            "name": business_name or business_registration,
+        }
+        if corp_sub_type_code:
+            entity_data["corpSubTypeCode"] = corp_sub_type_code
+
+        entity_record = requests.post(
+            url=account_svc_entity_url,
+            headers={**cls.CONTENT_TYPE_JSON, "Authorization": cls.BEARER + token},
+            data=json.dumps(entity_data),
+            timeout=cls.timeout,
+        )
+
+        # Create an account:business affiliation
+        affiliate_data = {"businessIdentifier": business_registration, "passCode": pass_code}
+        if details:
+            affiliate_data["entityDetails"] = details
+        affiliate = requests.post(
+            url=account_svc_affiliate_url,
+            headers={**cls.CONTENT_TYPE_JSON, "Authorization": cls.BEARER + token},
+            data=json.dumps(affiliate_data),
+            timeout=cls.timeout,
+        )
+
+        # @TODO delete affiliation and entity record next sprint when affiliation service is updated
+        if affiliate.status_code != HTTPStatus.CREATED or entity_record.status_code != HTTPStatus.CREATED:
+            return HTTPStatus.BAD_REQUEST
+        return HTTPStatus.OK
+
+    @classmethod
+    def update_entity(cls, business_registration: str, business_name: str, corp_type_code: str, state: str = None):
+        """Update an entity."""
+        auth_url = current_app.config.get("AUTH_SVC_URL")
+        account_svc_entity_url = f"{auth_url}/entities"
+
+        token = cls.get_bearer_token()
+
+        if not token:
+            return HTTPStatus.UNAUTHORIZED
+
+        # Create an entity record
+        entity_data = {
+            "businessIdentifier": business_registration,
+            "corpTypeCode": corp_type_code,
+            "name": business_name,
+        }
+        if state:
+            entity_data["state"] = state
+
+        entity_record = requests.patch(
+            url=account_svc_entity_url + "/" + business_registration,
+            headers={**cls.CONTENT_TYPE_JSON, "Authorization": cls.BEARER + token},
+            data=json.dumps(entity_data),
+            timeout=cls.timeout,
+        )
+
+        if entity_record.status_code != HTTPStatus.OK:
+            return HTTPStatus.BAD_REQUEST
+        return HTTPStatus.OK
+
+    @classmethod
+    def delete_affiliation(cls, account: int, business_registration: str) -> Dict:
+        """Affiliate a business to an account.
+
+        @TODO Update this when account affiliation is changed next sprint.
+        """
+        auth_url = current_app.config.get("AUTH_SVC_URL")
+        account_svc_entity_url = f"{auth_url}/entities"
+        account_svc_affiliate_url = f"{auth_url}/orgs/{account}/affiliations"
+
+        token = cls.get_bearer_token()
+
+        # Delete an account:business affiliation
+        affiliate = requests.delete(
+            url=account_svc_affiliate_url + "/" + business_registration,
+            headers={**cls.CONTENT_TYPE_JSON, "Authorization": cls.BEARER + token},
+            timeout=cls.timeout,
+        )
+        # Delete an entity record
+        entity_record = requests.delete(
+            url=account_svc_entity_url + "/" + business_registration,
+            headers={**cls.CONTENT_TYPE_JSON, "Authorization": cls.BEARER + token},
+            timeout=cls.timeout,
+        )
+
+        if affiliate.status_code != HTTPStatus.OK or entity_record.status_code not in (
+            HTTPStatus.OK,
+            HTTPStatus.NO_CONTENT,
+        ):
+            return HTTPStatus.BAD_REQUEST
+        return HTTPStatus.OK
+
+    @classmethod
+    def get_account_by_affiliated_identifier(cls, identifier: str):
+        """Return the account affiliated to the LegalEntity."""
+        token = cls.get_bearer_token()
+        auth_url = current_app.config.get("AUTH_SVC_URL")
+        url = f"{auth_url}/orgs?affiliation={identifier}"
+
+        res = requests.get(url, headers={**cls.CONTENT_TYPE_JSON, "Authorization": cls.BEARER + token})
+        try:
+            return res.json()
+        except Exception:  # noqa B902; pylint: disable=W0703;
+            current_app.logger.error("Failed to get response")
+            return None

--- a/queue_services/entity-filer/src/entity_filer/services/bootstrap.py
+++ b/queue_services/entity-filer/src/entity_filer/services/bootstrap.py
@@ -23,11 +23,10 @@ from http import HTTPStatus
 from typing import Dict, Union
 
 import requests
+from business_model import RegistrationBootstrap  # noqa: D204, I003, I001;# due to babel cast above
 from flask import current_app
 from flask_babel import _ as babel  # noqa: N813, I001, I003 casting _ to babel
 from sqlalchemy.orm.exc import FlushError  # noqa: I001
-
-from business_model import RegistrationBootstrap  # noqa: D204, I003, I001;# due to babel cast above
 
 
 class RegistrationBootstrapService:

--- a/queue_services/entity-filer/src/entity_filer/services/business_service.py
+++ b/queue_services/entity-filer/src/entity_filer/services/business_service.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# TODO: remove this file once filer refers to common module
 """This provides the service for businesses(legal entities and alternate name entities."""
-from __future__ import annotations
-
 from business_model import AlternateName, BusinessCommon, LegalEntity
 
 
@@ -33,14 +32,7 @@ class BusinessService:
             return legal_entity
 
         if identifier.startswith("FM") and (alternate_name := AlternateName.find_by_identifier(identifier)):
-            if alternate_name.is_owned_by_colin_entity:
-                return alternate_name
-
-            legal_entity = LegalEntity.find_by_id(alternate_name.legal_entity_id)
-            alternate_name_entity = (
-                alternate_name if legal_entity.entity_type != BusinessCommon.EntityTypes.PARTNERSHIP.value else None
-            )
-            return alternate_name_entity
+            return alternate_name
 
         return None
 
@@ -58,13 +50,6 @@ class BusinessService:
         if (alternate_name_id := filing.alternate_name_id) and (
             alternate_name := AlternateName.find_by_internal_id(alternate_name_id)
         ):
-            if alternate_name.is_owned_by_colin_entity:
-                return alternate_name
-
-            legal_entity = LegalEntity.find_by_id(alternate_name.legal_entity_id)
-            alternate_name_entity = (
-                alternate_name if legal_entity.entity_type != BusinessCommon.EntityTypes.PARTNERSHIP.value else None
-            )
-            return alternate_name_entity
+            return alternate_name
 
         return None

--- a/queue_services/entity-filer/src/entity_filer/services/naics.py
+++ b/queue_services/entity-filer/src/entity_filer/services/naics.py
@@ -1,0 +1,41 @@
+# Copyright © 2022 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TODO: remove this file once filer refers to common module
+"""This provides the service for naics-api calls."""
+
+import requests
+from flask import current_app
+
+from .bootstrap import AccountService
+
+
+class NaicsService:
+    """Provides services to use the naics-api."""
+
+    @staticmethod
+    def find_by_code(naics_code: str):
+        """Return NAICS Structure matching code."""
+        try:
+            naics_url = current_app.config.get("NAICS_API_URL")
+            token = AccountService.get_bearer_token()
+            response = requests.get(
+                naics_url + "/" + naics_code,
+                headers={"Content-Type": "application/json", "Authorization": "Bearer " + token},
+            )
+            response.raise_for_status()
+            return response.json()
+        except Exception as err:
+            current_app.logger.error(err)
+            return None

--- a/queue_services/entity-filer/tests/unit/__init__.py
+++ b/queue_services/entity-filer/tests/unit/__init__.py
@@ -16,7 +16,7 @@ import base64
 import uuid
 from contextlib import contextmanager
 
-from business_model.models import Filing, ShareClass, ShareSeries, db
+from business_model.models import AlternateName, BusinessCommon, Filing, ShareClass, ShareSeries, db
 from business_model.models.colin_event_id import ColinEventId
 from freezegun import freeze_time
 from sqlalchemy import exc
@@ -464,7 +464,8 @@ def create_entity(identifier, legal_type, legal_name):
     if legal_entity.entity_type == LegalEntity.EntityTypes.PERSON.value:
         legal_entity.first_name = "my"
         legal_entity.last_name = "self"
-    legal_entity._legal_name = legal_name
+    else:
+        legal_entity._legal_name = legal_name
     legal_entity.identifier = identifier
     legal_entity.save()
     return legal_entity
@@ -511,7 +512,7 @@ def create_office_address(business, office, address_type):
 
 
 def create_entity_person(party_json):
-    """Create a director."""
+    """Create a director/partner/proprietor."""
     from business_model import Address, LegalEntity
 
     new_party = LegalEntity(
@@ -627,6 +628,45 @@ def factory_completed_filing(
         legal_entity.save()
 
     return filing
+
+
+def create_alternate_name(
+    identifier=None,
+    entity_type=None,
+    name="OPERATING NAME",
+    name_type=AlternateName.NameType.DBA,
+    bn15=None,
+    legal_entity_id=None,
+    business_start_date=EPOCH_DATETIME,
+    start_date=EPOCH_DATETIME,
+    end_date=None,
+    state=BusinessCommon.State.ACTIVE,
+    naics_code=None,
+    naics_desc=None,
+    admin_freeze=False,
+    change_filing_id=None,
+):
+    """Create an alternate name."""
+
+    alternate_name = AlternateName(
+        identifier=identifier,
+        name=name,
+        name_type=name_type,
+        bn15=bn15,
+        legal_entity_id=legal_entity_id,
+        business_start_date=business_start_date,
+        start_date=start_date,
+        end_date=end_date,
+        state=state,
+        naics_code=naics_code,
+        naics_description=naics_desc,
+        admin_freeze=admin_freeze,
+        change_filing_id=change_filing_id,
+        entity_type=entity_type,
+    )
+
+    alternate_name.save()
+    return alternate_name
 
 
 @contextmanager

--- a/queue_services/entity-filer/tests/unit/worker/test_change_of_registration.py
+++ b/queue_services/entity-filer/tests/unit/worker/test_change_of_registration.py
@@ -96,8 +96,7 @@ def test_change_of_registration_operating_name_sp(
         identifier=identifier,
         entity_type=BusinessCommon.EntityTypes.SOLE_PROP,
         name=operating_name,
-        change_filing_id=filing.id
-
+        change_filing_id=filing.id,
     )
     proprietor.alternate_names.append(alternate_name)
     proprietor.save()
@@ -170,7 +169,6 @@ def test_change_of_registration_operating_name_gp(
 
     business = create_entity(identifier, legal_type, None)
 
-
     alternate_name = create_alternate_name(
         identifier=identifier,
         entity_type=BusinessCommon.EntityTypes.PARTNERSHIP,
@@ -230,17 +228,13 @@ def test_change_of_registration_business_address(
     proprietor_identifier = "P1234567"
     if legal_type == BusinessCommon.EntityTypes.SOLE_PROP.value:
         proprietor = create_entity(proprietor_identifier, "person", legal_name)
-        business = create_alternate_name(
-            identifier=identifier,
-            entity_type=BusinessCommon.EntityTypes.SOLE_PROP
-        )
+        business = create_alternate_name(identifier=identifier, entity_type=BusinessCommon.EntityTypes.SOLE_PROP)
         proprietor.alternate_names.append(business)
         proprietor.save()
     else:
         business = create_entity(identifier, legal_type, legal_name)
         alternate_name = create_alternate_name(
-            identifier=identifier,
-            entity_type=BusinessCommon.EntityTypes.PARTNERSHIP
+            identifier=identifier, entity_type=BusinessCommon.EntityTypes.PARTNERSHIP
         )
         business.alternate_names.append(alternate_name)
         business.save()
@@ -315,23 +309,21 @@ def test_change_of_registration_business_address(
         ("sp_court_order", "SP", "Test Firm", SP_CHANGE_OF_REGISTRATION),
     ],
 )
-def test_worker_change_of_registration_court_order(app, session, mocker, test_name, legal_type, legal_name, filing_template):
+def test_worker_change_of_registration_court_order(
+    app, session, mocker, test_name, legal_type, legal_name, filing_template
+):
     """Assert the worker process the court order correctly."""
     identifier = "FM1234567"
     proprietor_identifier = "P1234567"
     if legal_type == BusinessCommon.EntityTypes.SOLE_PROP.value:
         proprietor = create_entity(proprietor_identifier, "person", legal_name)
-        business = create_alternate_name(
-            identifier=identifier,
-            entity_type=BusinessCommon.EntityTypes.SOLE_PROP
-        )
+        business = create_alternate_name(identifier=identifier, entity_type=BusinessCommon.EntityTypes.SOLE_PROP)
         proprietor.alternate_names.append(business)
         proprietor.save()
     else:
         business = create_entity(identifier, legal_type, legal_name)
         alternate_name = create_alternate_name(
-            identifier=identifier,
-            entity_type=BusinessCommon.EntityTypes.PARTNERSHIP
+            identifier=identifier, entity_type=BusinessCommon.EntityTypes.PARTNERSHIP
         )
         business.alternate_names.append(alternate_name)
         business.save()
@@ -384,10 +376,7 @@ def test_worker_change_of_registration_court_order(app, session, mocker, test_na
 def test_worker_proprietor_name_and_address_change(app, session, mocker):
     """Assert the worker process the name and address change correctly."""
     identifier = "FM1234567"
-    alternate_name = create_alternate_name(
-        identifier=identifier,
-        entity_type=BusinessCommon.EntityTypes.SOLE_PROP
-    )
+    alternate_name = create_alternate_name(identifier=identifier, entity_type=BusinessCommon.EntityTypes.SOLE_PROP)
 
     party = create_entity_person(SP_CHANGE_OF_REGISTRATION["filing"]["changeOfRegistration"]["parties"][0])
     party_id = party.id
@@ -427,7 +416,9 @@ def test_worker_proprietor_name_and_address_change(app, session, mocker):
     # Check outcome
     party = LegalEntity.find_by_internal_id(party_id)
     assert party.first_name == filing["filing"]["changeOfRegistration"]["parties"][0]["officer"]["firstName"].upper()
-    assert party.middle_initial == filing["filing"]["changeOfRegistration"]["parties"][0]["officer"]["middleName"].upper()
+    assert (
+        party.middle_initial == filing["filing"]["changeOfRegistration"]["parties"][0]["officer"]["middleName"].upper()
+    )
     assert party.last_name == filing["filing"]["changeOfRegistration"]["parties"][0]["officer"]["lastName"].upper()
     assert (
         party.entity_delivery_address.street
@@ -451,10 +442,7 @@ def test_worker_partner_name_and_address_change(app, session, mocker, test_name)
     """Assert the worker process the partner name and address change correctly."""
     identifier = "FM1234567"
     business = create_entity(identifier, "GP", "Test Entity")
-    alternate_name = create_alternate_name(
-        identifier=identifier,
-        entity_type=BusinessCommon.EntityTypes.PARTNERSHIP
-    )
+    alternate_name = create_alternate_name(identifier=identifier, entity_type=BusinessCommon.EntityTypes.PARTNERSHIP)
     business.alternate_names.append(alternate_name)
     business_id = business.id
 

--- a/queue_services/entity-filer/tests/unit/worker/test_change_of_registration.py
+++ b/queue_services/entity-filer/tests/unit/worker/test_change_of_registration.py
@@ -18,7 +18,7 @@ from typing import Final
 from unittest.mock import patch
 
 import pytest
-from business_model import Address, AlternateName, EntityRole, Filing, LegalEntity
+from business_model import Address, AlternateName, BusinessCommon, EntityRole, Filing, LegalEntity
 
 # from datetime import datetime
 from business_model.utils.datetime import datetime
@@ -28,6 +28,7 @@ from registry_schemas.example_data import CHANGE_OF_REGISTRATION_TEMPLATE, COURT
 from entity_filer.filing_processors.filing_components.legal_entity_info import NaicsService
 from entity_filer.resources.worker import FilingMessage, process_filing
 from tests.unit import (
+    create_alternate_name,
     create_entity,
     create_entity_person,
     create_entity_role,
@@ -40,8 +41,6 @@ CONTACT_POINT = {"email": "no_one@never.get", "phone": "123-456-7890"}
 
 GP_CHANGE_OF_REGISTRATION = copy.deepcopy(CHANGE_OF_REGISTRATION_TEMPLATE)
 GP_CHANGE_OF_REGISTRATION["filing"]["changeOfRegistration"]["parties"].append(REGISTRATION["parties"][1])
-del GP_CHANGE_OF_REGISTRATION["filing"]["changeOfRegistration"]["parties"][0]["officer"]["id"]
-del GP_CHANGE_OF_REGISTRATION["filing"]["changeOfRegistration"]["parties"][1]["officer"]["id"]
 
 SP_CHANGE_OF_REGISTRATION = copy.deepcopy(CHANGE_OF_REGISTRATION_TEMPLATE)
 SP_CHANGE_OF_REGISTRATION["filing"]["business"]["legalType"] = "SP"
@@ -50,7 +49,6 @@ SP_CHANGE_OF_REGISTRATION["filing"]["changeOfRegistration"]["parties"][0]["roles
     {"roleType": "Completing Party", "appointmentDate": "2022-01-01"},
     {"roleType": "Proprietor", "appointmentDate": "2022-01-01"},
 ]
-del SP_CHANGE_OF_REGISTRATION["filing"]["changeOfRegistration"]["parties"][0]["officer"]["id"]
 
 naics_response = {
     "code": REGISTRATION["business"]["naics"]["naicsCode"],
@@ -59,19 +57,19 @@ naics_response = {
 
 
 @pytest.mark.parametrize(
-    "test_name, legal_name, new_legal_name,legal_type, filing_template",
+    "test_name, operating_name, new_operating_name,legal_type, filing_template",
     [
-        ("name_change", "Test Firm", "New Name", "SP", SP_CHANGE_OF_REGISTRATION),
-        ("no_change", "Test Firm", None, "SP", SP_CHANGE_OF_REGISTRATION),
+        ("name_change", "Old Name", "New Name", "SP", SP_CHANGE_OF_REGISTRATION),
+        ("no_change", "Old Name", None, "SP", SP_CHANGE_OF_REGISTRATION),
     ],
 )
-def test_change_of_registration_legal_name_sp(
+def test_change_of_registration_operating_name_sp(
     app,
     session,
     mocker,
     test_name,
-    legal_name,
-    new_legal_name,
+    operating_name,
+    new_operating_name,
     legal_type,
     filing_template,
 ):
@@ -81,7 +79,7 @@ def test_change_of_registration_legal_name_sp(
 
     filing = copy.deepcopy(filing_template)
     if test_name == "name_change":
-        filing["filing"]["changeOfRegistration"]["nameRequest"]["legalName"] = new_legal_name
+        filing["filing"]["changeOfRegistration"]["nameRequest"]["legalName"] = new_operating_name
     else:
         del filing["filing"]["changeOfRegistration"]["nameRequest"]
 
@@ -94,21 +92,19 @@ def test_change_of_registration_legal_name_sp(
     filing["filing"]["business"]["identifier"] = identifier
     filing = create_filing(payment_id, filing)
 
-    alternate_name = AlternateName(
+    alternate_name = create_alternate_name(
         identifier=identifier,
-        name_type=AlternateName.NameType.OPERATING,
-        change_filing_id=filing.id,
-        end_date=None,
-        name=legal_name,
-        start_date=datetime.utcnow(),
-        registration_date=datetime.utcnow(),
+        entity_type=BusinessCommon.EntityTypes.SOLE_PROP,
+        name=operating_name,
+        change_filing_id=filing.id
+
     )
     proprietor.alternate_names.append(alternate_name)
     proprietor.save()
     proprietor_id = proprietor.id
 
     filing_id = filing.id
-    filing.legal_entity_id = proprietor_id
+    filing.alternate_name_id = alternate_name.id
     filing.save()
 
     filing_msg = FilingMessage(filing_identifier=filing_id)
@@ -131,40 +127,40 @@ def test_change_of_registration_legal_name_sp(
     business = LegalEntity.find_by_internal_id(proprietor_id)
     alternate_name = business.alternate_names.all()[0]
 
-    if new_legal_name:
-        assert alternate_name.name == new_legal_name
-        assert change_of_registration.get("toLegalName") == new_legal_name
-        assert change_of_registration.get("fromLegalName") == legal_name
+    if new_operating_name:
+        assert alternate_name.name == new_operating_name
+        assert change_of_registration.get("toLegalName") == new_operating_name
+        assert change_of_registration.get("fromLegalName") == operating_name
     else:
-        assert alternate_name.name == legal_name
+        assert alternate_name.name == operating_name
         assert change_of_registration.get("toLegalName") is None
         assert change_of_registration.get("fromLegalName") is None
 
 
 @pytest.mark.parametrize(
-    "test_name, legal_name, new_legal_name,legal_type, filing_template",
+    "test_name, operating_name, new_operating_name,legal_type, filing_template",
     [
-        ("name_change", "Test Firm", "New Name", "GP", GP_CHANGE_OF_REGISTRATION),
-        ("no_change", "Test Firm", None, "GP", GP_CHANGE_OF_REGISTRATION),
+        ("name_change", "Old Name", "New Name", "GP", GP_CHANGE_OF_REGISTRATION),
+        ("no_change", "Old Name", None, "GP", GP_CHANGE_OF_REGISTRATION),
     ],
 )
-def test_change_of_registration_legal_name_gp(
+def test_change_of_registration_operating_name_gp(
     app,
     session,
     mocker,
     test_name,
-    legal_name,
-    new_legal_name,
+    operating_name,
+    new_operating_name,
     legal_type,
     filing_template,
 ):
-    """Assert the worker process calls the legal name change correctly."""
+    """Assert the worker process calls the operating name change correctly."""
 
     identifier = "FM1234567"
 
     filing = copy.deepcopy(filing_template)
     if test_name == "name_change":
-        filing["filing"]["changeOfRegistration"]["nameRequest"]["legalName"] = new_legal_name
+        filing["filing"]["changeOfRegistration"]["nameRequest"]["legalName"] = new_operating_name
     else:
         del filing["filing"]["changeOfRegistration"]["nameRequest"]
 
@@ -172,16 +168,14 @@ def test_change_of_registration_legal_name_gp(
 
     filing = create_filing(payment_id, filing)
 
-    business = create_entity(identifier, legal_type, legal_name)
+    business = create_entity(identifier, legal_type, None)
 
-    alternate_name = AlternateName(
+
+    alternate_name = create_alternate_name(
         identifier=identifier,
-        name_type=AlternateName.NameType.OPERATING,
+        entity_type=BusinessCommon.EntityTypes.PARTNERSHIP,
+        name=operating_name,
         change_filing_id=filing.id,
-        end_date=None,
-        name=legal_name,
-        start_date=datetime.utcnow(),
-        registration_date=datetime.utcnow(),
     )
     business.alternate_names.append(alternate_name)
     business.save()
@@ -209,12 +203,14 @@ def test_change_of_registration_legal_name_gp(
     change_of_registration = final_filing.meta_data.get("changeOfRegistration", {})
     business = LegalEntity.find_by_internal_id(business_id)
 
-    if new_legal_name:
-        assert business.business_name == new_legal_name
-        assert change_of_registration.get("toLegalName") == new_legal_name
-        assert change_of_registration.get("fromLegalName") == legal_name
+    if new_operating_name:
+        assert len(business.alternate_names.all()) > 0
+        assert business.alternate_names[0].name == new_operating_name
+        assert change_of_registration.get("toLegalName") == new_operating_name
+        assert change_of_registration.get("fromLegalName") == operating_name
     else:
-        assert business.business_name == legal_name
+        assert len(business.alternate_names.all()) > 0
+        assert business.alternate_names[0].name == operating_name
         assert change_of_registration.get("toLegalName") is None
         assert change_of_registration.get("fromLegalName") is None
 
@@ -231,8 +227,24 @@ def test_change_of_registration_business_address(
 ):
     """Assert the worker process calls the business address change correctly."""
     identifier = "FM1234567"
-    business = create_entity(identifier, legal_type, legal_name)
-    business.save()
+    proprietor_identifier = "P1234567"
+    if legal_type == BusinessCommon.EntityTypes.SOLE_PROP.value:
+        proprietor = create_entity(proprietor_identifier, "person", legal_name)
+        business = create_alternate_name(
+            identifier=identifier,
+            entity_type=BusinessCommon.EntityTypes.SOLE_PROP
+        )
+        proprietor.alternate_names.append(business)
+        proprietor.save()
+    else:
+        business = create_entity(identifier, legal_type, legal_name)
+        alternate_name = create_alternate_name(
+            identifier=identifier,
+            entity_type=BusinessCommon.EntityTypes.PARTNERSHIP
+        )
+        business.alternate_names.append(alternate_name)
+        business.save()
+
     business_id = business.id
 
     office = create_office(business, "registeredOffice")
@@ -257,8 +269,14 @@ def test_change_of_registration_business_address(
 
     payment_id = str(random.SystemRandom().getrandbits(0x58))
 
-    filing_id = (create_filing(payment_id, filing, business_id=business_id)).id
-    filing_msg = FilingMessage(filing_identifier=filing_id)
+    filing_submission = create_filing(payment_id, filing)
+    if business.is_alternate_name_entity:
+        filing_submission.legal_entity_id = None
+        filing_submission.alternate_name_id = business_id
+    else:
+        filing_submission.legal_entity_id = business_id
+    filing_submission.save()
+    filing_msg = FilingMessage(filing_identifier=filing_submission.id)
 
     # mock out the email sender and event publishing
     # mocker.patch('entity_filer.worker.publish_email_message', return_value=None)
@@ -291,16 +309,34 @@ def test_change_of_registration_business_address(
 
 
 @pytest.mark.parametrize(
-    "test_name, legal_type, filing_template",
+    "test_name, legal_type, legal_name, filing_template",
     [
-        ("gp_court_order", "GP", GP_CHANGE_OF_REGISTRATION),
-        ("sp_court_order", "SP", SP_CHANGE_OF_REGISTRATION),
+        ("gp_court_order", "GP", "Test Firm", GP_CHANGE_OF_REGISTRATION),
+        ("sp_court_order", "SP", "Test Firm", SP_CHANGE_OF_REGISTRATION),
     ],
 )
-def test_worker_change_of_registration_court_order(app, session, mocker, test_name, legal_type, filing_template):
+def test_worker_change_of_registration_court_order(app, session, mocker, test_name, legal_type, legal_name, filing_template):
     """Assert the worker process the court order correctly."""
     identifier = "FM1234567"
-    business = create_entity(identifier, legal_type, "Test Entity")
+    proprietor_identifier = "P1234567"
+    if legal_type == BusinessCommon.EntityTypes.SOLE_PROP.value:
+        proprietor = create_entity(proprietor_identifier, "person", legal_name)
+        business = create_alternate_name(
+            identifier=identifier,
+            entity_type=BusinessCommon.EntityTypes.SOLE_PROP
+        )
+        proprietor.alternate_names.append(business)
+        proprietor.save()
+    else:
+        business = create_entity(identifier, legal_type, legal_name)
+        alternate_name = create_alternate_name(
+            identifier=identifier,
+            entity_type=BusinessCommon.EntityTypes.PARTNERSHIP
+        )
+        business.alternate_names.append(alternate_name)
+        business.save()
+
+    business_id = business.id
 
     filing = copy.deepcopy(filing_template)
 
@@ -317,9 +353,14 @@ def test_worker_change_of_registration_court_order(app, session, mocker, test_na
     del filing["filing"]["changeOfRegistration"]["parties"]
 
     payment_id = str(random.SystemRandom().getrandbits(0x58))
-    filing_id = (create_filing(payment_id, filing, business_id=business.id)).id
+    filing_submission = create_filing(payment_id, filing)
+    if business.is_alternate_name_entity:
+        filing_submission.legal_entity_id = None
+        filing_submission.alternate_name_id = business_id
+    else:
+        filing_submission.legal_entity_id = business_id
 
-    filing_msg = FilingMessage(filing_identifier=filing_id)
+    filing_msg = FilingMessage(filing_identifier=filing_submission.id)
 
     # mock out the email sender and event publishing
     # mocker.patch('entity_filer.worker.publish_email_message', return_value=None)
@@ -334,7 +375,7 @@ def test_worker_change_of_registration_court_order(app, session, mocker, test_na
         process_filing(filing_msg)
 
     # Check outcome
-    final_filing = Filing.find_by_id(filing_id)
+    final_filing = Filing.find_by_id(filing_submission.id)
     assert file_number == final_filing.court_order_file_number
     assert datetime.fromisoformat(order_date) == final_filing.court_order_date
     assert effect_of_order == final_filing.court_order_effect_of_order
@@ -343,28 +384,33 @@ def test_worker_change_of_registration_court_order(app, session, mocker, test_na
 def test_worker_proprietor_name_and_address_change(app, session, mocker):
     """Assert the worker process the name and address change correctly."""
     identifier = "FM1234567"
-    business = create_entity(identifier, "SP", "Test Entity")
-    business_id = business.id
+    alternate_name = create_alternate_name(
+        identifier=identifier,
+        entity_type=BusinessCommon.EntityTypes.SOLE_PROP
+    )
 
     party = create_entity_person(SP_CHANGE_OF_REGISTRATION["filing"]["changeOfRegistration"]["parties"][0])
     party_id = party.id
+    party.alternate_names.append(alternate_name)
 
-    create_entity_role(business, party, ["proprietor"], datetime.utcnow())
+    party.save()
 
     filing = copy.deepcopy(SP_CHANGE_OF_REGISTRATION)
     filing["filing"]["changeOfRegistration"]["contactPoint"] = CONTACT_POINT
     filing["filing"]["changeOfRegistration"]["parties"][0]["officer"]["id"] = party_id
-    filing["filing"]["changeOfRegistration"]["parties"][0]["officer"]["firstName"] = "New Name"
-    filing["filing"]["changeOfRegistration"]["parties"][0]["officer"]["middleInitial"] = "New Name"
-    filing["filing"]["changeOfRegistration"]["parties"][0]["mailingAddress"]["streetAddress"] = "New Name"
-    filing["filing"]["changeOfRegistration"]["parties"][0]["deliveryAddress"]["streetAddress"] = "New Name"
+    filing["filing"]["changeOfRegistration"]["parties"][0]["officer"]["firstName"] = "New First Name"
+    filing["filing"]["changeOfRegistration"]["parties"][0]["officer"]["middleName"] = "New Middle Name"
+    filing["filing"]["changeOfRegistration"]["parties"][0]["officer"]["lastName"] = "New Last Name"
+    filing["filing"]["changeOfRegistration"]["parties"][0]["mailingAddress"]["streetAddress"] = "New Mailing Address"
+    filing["filing"]["changeOfRegistration"]["parties"][0]["deliveryAddress"]["streetAddress"] = "New Delivery Address"
 
     del filing["filing"]["changeOfRegistration"]["nameRequest"]
 
     payment_id = str(random.SystemRandom().getrandbits(0x58))
-    filing_id = (create_filing(payment_id, filing, business_id=business.id)).id
-
-    filing_msg = FilingMessage(filing_identifier=filing_id)
+    filing_submission = create_filing(payment_id, filing)
+    filing_submission.alternate_name_id = alternate_name.id
+    filing_submission.save()
+    filing_msg = FilingMessage(filing_identifier=filing_submission.id)
 
     # mock out the email sender and event publishing
     # mocker.patch('entity_filer.worker.publish_email_message', return_value=None)
@@ -379,9 +425,10 @@ def test_worker_proprietor_name_and_address_change(app, session, mocker):
         process_filing(filing_msg)
 
     # Check outcome
-    business = LegalEntity.find_by_internal_id(business_id)
-    party = business.entity_roles.all()[0].related_entity
+    party = LegalEntity.find_by_internal_id(party_id)
     assert party.first_name == filing["filing"]["changeOfRegistration"]["parties"][0]["officer"]["firstName"].upper()
+    assert party.middle_initial == filing["filing"]["changeOfRegistration"]["parties"][0]["officer"]["middleName"].upper()
+    assert party.last_name == filing["filing"]["changeOfRegistration"]["parties"][0]["officer"]["lastName"].upper()
     assert (
         party.entity_delivery_address.street
         == filing["filing"]["changeOfRegistration"]["parties"][0]["deliveryAddress"]["streetAddress"]
@@ -404,6 +451,11 @@ def test_worker_partner_name_and_address_change(app, session, mocker, test_name)
     """Assert the worker process the partner name and address change correctly."""
     identifier = "FM1234567"
     business = create_entity(identifier, "GP", "Test Entity")
+    alternate_name = create_alternate_name(
+        identifier=identifier,
+        entity_type=BusinessCommon.EntityTypes.PARTNERSHIP
+    )
+    business.alternate_names.append(alternate_name)
     business_id = business.id
 
     party1 = create_entity_person(GP_CHANGE_OF_REGISTRATION["filing"]["changeOfRegistration"]["parties"][0])
@@ -414,24 +466,24 @@ def test_worker_partner_name_and_address_change(app, session, mocker, test_name)
     create_entity_role(business, party1, ["partner"], datetime.utcnow())
     create_entity_role(business, party2, ["partner"], datetime.utcnow())
 
+    business.save()
+
     filing = copy.deepcopy(GP_CHANGE_OF_REGISTRATION)
     filing["filing"]["changeOfRegistration"]["contactPoint"] = CONTACT_POINT
+    filing["filing"]["changeOfRegistration"]["parties"][0]["officer"]["id"] = party_id_1
+    filing["filing"]["changeOfRegistration"]["parties"][1]["officer"]["id"] = party_id_2
 
     if test_name == "gp_add_partner":
-        filing["filing"]["changeOfRegistration"]["parties"][0]["officer"]["id"] = party_id_1
-        filing["filing"]["changeOfRegistration"]["parties"][1]["officer"]["id"] = party_id_2
         new_party_json = GP_CHANGE_OF_REGISTRATION["filing"]["changeOfRegistration"]["parties"][1]
         del new_party_json["officer"]["id"]
         new_party_json["officer"]["firstName"] = "New Name"
         filing["filing"]["changeOfRegistration"]["parties"].append(new_party_json)
 
     if test_name == "gp_edit_partner_name_and_address":
-        filing["filing"]["changeOfRegistration"]["parties"][0]["officer"]["id"] = party_id_1
         filing["filing"]["changeOfRegistration"]["parties"][0]["officer"]["firstName"] = "New Name a"
-        filing["filing"]["changeOfRegistration"]["parties"][0]["officer"]["middleInitial"] = "New Name a"
+        filing["filing"]["changeOfRegistration"]["parties"][0]["officer"]["middleName"] = "New Name a"
         filing["filing"]["changeOfRegistration"]["parties"][0]["mailingAddress"]["streetAddress"] = "New Name"
         filing["filing"]["changeOfRegistration"]["parties"][0]["deliveryAddress"]["streetAddress"] = "New Name"
-        filing["filing"]["changeOfRegistration"]["parties"][1]["officer"]["id"] = party_id_2
 
     if test_name == "gp_delete_partner":
         del filing["filing"]["changeOfRegistration"]["parties"][1]

--- a/queue_services/entity-filer/tests/unit/worker/test_change_of_registration.py
+++ b/queue_services/entity-filer/tests/unit/worker/test_change_of_registration.py
@@ -528,8 +528,7 @@ def test_worker_partner_name_and_address_change(app, session, mocker, test_name)
         assert business.entity_roles.all()[1].cessation_date is None
 
     if test_name == "gp_delete_partner":
-        deleted_role = EntityRole.get_entity_roles_by_party_id(business_id, party_id_2)[0]
-        assert deleted_role.cessation_date is not None
+        assert len(business.entity_roles.all())==1
 
     if test_name == "gp_add_partner":
         assert len(EntityRole.get_parties_by_role(business_id, "partner")) == 3

--- a/queue_services/entity-filer/tests/unit/worker/test_change_of_registration.py
+++ b/queue_services/entity-filer/tests/unit/worker/test_change_of_registration.py
@@ -27,6 +27,7 @@ from registry_schemas.example_data import CHANGE_OF_REGISTRATION_TEMPLATE, COURT
 # from legal_api.services import NaicsService
 from entity_filer.filing_processors.filing_components.legal_entity_info import NaicsService
 from entity_filer.resources.worker import FilingMessage, process_filing
+from entity_filer.services import BusinessService
 from tests.unit import (
     create_alternate_name,
     create_entity,
@@ -288,17 +289,22 @@ def test_change_of_registration_business_address(
         process_filing(filing_msg)
 
     # Check outcome
-    changed_delivery_address = Address.find_by_id(business_delivery_address_id)
+    business = BusinessService.fetch_business_by_filing(filing_submission)
+    mailing_address = business.office_mailing_address.one_or_none()
+    delivery_address = business.office_delivery_address.one_or_none()
+
+    assert mailing_address
+    assert delivery_address
     for key in ["streetAddress", "postalCode", "addressCity", "addressRegion"]:
         assert (
-            changed_delivery_address.json[key]
-            == filing["filing"]["changeOfRegistration"]["offices"]["businessOffice"]["deliveryAddress"][key]
-        )
-    changed_mailing_address = Address.find_by_id(business_mailing_address_id)
-    for key in ["streetAddress", "postalCode", "addressCity", "addressRegion"]:
-        assert (
-            changed_mailing_address.json[key]
+            mailing_address.json[key]
             == filing["filing"]["changeOfRegistration"]["offices"]["businessOffice"]["mailingAddress"][key]
+        )
+
+    for key in ["streetAddress", "postalCode", "addressCity", "addressRegion"]:
+        assert (
+            delivery_address.json[key]
+            == filing["filing"]["changeOfRegistration"]["offices"]["businessOffice"]["deliveryAddress"][key]
         )
 
 

--- a/queue_services/entity-filer/tests/unit/worker/test_change_of_registration.py
+++ b/queue_services/entity-filer/tests/unit/worker/test_change_of_registration.py
@@ -528,7 +528,7 @@ def test_worker_partner_name_and_address_change(app, session, mocker, test_name)
         assert business.entity_roles.all()[1].cessation_date is None
 
     if test_name == "gp_delete_partner":
-        assert len(business.entity_roles.all())==1
+        assert len(business.entity_roles.all()) == 1
 
     if test_name == "gp_add_partner":
         assert len(EntityRole.get_parties_by_role(business_id, "partner")) == 3


### PR DESCRIPTION
*Issue #:* /bcgov/entity#20328

*Description of changes:*
- Update change of registration filing processor to work with alternate name changes
- Update relevant unit tests
- Set `entity_type` values for registration filing processor since `alternate_names.entity_type` was introduced into db
- Temporarily copy `NaicsService` and `RegistrationBootstrapService` from legal-api (also `BusinessService` in previous PR). The files should be removed once filer can refer to common module
- Misc fixes & updates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
