### PR TITLE
20775 - fix sorted and first 2 legal name outputs for registration and change of registration

### DIFF
--- a/queue_services/entity-bn/q_cli.py
+++ b/queue_services/entity-bn/q_cli.py
@@ -27,10 +27,9 @@ import random
 import signal
 import sys
 
+from entity_queue_common.service_utils import error_cb, logger, signal_handler
 from nats.aio.client import Client as NATS  # noqa N814; by convention the name is NATS
 from stan.aio.client import Client as STAN  # noqa N814; by convention the name is STAN
-
-from entity_queue_common.service_utils import error_cb, logger, signal_handler
 
 
 async def run(loop, identifier, filing_id, filing_type):  # pylint: disable=too-many-locals

--- a/queue_services/entity-bn/setup.py
+++ b/queue_services/entity-bn/setup.py
@@ -14,11 +14,12 @@
 """Installer and setup for this module
 """
 import ast
+import re
 from glob import glob
 from os.path import basename, splitext
-import re
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
 
 _version_re = re.compile(r'__version__\s+=\s+(.*)')  # pylint: disable=invalid-name
 

--- a/queue_services/entity-bn/src/entity_bn/bn_processors/change_of_registration.py
+++ b/queue_services/entity-bn/src/entity_bn/bn_processors/change_of_registration.py
@@ -15,14 +15,13 @@
 import xml.etree.ElementTree as Et
 from contextlib import suppress
 from http import HTTPStatus
-from sqlalchemy import func
 
 import dpath
 from flask import current_app
 from legal_api.models import Address, Business, Filing, Party, PartyRole, RequestTracker, db
 from legal_api.utils.datetime import datetime
 from legal_api.utils.legislation_datetime import LegislationDatetime
-from sqlalchemy import and_
+from sqlalchemy import and_, func
 from sqlalchemy_continuum import version_class
 
 from entity_bn.bn_processors import (
@@ -105,7 +104,7 @@ def change_name(business: Business, filing: Filing,  # pylint: disable=too-many-
             ]]),
             PartyRole.cessation_date.is_(None)
         ).order_by(sort_name)
-        
+
         parties = [party_role.party for party_role in parties_query.all()]
         new_name = ','.join(party.name for party in parties[:2])
         if len(parties) > 2:

--- a/queue_services/entity-bn/src/entity_bn/bn_processors/registration.py
+++ b/queue_services/entity-bn/src/entity_bn/bn_processors/registration.py
@@ -242,22 +242,6 @@ def _get_program_account(identifier, transaction_id):
         return None, str(err)
 
 
-def _sort_party_name(party):
-    """Sort party's name """
-    organization_name = party.get('organization_name', '')
-    last_name = party.get('last_name', '')
-    first_name = party.get('first_name', '')
-    middle_initial = party.get('middle_initial', '')
-
-    sort_name = (
-        organization_name +
-        (' ' + last_name if last_name else '') +
-        (' ' + first_name if first_name else '') +
-        (' ' + middle_initial if middle_initial else '')
-    )
-    return sort_name.strip()
-
-
 def _get_firm_legal_name(business: Business):
     """Get sorted firm legal name."""
     sort_name = func.trim(

--- a/queue_services/entity-bn/src/entity_bn/bn_processors/registration.py
+++ b/queue_services/entity-bn/src/entity_bn/bn_processors/registration.py
@@ -16,7 +16,6 @@ import json
 import xml.etree.ElementTree as Et
 from contextlib import suppress
 from http import HTTPStatus
-from sqlalchemy import func
 
 import requests
 from entity_queue_common.service_utils import QueueException, logger
@@ -25,6 +24,7 @@ from legal_api.models import Business, Party, PartyRole, RequestTracker
 from legal_api.services.bootstrap import AccountService
 from legal_api.utils.datetime import datetime
 from legal_api.utils.legislation_datetime import LegislationDatetime
+from sqlalchemy import func
 
 from entity_bn.bn_processors import (
     build_input_xml,

--- a/queue_services/entity-bn/src/entity_bn/bn_processors/registration.py
+++ b/queue_services/entity-bn/src/entity_bn/bn_processors/registration.py
@@ -258,7 +258,7 @@ def _sort_party_name(party):
     return sort_name.strip()
 
 
-def _get_firm_legal_name(business: Business, filing: Filing):
+def _get_firm_legal_name(business: Business):
     """Get sorted firm legal name."""
     sort_name = func.trim(
         func.coalesce(Party.organization_name, '') +
@@ -272,10 +272,10 @@ def _get_firm_legal_name(business: Business, filing: Filing):
             PartyRole.RoleTypes.PARTNER.value,
             PartyRole.RoleTypes.PROPRIETOR.value
         ]])
-    ).order_by(sort_name)  
-    
+    ).order_by(sort_name)
+
     parties = [party_role.party for party_role in parties_query.all()]
-    
+
     legal_names = ','.join(party.name for party in parties[:2])
     if len(parties) > 2:  # Include only 2 parties in legal name
         legal_names += ', et al'

--- a/queue_services/entity-bn/tests/unit/__init__.py
+++ b/queue_services/entity-bn/tests/unit/__init__.py
@@ -82,7 +82,6 @@ def create_party(party_json):
         organization_name=party_json['officer'].get('organizationName', '').upper(),
         email=party_json['officer'].get('email'),
         identifier=party_json['officer'].get('identifier'),
-        tax_id=party_json['officer'].get('taxId'),
         party_type=party_json['officer'].get('partyType')
     )
     if party_json.get('mailingAddress'):

--- a/queue_services/entity-bn/tests/unit/bn_processors/test_change_of_registration.py
+++ b/queue_services/entity-bn/tests/unit/bn_processors/test_change_of_registration.py
@@ -27,6 +27,8 @@ from tests.unit import create_filing, create_registration_data
     ('SP'),
     ('GP'),
 ])
+
+@pytest.mark.asyncio
 async def test_change_of_registration(app, session, mocker, legal_type):
     """Test inform cra about change of SP/GP registration."""
     filing_id, business_id = create_registration_data(legal_type, tax_id='993775204BC0001')
@@ -111,7 +113,7 @@ async def test_change_of_registration(app, session, mocker, legal_type):
     assert request_trackers[0].is_processed
     assert request_trackers[0].retry_number == 0
 
-
+@pytest.mark.asyncio
 @pytest.mark.parametrize('legal_type, tax_id', [
     ('SP', None),
     ('SP', ''),
@@ -196,7 +198,7 @@ async def test_bn15_not_available_change_of_registration(app, session, mocker, l
     assert request_trackers[0].response_object == bn_note
     assert request_trackers[0].retry_number == 0
 
-
+@pytest.mark.asyncio
 @pytest.mark.parametrize('request_type, data', [
     (RequestTracker.RequestType.CHANGE_NAME, {'nameRequest': {'legalName': 'new name'}}),
     (RequestTracker.RequestType.CHANGE_PARTY, {'parties': [{}]}),
@@ -205,6 +207,7 @@ async def test_bn15_not_available_change_of_registration(app, session, mocker, l
     (RequestTracker.RequestType.CHANGE_MAILING_ADDRESS, {'offices': {'businessOffice': {'mailingAddress': {},
                                                                                         'deliveryAddress': {}}}}),
 ])
+
 async def test_retry_change_of_registration(app, session, mocker, request_type, data):
     """Test retry change of SP/GP registration."""
     filing_id, business_id = create_registration_data('SP', tax_id='993775204BC0001')

--- a/queue_services/entity-bn/tests/unit/bn_processors/test_registration.py
+++ b/queue_services/entity-bn/tests/unit/bn_processors/test_registration.py
@@ -35,6 +35,8 @@ acknowledgement_response = """<?xml version="1.0"?>
     ('SP'),
     ('GP'),
 ])
+
+@pytest.mark.asyncio
 async def test_registration(app, session, mocker, legal_type):
     """Test inform cra about new SP/GP registration."""
     filing_id, business_id = create_registration_data(legal_type)
@@ -85,7 +87,7 @@ async def test_registration(app, session, mocker, legal_type):
     business = Business.find_by_internal_id(business_id)
     assert business.tax_id == f'{business_number}{business_program_id}{str(program_account_ref_no).zfill(4)}'
 
-
+@pytest.mark.asyncio
 @pytest.mark.parametrize('request_type', [
     (RequestTracker.RequestType.INFORM_CRA),
     (RequestTracker.RequestType.GET_BN),


### PR DESCRIPTION
*Issue #:* /bcgov/entity#20775

*Description of changes:*

- the output legal name is sorted and only shows first 2 names
- unit tests for registration
<img width="840" alt="image" src="https://github.com/bcgov/lear/assets/144159934/4816653c-fc5e-43a6-b919-aaa1650a9784">

- unit tests for change of registration

<img width="832" alt="image" src="https://github.com/bcgov/lear/assets/144159934/a054236a-9e04-4976-99c4-1ee197a9711b">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
