### PR TITLE
20777 - Update logic for legalName field in business response

### DIFF
--- a/legal-api/flags.json
+++ b/legal-api/flags.json
@@ -2,6 +2,7 @@
     "flagValues": {
         "string-flag": "a string value",
         "bool-flag": true,
-        "integer-flag": 10
+        "integer-flag": 10,
+        "enable-legal-name-fix": true
     }
 }

--- a/legal-api/src/legal_api/models/business.py
+++ b/legal-api/src/legal_api/models/business.py
@@ -290,11 +290,9 @@ class Business(db.Model):  # pylint: disable=too-many-instance-attributes,disabl
             )
 
             parties_query = self.party_roles.join(Party).filter(
-                func.lower(PartyRole.role).in_([
-                    func.lower(value) for value in [
-                        PartyRole.RoleTypes.PARTNER.value,
-                        PartyRole.RoleTypes.PROPRIETOR.value
-                    ]
+                PartyRole.role.in_([
+                    PartyRole.RoleTypes.PARTNER.value,
+                    PartyRole.RoleTypes.PROPRIETOR.value
                 ])
             ).order_by(sort_name)
 

--- a/legal-api/src/legal_api/models/business.py
+++ b/legal-api/src/legal_api/models/business.py
@@ -290,7 +290,7 @@ class Business(db.Model):  # pylint: disable=too-many-instance-attributes,disabl
             )
 
             parties_query = self.party_roles.join(Party).filter(
-                PartyRole.role.in_([
+                func.lower(PartyRole.role).in_([
                     PartyRole.RoleTypes.PARTNER.value,
                     PartyRole.RoleTypes.PROPRIETOR.value
                 ])

--- a/legal-api/src/legal_api/models/business.py
+++ b/legal-api/src/legal_api/models/business.py
@@ -281,10 +281,7 @@ class Business(db.Model):  # pylint: disable=too-many-instance-attributes,disabl
         from legal_api.services import flags  # pylint: disable=import-outside-toplevel
 
         flag_on = flags.is_on('enable-legal-name-fix')
-        if self.legal_type in [
-            Business.LegalTypes.PARTNERSHIP.value,
-            Business.LegalTypes.SOLE_PROP.value
-        ] and flag_on:
+        if self.is_firm and flag_on:
             sort_name = func.trim(
                 func.coalesce(Party.organization_name, '') +
                 func.coalesce(Party.last_name+' ', '') +

--- a/legal-api/src/legal_api/reports/business_document.py
+++ b/legal-api/src/legal_api/reports/business_document.py
@@ -122,6 +122,7 @@ class BusinessDocument:
             # get document data
             business_json['reportType'] = self._document_key
             business_json['business'] = self._business.json()
+            business_json['business']['legalName'] = self._business.legal_name  # legal name easy fix
             business_json['registrarInfo'] = {**RegistrarInfo.get_registrar_info(self._report_date_time)}
             self._set_description(business_json)
             self._set_epoch_date(business_json)

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -465,6 +465,7 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
             business_json = VersionedBusinessDetailsService.get_business_revision(filing.transaction_id, business)
         else:
             business_json = business.json()
+            business_json['legalName'] = business.legal_name  # legal name easy fix
         business_json['formatted_founding_date_time'] = LegislationDatetime.format_as_report_string(founding_datetime)
         business_json['formatted_founding_date'] = founding_datetime.strftime(OUTPUT_DATE_FORMAT)
         filing.filing_json['filing']['business'] = business_json

--- a/legal-api/tests/unit/models/test_business.py
+++ b/legal-api/tests/unit/models/test_business.py
@@ -480,8 +480,10 @@ def test_amalgamated_into_business_json(session, test_name, existing_business_st
 
 @pytest.mark.parametrize('test_name, legal_type, flag_on', [
     ('GP_FLAG_ON', 'GP', True),
+    ('GP_FLAG_ON_MORE_PARTNERS', 'GP', True),
     ('SP_FLAG_ON', 'SP', True),
     ('GP_FLAG_OFF', 'GP', False),
+    ('GP_FLAG_OFF_MORE_PARTNERS', 'GP', False),
     ('SP_FLAG_OFF', 'SP', False),
     ('NON_FIRM_FLAG_ON', 'BC', True),
     ('NON_FIRM_FLAG_OFF', 'BC', False),
@@ -513,6 +515,14 @@ def test_firm_business_json(session, test_name, legal_type, flag_on):
         'organizationName': ''
     }
 
+    officer3 = {
+        'firstName': 'John',
+        'lastName': 'Doe',
+        'middleInitial': 'C',
+        'partyType': 'person',
+        'organizationName': ''
+    }
+
     if legal_type == Business.LegalTypes.SOLE_PROP:
         proprietor_role = factory_party_role(None, None, officer1, None, None, PartyRole.RoleTypes.PROPRIETOR)
         business.party_roles.append(proprietor_role)
@@ -521,6 +531,10 @@ def test_firm_business_json(session, test_name, legal_type, flag_on):
         partner_role2 = factory_party_role(None, None, officer2, None, None, PartyRole.RoleTypes.PARTNER)
         business.party_roles.append(partner_role1)
         business.party_roles.append(partner_role2)
+
+        if 'MORE_PARTNERS' in test_name:
+            partner_role3 = factory_party_role(None, None, officer3, None, None, PartyRole.RoleTypes.PARTNER)
+            business.party_roles.append(partner_role3)
     else:
         party_role = factory_party_role(None, None, officer1, None, None, PartyRole.RoleTypes.DIRECTOR)
         business.party_roles.append(party_role)
@@ -536,6 +550,9 @@ def test_firm_business_json(session, test_name, legal_type, flag_on):
                 if legal_type == Business.LegalTypes.SOLE_PROP.value:
                     assert business_json['legalName'] == 'JANE A DOE'
                 else:
-                    assert business_json['legalName'] == 'JANE A DOE, JOHN B DOE'
+                    if 'MORE_PARTNERS' in test_name:
+                        assert business_json['legalName'] == 'JANE A DOE, JOHN B DOE, et al'
+                    else:
+                        assert business_json['legalName'] == 'JANE A DOE, JOHN B DOE'
         else:
             assert business_json['legalName'] == 'TEST ABC'


### PR DESCRIPTION
*Issue #:* /bcgov/entity#20777

*Description of changes:*
- Add `business_legal_name` hybrid property in business model to return correct legal name for SP/GPs when `enable-legal-name-fix` feature flag is on. Note that `legal_name` is frequently used in the outputs as business name so I use another name to prevent incorrect use.
- Fix some potential issues in the outputs where `legalName` in `business.json()` is used
- Update unit tests

*Some testing examples when flag is on*
- SP Individual - FM1028594
![image](https://github.com/bcgov/lear/assets/60866283/0526005b-eedb-47cf-bfef-d2692513f823)

- SP DBA - FM1054864
![image](https://github.com/bcgov/lear/assets/60866283/74be060c-db11-4055-a11d-137268e71bab)

- GP (2 partners) - FM1044962
![image](https://github.com/bcgov/lear/assets/60866283/f829d2e1-c6b8-4b15-8cf1-2c65a675e60b)

- GP (>2 partners)
![image](https://github.com/bcgov/lear/assets/60866283/89786fb4-c40b-4b2c-829b-8aa44f66db4a)

- Non firm - BC1218875
![image](https://github.com/bcgov/lear/assets/60866283/ac910c4b-de42-4659-9f83-5447ce2b78c2)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
