### PR TITLE
20777 - Filter out party when cessation date is not null

### DIFF
--- a/legal-api/src/legal_api/models/business.py
+++ b/legal-api/src/legal_api/models/business.py
@@ -312,7 +312,8 @@ class Business(db.Model):  # pylint: disable=too-many-instance-attributes,disabl
                 func.lower(PartyRole.role).in_([
                     PartyRole.RoleTypes.PARTNER.value,
                     PartyRole.RoleTypes.PROPRIETOR.value
-                ])
+                ]),
+                PartyRole.cessation_date.is_(None)
             ).order_by(sort_name)
 
             parties = [party_role.party for party_role in parties_query.all()]


### PR DESCRIPTION
*Issue #:* /bcgov/entity#20777

*Description of changes:*
- Bug fix

*Local testing result*
GP(2 partners without cessation date) - FM1000001
![image](https://github.com/bcgov/lear/assets/60866283/6f0dbb80-0f67-44b4-92f8-5fba6b104adf)

GP(>2 parners without cessation date) - FM1000013
![image](https://github.com/bcgov/lear/assets/60866283/38192af8-6794-4d48-86b9-9e16cf4b79ac)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
