### PR TITLE
21202 Integrate disable-nr-check feature flag with NR validate code

### DIFF
--- a/legal-api/flags.json
+++ b/legal-api/flags.json
@@ -3,6 +3,7 @@
         "string-flag": "a string value",
         "bool-flag": true,
         "integer-flag": 10,
-        "enable-legal-name-fix": true
+        "enable-legal-name-fix": true,
+        "disable-nr-check": false
     }
 }

--- a/legal-api/src/legal_api/services/namex.py
+++ b/legal-api/src/legal_api/services/namex.py
@@ -116,6 +116,19 @@ class NameXService():
     def validate_nr(nr_json):
         """Provide validation info based on a name request response payload."""
         # Initial validation result state
+        from . import flags  # pylint: disable=import-outside-toplevel
+
+        # This is added specifically for the sandbox environment.
+        # i.e. NR check should only ever have feature flag disabled for sandbox environment.
+        if flags.is_on('disable-nr-check'):
+            return {
+                'is_consumable': True,
+                'is_approved': True,
+                'is_expired': False,
+                'consent_required': None,
+                'consent_received': None
+            }
+
         is_consumable = False
         is_approved = False
         is_expired = False

--- a/legal-api/tests/unit/resources/v1/test_name_requests.py
+++ b/legal-api/tests/unit/resources/v1/test_name_requests.py
@@ -19,10 +19,12 @@ Test-Suite to ensure that the /nameRequests endpoint is working as expected.
 from http import HTTPStatus
 
 import copy
+from unittest.mock import patch
+
 import datedelta
 import pytz
 
-from legal_api.services import namex
+from legal_api.services import flags, namex
 from legal_api.utils.legislation_datetime import LegislationDatetime
 from tests import integration_namerequests
 
@@ -179,97 +181,103 @@ def test_name_request_update_expiration(app, client):
 
 def test_validate_nr_consumable_approved():
     """Assert that nr mock data is consumable."""
-    validation_result = namex.validate_nr(nr_consumable_approved)
+    with patch.object(flags, 'is_on', return_value=False):
+        validation_result = namex.validate_nr(nr_consumable_approved)
 
-    assert validation_result['is_consumable']
-    assert validation_result['is_approved']
-    assert not validation_result['is_expired']
-    assert not validation_result['consent_required']
-    assert not validation_result['consent_received']
+        assert validation_result['is_consumable']
+        assert validation_result['is_approved']
+        assert not validation_result['is_expired']
+        assert not validation_result['consent_required']
+        assert not validation_result['consent_received']
 
 
 def test_validate_nr_not_consumable_rejected():
     """Assert that nr mock data is not consumable as it has been rejected."""
-    validation_result = namex.validate_nr(nr_not_consumable_rejected)
+    with patch.object(flags, 'is_on', return_value=False):
+        validation_result = namex.validate_nr(nr_not_consumable_rejected)
 
-    assert not validation_result['is_consumable']
-    assert not validation_result['is_approved']
-    assert not validation_result['is_expired']
-    assert not validation_result['consent_required']
-    assert not validation_result['consent_received']
+        assert not validation_result['is_consumable']
+        assert not validation_result['is_approved']
+        assert not validation_result['is_expired']
+        assert not validation_result['consent_required']
+        assert not validation_result['consent_received']
 
 
 def test_validate_nr_not_consumable_expired():
     """Assert that nr mock data is not consumable as it has expired."""
-    validation_result = namex.validate_nr(nr_not_consumable_expired)
+    with patch.object(flags, 'is_on', return_value=False):
+        validation_result = namex.validate_nr(nr_not_consumable_expired)
 
-    assert not validation_result['is_consumable']
-    assert not validation_result['is_approved']
-    assert validation_result['is_expired']
-    assert not validation_result['consent_required']
-    assert not validation_result['consent_received']
+        assert not validation_result['is_consumable']
+        assert not validation_result['is_approved']
+        assert validation_result['is_expired']
+        assert not validation_result['consent_required']
+        assert not validation_result['consent_received']
 
 
 def test_validate_nr_already_consumed():
     """Assert that nr mock data has already been consumed."""
-    validation_result = namex.validate_nr(nr_already_consumed)
+    with patch.object(flags, 'is_on', return_value=False):
+        validation_result = namex.validate_nr(nr_already_consumed)
 
-    assert not validation_result['is_consumable']
-    assert not validation_result['is_approved']
-    assert not validation_result['is_expired']
-    assert not validation_result['consent_required']
-    assert not validation_result['consent_received']
+        assert not validation_result['is_consumable']
+        assert not validation_result['is_approved']
+        assert not validation_result['is_expired']
+        assert not validation_result['consent_required']
+        assert not validation_result['consent_received']
 
 
 def test_validate_nr_consent_required_not_received():
     """Assert that nr mock data is conditionally approved, but consent not received."""
-    nr_consent_required = copy.deepcopy(nr_consumable_conditional)
-    nr_consent_required['consentFlag'] = 'Y'
-    validation_result = namex.validate_nr(nr_consent_required)
-    assert not validation_result['is_consumable']
-    assert validation_result['is_approved']
-    assert not validation_result['is_expired']
-    assert validation_result['consent_required']
-    assert not validation_result['consent_received']
+    with patch.object(flags, 'is_on', return_value=False):
+        nr_consent_required = copy.deepcopy(nr_consumable_conditional)
+        nr_consent_required['consentFlag'] = 'Y'
+        validation_result = namex.validate_nr(nr_consent_required)
+        assert not validation_result['is_consumable']
+        assert validation_result['is_approved']
+        assert not validation_result['is_expired']
+        assert validation_result['consent_required']
+        assert not validation_result['consent_received']
 
 
 def test_validate_nr_consent_required_received():
     """Assert that nr mock data is conditionally approved and consent was received."""
-    validation_result = namex.validate_nr(nr_consumable_conditional)
-    assert validation_result['is_consumable']
-    assert validation_result['is_approved']
-    assert not validation_result['is_expired']
-    assert validation_result['consent_required']
-    assert validation_result['consent_received']
+    with patch.object(flags, 'is_on', return_value=False):
+        validation_result = namex.validate_nr(nr_consumable_conditional)
+        assert validation_result['is_consumable']
+        assert validation_result['is_approved']
+        assert not validation_result['is_expired']
+        assert validation_result['consent_required']
+        assert validation_result['consent_received']
 
-    # N = consent waived
-    nr_consent_waived = copy.deepcopy(nr_consumable_conditional)
-    nr_consent_waived['consentFlag'] = 'N'
-    validation_result = namex.validate_nr(nr_consent_waived)
-    assert validation_result['is_consumable']
-    assert validation_result['is_approved']
-    assert not validation_result['is_expired']
-    assert not validation_result['consent_required']
-    assert not validation_result['consent_received']
+        # N = consent waived
+        nr_consent_waived = copy.deepcopy(nr_consumable_conditional)
+        nr_consent_waived['consentFlag'] = 'N'
+        validation_result = namex.validate_nr(nr_consent_waived)
+        assert validation_result['is_consumable']
+        assert validation_result['is_approved']
+        assert not validation_result['is_expired']
+        assert not validation_result['consent_required']
+        assert not validation_result['consent_received']
 
-    # None = consent not required
-    nr_consent_not_required = copy.deepcopy(nr_consumable_conditional)
-    nr_consent_not_required['consentFlag'] = None
-    validation_result = namex.validate_nr(nr_consent_not_required)
-    assert validation_result['is_consumable']
-    assert validation_result['is_approved']
-    assert not validation_result['is_expired']
-    assert not validation_result['consent_required']
-    assert not validation_result['consent_received']
+        # None = consent not required
+        nr_consent_not_required = copy.deepcopy(nr_consumable_conditional)
+        nr_consent_not_required['consentFlag'] = None
+        validation_result = namex.validate_nr(nr_consent_not_required)
+        assert validation_result['is_consumable']
+        assert validation_result['is_approved']
+        assert not validation_result['is_expired']
+        assert not validation_result['consent_required']
+        assert not validation_result['consent_received']
 
-    nr_consent_not_required = copy.deepcopy(nr_consumable_conditional)
-    nr_consent_not_required['consentFlag'] = ''
-    validation_result = namex.validate_nr(nr_consent_not_required)
-    assert validation_result['is_consumable']
-    assert validation_result['is_approved']
-    assert not validation_result['is_expired']
-    assert not validation_result['consent_required']
-    assert not validation_result['consent_received']
+        nr_consent_not_required = copy.deepcopy(nr_consumable_conditional)
+        nr_consent_not_required['consentFlag'] = ''
+        validation_result = namex.validate_nr(nr_consent_not_required)
+        assert validation_result['is_consumable']
+        assert validation_result['is_approved']
+        assert not validation_result['is_expired']
+        assert not validation_result['consent_required']
+        assert not validation_result['consent_received']
 
 
 def test_get_approved_name():

--- a/legal-api/tests/unit/services/filings/validations/test_alteration.py
+++ b/legal-api/tests/unit/services/filings/validations/test_alteration.py
@@ -20,7 +20,7 @@ import pytest
 from registry_schemas.example_data import ALTERATION_FILING_TEMPLATE
 from reportlab.lib.pagesizes import letter
 
-from legal_api.services import NameXService
+from legal_api.services import flags, NameXService
 from legal_api.services.filings import validate
 from tests.unit.models import factory_business
 from tests.unit.services.filings.test_utils import _upload_file
@@ -82,9 +82,9 @@ def test_alteration(session, use_nr, new_name, legal_type, nr_type, should_pass,
         }
 
         nr_response = MockResponse(nr_json, 200)
-
-        with patch.object(NameXService, 'query_nr_number', return_value=nr_response):
-            err = validate(business, f)
+        with patch.object(flags, 'is_on', return_value=False):
+            with patch.object(NameXService, 'query_nr_number', return_value=nr_response):
+                    err = validate(business, f)
     else:
         del f['filing']['alteration']['nameRequest']
         err = validate(business, f)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21202

*Description of changes:*
**Note: this feature flag is only intended to disable NR check in the sandbox.**

* Integrate `disable-nr-check` feature flag with namex service's `nr_validate` function.  Always returns that NR is valid when flag is on.
* Fix broken tests
* Add tests to test valid NR is always returned when flag is on

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
