### PR TITLE
21020 Fix wrong AR year is being displayed in the annual report output

### DIFF
--- a/legal-api/report-templates/bcAnnualReport.html
+++ b/legal-api/report-templates/bcAnnualReport.html
@@ -15,7 +15,7 @@
             [[logo.html]]
           </td>
           <td>
-            <div class="report-type">{{ effective_date[-4:] }} ANNUAL REPORT</div>
+            <div class="report-type">{{ header.ARFilingYear }} ANNUAL REPORT</div>
             <div class="report-type-desc">{{ entityDescription }} - {{ entityAct }}</div>
           </td>
         </tr>

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -729,6 +729,7 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
 
     def _set_amalgamating_businesses(self, filing):
         amalgamating_businesses = []
+        business_legal_name = None
         for amalgamating_business in filing['amalgamationApplication']['amalgamatingBusinesses']:
             identifier = amalgamating_business.get('identifier')
             if foreign_legal_name := amalgamating_business.get('legalName'):

--- a/legal-api/src/legal_api/resources/v1/business/business_filings.py
+++ b/legal-api/src/legal_api/resources/v1/business/business_filings.py
@@ -723,6 +723,7 @@ class ListFilingResource(Resource):
         }
         """
         payment_svc_url = current_app.config.get('PAYMENT_SVC_URL')
+        mailing_address = {}
 
         if filing.filing_type in (
             Filing.FILINGS['incorporationApplication']['name'],


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21020

*Description of changes:*
- Fixed incorrect AR year in the outputs. A similar issue was fixed previously for co-ops https://github.com/bcgov/lear/pull/1105

Before:
<img width="1018" alt="Screenshot 2024-05-14 at 9 49 01 AM" src="https://github.com/bcgov/lear/assets/122323255/4b3d495b-ddfc-47b5-b9e2-4f89dba0a260">

After:
<img width="1031" alt="Screenshot 2024-05-14 at 9 49 06 AM" src="https://github.com/bcgov/lear/assets/122323255/d901a902-8f1e-4bfb-9c66-2f3693ad6882">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
