### PR TITLE
21202 Add additional checks to disable NR related functionality when disable-nr-check flag is on

### DIFF
--- a/legal-api/src/legal_api/services/filings/validations/alteration.py
+++ b/legal-api/src/legal_api/services/filings/validations/alteration.py
@@ -20,7 +20,7 @@ from flask_babel import _ as babel  # noqa: N81
 from legal_api.core.filing import Filing
 from legal_api.errors import Error
 from legal_api.models import Business
-from legal_api.services import namex
+from legal_api.services import flags, namex
 from legal_api.services.utils import get_bool, get_str
 
 from .common_validations import (
@@ -75,6 +75,11 @@ def share_structure_validation(filing):
 
 def company_name_validation(filing):
     """Validate company name."""
+    # This is added specifically for the sandbox environment.
+    # i.e. NR check should only ever have feature flag disabled for sandbox environment.
+    if flags.is_on('disable-nr-check'):
+        return []
+
     msg = []
     nr_path: Final = '/filing/alteration/nameRequest/nrNumber'
     if nr_number := get_str(filing, nr_path):

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -22,7 +22,7 @@ from flask_babel import _
 
 from legal_api.errors import Error
 from legal_api.models import Business
-from legal_api.services import MinioService, namex
+from legal_api.services import MinioService, flags, namex
 from legal_api.services.utils import get_str
 from legal_api.utils.datetime import datetime as dt
 
@@ -234,6 +234,11 @@ def validate_name_request(filing_json: dict,  # pylint: disable=too-many-locals
                           filing_type: str,
                           accepted_request_types: list = None) -> list:
     """Validate name request section."""
+    # This is added specifically for the sandbox environment.
+    # i.e. NR check should only ever have feature flag disabled for sandbox environment.
+    if flags.is_on('disable-nr-check'):
+        return []
+
     nr_path = f'/filing/{filing_type}/nameRequest'
     nr_number_path = f'{nr_path}/nrNumber'
     legal_name_path = f'{nr_path}/legalName'

--- a/legal-api/src/legal_api/services/filings/validations/incorporation_application.py
+++ b/legal-api/src/legal_api/services/filings/validations/incorporation_application.py
@@ -19,13 +19,13 @@ from typing import Final, Optional
 import pycountry
 from flask_babel import _ as babel  # noqa: N813, I004, I001, I003
 
+from legal_api.core.filing import Filing as coreFiling  # noqa: I001
 from legal_api.errors import Error
 from legal_api.models import Business, Filing
-from legal_api.services import namex
+from legal_api.services import flags, namex
 from legal_api.services.utils import get_str
 from legal_api.utils.datetime import datetime as dt
 
-from legal_api.core.filing import Filing as coreFiling  # noqa: I001
 from .common_validations import (  # noqa: I001
     validate_court_order,
     validate_name_request,
@@ -359,6 +359,11 @@ def validate_correction_effective_date(filing: dict, corrected_filing: dict) -> 
 
 def validate_correction_name_request(filing: dict, corrected_filing: dict) -> Optional[list]:
     """Validate correction of Name Request."""
+    # This is added specifically for the sandbox environment.
+    # i.e. NR check should only ever have feature flag disabled for sandbox environment.
+    if flags.is_on('disable-nr-check'):
+        return []
+
     nr_path = '/filing/incorporationApplication/nameRequest/nrNumber'
     nr_number = get_str(corrected_filing.json, nr_path)
     new_nr_number = get_str(filing, nr_path)

--- a/legal-api/src/legal_api/services/namex.py
+++ b/legal-api/src/legal_api/services/namex.py
@@ -180,6 +180,15 @@ class NameXService():
     @staticmethod
     def get_approved_name(nr_json) -> str:
         """Get an approved name from nr json, if any."""
+        from . import flags  # pylint: disable=import-outside-toplevel
+
+        # This is added specifically for the sandbox environment.
+        # i.e. NR check should only ever have feature flag disabled for sandbox environment.
+        if flags.is_on('disable-nr-check'):
+            return next((name['name'] for name in nr_json['names']
+                         if name['state']
+                         in ['APPROVED', 'CONDITION']), None)
+
         nr_name = None
         state_to_check = None
         nr_state = nr_json['state']

--- a/legal-api/tests/unit/resources/v1/test_name_requests.py
+++ b/legal-api/tests/unit/resources/v1/test_name_requests.py
@@ -282,7 +282,19 @@ def test_validate_nr_consent_required_received():
 
 def test_get_approved_name():
     """Get Approved/Conditional Approved name."""
-    nr_name = namex.get_approved_name(nr_consumable_approved)
-    assert nr_name == nr_consumable_approved['names'][0]['name']
-    nr_name = namex.get_approved_name(nr_consumable_conditional)
-    assert nr_name == nr_consumable_conditional['names'][1]['name']
+    with patch.object(flags, 'is_on', return_value=False):
+        nr_name = namex.get_approved_name(nr_consumable_approved)
+        assert nr_name == nr_consumable_approved['names'][0]['name']
+        nr_name = namex.get_approved_name(nr_consumable_conditional)
+        assert nr_name == nr_consumable_conditional['names'][1]['name']
+
+
+def test_get_approved_name_skips_nr_state_check():
+    """Get Approved/Conditional Approved name for NR has already been consumed."""
+    nr_consumed_approved = copy.deepcopy(nr_consumable_approved)
+    nr_consumed_approved['state'] = 'CONSUMED'
+    with patch.object(flags, 'is_on', return_value=True):
+        nr_name = namex.get_approved_name(nr_consumable_approved)
+        assert nr_name == nr_consumable_approved['names'][0]['name']
+        nr_name = namex.get_approved_name(nr_consumable_conditional)
+        assert nr_name == nr_consumable_conditional['names'][1]['name']

--- a/legal-api/tests/unit/resources/v2/test_name_requests.py
+++ b/legal-api/tests/unit/resources/v2/test_name_requests.py
@@ -346,7 +346,19 @@ def test_validate_nr_consent_required_received_skips_nr_check():
 
 def test_get_approved_name():
     """Get Approved/Conditional Approved name."""
-    nr_name = namex.get_approved_name(nr_consumable_approved)
-    assert nr_name == nr_consumable_approved['names'][0]['name']
-    nr_name = namex.get_approved_name(nr_consumable_conditional)
-    assert nr_name == nr_consumable_conditional['names'][1]['name']
+    with patch.object(flags, 'is_on', return_value=False):
+        nr_name = namex.get_approved_name(nr_consumable_approved)
+        assert nr_name == nr_consumable_approved['names'][0]['name']
+        nr_name = namex.get_approved_name(nr_consumable_conditional)
+        assert nr_name == nr_consumable_conditional['names'][1]['name']
+
+
+def test_get_approved_name_skips_nr_state_check():
+    """Get Approved/Conditional Approved name for NR has already been consumed."""
+    nr_consumed_approved = copy.deepcopy(nr_consumable_approved)
+    nr_consumed_approved['state'] = 'CONSUMED'
+    with patch.object(flags, 'is_on', return_value=True):
+        nr_name = namex.get_approved_name(nr_consumable_approved)
+        assert nr_name == nr_consumable_approved['names'][0]['name']
+        nr_name = namex.get_approved_name(nr_consumable_conditional)
+        assert nr_name == nr_consumable_conditional['names'][1]['name']


### PR DESCRIPTION


*Issue #:* /bcgov/entity#21202

*Description of changes:*
* Update to return with no NR validation errors for all top level functions that validate NRs when NR check flag is off
* Update get_approved_name in namex service to return an approved or conditionally approved name regardless of NR's state when NR check flag is off.  This is called separately in some places in code base.
* Update/add tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
