### PR TITLE
21123 add in dissolution property to business model

### DIFF
--- a/legal-api/src/legal_api/models/business.py
+++ b/legal-api/src/legal_api/models/business.py
@@ -422,7 +422,8 @@ class Business(db.Model):  # pylint: disable=too-many-instance-attributes,disabl
         # check a business has a batch_processing entry that matches business_id and status is not COMPLETED
         find_in_batch_processing = db.session.query(BatchProcessing).filter(
             BatchProcessing.business_id == self.id,
-            BatchProcessing.status != BatchProcessing.BatchProcessingStatus.COMPLETED
+            BatchProcessing.status != BatchProcessing.BatchProcessingStatus.COMPLETED,
+            BatchProcessing.status != BatchProcessing.BatchProcessingStatus.WITHDRAWN,
         ).one_or_none()
         if not find_in_batch_processing:
             return False

--- a/legal-api/src/legal_api/models/business.py
+++ b/legal-api/src/legal_api/models/business.py
@@ -48,8 +48,6 @@ from .office import Office  # noqa: F401 pylint: disable=unused-import; needed b
 from .party_role import PartyRole  # noqa: F401 pylint: disable=unused-import; needed by the SQLAlchemy relationship
 from .resolution import Resolution  # noqa: F401 pylint: disable=unused-import; needed by the SQLAlchemy backref
 from .user import User  # noqa: F401,I003 pylint: disable=unused-import; needed by the SQLAlchemy backref
-from .batch import Batch
-from .batch_processing import BatchProcessing
 
 
 class Business(db.Model):  # pylint: disable=too-many-instance-attributes,disable=too-many-public-methods
@@ -417,13 +415,10 @@ class Business(db.Model):  # pylint: disable=too-many-instance-attributes,disabl
                 date_cutoff = last_ar_date + datedelta.datedelta(years=1, months=2, days=1)
                 return date_cutoff.replace(tzinfo=pytz.UTC) > datetime.utcnow()
         return True
-    
+
     @property
     def in_dissolution(self):
-        """
-        Return true if in dissolution, otherwise false.
-        """
-        
+        """Return true if in dissolution, otherwise false."""
         # check a business has a batch_processing entry that matches business_id and status is not COMPLETED
         find_in_batch_processing = db.session.query(BatchProcessing).filter(
             BatchProcessing.business_id == self.id,
@@ -431,13 +426,11 @@ class Business(db.Model):  # pylint: disable=too-many-instance-attributes,disabl
         ).one_or_none()
         if not find_in_batch_processing:
             return False
-        
         # check the business belongs to a batch in batches where status is not COMPLETED
-        if find_in_batch_processing:
-            check_batches = db.session.query(Batch). \
-                filter(Batch.id == find_in_batch_processing.batch_id). \
-                filter(Batch.status != Batch.BatchStatus.COMPLETED). \
-                one_or_none()
+        check_batches = db.session.query(Batch). \
+            filter(Batch.id == find_in_batch_processing.batch_id). \
+            filter(Batch.status != Batch.BatchStatus.COMPLETED). \
+            one_or_none()
         return check_batches is not None
 
     @property

--- a/legal-api/src/legal_api/models/business.py
+++ b/legal-api/src/legal_api/models/business.py
@@ -41,13 +41,13 @@ from .share_class import ShareClass  # noqa: F401,I001,I003 pylint: disable=unus
 
 from .address import Address  # noqa: F401,I003 pylint: disable=unused-import; needed by the SQLAlchemy relationship
 from .alias import Alias  # noqa: F401 pylint: disable=unused-import; needed by the SQLAlchemy relationship
+from .batch import Batch  # noqa: F401, I001, I003 pylint: disable=unused-import
+from .batch_processing import BatchProcessing  # noqa: F401, I001, I003 pylint: disable=unused-import
 from .filing import Filing  # noqa: F401, I003 pylint: disable=unused-import; needed by the SQLAlchemy backref
 from .office import Office  # noqa: F401 pylint: disable=unused-import; needed by the SQLAlchemy relationship
 from .party_role import PartyRole  # noqa: F401 pylint: disable=unused-import; needed by the SQLAlchemy relationship
 from .resolution import Resolution  # noqa: F401 pylint: disable=unused-import; needed by the SQLAlchemy backref
 from .user import User  # noqa: F401,I003 pylint: disable=unused-import; needed by the SQLAlchemy backref
-from .batch import Batch
-from .batch_processing import BatchProcessing
 
 
 class Business(db.Model):  # pylint: disable=too-many-instance-attributes,disable=too-many-public-methods
@@ -415,13 +415,10 @@ class Business(db.Model):  # pylint: disable=too-many-instance-attributes,disabl
                 date_cutoff = last_ar_date + datedelta.datedelta(years=1, months=2, days=1)
                 return date_cutoff.replace(tzinfo=pytz.UTC) > datetime.utcnow()
         return True
-    
+
     @property
     def in_dissolution(self):
-        """
-        Return true if in dissolution, otherwise false.
-        """
-        
+        """Return true if in dissolution, otherwise false."""
         # check a business has a batch_processing entry that matches business_id and status is not COMPLETED
         find_in_batch_processing = db.session.query(BatchProcessing).filter(
             BatchProcessing.business_id == self.id,
@@ -429,13 +426,11 @@ class Business(db.Model):  # pylint: disable=too-many-instance-attributes,disabl
         ).one_or_none()
         if not find_in_batch_processing:
             return False
-        
         # check the business belongs to a batch in batches where status is not COMPLETED
-        if find_in_batch_processing:
-            check_batches = db.session.query(Batch). \
-                filter(Batch.id == find_in_batch_processing.batch_id). \
-                filter(Batch.status != Batch.BatchStatus.COMPLETED). \
-                one_or_none()
+        check_batches = db.session.query(Batch). \
+            filter(Batch.id == find_in_batch_processing.batch_id). \
+            filter(Batch.status != Batch.BatchStatus.COMPLETED). \
+            one_or_none()
         return check_batches is not None
 
     def save(self):

--- a/legal-api/src/legal_api/models/business.py
+++ b/legal-api/src/legal_api/models/business.py
@@ -48,6 +48,8 @@ from .office import Office  # noqa: F401 pylint: disable=unused-import; needed b
 from .party_role import PartyRole  # noqa: F401 pylint: disable=unused-import; needed by the SQLAlchemy relationship
 from .resolution import Resolution  # noqa: F401 pylint: disable=unused-import; needed by the SQLAlchemy backref
 from .user import User  # noqa: F401,I003 pylint: disable=unused-import; needed by the SQLAlchemy backref
+from .batch import Batch
+from .batch_processing import BatchProcessing
 
 
 class Business(db.Model):  # pylint: disable=too-many-instance-attributes,disable=too-many-public-methods
@@ -415,6 +417,28 @@ class Business(db.Model):  # pylint: disable=too-many-instance-attributes,disabl
                 date_cutoff = last_ar_date + datedelta.datedelta(years=1, months=2, days=1)
                 return date_cutoff.replace(tzinfo=pytz.UTC) > datetime.utcnow()
         return True
+    
+    @property
+    def in_dissolution(self):
+        """
+        Return true if in dissolution, otherwise false.
+        """
+        
+        # check a business has a batch_processing entry that matches business_id and status is not COMPLETED
+        find_in_batch_processing = db.session.query(BatchProcessing).filter(
+            BatchProcessing.business_id == self.id,
+            BatchProcessing.status != BatchProcessing.BatchProcessingStatus.COMPLETED
+        ).one_or_none()
+        if not find_in_batch_processing:
+            return False
+        
+        # check the business belongs to a batch in batches where status is not COMPLETED
+        if find_in_batch_processing:
+            check_batches = db.session.query(Batch). \
+                filter(Batch.id == find_in_batch_processing.batch_id). \
+                filter(Batch.status != Batch.BatchStatus.COMPLETED). \
+                one_or_none()
+        return check_batches is not None
 
     @property
     def in_dissolution(self):

--- a/legal-api/src/legal_api/models/business.py
+++ b/legal-api/src/legal_api/models/business.py
@@ -46,6 +46,8 @@ from .office import Office  # noqa: F401 pylint: disable=unused-import; needed b
 from .party_role import PartyRole  # noqa: F401 pylint: disable=unused-import; needed by the SQLAlchemy relationship
 from .resolution import Resolution  # noqa: F401 pylint: disable=unused-import; needed by the SQLAlchemy backref
 from .user import User  # noqa: F401,I003 pylint: disable=unused-import; needed by the SQLAlchemy backref
+from .batch import Batch
+from .batch_processing import BatchProcessing
 
 
 class Business(db.Model):  # pylint: disable=too-many-instance-attributes,disable=too-many-public-methods
@@ -413,6 +415,28 @@ class Business(db.Model):  # pylint: disable=too-many-instance-attributes,disabl
                 date_cutoff = last_ar_date + datedelta.datedelta(years=1, months=2, days=1)
                 return date_cutoff.replace(tzinfo=pytz.UTC) > datetime.utcnow()
         return True
+    
+    @property
+    def in_dissolution(self):
+        """
+        Return true if in dissolution, otherwise false.
+        """
+        
+        # check a business has a batch_processing entry that matches business_id and status is not COMPLETED
+        find_in_batch_processing = db.session.query(BatchProcessing).filter(
+            BatchProcessing.business_id == self.id,
+            BatchProcessing.status != BatchProcessing.BatchProcessingStatus.COMPLETED
+        ).one_or_none()
+        if not find_in_batch_processing:
+            return False
+        
+        # check the business belongs to a batch in batches where status is not COMPLETED
+        if find_in_batch_processing:
+            check_batches = db.session.query(Batch). \
+                filter(Batch.id == find_in_batch_processing.batch_id). \
+                filter(Batch.status != Batch.BatchStatus.COMPLETED). \
+                one_or_none()
+        return check_batches is not None
 
     def save(self):
         """Render a Business to the local cache."""

--- a/legal-api/src/legal_api/models/business.py
+++ b/legal-api/src/legal_api/models/business.py
@@ -433,40 +433,6 @@ class Business(db.Model):  # pylint: disable=too-many-instance-attributes,disabl
             one_or_none()
         return check_batches is not None
 
-    @property
-    def in_dissolution(self):
-        """Return true if in dissolution, otherwise false."""
-        # check a business has a batch_processing entry that matches business_id and status is not COMPLETED
-        find_in_batch_processing = db.session.query(BatchProcessing).filter(
-            BatchProcessing.business_id == self.id,
-            BatchProcessing.status != BatchProcessing.BatchProcessingStatus.COMPLETED
-        ).one_or_none()
-        if not find_in_batch_processing:
-            return False
-        # check the business belongs to a batch in batches where status is not COMPLETED
-        check_batches = db.session.query(Batch). \
-            filter(Batch.id == find_in_batch_processing.batch_id). \
-            filter(Batch.status != Batch.BatchStatus.COMPLETED). \
-            one_or_none()
-        return check_batches is not None
-
-    @property
-    def in_dissolution(self):
-        """Return true if in dissolution, otherwise false."""
-        # check a business has a batch_processing entry that matches business_id and status is not COMPLETED
-        find_in_batch_processing = db.session.query(BatchProcessing).filter(
-            BatchProcessing.business_id == self.id,
-            BatchProcessing.status != BatchProcessing.BatchProcessingStatus.COMPLETED
-        ).one_or_none()
-        if not find_in_batch_processing:
-            return False
-        # check the business belongs to a batch in batches where status is not COMPLETED
-        check_batches = db.session.query(Batch). \
-            filter(Batch.id == find_in_batch_processing.batch_id). \
-            filter(Batch.status != Batch.BatchStatus.COMPLETED). \
-            one_or_none()
-        return check_batches is not None
-
     def save(self):
         """Render a Business to the local cache."""
         db.session.add(self)

--- a/legal-api/tests/unit/models/test_business.py
+++ b/legal-api/tests/unit/models/test_business.py
@@ -819,6 +819,7 @@ def test_firm_business_json(session, test_name, legal_type, flag_on):
         ('test_batch_processing_withdrawn', False, Batch.BatchStatus.PROCESSING, BatchProcessing.BatchProcessingStatus.WITHDRAWN, False)
     ])
 def test_in_dissolution(session, test_name, is_testing_business_id, batch_status, batch_processing_status, expected):
+    """Assert in_dissolution works as expected, did not test with different batch types, since at this moment we only have one option in the BatchType Enum"""
     if is_testing_business_id:
         business_identifier_in = 'BC1234567'
         business_identifier_not_in = 'BC7654321'

--- a/legal-api/tests/unit/models/test_business.py
+++ b/legal-api/tests/unit/models/test_business.py
@@ -910,3 +910,21 @@ def test_in_dissolution_no_matched_business_id(session):
     )
     batch_processing.save()
     assert business_not_in_dissolution.in_dissolution is False
+
+def test_in_dissolution_batch_processing_withdrawn(session):
+    """Assert that when a batch_processing is withdrawn, business in_dissolution is False"""
+    business_identifier = 'BC1234567'
+    business = factory_business(business_identifier)
+    business.save()
+    batch = factory_batch()
+    batch.save()
+    batch_processing = BatchProcessing(
+        batch_id = batch.id,
+        business_id = business.id,
+        business_identifier = business_identifier,
+        step = BatchProcessing.BatchProcessingStep.WARNING_LEVEL_2,
+        status = BatchProcessing.BatchProcessingStatus.WITHDRAWN,
+        notes = ''
+    )
+    batch_processing.save()
+    assert business.in_dissolution is False


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21123

*Description of changes:*
- Add in_dissolution property to business model
  - checks that a business belongs to a batches entry where status is not COMPLETED
  - checks that a business has a batch_processing entry that matches on business_id and status is not COMPLETED or WITHDRAWN
- Add unit tests for the logic added above

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
