### PR TITLE
21262 Added inDissolution to slim json

### DIFF
--- a/legal-api/src/legal_api/models/business.py
+++ b/legal-api/src/legal_api/models/business.py
@@ -465,7 +465,6 @@ class Business(db.Model):  # pylint: disable=too-many-instance-attributes,disabl
             'foundingDate': self.founding_date.isoformat(),
             'hasRestrictions': self.restriction_ind,
             'complianceWarnings': self.compliance_warnings,
-            'warnings': self.warnings,
             'lastAnnualGeneralMeetingDate': datetime.date(self.last_agm_date).isoformat() if self.last_agm_date else '',
             'lastAnnualReportDate': datetime.date(self.last_ar_date).isoformat() if self.last_ar_date else '',
             'lastLedgerTimestamp': self.last_ledger_timestamp.isoformat(),
@@ -496,7 +495,8 @@ class Business(db.Model):  # pylint: disable=too-many-instance-attributes,disabl
             'identifier': self.identifier,
             'legalName': self.business_legal_name,
             'legalType': self.legal_type,
-            'state': self.state.name if self.state else Business.State.ACTIVE.name
+            'state': self.state.name if self.state else Business.State.ACTIVE.name,
+            'warnings': self.warnings
         }
 
         if flags.is_on('enable-legal-name-fix'):

--- a/legal-api/src/legal_api/models/business.py
+++ b/legal-api/src/legal_api/models/business.py
@@ -478,6 +478,7 @@ class Business(db.Model):  # pylint: disable=too-many-instance-attributes,disabl
             'nextAnnualReport': LegislationDatetime.as_legislation_timezone_from_date(
                 self.next_anniversary
             ).astimezone(timezone.utc).isoformat(),
+            'noDissolution': self.no_dissolution,
             'associationType': self.association_type,
             'allowedActions': self.allowable_actions
         }
@@ -493,9 +494,9 @@ class Business(db.Model):  # pylint: disable=too-many-instance-attributes,disabl
             'adminFreeze': self.admin_freeze or False,
             'goodStanding': self.good_standing,
             'identifier': self.identifier,
+            'inDissolution': self.in_dissolution,
             'legalName': self.business_legal_name,
             'legalType': self.legal_type,
-            'noDissolution': self.no_dissolution,
             'state': self.state.name if self.state else Business.State.ACTIVE.name
         }
 

--- a/legal-api/src/legal_api/models/business.py
+++ b/legal-api/src/legal_api/models/business.py
@@ -465,6 +465,7 @@ class Business(db.Model):  # pylint: disable=too-many-instance-attributes,disabl
             'foundingDate': self.founding_date.isoformat(),
             'hasRestrictions': self.restriction_ind,
             'complianceWarnings': self.compliance_warnings,
+            'warnings': self.warnings,
             'lastAnnualGeneralMeetingDate': datetime.date(self.last_agm_date).isoformat() if self.last_agm_date else '',
             'lastAnnualReportDate': datetime.date(self.last_ar_date).isoformat() if self.last_ar_date else '',
             'lastLedgerTimestamp': self.last_ledger_timestamp.isoformat(),
@@ -477,7 +478,6 @@ class Business(db.Model):  # pylint: disable=too-many-instance-attributes,disabl
             'nextAnnualReport': LegislationDatetime.as_legislation_timezone_from_date(
                 self.next_anniversary
             ).astimezone(timezone.utc).isoformat(),
-            'noDissolution': self.no_dissolution,
             'associationType': self.association_type,
             'allowedActions': self.allowable_actions
         }
@@ -495,8 +495,8 @@ class Business(db.Model):  # pylint: disable=too-many-instance-attributes,disabl
             'identifier': self.identifier,
             'legalName': self.business_legal_name,
             'legalType': self.legal_type,
-            'state': self.state.name if self.state else Business.State.ACTIVE.name,
-            'warnings': self.warnings
+            'noDissolution': self.no_dissolution,
+            'state': self.state.name if self.state else Business.State.ACTIVE.name
         }
 
         if flags.is_on('enable-legal-name-fix'):

--- a/legal-api/tests/unit/models/test_business.py
+++ b/legal-api/tests/unit/models/test_business.py
@@ -285,7 +285,8 @@ def test_business_json(session):
         'legalName': 'legal_name',
         'legalType': Business.LegalTypes.COOP.value,
         'state': Business.State.ACTIVE.name,
-        'taxId': '123456789'
+        'taxId': '123456789',
+        'warnings': [],
     }
 
     with patch.object(flags, 'is_on', return_value=True):
@@ -312,7 +313,6 @@ def test_business_json(session):
         'arMinDate': '1971-01-01',
         'arMaxDate': '1972-04-30',
         'complianceWarnings': [],
-        'warnings': [],
         'hasCorrections': False,
         'associationType': 'CP',
         'startDate': '2021-08-05',

--- a/legal-api/tests/unit/models/test_business.py
+++ b/legal-api/tests/unit/models/test_business.py
@@ -284,9 +284,9 @@ def test_business_json(session):
         'identifier': 'CP1234567',
         'legalName': 'legal_name',
         'legalType': Business.LegalTypes.COOP.value,
+        'noDissolution': False,
         'state': Business.State.ACTIVE.name,
-        'taxId': '123456789',
-        'warnings': [],
+        'taxId': '123456789'
     }
 
     with patch.object(flags, 'is_on', return_value=True):
@@ -313,12 +313,12 @@ def test_business_json(session):
         'arMinDate': '1971-01-01',
         'arMaxDate': '1972-04-30',
         'complianceWarnings': [],
+        'warnings': [],
         'hasCorrections': False,
         'associationType': 'CP',
         'startDate': '2021-08-05',
         'hasCourtOrders': False,
-        'allowedActions': {},
-        'noDissolution': False
+        'allowedActions': {}
     }
 
     with patch.object(flags, 'is_on', return_value=True):

--- a/legal-api/tests/unit/models/test_business.py
+++ b/legal-api/tests/unit/models/test_business.py
@@ -282,9 +282,9 @@ def test_business_json(session):
         'alternateNames': [],
         'goodStanding': False,  # good standing will be false because the epoch is 1970
         'identifier': 'CP1234567',
+        'inDissolution': False,
         'legalName': 'legal_name',
         'legalType': Business.LegalTypes.COOP.value,
-        'noDissolution': False,
         'state': Business.State.ACTIVE.name,
         'taxId': '123456789'
     }
@@ -318,7 +318,8 @@ def test_business_json(session):
         'associationType': 'CP',
         'startDate': '2021-08-05',
         'hasCourtOrders': False,
-        'allowedActions': {}
+        'allowedActions': {},
+        'noDissolution': False
     }
 
     with patch.object(flags, 'is_on', return_value=True):


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21262

*Description of changes:*
Moved the ~warnings array~ inDissolution to slim json

Currently, in Auth Web, the search endpoint for all the businesses returns the slim json:
![something like this serach](https://github.com/bcgov/lear/assets/122301442/733648d8-d42a-4f77-84f5-db93042c8c8f)

So, as of right now, there's no way of actually knowing that the business is the process of being dissolved (D1 state for example).

Now that the inDissolution is in the slim json, I will be able to use it in AUTH WEB. And In doing so, I can actually add the alert when inDissolution is true.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
