### PR TITLE
21455 add criterion to exclude frozen businesses from being selected to involuntary dissolution

### DIFF
--- a/legal-api/src/legal_api/services/involuntary_dissolution.py
+++ b/legal-api/src/legal_api/services/involuntary_dissolution.py
@@ -59,7 +59,7 @@ class InvoluntaryDissolutionService():
                                   Batch.batch_type == Batch.BatchType.INVOLUNTARY_DISSOLUTION)
 
         query = db.session.query(Business).\
-            filter(not_(Business.admin_freeze == True)).\
+            filter(not_(Business.admin_freeze.is_(True))).\
             filter(Business.state == Business.State.ACTIVE).\
             filter(Business.legal_type.in_(eligible_types)).\
             filter(Business.no_dissolution.is_(False)).\

--- a/legal-api/src/legal_api/services/involuntary_dissolution.py
+++ b/legal-api/src/legal_api/services/involuntary_dissolution.py
@@ -59,6 +59,7 @@ class InvoluntaryDissolutionService():
                                   Batch.batch_type == Batch.BatchType.INVOLUNTARY_DISSOLUTION)
 
         query = db.session.query(Business).\
+            filter(not_(Business.admin_freeze == True)).\
             filter(Business.state == Business.State.ACTIVE).\
             filter(Business.legal_type.in_(eligible_types)).\
             filter(Business.no_dissolution.is_(False)).\

--- a/legal-api/tests/unit/services/test_involuntary_dissolution.py
+++ b/legal-api/tests/unit/services/test_involuntary_dissolution.py
@@ -296,10 +296,7 @@ def test_get_businesses_eligible_query_xpro_from_nwpta(session, test_name, juris
 def test_exclude_admin_frozen_businesses(session, test_name, admin_freeze, eligible):
     """Assert service returns eligible business excluding admin frozen businesses"""
     identifier = 'BC1234567'
-    business = factory_business(identifier=identifier, admin_freeze=admin_freeze, entity_type=Business.LegalTypes.COMP.value)
-    if not eligible:
-        business.no_dissolution = True
-        business.save()
+    factory_business(identifier=identifier, admin_freeze=admin_freeze, entity_type=Business.LegalTypes.COMP.value)
 
     check_query = InvoluntaryDissolutionService._get_businesses_eligible_query().\
                     filter(Business.admin_freeze.is_(True)).count()

--- a/legal-api/tests/unit/services/test_involuntary_dissolution.py
+++ b/legal-api/tests/unit/services/test_involuntary_dissolution.py
@@ -39,16 +39,15 @@ RESTORATION_FILING['filing']['restoration'] = RESTORATION
 
 
 @pytest.mark.parametrize(
-        'test_name, isAdminFreeze, eligible', [
-            ('TEST_ELIGIBLE', False, True),
-            ('TEST_INELIGIBLE', False, False),
-            ('TEST_INELIGIBLE_ADMIN_FREEZE', True, False)
+        'test_name, eligible', [
+            ('TEST_ELIGIBLE', True),
+            ('TEST_INELIGIBLE', False)
         ]
 )
-def test_check_business_eligibility(session, test_name, isAdminFreeze, eligible):
+def test_check_business_eligibility(session, test_name, eligible):
     """Assert service returns check of business eligibility for involuntary dissolution."""
     identifier = 'BC7654321'
-    business = factory_business(identifier=identifier, entity_type=Business.LegalTypes.COMP.value, admin_freeze=isAdminFreeze)
+    business = factory_business(identifier=identifier, entity_type=Business.LegalTypes.COMP.value)
     if not eligible:
         business.no_dissolution = True
         business.save()

--- a/legal-api/tests/unit/services/test_involuntary_dissolution.py
+++ b/legal-api/tests/unit/services/test_involuntary_dissolution.py
@@ -39,15 +39,16 @@ RESTORATION_FILING['filing']['restoration'] = RESTORATION
 
 
 @pytest.mark.parametrize(
-        'test_name, eligible', [
-            ('TEST_ELIGIBLE', True),
-            ('TEST_INELIGIBLE', False)
+        'test_name, isAdminFreeze, eligible', [
+            ('TEST_ELIGIBLE', False, True),
+            ('TEST_INELIGIBLE', False, False),
+            ('TEST_INELIGIBLE_ADMIN_FREEZE', True, False)
         ]
 )
-def test_check_business_eligibility(session, test_name, eligible):
+def test_check_business_eligibility(session, test_name, isAdminFreeze, eligible):
     """Assert service returns check of business eligibility for involuntary dissolution."""
     identifier = 'BC7654321'
-    business = factory_business(identifier=identifier, entity_type=Business.LegalTypes.COMP.value)
+    business = factory_business(identifier=identifier, entity_type=Business.LegalTypes.COMP.value, admin_freeze=isAdminFreeze)
     if not eligible:
         business.no_dissolution = True
         business.save()


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21455

*Description of changes:*
- Add a criterion to exclude frozen businesses by checking _Business.admin_freeze_ is not True
- Update unit tests, expecting business eligibility returns false when the business is admin frozen
- Passed all unit tests in _test_involuntary_dissolution.py_ including the updated one

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
