### PR TITLE
21442 Legal API - Add filter to configurations endpoint

### DIFF
--- a/legal-api/src/legal_api/models/configuration.py
+++ b/legal-api/src/legal_api/models/configuration.py
@@ -90,6 +90,11 @@ class Configuration(db.Model):  # pylint: disable=too-many-instance-attributes
             configuration = cls.query.filter_by(name=config_name).one_or_none()
         return configuration
 
+    @classmethod
+    def find_by_names(cls, config_names: List[str]) -> List[Configuration]:
+        """Return the configurations matching the names."""
+        return cls.query.filter(cls.name.in_(config_names)).all()
+
     def validate_value(self):
         """Ensure the value is the correct type before insert or update."""
         # Define keys that should have specific value types

--- a/legal-api/src/legal_api/resources/v2/admin/configuration.py
+++ b/legal-api/src/legal_api/resources/v2/admin/configuration.py
@@ -31,7 +31,7 @@ def get_configurations():
     """Return a list of configurations, optionally filtered by names."""
     filter_names = request.args.get('names', None)
     if filter_names:
-        names_list = [name.strip() for name in filter_names.split(',') if name.strip()]
+        names_list = [name.strip().upper() for name in filter_names.split(',') if name.strip()]
         if not names_list:
             return {'message': 'Configuration names are invalid'}, HTTPStatus.BAD_REQUEST
 

--- a/legal-api/src/legal_api/resources/v2/admin/configuration.py
+++ b/legal-api/src/legal_api/resources/v2/admin/configuration.py
@@ -28,23 +28,24 @@ from .bp import bp_admin
 @cross_origin(origin='*')
 @jwt.has_one_of_roles([UserRoles.staff])
 def get_configurations():
-    """Return a list of configurations, optionally filtered by name."""
-    filter_name = request.args.get('name', None)
-    if filter_name:
-        configuration = Configuration.find_by_name(filter_name)
-        if configuration:
-            return jsonify({
-                'configurations': [configuration.json]
-            }), HTTPStatus.OK
-        else:
-            return {'message': 'Configuration not found'}, HTTPStatus.NOT_FOUND
+    """Return a list of configurations, optionally filtered by names."""
+    filter_names = request.args.get('names', None)
+    if filter_names:
+        names_list = [name.strip() for name in filter_names.split(',') if name.strip()]
+        if not names_list:
+            return {'message': 'Configuration names are invalid'}, HTTPStatus.BAD_REQUEST
+
+        configurations = Configuration.find_by_names(names_list)
+        if not configurations:
+            return {'message': 'Configurations not found'}, HTTPStatus.NOT_FOUND
     else:
         configurations = Configuration.all()
-        return jsonify({
-            'configurations': [
-                configuration.json for configuration in configurations
-            ]
-        }), HTTPStatus.OK
+
+    return jsonify({
+        'configurations': [
+            configuration.json for configuration in configurations
+        ]
+    }), HTTPStatus.OK
 
 
 @bp_admin.route('/configurations', methods=['PUT'])

--- a/legal-api/src/legal_api/resources/v2/admin/configuration.py
+++ b/legal-api/src/legal_api/resources/v2/admin/configuration.py
@@ -28,13 +28,23 @@ from .bp import bp_admin
 @cross_origin(origin='*')
 @jwt.has_one_of_roles([UserRoles.staff])
 def get_configurations():
-    """Return a list of configurations."""
-    configurations = Configuration.all()
-    return jsonify({
-        'configurations': [
-            configuration.json for configuration in configurations
-        ]
-    }), HTTPStatus.OK
+    """Return a list of configurations, optionally filtered by name."""
+    filter_name = request.args.get('name', None)
+    if filter_name:
+        configuration = Configuration.find_by_name(filter_name)
+        if configuration:
+            return jsonify({
+                'configurations': [configuration.json]
+            }), HTTPStatus.OK
+        else:
+            return {'message': 'Configuration not found'}, HTTPStatus.NOT_FOUND
+    else:
+        configurations = Configuration.all()
+        return jsonify({
+            'configurations': [
+                configuration.json for configuration in configurations
+            ]
+        }), HTTPStatus.OK
 
 
 @bp_admin.route('/configurations', methods=['PUT'])

--- a/legal-api/tests/unit/resources/v2/test_configuration.py
+++ b/legal-api/tests/unit/resources/v2/test_configuration.py
@@ -78,8 +78,8 @@ def test_get_configurations_with_single_filter_name(app, session, client, jwt):
 
 def test_get_configurations_with_multiple_filter_names(app, session, client, jwt):
     """Assert that get results with multiple filter names are returned."""
-    filter_names = 'DISSOLUTIONS_SUMMARY_EMAIL, NUM_DISSOLUTIONS_ALLOWED'
-    expected_names = [name.strip() for name in filter_names.split(',') if name.strip()]
+    filter_names = 'DISSOLUTIONS_SUMMARY_EMAIL, NUM_DISSOLUTIONS_ALLOWED, dissolutions_on_hold'
+    expected_names = [name.strip().upper() for name in filter_names.split(',') if name.strip()]
 
     # test
     rv = client.get(f'/api/v2/admin/configurations?names={filter_names}',

--- a/legal-api/tests/unit/resources/v2/test_configuration.py
+++ b/legal-api/tests/unit/resources/v2/test_configuration.py
@@ -59,12 +59,12 @@ def test_get_configurations_with_invalid_user(app, session, client, jwt):
     assert rv.status_code == HTTPStatus.UNAUTHORIZED
 
 
-def test_get_configurations_with_filter_name(app, session, client, jwt):
-    """Assert that get results with filter name are returned."""
+def test_get_configurations_with_single_filter_name(app, session, client, jwt):
+    """Assert that get results with a single filter name are returned."""
     filter_name = 'DISSOLUTIONS_SUMMARY_EMAIL'
 
     # test
-    rv = client.get(f'/api/v2/admin/configurations?name={filter_name}',
+    rv = client.get(f'/api/v2/admin/configurations?names={filter_name}',
                     headers=create_header(jwt, [STAFF_ROLE], 'user'))
 
     # check
@@ -74,6 +74,50 @@ def test_get_configurations_with_filter_name(app, session, client, jwt):
     assert len(results) == 1
     for res in results:
         assert res['name'] == filter_name
+
+
+def test_get_configurations_with_multiple_filter_names(app, session, client, jwt):
+    """Assert that get results with multiple filter names are returned."""
+    filter_names = 'DISSOLUTIONS_SUMMARY_EMAIL, NUM_DISSOLUTIONS_ALLOWED'
+    expected_names = [name.strip() for name in filter_names.split(',') if name.strip()]
+
+    # test
+    rv = client.get(f'/api/v2/admin/configurations?names={filter_names}',
+                    headers=create_header(jwt, [STAFF_ROLE], 'user'))
+
+    # check
+    assert rv.status_code == HTTPStatus.OK
+    assert 'configurations' in rv.json
+    results = rv.json['configurations']
+    assert len(results) == len(expected_names)
+    for res in results:
+        assert res['name'] in expected_names
+
+
+def test_get_configurations_with_empty_filter_names(app, session, client, jwt):
+    """Assert that a bad request is returned when configuration names are invalid."""
+    empty_names = ' '
+
+    # Test
+    rv = client.get(f'/api/v2/admin/configurations?names={empty_names}',
+                    headers=create_header(jwt, [STAFF_ROLE], 'user'))
+
+    # Check
+    assert rv.status_code == HTTPStatus.BAD_REQUEST
+    assert rv.json['message'] == 'Configuration names are invalid'
+
+
+def test_get_configurations_with_filter_names_no_matching_configurations(app, session, client, jwt):
+    """Assert that not found is returned when configuration names have no matches."""
+    filter_names = 'NON_EXISTENT_CONFIGURATION_NAME1, NON_EXISTENT_CONFIGURATION_NAME2'
+
+    # Test
+    rv = client.get(f'/api/v2/admin/configurations?names={filter_names}',
+                    headers=create_header(jwt, [STAFF_ROLE], 'user'))
+
+    # Check
+    assert rv.status_code == HTTPStatus.NOT_FOUND
+    assert rv.json['message'] == 'Configurations not found'
 
 
 def test_put_configurations_with_valid_data(app, session, client, jwt):

--- a/legal-api/tests/unit/resources/v2/test_configuration.py
+++ b/legal-api/tests/unit/resources/v2/test_configuration.py
@@ -59,6 +59,23 @@ def test_get_configurations_with_invalid_user(app, session, client, jwt):
     assert rv.status_code == HTTPStatus.UNAUTHORIZED
 
 
+def test_get_configurations_with_filter_name(app, session, client, jwt):
+    """Assert that get results with filter name are returned."""
+    filter_name = 'DISSOLUTIONS_SUMMARY_EMAIL'
+
+    # test
+    rv = client.get(f'/api/v2/admin/configurations?name={filter_name}',
+                    headers=create_header(jwt, [STAFF_ROLE], 'user'))
+
+    # check
+    assert rv.status_code == HTTPStatus.OK
+    assert 'configurations' in rv.json
+    results = rv.json['configurations']
+    assert len(results) == 1
+    for res in results:
+        assert res['name'] == filter_name
+
+
 def test_put_configurations_with_valid_data(app, session, client, jwt):
     """Assert that update values successfully."""
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21442

*Description of changes:*

- Add filter query param to GET /configurations endpoint to retrieve configuration items by name
- Add unit tests

<img width="947" alt="image" src="https://github.com/bcgov/lear/assets/168996250/14e166fd-3ac7-42ba-9937-959fa88732d6">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
