### PR TITLE
Small tweak on legal-api setup.py to add NATS requirements as optional

### DIFF
--- a/legal-api/setup.py
+++ b/legal-api/setup.py
@@ -51,6 +51,7 @@ def read(filepath):
 
 
 REQUIREMENTS = read_requirements('requirements.txt')
+REQUIREMENTS_NATS = read_requirements('requirements-nats.txt')
 
 setup(
     name="legal_api",
@@ -66,4 +67,7 @@ setup(
     install_requires=REQUIREMENTS,
     setup_requires=["pytest-runner", ],
     tests_require=["pytest", ],
+    extras_require={
+        'nats': REQUIREMENTS_NATS
+    }
 )


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*
- Add `requirements-nats.txt` as optional dependency

Note that using `pip install <legal-api path>/legal-api` just installs partial dependencies excluding supports for NATS.
To install all dependencies for legal-api, use `pip install <legal-api path>/legal-api[nats]` instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
