### PR TITLE
21475 Dissolutions job - Update stage 1 & stage 2 processes

### DIFF
--- a/jobs/involuntary-dissolutions/config.py
+++ b/jobs/involuntary-dissolutions/config.py
@@ -79,8 +79,8 @@ class _Config(object):  # pylint: disable=too-few-public-methods
 
     SUMMARY_STORAGE_PATH = os.getenv('SUMMARY_STORAGE_PATH', '')
     SECOND_NOTICE_DELAY = os.getenv('SECOND_NOTICE_DELAY', None)
-    STAGE_1_DELAY = os.getenv('STAGE_1_DELAY', None)
-    STAGE_2_DELAY = os.getenv('STAGE_2_DELAY', None)
+    STAGE_1_DELAY = int(os.getenv('STAGE_1_DELAY', '42'))
+    STAGE_2_DELAY = int(os.getenv('STAGE_2_DELAY', '30'))
 
 
 class DevConfig(_Config):  # pylint: disable=too-few-public-methods

--- a/jobs/involuntary-dissolutions/involuntary_dissolutions.py
+++ b/jobs/involuntary-dissolutions/involuntary_dissolutions.py
@@ -25,7 +25,7 @@ from legal_api.models import Batch, BatchProcessing, Configuration, db  # noqa: 
 from legal_api.services.flags import Flags
 from legal_api.services.involuntary_dissolution import InvoluntaryDissolutionService
 from sentry_sdk.integrations.logging import LoggingIntegration
-from sqlalchemy import Date, cast, func, text
+from sqlalchemy import Date, cast, func
 
 import config  # pylint: disable=import-error
 from utils.logging import setup_logging  # pylint: disable=import-error
@@ -77,8 +77,7 @@ def initiate_dissolution_process(app: Flask):  # pylint: disable=redefined-outer
     """Initiate dissolution process for new businesses that meet dissolution criteria."""
     try:
         # check if batch has already run today
-        tz = pytz.timezone('US/Pacific')
-        today_date = tz.localize(datetime.today()).date()
+        today_date = datetime.utcnow().date()
 
         batch_today = (
             db.session.query(Batch)
@@ -98,11 +97,22 @@ def initiate_dissolution_process(app: Flask):  # pylint: disable=redefined-outer
             app.logger.debug('Skipping job run since there are no businesses eligible for dissolution.')
             return
 
+        # get stage_1 & stage_2 delay configs
+        if (stage_1_delay_config := app.config.get('STAGE_1_DELAY', 0)):
+            stage_1_delay = timedelta(days=int(stage_1_delay_config))
+        else:
+            stage_1_delay = timedelta(days=0)
+
+        if (stage_2_delay_config := app.config.get('STAGE_2_DELAY', 0)):
+            stage_2_delay = timedelta(days=int(stage_2_delay_config))
+        else:
+            stage_2_delay = timedelta(days=0)
+
         # create new entry in batches table
         batch = Batch(batch_type=Batch.BatchType.INVOLUNTARY_DISSOLUTION,
                       status=Batch.BatchStatus.PROCESSING,
                       size=len(businesses_eligible),
-                      start_date=datetime.now())
+                      start_date=datetime.utcnow())
         batch.save()
 
         # create batch processing entries for each business being dissolved
@@ -111,19 +121,10 @@ def initiate_dissolution_process(app: Flask):  # pylint: disable=redefined-outer
             batch_processing = BatchProcessing(business_identifier=business.identifier,
                                                step=BatchProcessing.BatchProcessingStep.WARNING_LEVEL_1,
                                                status=BatchProcessing.BatchProcessingStatus.PROCESSING,
-                                               created_date=datetime.now(),
+                                               created_date=datetime.utcnow(),
+                                               trigger_date=datetime.utcnow()+stage_1_delay,
                                                batch_id=batch.id,
                                                business_id=business.id)
-
-            if (stage_1_delay_config := app.config.get('STAGE_1_DELAY', 0)):
-                stage_1_delay = timedelta(days=int(stage_1_delay_config))
-            else:
-                stage_1_delay = timedelta(days=0)
-
-            if (stage_2_delay_config := app.config.get('STAGE_2_DELAY', 0)):
-                stage_2_delay = timedelta(days=int(stage_2_delay_config))
-            else:
-                stage_2_delay = timedelta(days=0)
 
             target_dissolution_date = batch_processing.created_date + stage_1_delay + stage_2_delay
 
@@ -140,8 +141,8 @@ def initiate_dissolution_process(app: Flask):  # pylint: disable=redefined-outer
 
 def stage_2_process(app: Flask):
     """Run dissolution stage 2 process for businesses meet moving criteria."""
-    if not (stage_1_delay := app.config.get('STAGE_1_DELAY', None)):
-        app.logger.debug('Skipping stage 2 run since config STAGE_1_DELAY is missing.')
+    if not (stage_2_delay_config := app.config.get('STAGE_2_DELAY', None)):
+        app.logger.debug('Skipping stage 2 run since config STAGE_2_DELAY is missing.')
         return
 
     batch_processings = (
@@ -156,8 +157,7 @@ def stage_2_process(app: Flask):
             BatchProcessing.step == BatchProcessing.BatchProcessingStep.WARNING_LEVEL_1
         )
         .filter(
-            BatchProcessing.created_date + text(f"""INTERVAL '{stage_1_delay} DAYS'""")
-            <= func.timezone('UTC', func.now())
+            BatchProcessing.trigger_date <= func.timezone('UTC', func.now())
         )
         .all()
     )
@@ -170,6 +170,7 @@ def stage_2_process(app: Flask):
         )
         if eligible:
             batch_processing.step = BatchProcessing.BatchProcessingStep.WARNING_LEVEL_2
+            batch_processing.trigger_date = datetime.utcnow() + timedelta(days=int(stage_2_delay_config))
         else:
             batch_processing.status = BatchProcessing.BatchProcessingStatus.WITHDRAWN
             batch_processing.notes = 'Moved back into good standing'

--- a/jobs/involuntary-dissolutions/tests/unit/__init__.py
+++ b/jobs/involuntary-dissolutions/tests/unit/__init__.py
@@ -14,6 +14,7 @@
 """The Test-Suite used to ensure that the Involuntary Dissolutions Job is working correctly."""
 
 import datetime
+from datedelta import datedelta
 
 from legal_api.models import Batch, BatchProcessing, Business
 
@@ -66,6 +67,7 @@ def factory_batch_processing(batch_id,
                              step=BatchProcessing.BatchProcessingStep.WARNING_LEVEL_1,
                              status=BatchProcessing.BatchProcessingStatus.PROCESSING,
                              created_date=datetime.datetime.utcnow(),
+                             trigger_date=datetime.datetime.utcnow()+datedelta(days=42),
                              last_modified=datetime.datetime.utcnow(),
                              notes=''):
     """Create a batch processing entry."""
@@ -76,6 +78,7 @@ def factory_batch_processing(batch_id,
         step=step,
         status=status,
         created_date=created_date,
+        trigger_date=trigger_date,
         last_modified=last_modified,
         notes=notes
     )


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21475

*Description of changes:*
- Updated stage 1 & stage 2 processes for dissolutions job.
Now `batch_processing.trigger_date` is set in stage 1, and stage 2 & 3 can use this to check whether the business can be processed.
- Fix unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
