### PR TITLE
fix: add in temp identifier to gcp event call

### DIFF
--- a/queue_services/entity-filer/src/entity_filer/worker.py
+++ b/queue_services/entity-filer/src/entity_filer/worker.py
@@ -140,6 +140,18 @@ def publish_gcp_queue_event(business: Business, filing: Filing):
     """Publish the filing message onto the NATS filing subject."""
     try:
         subject = APP_CONFIG.BUSINESS_EVENTS_TOPIC
+        data= {
+                'filing': {
+                    'header': {'filingId': filing.id,
+                               'effectiveDate': filing.effective_date.isoformat()
+                               },
+                    'business': {'identifier': business.identifier},
+                    'legalFilings': get_filing_types(filing.filing_json)
+                }
+            }
+        if filing.temp_reg:
+            data['tempidentifier'] = filing.temp_reg
+
         ce = SimpleCloudEvent(
             id=str(uuid.uuid4()),
             source=''.join([
@@ -151,15 +163,7 @@ def publish_gcp_queue_event(business: Business, filing: Filing):
                 subject=subject,
             time=datetime.now(timezone.utc),
             type='bc.registry.business.' + filing.filing_type,
-            data= {
-                'filing': {
-                    'header': {'filingId': filing.id,
-                               'effectiveDate': filing.effective_date.isoformat()
-                               },
-                    'business': {'identifier': business.identifier},
-                    'legalFilings': get_filing_types(filing.filing_json)
-                }
-            }
+            data=data
         )
         
         gcp_queue.publish(subject,to_queue_message(ce))

--- a/queue_services/entity-filer/src/entity_filer/worker.py
+++ b/queue_services/entity-filer/src/entity_filer/worker.py
@@ -137,7 +137,7 @@ async def publish_event(business: Business, filing: Filing):
 
 
 def publish_gcp_queue_event(business: Business, filing: Filing):
-    """Publish the filing message onto the NATS filing subject."""
+    """Publish the filing message onto the GCP-QUEUE filing subject."""
     try:
         subject = APP_CONFIG.BUSINESS_EVENTS_TOPIC
         data= {


### PR DESCRIPTION
*Issue #:* n/a

*Description of changes:*
add back in temp identifier that was pulled in gcp event for testing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
