### PR TITLE
21476 update good standing logic to include transition filing criteria

### DIFF
--- a/legal-api/src/legal_api/models/business.py
+++ b/legal-api/src/legal_api/models/business.py
@@ -402,12 +402,12 @@ class Business(db.Model):  # pylint: disable=too-many-instance-attributes,disabl
         # A firm is always in good standing
         if self.is_firm:
             return True
-        # Date of last AR or founding date if they haven't yet filed one
-        last_ar_date = self.last_ar_date or self.founding_date
         # When involuntary dissolution feature flag is on, check transition filing
         if flags.is_on('enable_involuntary_dissolution'):
             if self._has_no_transition_filed_after_restoration():
                 return False
+        # Date of last AR or founding date if they haven't yet filed one
+        last_ar_date = self.last_ar_date or self.founding_date
         # Good standing is if last AR was filed within the past 1 year, 2 months and 1 day and is in an active state
         if self.state == Business.State.ACTIVE:
             if self.restoration_expiry_date:

--- a/legal-api/tests/unit/models/test_business.py
+++ b/legal-api/tests/unit/models/test_business.py
@@ -16,6 +16,7 @@
 
 Test-Suite to ensure that the Business Model is working as expected.
 """
+import copy
 from datetime import datetime, timedelta
 from flask import current_app
 from unittest.mock import patch
@@ -23,6 +24,7 @@ from unittest.mock import patch
 import datedelta
 import pytest
 from sqlalchemy_continuum import versioning_manager
+from registry_schemas.example_data import FILING_HEADER, RESTORATION, TRANSITION_FILING_TEMPLATE
 
 from legal_api.exceptions import BusinessException
 from legal_api.models import AmalgamatingBusiness, Amalgamation, Batch, BatchProcessing, Business, Filing, Party, PartyRole, db
@@ -30,7 +32,12 @@ from legal_api.services import flags
 from legal_api.utils.legislation_datetime import LegislationDatetime
 from tests import EPOCH_DATETIME, TIMEZONE_OFFSET
 from tests.unit import has_expected_date_str_format
-from tests.unit.models import factory_party_role, factory_batch
+from tests.unit.models import (
+    factory_party_role, 
+    factory_batch, 
+    factory_business as factory_business_from_tests,
+    factory_completed_filing
+)
 
 
 def factory_business(designation: str = '001'):
@@ -253,6 +260,35 @@ def test_good_standing(session, last_ar_date, legal_type, state, limited_restora
     business.save()
 
     assert business.good_standing is expected
+
+RESTORATION_FILING = copy.deepcopy(FILING_HEADER)
+RESTORATION_FILING['filing']['restoration'] = RESTORATION
+@pytest.mark.parametrize('test_name, has_no_transition_filed, good_standing', [
+    ('NO_NEED_TRANSITION_NEW_ACT', False, True),
+    ('NO_NEED_TRANSITION_BUT_IN_LIMITED_RESTORATION', False, False),
+    ('TRANSITION_COMPLETED', False, True),
+    ('TRANSITION_NOT_FILED', True, False)
+])
+def test_good_standing_check_transition_filing(session, test_name, has_no_transition_filed, good_standing):
+    "Assert that the business is in good standing with additional check for transition filing"
+    business = factory_business_from_tests(identifier='BC1234567', entity_type=Business.LegalTypes.COMP.value, last_ar_date=datetime.utcnow())
+    restoration_filing = factory_completed_filing(business, RESTORATION_FILING, filing_type='restoration')
+    if test_name == 'NO_NEED_TRANSITION_NEW_ACT':
+        business.founding_date = datetime.utcnow()
+        business.save()
+    elif test_name == 'NO_NEED_TRANSITION_BUT_IN_LIMITED_RESTORATION':
+        business.restoration_expiry_date = datetime.utcnow() + datedelta.datedelta(years=1)
+        business.save()
+        restoration_filing.effective_date = datetime.utcnow()
+        restoration_filing.save()
+    elif test_name == 'TRANSITION_COMPLETED':
+        factory_completed_filing(business, TRANSITION_FILING_TEMPLATE, filing_type='transition')
+    
+    check_result = business._has_no_transition_filed_after_restoration()
+    assert check_result == has_no_transition_filed
+    with patch.object(flags, 'is_on', return_value=True):
+        assert business.good_standing == good_standing
+
 
 
 def test_business_json(session):

--- a/legal-api/tests/unit/models/test_business.py
+++ b/legal-api/tests/unit/models/test_business.py
@@ -261,8 +261,11 @@ def test_good_standing(session, last_ar_date, legal_type, state, limited_restora
 
     assert business.good_standing is expected
 
+
 RESTORATION_FILING = copy.deepcopy(FILING_HEADER)
 RESTORATION_FILING['filing']['restoration'] = RESTORATION
+
+
 @pytest.mark.parametrize('test_name, has_no_transition_filed, good_standing', [
     ('NO_NEED_TRANSITION_NEW_ACT', False, True),
     ('NO_NEED_TRANSITION_BUT_IN_LIMITED_RESTORATION', False, False),
@@ -288,7 +291,6 @@ def test_good_standing_check_transition_filing(session, test_name, has_no_transi
     assert check_result == has_no_transition_filed
     with patch.object(flags, 'is_on', return_value=True):
         assert business.good_standing == good_standing
-
 
 
 def test_business_json(session):


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21476

*Description of changes:*
Implemented the logic to include transition filing logic used in involuntary dissolution eligibility check in `business.good_standing`.
(`enable_involuntary_dissolution` feature flag)

The main logic is same as the `_has_no_transition_filed_after_restoration()` method in involuntary dissolution. 
Differences are: 
- instead of checking with a given Business, this implementation checks with itself.
- instead of returning a SQLAlchemy clause, this implementation returns a boolean value, implemented using `.scalar()` after the query.

Also added unit tests to check 4 situations:
- New established business
- In limited restoration, not expired, no need for transition 
- Transition filed and completed
- Transition not filed 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
