### PR TITLE
21696-Fix broken code coverage uploads in all CI pipelines - Try out add token

### DIFF
--- a/.github/workflows/legal-api-ci.yml
+++ b/.github/workflows/legal-api-ci.yml
@@ -102,6 +102,7 @@ jobs:
           file: ./legal-api/coverage.xml
           flags: legalapi
           name: codecov-legal-api
+          token: ${{ secrets.CODECOV_TOKEN}}
           fail_ci_if_error: true
 
   build-check:


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21696

*Description of changes:*
This is a tiny PR. As part of the ticket.
Add token to legal-api-ci, need to merge and test with legal api CI action before doing other changes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
