### PR TITLE
Get future effective filings in Colin

### DIFF
--- a/colin-api/src/colin_api/models/filing.py
+++ b/colin-api/src/colin_api/models/filing.py
@@ -926,6 +926,56 @@ class Filing:  # pylint: disable=too-many-instance-attributes;
             raise err
 
     @classmethod
+    def get_future_effective_filings(cls, business: Business) -> List:
+        """Get the list of all future effective filings for a business."""
+        try:
+            future_effective_filings = []
+            current_date = datetime.datetime.utcnow().strftime('%Y-%m-%d')
+            cursor = DB.connection.cursor()
+            cursor.execute(
+                """
+                select event.event_id, event_timestmp, filing_typ_cd, effective_dt, period_end_dt, agm_date
+                from event join filing on event.event_id = filing.event_id
+                where corp_num=:identifier
+                and filing.effective_dt > TO_DATE(:current_date, 'YYYY-mm-dd')
+                order by event_timestmp
+                """,
+                identifier=business.corp_num,
+                current_date=current_date
+            )
+            filings_info_list = []
+
+            for filing_info in cursor:
+                filings_info_list.append(dict(zip([x[0].lower() for x in cursor.description], filing_info)))
+            for filing_info in filings_info_list:
+                filing_info['filing_type'] = cls._get_filing_type(filing_info['filing_typ_cd'])
+                date = convert_to_json_date(filing_info['event_timestmp'])
+                filing = Filing()
+                filing.business = business
+                filing.header = {
+                    'date': date,
+                    'name': filing_info['filing_type'],
+                    'effectiveDate': convert_to_json_date(filing_info['effective_dt']),
+                    'availableOnPaperOnly': True,
+                    'colinIds': [filing_info['event_id']]
+                }
+                filing.body = {
+                        filing_info['filing_type']: {
+                        }
+                }
+                future_effective_filings.append(filing.as_dict())
+            return future_effective_filings
+
+        except InvalidFilingTypeException as err:
+            current_app.logger.error('Unknown filing type found when getting future effective filings for '
+                                     f'{business.get_corp_num()}.')
+            raise err
+
+        except Exception as err:
+            current_app.logger.error(err.with_traceback(None))
+            raise err
+
+    @classmethod
     def add_administrative_dissolution_event(cls, con, corp_num) -> int:
         """Add administrative dissolution event."""
         cursor = con.cursor()

--- a/colin-api/src/colin_api/resources/filing.py
+++ b/colin-api/src/colin_api/resources/filing.py
@@ -58,6 +58,11 @@ class FilingInfo(Resource):
             corp_types = Business.CORP_TYPE_CONVERSION[legal_type]
             business = Business.find_by_identifier(identifier, corp_types)
 
+            # get future effective filings
+            if filing_type == 'future':
+                future_effective_filings_info = Filing.get_future_effective_filings(business=business)
+                return jsonify(future_effective_filings_info)
+
             # get filings history from before bob-date
             if filing_type == 'historic':
                 historic_filings_info = Filing.get_historic_filings(business=business)

--- a/colin-api/tests/postman/colin-api.postman_collection.json
+++ b/colin-api/tests/postman/colin-api.postman_collection.json
@@ -1,11 +1,10 @@
 {
 	"info": {
-		"_postman_id": "4c9af778-f52b-420f-b381-38632538ce00",
+		"_postman_id": "92f3af20-fd0f-40ea-a41a-ac2efcdc44d4",
 		"name": "colin-api",
 		"description": "version=0.108 - This is a Colin API description",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "6835935",
-		"_collection_link": "https://warped-escape-616276.postman.co/workspace/bc-registries~8ef8e652-492a-4d19-b978-d4f0da255b2c/collection/6835935-4c9af778-f52b-420f-b381-38632538ce00?action=share&creator=6835935&source=collection_link"
+		"_exporter_id": "31792407"
 	},
 	"item": [
 		{
@@ -4425,6 +4424,128 @@
 										"CP0002098",
 										"filings",
 										"historic"
+									]
+								}
+							},
+							"response": [
+								{
+									"name": "GET HF CP0002098",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"type": "text",
+												"value": "application/json",
+												"disabled": true
+											}
+										],
+										"url": {
+											"raw": "{{url}}/api/v1/businesses/CP0002098/filings/historic",
+											"host": [
+												"{{url}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"businesses",
+												"CP0002098",
+												"filings",
+												"historic"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Access-Control-Allow-Origin",
+											"value": "*"
+										},
+										{
+											"key": "Access-Control-Allow-Methods",
+											"value": "GET, HEAD, OPTIONS, POST"
+										},
+										{
+											"key": "Access-Control-Max-Age",
+											"value": "21600"
+										},
+										{
+											"key": "API",
+											"value": "colin_api/2.0.0"
+										},
+										{
+											"key": "Server",
+											"value": "Werkzeug/0.16.0 Python/3.7.4"
+										},
+										{
+											"key": "Date",
+											"value": "Thu, 10 Oct 2019 23:41:23 GMT"
+										}
+									],
+									"cookie": [],
+									"body": "[\n    {\n        \"filing\": {\n            \"business\": {\n                \"businessNumber\": null,\n                \"cacheId\": 0,\n                \"corpState\": \"ACT\",\n                \"foundingDate\": \"2010-10-15\",\n                \"identifier\": \"CP0002098\",\n                \"jurisdiction\": \"BC\",\n                \"lastAgmDate\": \"2017-09-11\",\n                \"lastArDate\": \"2017-09-11\",\n                \"lastLedgerTimestamp\": \"2017-12-21T00:00:00-00:00\",\n                \"legalName\": \"LAKES ARTISAN COOPERATIVE\",\n                \"legalType\": \"CP\",\n                \"status\": \"Active\"\n            },\n            \"header\": {\n                \"availableOnPaperOnly\": true,\n                \"date\": \"2010-10-15\",\n                \"name\": \"incorporationApplication\"\n            },\n            \"incorporationApplication\": {\n                \"agmDate\": null,\n                \"effectiveDate\": \"2010-10-15\",\n                \"eventDate\": \"2010-10-15\",\n                \"eventId\": 101990302,\n                \"periodEndDate\": null\n            }\n        }\n    },\n    {\n        \"filing\": {\n            \"annualReport\": {\n                \"agmDate\": null,\n                \"effectiveDate\": \"2011-03-30\",\n                \"eventDate\": \"2011-03-30\",\n                \"eventId\": 102024799,\n                \"periodEndDate\": \"2010-11-11\"\n            },\n            \"business\": {\n                \"businessNumber\": null,\n                \"cacheId\": 0,\n                \"corpState\": \"ACT\",\n                \"foundingDate\": \"2010-10-15\",\n                \"identifier\": \"CP0002098\",\n                \"jurisdiction\": \"BC\",\n                \"lastAgmDate\": \"2017-09-11\",\n                \"lastArDate\": \"2017-09-11\",\n                \"lastLedgerTimestamp\": \"2017-12-21T00:00:00-00:00\",\n                \"legalName\": \"LAKES ARTISAN COOPERATIVE\",\n                \"legalType\": \"CP\",\n                \"status\": \"Active\"\n            },\n            \"header\": {\n                \"availableOnPaperOnly\": true,\n                \"date\": \"2011-03-30\",\n                \"name\": \"annualReport\"\n            }\n        }\n    },\n    {\n        \"filing\": {\n            \"business\": {\n                \"businessNumber\": null,\n                \"cacheId\": 0,\n                \"corpState\": \"ACT\",\n                \"foundingDate\": \"2010-10-15\",\n                \"identifier\": \"CP0002098\",\n                \"jurisdiction\": \"BC\",\n                \"lastAgmDate\": \"2017-09-11\",\n                \"lastArDate\": \"2017-09-11\",\n                \"lastLedgerTimestamp\": \"2017-12-21T00:00:00-00:00\",\n                \"legalName\": \"LAKES ARTISAN COOPERATIVE\",\n                \"legalType\": \"CP\",\n                \"status\": \"Active\"\n            },\n            \"header\": {\n                \"availableOnPaperOnly\": true,\n                \"date\": \"2012-02-16\",\n                \"name\": \"specialResolution\"\n            },\n            \"specialResolution\": {\n                \"agmDate\": null,\n                \"effectiveDate\": \"2012-02-16\",\n                \"eventDate\": \"2012-02-16\",\n                \"eventId\": 102065783,\n                \"periodEndDate\": null\n            }\n        }\n    },\n    {\n        \"filing\": {\n            \"business\": {\n                \"businessNumber\": null,\n                \"cacheId\": 0,\n                \"corpState\": \"ACT\",\n                \"foundingDate\": \"2010-10-15\",\n                \"identifier\": \"CP0002098\",\n                \"jurisdiction\": \"BC\",\n                \"lastAgmDate\": \"2017-09-11\",\n                \"lastArDate\": \"2017-09-11\",\n                \"lastLedgerTimestamp\": \"2017-12-21T00:00:00-00:00\",\n                \"legalName\": \"LAKES ARTISAN COOPERATIVE\",\n                \"legalType\": \"CP\",\n                \"status\": \"Active\"\n            },\n            \"changeOfDirectors\": {\n                \"agmDate\": null,\n                \"effectiveDate\": \"2012-05-08\",\n                \"eventDate\": \"2012-05-08\",\n                \"eventId\": 102024800,\n                \"periodEndDate\": null\n            },\n            \"header\": {\n                \"availableOnPaperOnly\": true,\n                \"date\": \"2012-05-08\",\n                \"name\": \"changeOfDirectors\"\n            }\n        }\n    },\n    {\n        \"filing\": {\n            \"annualReport\": {\n                \"agmDate\": null,\n                \"effectiveDate\": \"2012-05-08\",\n                \"eventDate\": \"2012-05-08\",\n                \"eventId\": 102024801,\n                \"periodEndDate\": \"2011-12-12\"\n            },\n            \"business\": {\n                \"businessNumber\": null,\n                \"cacheId\": 0,\n                \"corpState\": \"ACT\",\n                \"foundingDate\": \"2010-10-15\",\n                \"identifier\": \"CP0002098\",\n                \"jurisdiction\": \"BC\",\n                \"lastAgmDate\": \"2017-09-11\",\n                \"lastArDate\": \"2017-09-11\",\n                \"lastLedgerTimestamp\": \"2017-12-21T00:00:00-00:00\",\n                \"legalName\": \"LAKES ARTISAN COOPERATIVE\",\n                \"legalType\": \"CP\",\n                \"status\": \"Active\"\n            },\n            \"header\": {\n                \"availableOnPaperOnly\": true,\n                \"date\": \"2012-05-08\",\n                \"name\": \"annualReport\"\n            }\n        }\n    },\n    {\n        \"filing\": {\n            \"annualReport\": {\n                \"agmDate\": null,\n                \"effectiveDate\": \"2015-02-23\",\n                \"eventDate\": \"2015-02-23\",\n                \"eventId\": 102024803,\n                \"periodEndDate\": \"2013-09-15\"\n            },\n            \"business\": {\n                \"businessNumber\": null,\n                \"cacheId\": 0,\n                \"corpState\": \"ACT\",\n                \"foundingDate\": \"2010-10-15\",\n                \"identifier\": \"CP0002098\",\n                \"jurisdiction\": \"BC\",\n                \"lastAgmDate\": \"2017-09-11\",\n                \"lastArDate\": \"2017-09-11\",\n                \"lastLedgerTimestamp\": \"2017-12-21T00:00:00-00:00\",\n                \"legalName\": \"LAKES ARTISAN COOPERATIVE\",\n                \"legalType\": \"CP\",\n                \"status\": \"Active\"\n            },\n            \"header\": {\n                \"availableOnPaperOnly\": true,\n                \"date\": \"2015-02-23\",\n                \"name\": \"annualReport\"\n            }\n        }\n    },\n    {\n        \"filing\": {\n            \"annualReport\": {\n                \"agmDate\": null,\n                \"effectiveDate\": \"2015-02-23\",\n                \"eventDate\": \"2015-02-23\",\n                \"eventId\": 102024802,\n                \"periodEndDate\": \"2012-12-12\"\n            },\n            \"business\": {\n                \"businessNumber\": null,\n                \"cacheId\": 0,\n                \"corpState\": \"ACT\",\n                \"foundingDate\": \"2010-10-15\",\n                \"identifier\": \"CP0002098\",\n                \"jurisdiction\": \"BC\",\n                \"lastAgmDate\": \"2017-09-11\",\n                \"lastArDate\": \"2017-09-11\",\n                \"lastLedgerTimestamp\": \"2017-12-21T00:00:00-00:00\",\n                \"legalName\": \"LAKES ARTISAN COOPERATIVE\",\n                \"legalType\": \"CP\",\n                \"status\": \"Active\"\n            },\n            \"header\": {\n                \"availableOnPaperOnly\": true,\n                \"date\": \"2015-02-23\",\n                \"name\": \"annualReport\"\n            }\n        }\n    },\n    {\n        \"filing\": {\n            \"annualReport\": {\n                \"agmDate\": null,\n                \"effectiveDate\": \"2015-02-23\",\n                \"eventDate\": \"2015-02-23\",\n                \"eventId\": 102024804,\n                \"periodEndDate\": \"2014-09-27\"\n            },\n            \"business\": {\n                \"businessNumber\": null,\n                \"cacheId\": 0,\n                \"corpState\": \"ACT\",\n                \"foundingDate\": \"2010-10-15\",\n                \"identifier\": \"CP0002098\",\n                \"jurisdiction\": \"BC\",\n                \"lastAgmDate\": \"2017-09-11\",\n                \"lastArDate\": \"2017-09-11\",\n                \"lastLedgerTimestamp\": \"2017-12-21T00:00:00-00:00\",\n                \"legalName\": \"LAKES ARTISAN COOPERATIVE\",\n                \"legalType\": \"CP\",\n                \"status\": \"Active\"\n            },\n            \"header\": {\n                \"availableOnPaperOnly\": true,\n                \"date\": \"2015-02-23\",\n                \"name\": \"annualReport\"\n            }\n        }\n    },\n    {\n        \"filing\": {\n            \"annualReport\": {\n                \"agmDate\": null,\n                \"effectiveDate\": \"2015-10-14\",\n                \"eventDate\": \"2015-10-14\",\n                \"eventId\": 102024806,\n                \"periodEndDate\": \"2015-09-22\"\n            },\n            \"business\": {\n                \"businessNumber\": null,\n                \"cacheId\": 0,\n                \"corpState\": \"ACT\",\n                \"foundingDate\": \"2010-10-15\",\n                \"identifier\": \"CP0002098\",\n                \"jurisdiction\": \"BC\",\n                \"lastAgmDate\": \"2017-09-11\",\n                \"lastArDate\": \"2017-09-11\",\n                \"lastLedgerTimestamp\": \"2017-12-21T00:00:00-00:00\",\n                \"legalName\": \"LAKES ARTISAN COOPERATIVE\",\n                \"legalType\": \"CP\",\n                \"status\": \"Active\"\n            },\n            \"header\": {\n                \"availableOnPaperOnly\": true,\n                \"date\": \"2015-10-14\",\n                \"name\": \"annualReport\"\n            }\n        }\n    },\n    {\n        \"filing\": {\n            \"business\": {\n                \"businessNumber\": null,\n                \"cacheId\": 0,\n                \"corpState\": \"ACT\",\n                \"foundingDate\": \"2010-10-15\",\n                \"identifier\": \"CP0002098\",\n                \"jurisdiction\": \"BC\",\n                \"lastAgmDate\": \"2017-09-11\",\n                \"lastArDate\": \"2017-09-11\",\n                \"lastLedgerTimestamp\": \"2017-12-21T00:00:00-00:00\",\n                \"legalName\": \"LAKES ARTISAN COOPERATIVE\",\n                \"legalType\": \"CP\",\n                \"status\": \"Active\"\n            },\n            \"changeOfDirectors\": {\n                \"agmDate\": null,\n                \"effectiveDate\": \"2015-10-14\",\n                \"eventDate\": \"2015-10-14\",\n                \"eventId\": 102024805,\n                \"periodEndDate\": null\n            },\n            \"header\": {\n                \"availableOnPaperOnly\": true,\n                \"date\": \"2015-10-14\",\n                \"name\": \"changeOfDirectors\"\n            }\n        }\n    },\n    {\n        \"filing\": {\n            \"business\": {\n                \"businessNumber\": null,\n                \"cacheId\": 0,\n                \"corpState\": \"ACT\",\n                \"foundingDate\": \"2010-10-15\",\n                \"identifier\": \"CP0002098\",\n                \"jurisdiction\": \"BC\",\n                \"lastAgmDate\": \"2017-09-11\",\n                \"lastArDate\": \"2017-09-11\",\n                \"lastLedgerTimestamp\": \"2017-12-21T00:00:00-00:00\",\n                \"legalName\": \"LAKES ARTISAN COOPERATIVE\",\n                \"legalType\": \"CP\",\n                \"status\": \"Active\"\n            },\n            \"changeOfDirectors\": {\n                \"agmDate\": null,\n                \"effectiveDate\": \"2017-09-11\",\n                \"eventDate\": \"2017-09-11\",\n                \"eventId\": 102024808,\n                \"periodEndDate\": null\n            },\n            \"header\": {\n                \"availableOnPaperOnly\": true,\n                \"date\": \"2017-09-11\",\n                \"name\": \"changeOfDirectors\"\n            }\n        }\n    },\n    {\n        \"filing\": {\n            \"annualReport\": {\n                \"agmDate\": null,\n                \"effectiveDate\": \"2017-12-21\",\n                \"eventDate\": \"2017-12-21\",\n                \"eventId\": 102024807,\n                \"periodEndDate\": \"2016-09-13\"\n            },\n            \"business\": {\n                \"businessNumber\": null,\n                \"cacheId\": 0,\n                \"corpState\": \"ACT\",\n                \"foundingDate\": \"2010-10-15\",\n                \"identifier\": \"CP0002098\",\n                \"jurisdiction\": \"BC\",\n                \"lastAgmDate\": \"2017-09-11\",\n                \"lastArDate\": \"2017-09-11\",\n                \"lastLedgerTimestamp\": \"2017-12-21T00:00:00-00:00\",\n                \"legalName\": \"LAKES ARTISAN COOPERATIVE\",\n                \"legalType\": \"CP\",\n                \"status\": \"Active\"\n            },\n            \"header\": {\n                \"availableOnPaperOnly\": true,\n                \"date\": \"2017-12-21\",\n                \"name\": \"annualReport\"\n            }\n        }\n    },\n    {\n        \"filing\": {\n            \"annualReport\": {\n                \"agmDate\": null,\n                \"effectiveDate\": \"2017-12-21\",\n                \"eventDate\": \"2017-12-21\",\n                \"eventId\": 102024809,\n                \"periodEndDate\": \"2017-09-11\"\n            },\n            \"business\": {\n                \"businessNumber\": null,\n                \"cacheId\": 0,\n                \"corpState\": \"ACT\",\n                \"foundingDate\": \"2010-10-15\",\n                \"identifier\": \"CP0002098\",\n                \"jurisdiction\": \"BC\",\n                \"lastAgmDate\": \"2017-09-11\",\n                \"lastArDate\": \"2017-09-11\",\n                \"lastLedgerTimestamp\": \"2017-12-21T00:00:00-00:00\",\n                \"legalName\": \"LAKES ARTISAN COOPERATIVE\",\n                \"legalType\": \"CP\",\n                \"status\": \"Active\"\n            },\n            \"header\": {\n                \"availableOnPaperOnly\": true,\n                \"date\": \"2017-12-21\",\n                \"name\": \"annualReport\"\n            }\n        }\n    }\n]"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Future Effective Filings",
+					"item": [
+						{
+							"name": "GET FE CP0002098",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response time is less than 20000ms\", function () {",
+											"    pm.expect(pm.response.responseTime).to.be.below(20000);",
+											"});",
+											"",
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test('should return JSON', function () {",
+											"    pm.response.to.have.header('Content-Type', 'application/json');",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json",
+										"disabled": true
+									}
+								],
+								"url": {
+									"raw": "{{url}}/api/v1/businesses/CP/CP0002098/filings/future",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"businesses",
+										"CP",
+										"CP0002098",
+										"filings",
+										"future"
 									]
 								}
 							},

--- a/colin-api/tests/postman/colin-api.postman_collection.json
+++ b/colin-api/tests/postman/colin-api.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "92f3af20-fd0f-40ea-a41a-ac2efcdc44d4",
+		"_postman_id": "567fd008-1708-46f2-b7d6-babefc7b1da3",
 		"name": "colin-api",
 		"description": "version=0.108 - This is a Colin API description",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
@@ -4515,8 +4515,7 @@
 											"",
 											"pm.test('should return JSON', function () {",
 											"    pm.response.to.have.header('Content-Type', 'application/json');",
-											"});",
-											""
+											"});"
 										],
 										"type": "text/javascript",
 										"packages": {}
@@ -4528,9 +4527,8 @@
 								"header": [
 									{
 										"key": "Content-Type",
-										"type": "text",
 										"value": "application/json",
-										"disabled": true
+										"type": "text"
 									}
 								],
 								"url": {
@@ -4549,71 +4547,7 @@
 									]
 								}
 							},
-							"response": [
-								{
-									"name": "GET HF CP0002098",
-									"originalRequest": {
-										"method": "GET",
-										"header": [
-											{
-												"key": "Content-Type",
-												"type": "text",
-												"value": "application/json",
-												"disabled": true
-											}
-										],
-										"url": {
-											"raw": "{{url}}/api/v1/businesses/CP0002098/filings/historic",
-											"host": [
-												"{{url}}"
-											],
-											"path": [
-												"api",
-												"v1",
-												"businesses",
-												"CP0002098",
-												"filings",
-												"historic"
-											]
-										}
-									},
-									"status": "OK",
-									"code": 200,
-									"_postman_previewlanguage": "json",
-									"header": [
-										{
-											"key": "Content-Type",
-											"value": "application/json"
-										},
-										{
-											"key": "Access-Control-Allow-Origin",
-											"value": "*"
-										},
-										{
-											"key": "Access-Control-Allow-Methods",
-											"value": "GET, HEAD, OPTIONS, POST"
-										},
-										{
-											"key": "Access-Control-Max-Age",
-											"value": "21600"
-										},
-										{
-											"key": "API",
-											"value": "colin_api/2.0.0"
-										},
-										{
-											"key": "Server",
-											"value": "Werkzeug/0.16.0 Python/3.7.4"
-										},
-										{
-											"key": "Date",
-											"value": "Thu, 10 Oct 2019 23:41:23 GMT"
-										}
-									],
-									"cookie": [],
-									"body": "[\n    {\n        \"filing\": {\n            \"business\": {\n                \"businessNumber\": null,\n                \"cacheId\": 0,\n                \"corpState\": \"ACT\",\n                \"foundingDate\": \"2010-10-15\",\n                \"identifier\": \"CP0002098\",\n                \"jurisdiction\": \"BC\",\n                \"lastAgmDate\": \"2017-09-11\",\n                \"lastArDate\": \"2017-09-11\",\n                \"lastLedgerTimestamp\": \"2017-12-21T00:00:00-00:00\",\n                \"legalName\": \"LAKES ARTISAN COOPERATIVE\",\n                \"legalType\": \"CP\",\n                \"status\": \"Active\"\n            },\n            \"header\": {\n                \"availableOnPaperOnly\": true,\n                \"date\": \"2010-10-15\",\n                \"name\": \"incorporationApplication\"\n            },\n            \"incorporationApplication\": {\n                \"agmDate\": null,\n                \"effectiveDate\": \"2010-10-15\",\n                \"eventDate\": \"2010-10-15\",\n                \"eventId\": 101990302,\n                \"periodEndDate\": null\n            }\n        }\n    },\n    {\n        \"filing\": {\n            \"annualReport\": {\n                \"agmDate\": null,\n                \"effectiveDate\": \"2011-03-30\",\n                \"eventDate\": \"2011-03-30\",\n                \"eventId\": 102024799,\n                \"periodEndDate\": \"2010-11-11\"\n            },\n            \"business\": {\n                \"businessNumber\": null,\n                \"cacheId\": 0,\n                \"corpState\": \"ACT\",\n                \"foundingDate\": \"2010-10-15\",\n                \"identifier\": \"CP0002098\",\n                \"jurisdiction\": \"BC\",\n                \"lastAgmDate\": \"2017-09-11\",\n                \"lastArDate\": \"2017-09-11\",\n                \"lastLedgerTimestamp\": \"2017-12-21T00:00:00-00:00\",\n                \"legalName\": \"LAKES ARTISAN COOPERATIVE\",\n                \"legalType\": \"CP\",\n                \"status\": \"Active\"\n            },\n            \"header\": {\n                \"availableOnPaperOnly\": true,\n                \"date\": \"2011-03-30\",\n                \"name\": \"annualReport\"\n            }\n        }\n    },\n    {\n        \"filing\": {\n            \"business\": {\n                \"businessNumber\": null,\n                \"cacheId\": 0,\n                \"corpState\": \"ACT\",\n                \"foundingDate\": \"2010-10-15\",\n                \"identifier\": \"CP0002098\",\n                \"jurisdiction\": \"BC\",\n                \"lastAgmDate\": \"2017-09-11\",\n                \"lastArDate\": \"2017-09-11\",\n                \"lastLedgerTimestamp\": \"2017-12-21T00:00:00-00:00\",\n                \"legalName\": \"LAKES ARTISAN COOPERATIVE\",\n                \"legalType\": \"CP\",\n                \"status\": \"Active\"\n            },\n            \"header\": {\n                \"availableOnPaperOnly\": true,\n                \"date\": \"2012-02-16\",\n                \"name\": \"specialResolution\"\n            },\n            \"specialResolution\": {\n                \"agmDate\": null,\n                \"effectiveDate\": \"2012-02-16\",\n                \"eventDate\": \"2012-02-16\",\n                \"eventId\": 102065783,\n                \"periodEndDate\": null\n            }\n        }\n    },\n    {\n        \"filing\": {\n            \"business\": {\n                \"businessNumber\": null,\n                \"cacheId\": 0,\n                \"corpState\": \"ACT\",\n                \"foundingDate\": \"2010-10-15\",\n                \"identifier\": \"CP0002098\",\n                \"jurisdiction\": \"BC\",\n                \"lastAgmDate\": \"2017-09-11\",\n                \"lastArDate\": \"2017-09-11\",\n                \"lastLedgerTimestamp\": \"2017-12-21T00:00:00-00:00\",\n                \"legalName\": \"LAKES ARTISAN COOPERATIVE\",\n                \"legalType\": \"CP\",\n                \"status\": \"Active\"\n            },\n            \"changeOfDirectors\": {\n                \"agmDate\": null,\n                \"effectiveDate\": \"2012-05-08\",\n                \"eventDate\": \"2012-05-08\",\n                \"eventId\": 102024800,\n                \"periodEndDate\": null\n            },\n            \"header\": {\n                \"availableOnPaperOnly\": true,\n                \"date\": \"2012-05-08\",\n                \"name\": \"changeOfDirectors\"\n            }\n        }\n    },\n    {\n        \"filing\": {\n            \"annualReport\": {\n                \"agmDate\": null,\n                \"effectiveDate\": \"2012-05-08\",\n                \"eventDate\": \"2012-05-08\",\n                \"eventId\": 102024801,\n                \"periodEndDate\": \"2011-12-12\"\n            },\n            \"business\": {\n                \"businessNumber\": null,\n                \"cacheId\": 0,\n                \"corpState\": \"ACT\",\n                \"foundingDate\": \"2010-10-15\",\n                \"identifier\": \"CP0002098\",\n                \"jurisdiction\": \"BC\",\n                \"lastAgmDate\": \"2017-09-11\",\n                \"lastArDate\": \"2017-09-11\",\n                \"lastLedgerTimestamp\": \"2017-12-21T00:00:00-00:00\",\n                \"legalName\": \"LAKES ARTISAN COOPERATIVE\",\n                \"legalType\": \"CP\",\n                \"status\": \"Active\"\n            },\n            \"header\": {\n                \"availableOnPaperOnly\": true,\n                \"date\": \"2012-05-08\",\n                \"name\": \"annualReport\"\n            }\n        }\n    },\n    {\n        \"filing\": {\n            \"annualReport\": {\n                \"agmDate\": null,\n                \"effectiveDate\": \"2015-02-23\",\n                \"eventDate\": \"2015-02-23\",\n                \"eventId\": 102024803,\n                \"periodEndDate\": \"2013-09-15\"\n            },\n            \"business\": {\n                \"businessNumber\": null,\n                \"cacheId\": 0,\n                \"corpState\": \"ACT\",\n                \"foundingDate\": \"2010-10-15\",\n                \"identifier\": \"CP0002098\",\n                \"jurisdiction\": \"BC\",\n                \"lastAgmDate\": \"2017-09-11\",\n                \"lastArDate\": \"2017-09-11\",\n                \"lastLedgerTimestamp\": \"2017-12-21T00:00:00-00:00\",\n                \"legalName\": \"LAKES ARTISAN COOPERATIVE\",\n                \"legalType\": \"CP\",\n                \"status\": \"Active\"\n            },\n            \"header\": {\n                \"availableOnPaperOnly\": true,\n                \"date\": \"2015-02-23\",\n                \"name\": \"annualReport\"\n            }\n        }\n    },\n    {\n        \"filing\": {\n            \"annualReport\": {\n                \"agmDate\": null,\n                \"effectiveDate\": \"2015-02-23\",\n                \"eventDate\": \"2015-02-23\",\n                \"eventId\": 102024802,\n                \"periodEndDate\": \"2012-12-12\"\n            },\n            \"business\": {\n                \"businessNumber\": null,\n                \"cacheId\": 0,\n                \"corpState\": \"ACT\",\n                \"foundingDate\": \"2010-10-15\",\n                \"identifier\": \"CP0002098\",\n                \"jurisdiction\": \"BC\",\n                \"lastAgmDate\": \"2017-09-11\",\n                \"lastArDate\": \"2017-09-11\",\n                \"lastLedgerTimestamp\": \"2017-12-21T00:00:00-00:00\",\n                \"legalName\": \"LAKES ARTISAN COOPERATIVE\",\n                \"legalType\": \"CP\",\n                \"status\": \"Active\"\n            },\n            \"header\": {\n                \"availableOnPaperOnly\": true,\n                \"date\": \"2015-02-23\",\n                \"name\": \"annualReport\"\n            }\n        }\n    },\n    {\n        \"filing\": {\n            \"annualReport\": {\n                \"agmDate\": null,\n                \"effectiveDate\": \"2015-02-23\",\n                \"eventDate\": \"2015-02-23\",\n                \"eventId\": 102024804,\n                \"periodEndDate\": \"2014-09-27\"\n            },\n            \"business\": {\n                \"businessNumber\": null,\n                \"cacheId\": 0,\n                \"corpState\": \"ACT\",\n                \"foundingDate\": \"2010-10-15\",\n                \"identifier\": \"CP0002098\",\n                \"jurisdiction\": \"BC\",\n                \"lastAgmDate\": \"2017-09-11\",\n                \"lastArDate\": \"2017-09-11\",\n                \"lastLedgerTimestamp\": \"2017-12-21T00:00:00-00:00\",\n                \"legalName\": \"LAKES ARTISAN COOPERATIVE\",\n                \"legalType\": \"CP\",\n                \"status\": \"Active\"\n            },\n            \"header\": {\n                \"availableOnPaperOnly\": true,\n                \"date\": \"2015-02-23\",\n                \"name\": \"annualReport\"\n            }\n        }\n    },\n    {\n        \"filing\": {\n            \"annualReport\": {\n                \"agmDate\": null,\n                \"effectiveDate\": \"2015-10-14\",\n                \"eventDate\": \"2015-10-14\",\n                \"eventId\": 102024806,\n                \"periodEndDate\": \"2015-09-22\"\n            },\n            \"business\": {\n                \"businessNumber\": null,\n                \"cacheId\": 0,\n                \"corpState\": \"ACT\",\n                \"foundingDate\": \"2010-10-15\",\n                \"identifier\": \"CP0002098\",\n                \"jurisdiction\": \"BC\",\n                \"lastAgmDate\": \"2017-09-11\",\n                \"lastArDate\": \"2017-09-11\",\n                \"lastLedgerTimestamp\": \"2017-12-21T00:00:00-00:00\",\n                \"legalName\": \"LAKES ARTISAN COOPERATIVE\",\n                \"legalType\": \"CP\",\n                \"status\": \"Active\"\n            },\n            \"header\": {\n                \"availableOnPaperOnly\": true,\n                \"date\": \"2015-10-14\",\n                \"name\": \"annualReport\"\n            }\n        }\n    },\n    {\n        \"filing\": {\n            \"business\": {\n                \"businessNumber\": null,\n                \"cacheId\": 0,\n                \"corpState\": \"ACT\",\n                \"foundingDate\": \"2010-10-15\",\n                \"identifier\": \"CP0002098\",\n                \"jurisdiction\": \"BC\",\n                \"lastAgmDate\": \"2017-09-11\",\n                \"lastArDate\": \"2017-09-11\",\n                \"lastLedgerTimestamp\": \"2017-12-21T00:00:00-00:00\",\n                \"legalName\": \"LAKES ARTISAN COOPERATIVE\",\n                \"legalType\": \"CP\",\n                \"status\": \"Active\"\n            },\n            \"changeOfDirectors\": {\n                \"agmDate\": null,\n                \"effectiveDate\": \"2015-10-14\",\n                \"eventDate\": \"2015-10-14\",\n                \"eventId\": 102024805,\n                \"periodEndDate\": null\n            },\n            \"header\": {\n                \"availableOnPaperOnly\": true,\n                \"date\": \"2015-10-14\",\n                \"name\": \"changeOfDirectors\"\n            }\n        }\n    },\n    {\n        \"filing\": {\n            \"business\": {\n                \"businessNumber\": null,\n                \"cacheId\": 0,\n                \"corpState\": \"ACT\",\n                \"foundingDate\": \"2010-10-15\",\n                \"identifier\": \"CP0002098\",\n                \"jurisdiction\": \"BC\",\n                \"lastAgmDate\": \"2017-09-11\",\n                \"lastArDate\": \"2017-09-11\",\n                \"lastLedgerTimestamp\": \"2017-12-21T00:00:00-00:00\",\n                \"legalName\": \"LAKES ARTISAN COOPERATIVE\",\n                \"legalType\": \"CP\",\n                \"status\": \"Active\"\n            },\n            \"changeOfDirectors\": {\n                \"agmDate\": null,\n                \"effectiveDate\": \"2017-09-11\",\n                \"eventDate\": \"2017-09-11\",\n                \"eventId\": 102024808,\n                \"periodEndDate\": null\n            },\n            \"header\": {\n                \"availableOnPaperOnly\": true,\n                \"date\": \"2017-09-11\",\n                \"name\": \"changeOfDirectors\"\n            }\n        }\n    },\n    {\n        \"filing\": {\n            \"annualReport\": {\n                \"agmDate\": null,\n                \"effectiveDate\": \"2017-12-21\",\n                \"eventDate\": \"2017-12-21\",\n                \"eventId\": 102024807,\n                \"periodEndDate\": \"2016-09-13\"\n            },\n            \"business\": {\n                \"businessNumber\": null,\n                \"cacheId\": 0,\n                \"corpState\": \"ACT\",\n                \"foundingDate\": \"2010-10-15\",\n                \"identifier\": \"CP0002098\",\n                \"jurisdiction\": \"BC\",\n                \"lastAgmDate\": \"2017-09-11\",\n                \"lastArDate\": \"2017-09-11\",\n                \"lastLedgerTimestamp\": \"2017-12-21T00:00:00-00:00\",\n                \"legalName\": \"LAKES ARTISAN COOPERATIVE\",\n                \"legalType\": \"CP\",\n                \"status\": \"Active\"\n            },\n            \"header\": {\n                \"availableOnPaperOnly\": true,\n                \"date\": \"2017-12-21\",\n                \"name\": \"annualReport\"\n            }\n        }\n    },\n    {\n        \"filing\": {\n            \"annualReport\": {\n                \"agmDate\": null,\n                \"effectiveDate\": \"2017-12-21\",\n                \"eventDate\": \"2017-12-21\",\n                \"eventId\": 102024809,\n                \"periodEndDate\": \"2017-09-11\"\n            },\n            \"business\": {\n                \"businessNumber\": null,\n                \"cacheId\": 0,\n                \"corpState\": \"ACT\",\n                \"foundingDate\": \"2010-10-15\",\n                \"identifier\": \"CP0002098\",\n                \"jurisdiction\": \"BC\",\n                \"lastAgmDate\": \"2017-09-11\",\n                \"lastArDate\": \"2017-09-11\",\n                \"lastLedgerTimestamp\": \"2017-12-21T00:00:00-00:00\",\n                \"legalName\": \"LAKES ARTISAN COOPERATIVE\",\n                \"legalType\": \"CP\",\n                \"status\": \"Active\"\n            },\n            \"header\": {\n                \"availableOnPaperOnly\": true,\n                \"date\": \"2017-12-21\",\n                \"name\": \"annualReport\"\n            }\n        }\n    }\n]"
-								}
-							]
+							"response": []
 						}
 					]
 				}

--- a/colin-api/tests/unit/api/test_future_effective_filings.py
+++ b/colin-api/tests/unit/api/test_future_effective_filings.py
@@ -1,0 +1,51 @@
+# Copyright © 2024 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to assure the future effective filings end-point.
+
+Test-Suite to ensure that the future effective filings endpoint is working as expected.
+"""
+import json
+from datetime import datetime
+
+from dateutil.relativedelta import relativedelta
+from registry_schemas.example_data import ANNUAL_REPORT
+
+from tests import oracle_integration
+
+
+@oracle_integration
+def test_get_future_effective_filings(client):
+    """Assert that the future effective filings are successfully returned."""
+    identifier = 'CP0001965'
+    effective_date = datetime.utcnow() + relativedelta(months=5)
+
+    headers = {'content-type': 'application/json'}
+    fake_filing = ANNUAL_REPORT
+    fake_filing['filing']['header']['learEffectiveDate'] = \
+        f"{effective_date.strftime('%Y-%m-%d')}T15:22:39.868757+00:00"
+    fake_filing['filing']['business']['identifier'] = 'CP0001965'
+    fake_filing['filing']['annualReport']['annualGeneralMeetingDate'] = '2018-04-08'
+    fake_filing['filing']['annualReport']['annualReportDate'] = '2018-04-08'
+
+    rv = client.post('/api/v1/businesses/CP/CP0001965/filings/annualReport',
+                     data=json.dumps(fake_filing), headers=headers)
+
+    assert 201 == rv.status_code
+
+    rv = client.get(f'/api/v1/businesses/CP/{identifier}/filings/future')
+
+    assert 200 == rv.status_code
+    future_effective_filings = rv.json
+    assert len(future_effective_filings) > 0


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

https://app.zenhub.com/workspaces/annual-report-filing-for-corporations-661483a4f4f833001637ec44/issues/zh/26

*Description of changes:*
Modified the filing endpoint to return the future effective filings
Added tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
