### PR TITLE
22012 Legal API - implement endpoint to proxy MRAS get jurisdictions call

### DIFF
--- a/legal-api/devops/vaults.json
+++ b/legal-api/devops/vaults.json
@@ -31,9 +31,15 @@
         ]
     },
     {
-      "vault": "sentry",
-      "application": [
-        "entity"
-      ]
+        "vault": "sentry",
+        "application": [
+            "entity"
+        ]
+    },
+    {
+        "vault": "api",
+        "application": [
+            "mras-api"
+        ]
     }
 ]

--- a/legal-api/requirements.txt
+++ b/legal-api/requirements.txt
@@ -56,4 +56,5 @@ minio==7.0.2
 PyPDF2==1.26.0
 reportlab==3.6.12
 html-sanitizer==2.4.1
+lxml==5.2.2
 git+https://github.com/bcgov/business-schemas.git@2.18.27#egg=registry_schemas

--- a/legal-api/requirements/prod.txt
+++ b/legal-api/requirements/prod.txt
@@ -33,3 +33,4 @@ minio
 PyPDF2
 reportlab
 html-sanitizer
+lxml

--- a/legal-api/src/legal_api/config.py
+++ b/legal-api/src/legal_api/config.py
@@ -160,6 +160,10 @@ class _Config():  # pylint: disable=too-few-public-methods
     BUSINESS_SCHEMA_ID = os.getenv('BUSINESS_SCHEMA_ID')
     BUSINESS_CRED_DEF_ID = os.getenv('BUSINESS_CRED_DEF_ID')
 
+    # MRAS
+    MRAS_SVC_URL = os.getenv('MRAS_SVC_URL')
+    MRAS_SVC_API_KEY = os.getenv('MRAS_SVC_API_KEY')
+
     TESTING = False
     DEBUG = False
 

--- a/legal-api/src/legal_api/resources/v2/__init__.py
+++ b/legal-api/src/legal_api/resources/v2/__init__.py
@@ -22,6 +22,7 @@ from .business.business_digital_credentials import bp_dc as digital_credentials_
 from .document import bp as document_bp
 from .internal_services import bp as internal_bp
 from .meta import bp as meta_bp
+from .mras import bp as mras_bp
 from .naics import bp as naics_bp
 from .namerequest import bp as namerequest_bp
 from .request_tracker import bp as request_tracker_bp
@@ -50,6 +51,7 @@ class V2Endpoint:
         self.app.register_blueprint(naics_bp)
         self.app.register_blueprint(request_tracker_bp)
         self.app.register_blueprint(internal_bp)
+        self.app.register_blueprint(mras_bp)
 
 
 v2_endpoint = V2Endpoint()

--- a/legal-api/src/legal_api/resources/v2/mras.py
+++ b/legal-api/src/legal_api/resources/v2/mras.py
@@ -1,0 +1,42 @@
+# Copyright © 2024 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""API endpoints for managing MRAS resource."""
+from http import HTTPStatus
+
+from flask import Blueprint, jsonify
+from flask_cors import cross_origin
+
+from legal_api.models import UserRoles
+from legal_api.services import MrasService
+from legal_api.utils.auth import jwt
+
+
+bp = Blueprint('MRAS2', __name__, url_prefix='/api/v2/mras')
+
+
+@bp.route('/<string:identifier>', methods=['GET'])
+@cross_origin(origins='*')
+@jwt.has_one_of_roles([UserRoles.system])
+def get_jurisdicions(identifier: str):
+    """Return a list of foreign jurisdicions."""
+    jurisdictions = MrasService.get_jurisdictions(identifier)
+
+    if jurisdictions is None:
+        return jsonify(
+            message=f'Error getting foreign jurisdiction information for {identifier}.'
+        ), HTTPStatus.INTERNAL_SERVER_ERROR
+
+    return jsonify({
+        'jurisdictions': jurisdictions
+    }), HTTPStatus.OK

--- a/legal-api/src/legal_api/services/__init__.py
+++ b/legal-api/src/legal_api/services/__init__.py
@@ -36,6 +36,7 @@ from .document_meta import DocumentMetaService
 from .flags import Flags
 from .involuntary_dissolution import InvoluntaryDissolutionService
 from .minio import MinioService
+from .mras_service import MrasService
 from .naics import NaicsService
 from .namex import NameXService
 from .pdf_service import PdfService

--- a/legal-api/src/legal_api/services/mras_service.py
+++ b/legal-api/src/legal_api/services/mras_service.py
@@ -1,0 +1,62 @@
+# Copyright © 2024 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This provides the service for MRAS API calls."""
+from http import HTTPStatus
+
+import requests
+from flask import current_app
+from lxml import etree
+
+
+class MrasService:
+    """Provides services to use MRAS APIs."""
+
+    NAMESPACE = {'mras': 'http://mras.ca/schema/v1'}
+
+    @staticmethod
+    def get_jurisdictions(identifier: str):
+        """Return foreign jurisdiction info for the given BC corps."""
+        try:
+            mras_url = f'{current_app.config.get("MRAS_SVC_URL")}/api/v1/xpr/jurisdictions/{identifier}'
+            headers = {
+                'x-api-key': current_app.config.get('MRAS_SVC_API_KEY'),
+                'Accept': 'application/xml'
+            }
+            response = requests.get(
+                mras_url,
+                headers=headers
+            )
+
+            if response.status_code != HTTPStatus.OK:
+                return None
+
+            xml_content = etree.fromstring(response.content)  # pylint: disable=c-extension-no-member
+            registered_jurisdictions_info = xml_content.xpath(
+                './/mras:Jurisdiction[mras:TargetProfileID]',
+                namespaces=MrasService.NAMESPACE
+                )
+            results = []
+            for j in registered_jurisdictions_info:
+                info = {
+                    'id': j.find('.//mras:JurisdictionID', namespaces=MrasService.NAMESPACE).text,
+                    'name': j.find('.//mras:NameEn', namespaces=MrasService.NAMESPACE).text,
+                    'nameFr': j.find('.//mras:NameFr', namespaces=MrasService.NAMESPACE).text,
+                    'redirectUrl': j.find('.//mras:RedirectUrl', namespaces=MrasService.NAMESPACE).text,
+                    'targetProfileId': j.find('.//mras:TargetProfileID', namespaces=MrasService.NAMESPACE).text
+                }
+                results.append(info)
+            return results
+        except Exception as err:
+            current_app.logger.error(err)
+            return None

--- a/legal-api/tests/unit/resources/v2/test_mras.py
+++ b/legal-api/tests/unit/resources/v2/test_mras.py
@@ -1,0 +1,40 @@
+# Copyright © 2024 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to assure the MRAS end-point.
+
+Test-Suite to ensure that mras endpoints are working as expected.
+"""
+from http import HTTPStatus
+
+from legal_api.models import UserRoles
+from tests.unit.services.utils import create_header
+
+
+def test_get_jurisdictions(session, client, jwt):
+    """Assert that the endpoint returns foreign jurisdiction information."""
+    rv = client.get('/api/v2/mras/BC1234567',
+                    headers=create_header(jwt, [UserRoles.system]))
+
+    assert rv.status_code == HTTPStatus.OK
+    assert 'jurisdictions' in rv.json
+    assert rv.json['jurisdictions'] == []
+
+
+def test_get_jurisdictions_invalid_role(session, client, jwt):
+    """Assert that the endpoint validates invalid user role."""
+    rv = client.get('/api/v2/mras/BC1234567',
+                    headers=create_header(jwt, [UserRoles.basic]))
+
+    assert rv.status_code == HTTPStatus.UNAUTHORIZED

--- a/legal-api/tests/unit/resources/v2/test_mras.py
+++ b/legal-api/tests/unit/resources/v2/test_mras.py
@@ -17,19 +17,22 @@
 Test-Suite to ensure that mras endpoints are working as expected.
 """
 from http import HTTPStatus
+from unittest.mock import patch
 
 from legal_api.models import UserRoles
+from legal_api.services import MrasService
 from tests.unit.services.utils import create_header
 
 
 def test_get_jurisdictions(session, client, jwt):
     """Assert that the endpoint returns foreign jurisdiction information."""
-    rv = client.get('/api/v2/mras/BC1234567',
-                    headers=create_header(jwt, [UserRoles.system]))
+    with patch.object(MrasService, 'get_jurisdictions', return_value=[]):
+        rv = client.get('/api/v2/mras/BC1234567',
+                        headers=create_header(jwt, [UserRoles.system]))
 
-    assert rv.status_code == HTTPStatus.OK
-    assert 'jurisdictions' in rv.json
-    assert rv.json['jurisdictions'] == []
+        assert rv.status_code == HTTPStatus.OK
+        assert 'jurisdictions' in rv.json
+        assert rv.json['jurisdictions'] == []
 
 
 def test_get_jurisdictions_invalid_role(session, client, jwt):

--- a/legal-api/tests/unit/services/test_mras_service.py
+++ b/legal-api/tests/unit/services/test_mras_service.py
@@ -1,0 +1,117 @@
+# Copyright © 2024 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the MRAS service.
+
+Test suite to ensure that the MRAS service is working as expected.
+"""
+
+from http import HTTPStatus
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from legal_api.services import MrasService
+
+
+MRAS_CONTENT_TARGET = """
+<Jurisdictions xmlns="http://mras.ca/schema/v1">
+    <Jurisdiction>
+        <JurisdictionID>SK</JurisdictionID>
+        <NameEn>Saskatchewan</NameEn>
+        <NameFr>Saskatchewan</NameFr>
+        <RedirectUrl>asdf</RedirectUrl>
+        <TargetProfileID>1111</TargetProfileID>
+    </Jurisdiction>
+    <Jurisdiction>
+        <JurisdictionID>QC</JurisdictionID>
+        <NameEn>Quebec</NameEn>
+        <NameFr>Québec</NameFr>
+        <RedirectUrl>asdf</RedirectUrl>
+    </Jurisdiction>
+    <Jurisdiction>
+        <JurisdictionID>MB</JurisdictionID>
+        <NameEn>Manitoba</NameEn>
+        <NameFr>Manitoba</NameFr>
+        <RedirectUrl>asdf</RedirectUrl>
+    </Jurisdiction>
+    <Jurisdiction>
+        <JurisdictionID>AB</JurisdictionID>
+        <NameEn>Alberta</NameEn>
+        <NameFr>Alberta</NameFr>
+        <RedirectUrl>asdfasdf</RedirectUrl>
+        <TargetProfileID>2222</TargetProfileID>
+    </Jurisdiction>
+</Jurisdictions>
+"""
+
+MRAS_CONTENT_NO_TARGET = """
+<Jurisdictions xmlns="http://mras.ca/schema/v1">
+    <Jurisdiction>
+        <JurisdictionID>SK</JurisdictionID>
+        <NameEn>Saskatchewan</NameEn>
+        <NameFr>Saskatchewan</NameFr>
+        <RedirectUrl>asdf</RedirectUrl>
+    </Jurisdiction>
+    <Jurisdiction>
+        <JurisdictionID>QC</JurisdictionID>
+        <NameEn>Quebec</NameEn>
+        <NameFr>Québec</NameFr>
+        <RedirectUrl>asdf</RedirectUrl>
+    </Jurisdiction>
+    <Jurisdiction>
+        <JurisdictionID>MB</JurisdictionID>
+        <NameEn>Manitoba</NameEn>
+        <NameFr>Manitoba</NameFr>
+        <RedirectUrl>asdf</RedirectUrl>
+    </Jurisdiction>
+    <Jurisdiction>
+        <JurisdictionID>AB</JurisdictionID>
+        <NameEn>Alberta</NameEn>
+        <NameFr>Alberta</NameFr>
+        <RedirectUrl>asdf</RedirectUrl>
+    </Jurisdiction>
+</Jurisdictions>
+"""
+
+@pytest.mark.parametrize(
+        'test_name, mock_status, mock_return, expected', [
+            ('HAS_JURISDICTIONS', HTTPStatus.OK, MRAS_CONTENT_TARGET, [
+                {
+                    "id": "SK",
+                    "name": "Saskatchewan",
+                    "nameFr": "Saskatchewan",
+                    "redirectUrl": "asdf",
+                    "targetProfileId": "1111"
+                },
+                {
+                    "id": "AB",
+                    "name": "Alberta",
+                    "nameFr": "Alberta",
+                    "redirectUrl": "asdfasdf",
+                    "targetProfileId": "2222"
+                }
+            ]),
+            ('NO_JURISDICTIONS', HTTPStatus.OK, MRAS_CONTENT_NO_TARGET, []),
+            ('ERROR', HTTPStatus.UNAUTHORIZED, None, None)
+        ]
+)
+def test_get_jurisdictions(session, test_name, mock_status, mock_return, expected):
+    """Assert that returns foreign jurisdictions for the given business."""
+    mock_response = MagicMock()
+    mock_response.status_code = mock_status
+    mock_response.content = mock_return
+    with patch.object(requests, 'get', return_value=mock_response):
+        jurisdictions = MrasService.get_jurisdictions('BC1234567')
+        assert jurisdictions == expected


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22012

*Description of changes:*
- Implemented endpoint to proxy MRAS get jurisdictions call
```shell
GET <legal-api-base-url>/api/v2/mras/<identifier>

{
   "jurisdictions": [
        {
            "id": "SK",
            "name": "Saskatchewan",
            "nameFr": "Saskatchewan",
            "redirectUrl": ...,
            "targetProfileId": ...
        },
        {
            "id": "AB",
            "name": "Alberta",
            "nameFr": "Alberta",
            "redirectUrl": ...,
            "targetProfileId": ...
        }
    ]
}
```
- Added a service class to handle MRAS calls
- Added unit tests
- Updated config.py
- Updated vaults.json

*Local testings*
 - Business has EP registrations
 
![image](https://github.com/bcgov/lear/assets/60866283/1001917f-5c81-4506-94a8-e229d01059a1)

 - Business doesn't have EP registrations
 
![image](https://github.com/bcgov/lear/assets/60866283/3334ebec-70d9-4cf6-98f9-0cb640d3e0f9)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
