### PR TITLE
21953 Create datetime method to add business days to a date

### DIFF
--- a/jobs/involuntary-dissolutions/involuntary_dissolutions.py
+++ b/jobs/involuntary-dissolutions/involuntary_dissolutions.py
@@ -27,7 +27,6 @@ from legal_api.services.filings.validations.dissolution import DissolutionTypes
 from legal_api.services.flags import Flags
 from legal_api.services.involuntary_dissolution import InvoluntaryDissolutionService
 from legal_api.services.queue import QueueService
-from legal_api.utils.legislation_datetime import LegislationDatetime
 from sentry_sdk import capture_message
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sqlalchemy import Date, cast, func
@@ -292,7 +291,8 @@ async def stage_3_process(app: Flask, qsm: QueueService):
 
 def can_run_today(cron_value: str):
     """Check if cron string is valid for today."""
-    today = LegislationDatetime.now()
+    tz = pytz.timezone('US/Pacific')
+    today = tz.localize(datetime.today())
     result = croniter.match(cron_value, datetime(today.year, today.month, today.day))
     return result
 

--- a/jobs/involuntary-dissolutions/involuntary_dissolutions.py
+++ b/jobs/involuntary-dissolutions/involuntary_dissolutions.py
@@ -27,6 +27,7 @@ from legal_api.services.filings.validations.dissolution import DissolutionTypes
 from legal_api.services.flags import Flags
 from legal_api.services.involuntary_dissolution import InvoluntaryDissolutionService
 from legal_api.services.queue import QueueService
+from legal_api.utils.legislation_datetime import LegislationDatetime
 from sentry_sdk import capture_message
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sqlalchemy import Date, cast, func
@@ -291,8 +292,7 @@ async def stage_3_process(app: Flask, qsm: QueueService):
 
 def can_run_today(cron_value: str):
     """Check if cron string is valid for today."""
-    tz = pytz.timezone('US/Pacific')
-    today = tz.localize(datetime.today())
+    today = LegislationDatetime.now()
     result = croniter.match(cron_value, datetime(today.year, today.month, today.day))
     return result
 

--- a/legal-api/src/legal_api/utils/datetime.py
+++ b/legal-api/src/legal_api/utils/datetime.py
@@ -14,7 +14,7 @@
 """Date time utilities."""
 # from datetime import datetime, timezone
 import time as _time
-from datetime import date, datetime as _datetime, timezone  # pylint: disable=unused-import # noqa: F401, I001, I005
+from datetime import date, datetime as _datetime, timedelta, timezone  # pylint: disable=unused-import # noqa: E501, F401, I001, I005
 # noqa: I003,I005
 
 
@@ -31,3 +31,17 @@ class datetime(_datetime):  # pylint: disable=invalid-name; # noqa: N801; ha dat
     def from_date(cls, date_obj):
         """Get a datetime object from a date object."""
         return datetime(date_obj.year, date_obj.month, date_obj.day)
+
+    @classmethod
+    def add_business_days(cls, from_date: _datetime, num_days: int):
+        """Add business days to an initial date. Only accounts for weekends, not holidays."""
+        current_date = from_date
+        business_days_to_add = abs(num_days)
+        inc = 1 if num_days > 0 else -1
+        while business_days_to_add > 0:
+            current_date += timedelta(days=inc)
+            weekday = current_date.weekday()
+            if weekday >= 5:  # sunday = 6
+                continue
+            business_days_to_add -= 1
+        return current_date

--- a/legal-api/tests/unit/utils/test_datetime.py
+++ b/legal-api/tests/unit/utils/test_datetime.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 """Tests to ensure the datetime wrappers are working as expected."""
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
+import pytest
 from freezegun import freeze_time
 
 
@@ -38,3 +39,39 @@ def test_datetime_isoformat():
         iso = d.isoformat()
         tz = iso[iso.find('+'):]
         assert tz == '+00:00'
+
+
+@pytest.mark.parametrize(
+    'test_name, from_date_str, num_days, expected_date_str', [
+        (
+            'ADD_WITHIN_WEEKDAYS',
+            '2024-06-19',
+            2,
+            '2024-06-21'
+        ),
+        (
+            'ADD_OVER_WEEKEND',
+            '2024-06-19',
+            5,
+            '2024-06-26'
+        ),
+        (
+            'SUB_WITHIN_WEEKDAYS',
+            '2024-06-19',
+            -2,
+            '2024-06-17'
+        ),
+        (
+            'SUB_OVER_WEEKEND',
+            '2024-06-19',
+            -5,
+            '2024-06-12'
+        ),
+    ]
+)
+def test_datetime_add_business_days(test_name, from_date_str, num_days, expected_date_str):
+    """Assert that business days are added to a date correctly."""
+    import legal_api.utils.datetime as _datetime
+    from_date = date.fromisoformat(from_date_str)
+    new_date = _datetime.datetime.add_business_days(from_date, num_days)
+    assert new_date == date.fromisoformat(expected_date_str)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21953

*Description of changes:*
- Part of the tech design for the stage 1 letter flow for the furnishings job includes checking how many business days have elapsed since the furnishings email has been sent. 
- I could not find any existing method of adding business days to a date in the project, so I created a util function in the custom `datetime` object that handles this logic.
- The logic for `add_business_days` is fairly simple and only handles weekends. Holidays are not covered under this implementation.
- This should be merged before #2816 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
