### PR TITLE
21953 Fix issue when auth returns 404 for GET <auth_url>/entities/{identifier} endpoint

### DIFF
--- a/jobs/furnishings/Makefile
+++ b/jobs/furnishings/Makefile
@@ -39,7 +39,7 @@ clean-test: ## clean test files
 build-req: clean ## Upgrade requirements
 	test -f venv/bin/activate || python3.8 -m venv  $(CURRENT_ABS_DIR)/venv ;\
 	. venv/bin/activate ;\
-	pip install pip==20.1.1 ;\
+	pip install --upgrade pip ;\
 	pip install -Ur requirements/prod.txt ;\
 	pip freeze | sort > requirements.txt ;\
 	cat requirements/bcregistry-libraries.txt >> requirements.txt ;\
@@ -48,7 +48,7 @@ build-req: clean ## Upgrade requirements
 install: clean ## Install python virtual environment
 	test -f venv/bin/activate || python3.8 -m venv  $(CURRENT_ABS_DIR)/venv ;\
 	. venv/bin/activate ;\
-	pip install pip==20.1.1 ;\
+	pip install --upgrade pip ;\
 	pip install -Ur requirements.txt
 
 install-dev: ## Install local application

--- a/jobs/furnishings/requirements.txt
+++ b/jobs/furnishings/requirements.txt
@@ -22,12 +22,12 @@ pyasn1==0.4.8
 pyrsistent==0.17.3
 python-dotenv==0.17.1
 python-jose==3.2.0
-pytz==2021.1
+pytz==2024.1
 rsa==4.7.2
 sentry-sdk==1.20.0
 six==1.15.0
 urllib3==1.26.11
 requests==2.25.1
-cachelib==0.1.1
+cachelib==0.9.0
 git+https://github.com/bcgov/lear.git#egg=legal_api&subdirectory=legal-api
 git+https://github.com/bcgov/business-schemas.git@2.15.38#egg=registry_schemas

--- a/jobs/furnishings/src/furnishings/stage_processors/stage_one.py
+++ b/jobs/furnishings/src/furnishings/stage_processors/stage_one.py
@@ -18,7 +18,6 @@ from datetime import datetime
 import pytz
 import requests
 from flask import Flask, current_app
-
 from legal_api.models import Address, Batch, BatchProcessing, Business, Furnishing, db  # noqa: I001
 from legal_api.services.bootstrap import AccountService
 from legal_api.services.involuntary_dissolution import InvoluntaryDissolutionService

--- a/jobs/furnishings/src/furnishings/stage_processors/stage_one.py
+++ b/jobs/furnishings/src/furnishings/stage_processors/stage_one.py
@@ -18,6 +18,7 @@ from datetime import datetime
 import pytz
 import requests
 from flask import Flask, current_app
+
 from legal_api.models import Address, Batch, BatchProcessing, Business, Furnishing, db  # noqa: I001
 from legal_api.services.bootstrap import AccountService
 from legal_api.services.involuntary_dissolution import InvoluntaryDissolutionService
@@ -257,12 +258,12 @@ class StageOneProcessor:
             contact_info.raise_for_status()
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 404:
-                current_app.logger.info(f"No entity found for identifier: {identifier}")
+                current_app.logger.info(f'No entity found for identifier: {identifier}')
             else:
-                current_app.logger.error(f"HTTP error occurred: {e}, URL: {url}, Status code: {e.response.status_code}")
+                current_app.logger.error(f'HTTP error occurred: {e}, URL: {url}, Status code: {e.response.status_code}')
             return None
         except requests.exceptions.RequestException as e:
-            current_app.logger.error(f"Request failed: {e}, URL: {url}")
+            current_app.logger.error(f'Request failed: {e}, URL: {url}')
             return None
 
         contacts = contact_info.json().get('contacts', [])


### PR DESCRIPTION

*Issue #:* /bcgov/entity#21953

*Description of changes:*

* Handles scenario where an auth call to retrieve email info may return a 404.  This shouldn't really happen but for imported BC companies data, there may be entries that haven't been created in auth which leads to auth returning a 404.  For now, we will log this as an error and just return `None` for the contact email so the furnishings job can continue running

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
