### PR TITLE
21760 Additional furnishing record updates

### DIFF
--- a/queue_services/entity-emailer/src/entity_emailer/email_processors/involuntary_dissolution_stage_1_notification.py
+++ b/queue_services/entity-emailer/src/entity_emailer/email_processors/involuntary_dissolution_stage_1_notification.py
@@ -14,6 +14,7 @@
 """Email processing rules and actions for involuntary_dissolution stage 1 overdue ARs notifications."""
 from __future__ import annotations
 
+from datetime import datetime
 from pathlib import Path
 
 from entity_queue_common.service_utils import logger
@@ -93,4 +94,8 @@ def post_process(email_msg: dict, status: str):
     furnishing_id = email_msg['data']['furnishing']['furnishingId']
     furnishing = Furnishing.find_by_id(furnishing_id)
     furnishing.status = status
+    furnishing.processed_date = datetime.utcnow()
+    furnishing.last_modified = datetime.utcnow()
+    if status == Furnishing.FurnishingStatus.FAILED:
+        furnishing.notes = 'Failure to send email'
     furnishing.save()

--- a/queue_services/entity-emailer/tests/unit/test_worker.py
+++ b/queue_services/entity-emailer/tests/unit/test_worker.py
@@ -526,3 +526,5 @@ def test_involuntary_dissolution_stage_1_notification(app, db, session, mocker, 
 
             updated_furnishing = Furnishing.find_by_id(furnishing.id)
             assert updated_furnishing.status.name == expected_furnishing_status
+            if expected_furnishing_status == 'FAILED':
+                assert updated_furnishing.notes == 'Failure to send email'


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21760

- Update the `processed_date` and `last_modified`
- In a failure scenario, update the `notes` field with `Failure to send email`

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
