### PR TITLE
22368 Emailer - Add letter attachment to stage 1 AR email

### DIFF
--- a/queue_services/entity-emailer/src/entity_emailer/email_processors/__init__.py
+++ b/queue_services/entity-emailer/src/entity_emailer/email_processors/__init__.py
@@ -18,6 +18,7 @@ Processors hold the business logic for how an email is interpreted and sent.
 from __future__ import annotations
 
 from datetime import datetime
+from http import HTTPStatus
 from pathlib import Path
 from typing import Tuple
 
@@ -196,7 +197,7 @@ def substitute_template_parts(template_code: str) -> str:
     return template_code
 
 
-def get_jurisdictions(identifier: str, token: str) -> str:
+def get_jurisdictions(identifier: str, token: str) -> dict:
     """Get jurisdictions call."""
     headers = {
         'Accept': 'application/json',
@@ -206,5 +207,10 @@ def get_jurisdictions(identifier: str, token: str) -> str:
     response = requests.get(
         f'{current_app.config.get("LEGAL_API_URL")}/mras/{identifier}', headers=headers
     )
-
-    return response
+    if response.status_code != HTTPStatus.OK:
+        return None
+    try:
+        return response.json()
+    except Exception:  # noqa B902; pylint: disable=W0703;
+        current_app.logger.error('Failed to get MRAS response')
+        return None

--- a/queue_services/entity-emailer/tests/unit/test_worker.py
+++ b/queue_services/entity-emailer/tests/unit/test_worker.py
@@ -488,6 +488,10 @@ def test_involuntary_dissolution_stage_1_notification(app, db, session, mocker, 
     mocker.patch(
         'entity_emailer.email_processors.involuntary_dissolution_stage_1_notification.get_jurisdictions',
         return_value=[])
+    mocker.patch(
+        'entity_emailer.email_processors.involuntary_dissolution_stage_1_notification._get_pdfs',
+        return_value=[]
+    )
 
     message_payload = {
         'specversion': '1.x-wip',


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22368

*Description of changes:*
- To get coloured version of letter as email attachment
- Update unit tests
- Update `q_cli.py` so that it can inject queue message for furnishings job
- Fix http response processing described in bcgov/entity#22435

*Testing*
Note that my local testing is based on v2 of legal-api, and the email file can be downloaded at MailHog.
- overdue AR without EP registration
![image](https://github.com/user-attachments/assets/375f6b58-93c5-4c2b-a435-ab8be1e5c751)

- overdue AR with EP registration
![image](https://github.com/user-attachments/assets/447c6ab0-0216-4898-a7cc-8ab3444869b6)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
