### PR TITLE
21699 Revert update-colin-filing job to use entity vault's sentry config

### DIFF
--- a/jobs/update-colin-filings/devops/vaults.json
+++ b/jobs/update-colin-filings/devops/vaults.json
@@ -3,13 +3,8 @@
         "vault": "entity",
         "application": [
             "filings-jobs",
-            "entity-service-account"
-        ]
-    },
-    {
-        "vault": "sentry",
-        "application": [
-          "entity"
+            "entity-service-account",
+            "sentry"
         ]
     }
 ]


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21699

*Description of changes:*

* Revert sentry config for update-colin-filings job back to entity vault.   Will test this in dev first before updating other BE services

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
