### PR TITLE
22432 - Legal API - update dissolution warnings targetDissolutionDate

### DIFF
--- a/jobs/involuntary-dissolutions/involuntary_dissolutions.py
+++ b/jobs/involuntary-dissolutions/involuntary_dissolutions.py
@@ -204,8 +204,7 @@ def stage_1_process(app: Flask):  # pylint: disable=redefined-outer-name,too-man
 
             batch_processing.meta_data = {
                 'overdueARs': ar_overdue,
-                'overdueTransition': transition_overdue,
-                'targetDissolutionDate': target_dissolution_date.date().isoformat()
+                'overdueTransition': transition_overdue
             }
             batch_processing.save()
             app.logger.debug(f'New batch processing has been created with ID: {batch_processing.id}')

--- a/jobs/involuntary-dissolutions/involuntary_dissolutions.py
+++ b/jobs/involuntary-dissolutions/involuntary_dissolutions.py
@@ -179,7 +179,6 @@ def stage_1_process(app: Flask):  # pylint: disable=redefined-outer-name,too-man
 
         # get stage_1 & stage_2 delay configs
         stage_1_delay = timedelta(days=app.config.get('STAGE_1_DELAY'))
-        stage_2_delay = timedelta(days=app.config.get('STAGE_2_DELAY'))
 
         # create new entry in batches table
         batch = Batch(batch_type=Batch.BatchType.INVOLUNTARY_DISSOLUTION,
@@ -199,8 +198,6 @@ def stage_1_process(app: Flask):  # pylint: disable=redefined-outer-name,too-man
                                                trigger_date=datetime.utcnow()+stage_1_delay,
                                                batch_id=batch.id,
                                                business_id=business.id)
-
-            target_dissolution_date = batch_processing.created_date + stage_1_delay + stage_2_delay
 
             batch_processing.meta_data = {
                 'overdueARs': ar_overdue,

--- a/legal-api/requirements.txt
+++ b/legal-api/requirements.txt
@@ -30,7 +30,7 @@ ecdsa==0.14.1
 expiringdict==1.1.4
 flask-jwt-oidc==0.3.0
 flask-restx==0.3.0
-google-auth==2.16.2
+google-auth==2.29.0
 gunicorn==20.1.0
 idna==2.10
 itsdangerous==1.1.0

--- a/legal-api/src/legal_api/config.py
+++ b/legal-api/src/legal_api/config.py
@@ -175,6 +175,10 @@ class _Config():  # pylint: disable=too-few-public-methods
     REPORT_API_GOTENBERG_AUDIENCE = os.getenv('REPORT_API_GOTENBERG_AUDIENCE', '')
     REPORT_API_GOTENBERG_URL = os.getenv('REPORT_API_GOTENBERG_URL', 'https://')
 
+    # involuntary dissolution
+    STAGE_1_DELAY = int(os.getenv('STAGE_1_DELAY', '42'))
+    STAGE_2_DELAY = int(os.getenv('STAGE_2_DELAY', '30'))
+
     TESTING = False
     DEBUG = False
 

--- a/legal-api/tests/unit/models/__init__.py
+++ b/legal-api/tests/unit/models/__init__.py
@@ -412,13 +412,16 @@ def factory_batch_processing(batch_id,
                              identifier,
                              step = BatchProcessing.BatchProcessingStep.WARNING_LEVEL_1,
                              status = BatchProcessing.BatchProcessingStatus.PROCESSING,
-                             notes = ''):
+                             trigger_date=datetime.utcnow()+datedelta(days=42),
+                             notes = ''
+                            ):
     batch_processing = BatchProcessing(
         batch_id = batch_id,
         business_id = business_id,
         business_identifier = identifier,
         step = step,
         status = status,
+        trigger_date = trigger_date,
         notes = notes
     )
     batch_processing.save()

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/change_of_address.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/change_of_address.py
@@ -50,13 +50,9 @@ def process(business: Business, filing: Dict, filing_meta: FilingMeta, flag_on: 
                     BatchProcessing.BatchProcessingStatus.COMPLETED,
                     BatchProcessing.BatchProcessingStatus.WITHDRAWN
                 ] and datetime.utcnow() + datedelta(days=60) > batch_processing.trigger_date:
-                    old_trigger_date = batch_processing.trigger_date
                     batch_processing.trigger_date = datetime.utcnow() + datedelta(days=62)
                     batch_processing.meta_data = {
                         **batch_processing.meta_data,
                         'changeOfAddressDelay': True
                     }
-                    target_dissolution_date = date.fromisoformat(batch_processing.meta_data['targetDissolutionDate'])
-                    target_dissolution_date += batch_processing.trigger_date - old_trigger_date
-                    batch_processing.meta_data['targetDissolutionDate'] = target_dissolution_date.isoformat()
                     batch_processing.last_modified = datetime.utcnow()

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/change_of_address.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/change_of_address.py
@@ -16,7 +16,7 @@ from typing import Dict
 
 from datedelta import datedelta
 from legal_api.models import BatchProcessing, Business
-from legal_api.utils.datetime import date, datetime
+from legal_api.utils.datetime import datetime
 
 from entity_filer.filing_meta import FilingMeta
 from entity_filer.filing_processors.filing_components import create_address, update_address

--- a/queue_services/entity-filer/tests/unit/__init__.py
+++ b/queue_services/entity-filer/tests/unit/__init__.py
@@ -628,8 +628,5 @@ def factory_batch_processing(batch_id,
         notes=notes
     )
     target_dissolution_date = created_date + datedelta(days=72)
-    batch_processing.meta_data = {
-        'targetDissolutionDate': target_dissolution_date.date().isoformat()
-    }
     batch_processing.save()
     return batch_processing

--- a/queue_services/entity-filer/tests/unit/__init__.py
+++ b/queue_services/entity-filer/tests/unit/__init__.py
@@ -627,6 +627,6 @@ def factory_batch_processing(batch_id,
         last_modified=last_modified,
         notes=notes
     )
-    target_dissolution_date = created_date + datedelta(days=72)
+    batch_processing.meta_data = {}
     batch_processing.save()
     return batch_processing

--- a/queue_services/entity-filer/tests/unit/filing_processors/test_change_of_address.py
+++ b/queue_services/entity-filer/tests/unit/filing_processors/test_change_of_address.py
@@ -116,9 +116,7 @@ def test_change_of_address_delay_dissolution(app, session, test_name, status, st
                              trigger_date=trigger_date)
 
     utc_now = datetime.utcnow()
-    dissolution_date = utc_now + datedelta(days=72)
     trigger_date = batch_processing.trigger_date
-    delay_dissolution_date = utc_now + datedelta(days=92)
     delay_trigger_date = utc_now + datedelta(days=62)
     
     filing_meta = FilingMeta()
@@ -128,8 +126,6 @@ def test_change_of_address_delay_dissolution(app, session, test_name, status, st
     if delay:
         assert batch_processing.trigger_date.date() == delay_trigger_date.date()
         assert batch_processing.meta_data.get('changeOfAddressDelay') is True
-        assert batch_processing.meta_data.get('targetDissolutionDate') == delay_dissolution_date.date().isoformat()
     else:
         assert batch_processing.trigger_date == trigger_date
         assert batch_processing.meta_data.get('changeOfAddressDelay') is None
-        assert batch_processing.meta_data.get('targetDissolutionDate') == dissolution_date.date().isoformat()


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22432

*Description of changes:*
- update `targetDissolutionDate` in dissolution warnings
- update unit tests
- **Question: need to update vaults.json or not?**

*Notes for this update*
(from Dylan) We are just wanting to make sure we never display something stupid like a date in the past. 😄 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
