### PR TITLE
Attempt to fix sentry_dsn issue for legal api

### DIFF
--- a/legal-api/src/legal_api/config.py
+++ b/legal-api/src/legal_api/config.py
@@ -69,7 +69,8 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     GO_LIVE_DATE = os.getenv('GO_LIVE_DATE')
 
-    SENTRY_DSN = os.getenv('SENTRY_DSN', None)
+    SENTRY_DSN = os.getenv('SENTRY_DSN') or ''
+    SENTRY_DSN = '' if SENTRY_DSN.lower() == 'null' else SENTRY_DSN
     LD_SDK_KEY = os.getenv('LD_SDK_KEY', None)
     SECRET_KEY = 'a secret'
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*

* Attempt to fix sentry_dsn config issue where null value is populated in OCP secrets when sentry_dsn is populated with empty string in 1pass.  We need to initialize sentry with empty string in this case.

If this works, will update for all other BE services


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
