### PR TITLE
Fix sentry issue where sentry_dsn null string value should be converted to empty string

### DIFF
--- a/colin-api/src/colin_api/config.py
+++ b/colin-api/src/colin_api/config.py
@@ -62,7 +62,8 @@ class _Config:  # pylint: disable=too-few-public-methods
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
-    SENTRY_DSN = os.getenv('SENTRY_DSN', '')
+    SENTRY_DSN = os.getenv('SENTRY_DSN') or ''
+    SENTRY_DSN = '' if SENTRY_DSN.lower() == 'null' else SENTRY_DSN
 
     LD_SDK_KEY = os.getenv('LD_SDK_KEY', None)
 

--- a/jobs/email-reminder/config.py
+++ b/jobs/email-reminder/config.py
@@ -47,7 +47,8 @@ class _Config(object):  # pylint: disable=too-few-public-methods
     PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
     SEND_OUTSTANDING_BCOMPS = os.getenv('SEND_OUTSTANDING_BCOMPS', None)
-    SENTRY_DSN = os.getenv('SENTRY_DSN', '')
+    SENTRY_DSN = os.getenv('SENTRY_DSN') or ''
+    SENTRY_DSN = '' if SENTRY_DSN.lower() == 'null' else SENTRY_DSN
     LD_SDK_KEY = os.getenv('LD_SDK_KEY', None)
 
     ACCOUNT_SVC_AUTH_URL = os.getenv('ACCOUNT_SVC_AUTH_URL', None)

--- a/jobs/furnishings/src/furnishings/config.py
+++ b/jobs/furnishings/src/furnishings/config.py
@@ -47,7 +47,8 @@ class _Config:  # pylint: disable=too-few-public-methods
 
     PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
-    SENTRY_DSN = os.getenv('SENTRY_DSN', '')
+    SENTRY_DSN = os.getenv('SENTRY_DSN') or ''
+    SENTRY_DSN = '' if SENTRY_DSN.lower() == 'null' else SENTRY_DSN
     LD_SDK_KEY = os.getenv('LD_SDK_KEY', None)
 
     AUTH_URL = os.getenv('AUTH_URL', None)

--- a/jobs/future-effective-filings/config.py
+++ b/jobs/future-effective-filings/config.py
@@ -83,7 +83,8 @@ class _Config(object):  # pylint: disable=too-few-public-methods
     AUTH_URL = os.getenv('AUTH_URL', '')
     USERNAME = os.getenv('AUTH_USERNAME', '')
     PASSWORD = os.getenv('AUTH_PASSWORD', '')
-    SENTRY_DSN = os.getenv('SENTRY_DSN', '')
+    SENTRY_DSN = os.getenv('SENTRY_DSN') or ''
+    SENTRY_DSN = '' if SENTRY_DSN.lower() == 'null' else SENTRY_DSN
 
     SECRET_KEY = 'a secret'
 

--- a/jobs/involuntary-dissolutions/config.py
+++ b/jobs/involuntary-dissolutions/config.py
@@ -47,7 +47,8 @@ class _Config(object):  # pylint: disable=too-few-public-methods
 
     PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
-    SENTRY_DSN = os.getenv('SENTRY_DSN', '')
+    SENTRY_DSN = os.getenv('SENTRY_DSN') or ''
+    SENTRY_DSN = '' if SENTRY_DSN.lower() == 'null' else SENTRY_DSN
     LD_SDK_KEY = os.getenv('LD_SDK_KEY', None)
 
     NATS_SERVERS = os.getenv('NATS_SERVERS', None)

--- a/jobs/update-colin-filings/config.py
+++ b/jobs/update-colin-filings/config.py
@@ -48,7 +48,8 @@ class _Config(object):  # pylint: disable=too-few-public-methods
 
     COLIN_URL = os.getenv('COLIN_URL', '')
     LEGAL_API_URL = os.getenv('LEGAL_API_URL', '')
-    SENTRY_DSN = os.getenv('SENTRY_DSN', '')
+    SENTRY_DSN = os.getenv('SENTRY_DSN') or ''
+    SENTRY_DSN = '' if SENTRY_DSN.lower() == 'null' else SENTRY_DSN
 
     ACCOUNT_SVC_AUTH_URL = os.getenv('ACCOUNT_SVC_AUTH_URL', None)
     ACCOUNT_SVC_CLIENT_ID = os.getenv('ACCOUNT_SVC_CLIENT_ID', None)

--- a/jobs/update-legal-filings/config.py
+++ b/jobs/update-legal-filings/config.py
@@ -48,7 +48,8 @@ class _Config(object):  # pylint: disable=too-few-public-methods
 
     COLIN_URL = os.getenv('COLIN_URL', '')
     LEGAL_API_URL = os.getenv('LEGAL_API_URL', '')
-    SENTRY_DSN = os.getenv('SENTRY_DSN', '')
+    SENTRY_DSN = os.getenv('SENTRY_DSN') or ''
+    SENTRY_DSN = '' if SENTRY_DSN.lower() == 'null' else SENTRY_DSN
 
     ACCOUNT_SVC_AUTH_URL = os.getenv('ACCOUNT_SVC_AUTH_URL', None)
     ACCOUNT_SVC_CLIENT_ID = os.getenv('ACCOUNT_SVC_CLIENT_ID', None)

--- a/queue_services/business-pay/src/business_pay/config.py
+++ b/queue_services/business-pay/src/business_pay/config.py
@@ -82,7 +82,8 @@ class Config:  # pylint: disable=too-few-public-methods
 
     PAYMENT_SVC_URL = os.getenv("PAYMENT_SVC_URL", "")
 
-    SENTRY_DSN = os.getenv("SENTRY_DSN", None)
+    SENTRY_DSN = os.getenv('SENTRY_DSN') or ''
+    SENTRY_DSN = '' if SENTRY_DSN.lower() == 'null' else SENTRY_DSN
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
@@ -142,7 +143,7 @@ class Config:  # pylint: disable=too-few-public-methods
     )
     SUB_AUDIENCE = os.getenv("SUB_AUDIENCE", "")
     SUB_SERVICE_ACCOUNT = os.getenv("SUB_SERVICE_ACCOUNT", "")
-    
+
     SBC_CONNECT_GCP_QUEUE_DEBUG = os.getenv("SBC_CONNECT_GCP_QUEUE_DEBUG", "")
 
     NATS_CONNECT_ERROR_COUNT_MAX =  os.getenv("NATS_CONNECT_ERROR_COUNT_MAX", 10)

--- a/queue_services/entity-bn/src/entity_bn/config.py
+++ b/queue_services/entity-bn/src/entity_bn/config.py
@@ -60,7 +60,8 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
-    SENTRY_DSN = os.getenv('SENTRY_DSN', None)
+    SENTRY_DSN = os.getenv('SENTRY_DSN') or ''
+    SENTRY_DSN = '' if SENTRY_DSN.lower() == 'null' else SENTRY_DSN
     COLIN_API = f"{os.getenv('COLIN_API_URL', '')}{os.getenv('COLIN_API_VERSION', '')}"
 
     SEARCH_API = \

--- a/queue_services/entity-digital-credentials/src/entity_digital_credentials/config.py
+++ b/queue_services/entity-digital-credentials/src/entity_digital_credentials/config.py
@@ -60,7 +60,8 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
-    SENTRY_DSN = os.getenv('SENTRY_DSN', None)
+    SENTRY_DSN = os.getenv('SENTRY_DSN') or ''
+    SENTRY_DSN = '' if SENTRY_DSN.lower() == 'null' else SENTRY_DSN
     LD_SDK_KEY = os.getenv('LD_SDK_KEY', None)
 
     # variables

--- a/queue_services/entity-emailer/src/entity_emailer/config.py
+++ b/queue_services/entity-emailer/src/entity_emailer/config.py
@@ -62,6 +62,8 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     MSG_RETRY_NUM = int(os.getenv('MSG_RETRY_NUM', '5'))
 
+    SENTRY_DSN = os.getenv('SENTRY_DSN') or ''
+    SENTRY_DSN = '' if SENTRY_DSN.lower() == 'null' else SENTRY_DSN
     LD_SDK_KEY = os.getenv('LD_SDK_KEY', None)
 
     # urls

--- a/queue_services/entity-filer/src/entity_filer/config.py
+++ b/queue_services/entity-filer/src/entity_filer/config.py
@@ -62,7 +62,8 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     PAYMENT_SVC_URL = os.getenv('PAYMENT_SVC_URL', '')
 
-    SENTRY_DSN = os.getenv('SENTRY_DSN', None)
+    SENTRY_DSN = os.getenv('SENTRY_DSN') or ''
+    SENTRY_DSN = '' if SENTRY_DSN.lower() == 'null' else SENTRY_DSN
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 

--- a/queue_services/entity-pay/src/entity_pay/config.py
+++ b/queue_services/entity-pay/src/entity_pay/config.py
@@ -62,7 +62,8 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     PAYMENT_SVC_URL = os.getenv('PAYMENT_SVC_URL', '')
 
-    SENTRY_DSN = os.getenv('SENTRY_DSN', None)
+    SENTRY_DSN = os.getenv('SENTRY_DSN') or ''
+    SENTRY_DSN = '' if SENTRY_DSN.lower() == 'null' else SENTRY_DSN
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*

* Fix sentry_dsn config issue where null value is populated in OCP secrets when sentry_dsn is populated with empty string in 1pass. We need to initialize sentry with empty string in this case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
