### PR TITLE
Fix sentry issue where sentry_dsn null string value should be converted to empty string

### DIFF
--- a/queue_services/common/src/entity_queue_common/service_utils/service_logger.py
+++ b/queue_services/common/src/entity_queue_common/service_utils/service_logger.py
@@ -28,7 +28,8 @@ def before_breadcrumb(crumb, hint):  # pylint: disable=unused-argument; callback
 
 
 # Configure Sentry
-SENTRY_DSN = os.getenv('SENTRY_DSN', None)
+SENTRY_DSN = os.getenv('SENTRY_DSN') or ''
+SENTRY_DSN = '' if SENTRY_DSN.lower() == 'null' else SENTRY_DSN
 
 # Configure default log level to ERROR
 # Override with envirionment variable if needed


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*

* Updates to support disabling of sentry for Q listeners as well.  Q listeners initialize sentry from queue common service logger code as well. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
