### PR TITLE
21954 - Sync involuntary dissolutions back to COLIN

### DIFF
--- a/colin-api/src/colin_api/models/business.py
+++ b/colin-api/src/colin_api/models/business.py
@@ -64,6 +64,8 @@ class Business:  # pylint: disable=too-many-instance-attributes, too-many-public
         VOLUNTARY_DISSOLUTION = 'HDV'
         ADMINISTRATIVE_DISSOLUTION = 'HDA'
         AMALGAMATED = 'HAM'
+        INVOLUNTARY_DISSOLUTION_NO_AR = 'HDF'
+        INVOLUNTARY_DISSOLUTION_NO_TR = 'HDT'
 
     NUMBERED_CORP_NAME_SUFFIX = {
         TypeCodes.BCOMP.value: 'B.C. LTD.',

--- a/legal-api/src/legal_api/resources/v2/business/colin_sync.py
+++ b/legal-api/src/legal_api/resources/v2/business/colin_sync.py
@@ -87,7 +87,7 @@ def get_completed_filings_for_colin():
                     continue  # do not break this function because of one filing
             elif (filing.filing_type == 'dissolution' and
                   filing.filing_sub_type == 'involuntary'):
-                batch_processings = BatchProcessing.find_by(business_id=filing.business_id)
+                batch_processings = BatchProcessing.find_by(filing_id=filing.id)
                 if not batch_processings:
                     continue  # skip filing for missing batch processing info
                 filing_json['filing']['dissolution']['metaData'] = batch_processings[0].meta_data


### PR DESCRIPTION
*Issue #:* /bcgov/entity#21954

*Description of changes:*
- No updates for update-colin-filings job
- Updated colin-api to support adding events for involuntary dissolutions
- Updated legal-api to populate batch_processing.meta_data into filing json returned for COLIN related services

Note that similar with administrative dissolution, no filing will be created for involuntary dissolution. It just creates events and changes the state of the companies.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
