### PR TITLE
22586 Fixed COA effective time bug

### DIFF
--- a/legal-api/report-templates/template-parts/common/businessDetails.html
+++ b/legal-api/report-templates/template-parts/common/businessDetails.html
@@ -194,8 +194,7 @@
             <td>
                <div>{{business.identifier}}</div>
                <div class="pt-2">{{filing_date_time}}</div>
-               <!-- temporary override - should be fixed in code instead - see #4444 -->
-               <div class="pt-2">{{effective_date}} at 12:01 AM Pacific Time</div>
+               <div class="pt-2">{{effective_date_time}}</div>
                <div class="pt-2">{{report_date_time}}</div>
             </td>
          {% elif header.name == 'changeOfDirectors' %}

--- a/legal-api/src/legal_api/resources/v1/business/business_filings.py
+++ b/legal-api/src/legal_api/resources/v1/business/business_filings.py
@@ -836,7 +836,7 @@ class ListFilingResource(Resource):
 
         elif business.legal_type != Business.LegalTypes.COOP.value:
             if filing_type == 'changeOfAddress':
-                effective_date = LegislationDatetime.tomorrow_midnight()
+                effective_date = LegislationDatetime.tomorrow_one_minute_after_midnight()
                 filing.filing_json['filing']['header']['futureEffectiveDate'] = effective_date
                 filing.effective_date = effective_date
                 filing.save()

--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
@@ -890,7 +890,7 @@ class ListFilingResource():  # pylint: disable=too-many-public-methods
         """Set the effective date of the Filing."""
         filing_type = filing.filing_json['filing']['header']['name']
         if filing_type == 'changeOfAddress' and business.legal_type != Business.LegalTypes.COOP.value:
-            effective_date = LegislationDatetime.tomorrow_midnight()
+            effective_date = LegislationDatetime.tomorrow_one_minute_after_midnight()
             effective_date_utc = LegislationDatetime.as_utc_timezone(effective_date)
             filing_json_update = copy.deepcopy(filing.filing_json)
             filing_json_update['filing']['header']['futureEffectiveDate'] = effective_date_utc.isoformat()

--- a/legal-api/src/legal_api/utils/legislation_datetime.py
+++ b/legal-api/src/legal_api/utils/legislation_datetime.py
@@ -17,7 +17,7 @@ import pytz
 from dateutil.tz import gettz
 from flask import current_app
 
-from .datetime import date, datetime, timezone
+from .datetime import date, datetime, timedelta, timezone
 
 
 class LegislationDatetime():
@@ -45,7 +45,7 @@ class LegislationDatetime():
     @staticmethod
     def tomorrow_one_minute_after_midnight() -> datetime:
         """Construct a datetime tomorrow 12:01 AM using the legislation timezone."""
-        return LegislationDatetime.tomorrow_midnight() + datetime.timedelta(minutes=1)
+        return LegislationDatetime.tomorrow_midnight() + timedelta(minutes=1)
 
     @staticmethod
     def as_legislation_timezone(date_time: datetime) -> datetime:

--- a/legal-api/src/legal_api/utils/legislation_datetime.py
+++ b/legal-api/src/legal_api/utils/legislation_datetime.py
@@ -35,12 +35,17 @@ class LegislationDatetime():
 
     @staticmethod
     def tomorrow_midnight() -> datetime:
-        """Construct a datetime tomorrow midnight using the legislation timezone."""
+        """Construct a datetime tomorrow 12:00 AM using the legislation timezone."""
         _date = datetime.now().astimezone(pytz.timezone(current_app.config.get('LEGISLATIVE_TIMEZONE')))
         _date += datedelta.datedelta(days=1)
         _date = _date.replace(hour=0, minute=0, second=0, microsecond=0)
 
         return _date
+
+    @staticmethod
+    def tomorrow_one_minute_after_midnight() -> datetime:
+        """Construct a datetime tomorrow 12:01 AM using the legislation timezone."""
+        return LegislationDatetime.tomorrow_midnight() + datetime.timedelta(minutes=1)
 
     @staticmethod
     def as_legislation_timezone(date_time: datetime) -> datetime:

--- a/legal-api/tests/unit/resources/v1/test_business_filings/test_filings.py
+++ b/legal-api/tests/unit/resources/v1/test_business_filings/test_filings.py
@@ -1165,5 +1165,5 @@ def test_coa_future_effective(session, client, jwt):
     assert rv.status_code == HTTPStatus.CREATED
     assert 'effectiveDate' in rv.json['filing']['header']
     effective_date = parse(rv.json['filing']['header']['effectiveDate'])
-    valid_date = LegislationDatetime.tomorrow_midnight()
+    valid_date = LegislationDatetime.tomorrow_one_minute_after_midnight()
     assert effective_date == valid_date

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filings.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filings.py
@@ -1277,7 +1277,7 @@ def test_coa_future_effective(session, client, jwt):
     assert rv.status_code == HTTPStatus.CREATED
     assert 'effectiveDate' in rv.json['filing']['header']
     effective_date = parse(rv.json['filing']['header']['effectiveDate'])
-    valid_date = LegislationDatetime.tomorrow_midnight()
+    valid_date = LegislationDatetime.tomorrow_one_minute_after_midnight()
     assert effective_date == valid_date
 
 
@@ -1366,7 +1366,7 @@ def test_coa(session, requests_mock, client, jwt, test_name, legal_type, identif
 
     if future_effective_date_expected:
         effective_date = parse(rv.json['filing']['header']['effectiveDate'])
-        valid_date = LegislationDatetime.tomorrow_midnight()
+        valid_date = LegislationDatetime.tomorrow_one_minute_after_midnight()
         assert effective_date == valid_date
 
         assert 'futureEffectiveDate' in rv.json['filing']['header']


### PR DESCRIPTION
*Issue #:* bcgov/entity#22586

*Description of changes:*
- removed time workaround from businessDetails.html
- assigned new effective data for COA filing (2 places)
- added method for tomorrow 12:01 AM
- updated unit tests (3 places)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).