### PR TITLE
22323 Furnishings job - Add logic to generate XML for stage 3

### DIFF
--- a/jobs/furnishings/src/furnishings/stage_processors/post_processor.py
+++ b/jobs/furnishings/src/furnishings/stage_processors/post_processor.py
@@ -117,7 +117,8 @@ class XmlMeta:
             'subcategory': 'B.C.',
             'corp_class': 'BC Company(s)',
             'description': (
-                'The Registrar of Companies hereby gives notice the following companies were dissolved under section 317, 422 or 423 of the Business Corporations Act.'
+                'The Registrar of Companies hereby gives notice the following companies were dissolved under '
+                'section 317, 422 or 423 of the Business Corporations Act.'
             )
         },
     }

--- a/jobs/furnishings/src/furnishings/stage_processors/post_processor.py
+++ b/jobs/furnishings/src/furnishings/stage_processors/post_processor.py
@@ -77,7 +77,10 @@ class PostProcessor:
                 furnishing.save()
 
     def process(self):
-        """Postprocess to generate and upload file to external resources(BC Laws)."""
+        """Postprocess to generate and upload file to external resources (BC Laws)."""
+        if not self._furnishings_dict:
+            return
+
         self._format_furnishings()
         self._app.logger.debug('Formatted furnishing details presented in XML file')
         self._set_meta_info()
@@ -106,6 +109,15 @@ class XmlMeta:
                 'at any time after the expiration of one month from the date of publication of this notice, '
                 'unless cause is shown to the contrary, '
                 'be dissolved under section 422 of the Business Corporations Act.'
+            )
+        },
+        Furnishing.FurnishingName.CORP_DISSOLVED: {
+            'title': 'Dissolutions (B.C.)',
+            'category': 'DISSOLUTIONS',
+            'subcategory': 'B.C.',
+            'corp_class': 'BC Company(s)',
+            'description': (
+                'The Registrar of Companies hereby gives notice the following companies were dissolved under section 317, 422 or 423 of the Business Corporations Act.'
             )
         },
     }

--- a/jobs/furnishings/src/furnishings/stage_processors/stage_two.py
+++ b/jobs/furnishings/src/furnishings/stage_processors/stage_two.py
@@ -66,7 +66,8 @@ def process(app: Flask, xml_furnishings: dict):
             if business != Business.LegalTypes.EXTRA_PRO_A.value:
                 bc_furnishings.append(new_furnishing)
 
-        xml_furnishings[Furnishing.FurnishingName.INTENT_TO_DISSOLVE] = bc_furnishings
+        if bc_furnishings:
+            xml_furnishings[Furnishing.FurnishingName.INTENT_TO_DISSOLVE] = bc_furnishings
 
     except Exception as err:
         app.logger.error(err)

--- a/jobs/furnishings/src/furnishings/worker.py
+++ b/jobs/furnishings/src/furnishings/worker.py
@@ -128,5 +128,5 @@ async def run(application: Flask, qsm: QueueService):  # pylint: disable=redefin
                 application.logger.debug('Entering stage 3 of furnishings job.')
                 stage_three.process(application, xml_furnishings_dict)
                 application.logger.debug('Exiting stage 3 of furnishings job.')
-            
+
             post_processor.process(application, xml_furnishings_dict)

--- a/jobs/furnishings/src/furnishings/worker.py
+++ b/jobs/furnishings/src/furnishings/worker.py
@@ -126,7 +126,7 @@ async def run(application: Flask, qsm: QueueService):  # pylint: disable=redefin
                 application.logger.debug('Exiting stage 2 of furnishings job.')
             if stage_3_valid:
                 application.logger.debug('Entering stage 3 of furnishings job.')
-                stage_three.process(application)
+                stage_three.process(application, xml_furnishings_dict)
                 application.logger.debug('Exiting stage 3 of furnishings job.')
-
+            
             post_processor.process(application, xml_furnishings_dict)

--- a/jobs/furnishings/tests/unit/stage_processors/test_stage_three.py
+++ b/jobs/furnishings/tests/unit/stage_processors/test_stage_three.py
@@ -63,7 +63,20 @@ def test_process_create_furnishings(app, session, test_name, entity_type, step, 
         batch_id=batch.id,
         business_id=business.id,
         identifier=business.identifier,
-        step=step
+        step=step,
+        status=BatchProcessing.BatchProcessingStatus.COMPLETED
+    )
+
+    #stage 2 furnishing
+    factory_furnishing(
+        batch_id=batch.id,
+        business_id=business.id,
+        identifier=business.identifier,
+        furnishing_name=Furnishing.FurnishingName.INTENT_TO_DISSOLVE,
+        furnishing_type=Furnishing.FurnishingType.GAZETTE,
+        created_date=datetime.utcnow()+datedelta(years=1),
+        last_modified=datetime.utcnow()+datedelta(years=1),
+        business_name=business.legal_name
     )
 
     if test_name == 'STAGE_3_ALREADY_RUN':
@@ -78,12 +91,12 @@ def test_process_create_furnishings(app, session, test_name, entity_type, step, 
             business_name=business.legal_name
         )
 
-    process(app)
+    process(app, {})
 
     furnishings = Furnishing.find_by(business_id=business.id)
     if new_entry:
-        assert len(furnishings) == 1
-        furnishing = furnishings[0]
+        assert len(furnishings) == 2
+        furnishing = furnishings[1]
         assert furnishing.furnishing_type == Furnishing.FurnishingType.GAZETTE
         assert furnishing.business_name == business.legal_name
         if entity_type == Business.LegalTypes.EXTRA_PRO_A.value:
@@ -92,8 +105,8 @@ def test_process_create_furnishings(app, session, test_name, entity_type, step, 
             assert furnishing.furnishing_name == Furnishing.FurnishingName.CORP_DISSOLVED
     else:
         if test_name == 'STAGE_3_ALREADY_RUN':
-            assert len(furnishings) == 1
-            furnishing = furnishings[0]
+            assert len(furnishings) == 2
+            furnishing = furnishings[1]
             assert furnishing == existing_furnishing
         else:
-            assert len(furnishings) == 0
+            assert len(furnishings) == 1


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22323

*Description of changes:*
- Added logic to generate XML for stage 3 (excluding EPs)

### Local testing
**Test 1: Run furnishings job on stage 1 and stage 2 batch_processing entries**
1. Starting with these stage 1 and stage 2 batch_processing entries:
<img width="708" alt="Screenshot 2024-08-15 at 8 34 02 AM" src="https://github.com/user-attachments/assets/cb831e15-e9d8-45d4-923b-e20b01f20541">

2. Running the furnishings job (with all `cronstrings = * * * * *`) results in below. We expect to see:
  - `furnishing_type == MAIL or EMAIL` for stage 1 batch_processings
  - `furnishing_type == GAZETTE` for stage 2 batch_processings
<img width="963" alt="Screenshot 2024-08-15 at 8 35 26 AM" src="https://github.com/user-attachments/assets/b12f8d65-234d-44e5-bacc-e4e84eff80e8">

  - 2 different furnishing_groups
<img width="177" alt="Screenshot 2024-08-15 at 8 35 50 AM" src="https://github.com/user-attachments/assets/cb513b34-9f0d-4937-97f6-3973c1e0a5c0">

  - An `xml_payload` entry with the stage 2 batch_processing businesses with "Intent to Dissolve (B.C.)"
<img width="1305" alt="Screenshot 2024-08-15 at 8 36 27 AM" src="https://github.com/user-attachments/assets/92ca73ee-f911-417c-8311-69434c9a792c">

---

**Test 2: Run furnishings job on stage 2 and stage 3 batch_processing entries**
1. Using the same batch_processings from test 1, change the `trigger_date` to before today and run the dissolutions job again (with all `cronstrings = * * * * *`). This will move the batch_processings up a stage (`WARNING_LEVEL_1 -> WARNING_LEVEL_2` and `WARNING_LEVEL_2 -> DISSOLUTION`.
<img width="796" alt="Screenshot 2024-08-15 at 8 38 57 AM" src="https://github.com/user-attachments/assets/020351b7-1135-4f6d-b8a6-451b0b9d6608">

2. Running the furnishings job (with all `cronstrings = * * * * *`) results in below. We expect to see:
  - `furnishing_type == GAZETTE` for all entries
  - `furnishing_group_id` the same for all entries (97 in this case)
<img width="1167" alt="Screenshot 2024-08-15 at 9 21 46 AM" src="https://github.com/user-attachments/assets/6e2b3dbe-d2dc-4d8b-8077-2bd459a7fd36">


  - A single `xml_payload` entry that contains the information for both stage 2 "Intent to Dissolve (B.C.)" and stage 3 "Dissolutions (B.C.)". Note: the other entry shown with `id=12` is from the test 1 furnishings run.

<img width="1299" alt="Screenshot 2024-08-15 at 8 41 24 AM" src="https://github.com/user-attachments/assets/f50f38d1-c5dc-4dc4-82ba-81758e340ed8">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
