### PR TITLE
22496 Emailer - stage 1 overdue ARs notification (EP flow)

### DIFF
--- a/queue_services/entity-emailer/src/entity_emailer/email_templates/INVOL-DIS-STAGE-1.html
+++ b/queue_services/entity-emailer/src/entity_emailer/email_templates/INVOL-DIS-STAGE-1.html
@@ -24,9 +24,13 @@
             [[20px.html]]
 
             {% if 'NO_AR' in furnishing_name %}
-            <p>Your business is in the process of being dissolved because it hasn't 
-              filed its required annual reports. Please file your overdue annual 
-              reports as soon as possible by <a href="{{ entity_dashboard_url }}">logging into your Business Page</a>.
+            <p>
+              {% if 'XPRO' in furnishing_name %}
+              Your extraprovincial company is in the process of being cancelled because it hasn't filed its required annual reports. 
+              {% else %}
+              Your business is in the process of being dissolved because it hasn't filed its required annual reports. 
+              {% endif %}
+              Please file your overdue annual reports as soon as possible by <a href="{{ entity_dashboard_url }}">logging into your Business Page</a>.
             </p>
             {% else %}
             <p>Your business is in the process of being dissolved because it hasn't 
@@ -42,8 +46,13 @@
             <p>
               Under the Business Corporations Act, if you don't file these reports 
               within one month from today, the Registrar will post a public notice 
-              on <a href="https://www.bclaws.gov.bc.ca/">www.bclaws.ca</a>. This notice will state that your company may be 
+              on <a href="https://www.bclaws.gov.bc.ca/">www.bclaws.ca</a>. 
+              {% if 'XPRO' in furnishing_name %}
+              This notice will state that your extraprovincial company may be cancelled if the annual reports aren't filed after one month.
+              {% else %}
+              This notice will state that your company may be 
               dissolved if the annual reports aren't filed after one month.
+              {% endif %}
             </p>
             {% else %}
             <p>
@@ -71,8 +80,15 @@
             [[whitespace-16px.html]]
 
             <p>
-              You can ask for more time by requesting a delay of the dissolution or 
-              cancellation process. Go to your <a href="{{ entity_dashboard_url }}">business Page</a> and click on “Request 
+              You can ask for more time by requesting 
+              {% if furnishing_name == 'DISSOLUTION_COMMENCEMENT_NO_AR_XPRO' %}
+              a delay of the cancellation process. 
+              {% elif extra_provincials %}
+              a delay of the dissolution or cancellation process. 
+              {% else %}
+              a delay of the dissolution process. 
+              {% endif %}
+              Go to your <a href="{{ entity_dashboard_url }}">business page</a> and click on “Request 
               Delay of Dissolution or Cancellation" under the “More Actions” menu.
             </p>
             [[whitespace-16px.html]]
@@ -84,13 +100,14 @@
             </p>
             
             <ul class="outputs">
-              <li>Notice of Commencement of Dissolution
-              </li>
+              {% if furnishing_name == 'DISSOLUTION_COMMENCEMENT_NO_AR_XPRO' %}
+              <li>Notice of Commencement of Cancellation</li>
+              {% else %}
+              <li>Notice of Commencement of Dissolution</li>
+              {% endif %}
             </ul>
 
             [[whitespace-16px.html]]
-            [[business-dashboard-link.html]]
-            
             [[20px.html]]
             [[footer.html]]
           </div>


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22496

*Description of changes:*
- Update email templates for Xpro and correct some content for BC companies
- Update to support different attachment (assuming the other work for it is done and the endpoint to get Xpro document is unchanged)
- Update unit tests

*Local Testing*
The testing result can be found at MailHog for A0883551 (I created this and it can be also found in dev. However, auth-api and UI don't fully support this type of business)
![image](https://github.com/user-attachments/assets/4e9a50e4-08bf-42b5-afd3-112295f98db8)
![image](https://github.com/user-attachments/assets/fe4d255e-0a3b-40da-947b-dfe864fe4935)

*Unit Test*
The related tests are passed. And the other broken tests will be fixed in another work.
![image](https://github.com/user-attachments/assets/12db0ff9-f800-4cc2-a5c3-84e5d3d1c3c3)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
