### PR TITLE
22657 - Fixed stage 1 dissolution job email

### DIFF
--- a/queue_services/entity-emailer/src/entity_emailer/email_processors/involuntary_dissolution_stage_1_notification.py
+++ b/queue_services/entity-emailer/src/entity_emailer/email_processors/involuntary_dissolution_stage_1_notification.py
@@ -96,9 +96,11 @@ def get_extra_provincials(response: dict):
     extra_provincials = []
     if response:
         jurisdictions = response.get('jurisdictions', [])
+        # List of NWPTA jurisdictions
+        nwpta_Jurisdictions = ['Alberta', 'British Columbia', 'Manitoba', 'Saskatchewan']
         for jurisdiction in jurisdictions:
             name = jurisdiction.get('name')
-            if name:
+            if name and (name in nwpta_Jurisdictions):
                 extra_provincials.append(name)
         extra_provincials.sort()
     return extra_provincials

--- a/queue_services/entity-emailer/src/entity_emailer/email_processors/involuntary_dissolution_stage_1_notification.py
+++ b/queue_services/entity-emailer/src/entity_emailer/email_processors/involuntary_dissolution_stage_1_notification.py
@@ -97,10 +97,10 @@ def get_extra_provincials(response: dict):
     if response:
         jurisdictions = response.get('jurisdictions', [])
         # List of NWPTA jurisdictions
-        nwpta_Jurisdictions = ['Alberta', 'British Columbia', 'Manitoba', 'Saskatchewan']
+        nwpta_jurisdictions = ['Alberta', 'British Columbia', 'Manitoba', 'Saskatchewan']
         for jurisdiction in jurisdictions:
             name = jurisdiction.get('name')
-            if name and (name in nwpta_Jurisdictions):
+            if name and (name in nwpta_jurisdictions):
                 extra_provincials.append(name)
         extra_provincials.sort()
     return extra_provincials

--- a/queue_services/entity-emailer/src/entity_emailer/email_templates/INVOL-DIS-STAGE-1.html
+++ b/queue_services/entity-emailer/src/entity_emailer/email_templates/INVOL-DIS-STAGE-1.html
@@ -69,12 +69,12 @@
             <p>
               Our records indicate your company is registered in 
               {% for province in extra_provincials %}
-              {{ province }}{% if not loop.last %}{% if loop.revindex == 2 %}, and {% else %}, {% endif %}{% endif %}
+              {{ province }}{% if not loop.last %}{% if loop.length == 2 and loop.first %} and {% elif loop.revindex == 2 %}, and {% else %}, {% endif %}{% endif %}
               {% endfor %}
               as an extraprovincial company. Therefore, if your company is dissolved, its registration as an extraprovincial company 
               in 
               {% for province in extra_provincials %}
-              {{ province }}{% if not loop.last %}{% if loop.revindex == 2 %}, and {% else %}, {% endif %}{% endif %}
+              {{ province }}{% if not loop.last %}{% if loop.length == 2 and loop.first %} and {% elif loop.revindex == 2 %}, and {% else %}, {% endif %}{% endif %}
               {% endfor %}
               will automatically be cancelled as well.
             </p>

--- a/queue_services/entity-emailer/src/entity_emailer/email_templates/INVOL-DIS-STAGE-1.html
+++ b/queue_services/entity-emailer/src/entity_emailer/email_templates/INVOL-DIS-STAGE-1.html
@@ -69,12 +69,12 @@
             <p>
               Our records indicate your company is registered in 
               {% for province in extra_provincials %}
-              {{ province }}{% if forloop.revindex == 2 %}, and {% elif not forloop.last %}, {% endif %}
+              {{ province }}{% if not loop.last %}{% if loop.revindex == 2 %}, and {% else %}, {% endif %}{% endif %}
               {% endfor %}
               as an extraprovincial company. Therefore, if your company is dissolved, its registration as an extraprovincial company 
               in 
               {% for province in extra_provincials %}
-              {{ province }}{% if forloop.revindex == 2 %}, and {% elif not forloop.last %}, {% endif %}
+              {{ province }}{% if not loop.last %}{% if loop.revindex == 2 %}, and {% else %}, {% endif %}{% endif %}
               {% endfor %}
               will automatically be cancelled as well.
             </p>

--- a/queue_services/entity-emailer/src/entity_emailer/email_templates/INVOL-DIS-STAGE-1.html
+++ b/queue_services/entity-emailer/src/entity_emailer/email_templates/INVOL-DIS-STAGE-1.html
@@ -68,9 +68,14 @@
             {% if extra_provincials %}
             <p>
               Our records indicate your company is registered in 
-              {% for province in extra_provincials %}{{ province }}{% if not loop.last %} and {% endif %}{% endfor %} 
+              {% for province in extra_provincials %}
+              {{ province }}{% if forloop.revindex == 2 %}, and {% elif not forloop.last %}, {% endif %}
+              {% endfor %}
               as an extraprovincial company. Therefore, if your company is dissolved, its registration as an extraprovincial company 
-              in {% for province in extra_provincials %}{{ province }}{% if not loop.last %} and {% endif %}{% endfor %} 
+              in 
+              {% for province in extra_provincials %}
+              {{ province }}{% if forloop.revindex == 2 %}, and {% elif not forloop.last %}, {% endif %}
+              {% endfor %}
               will automatically be cancelled as well.
             </p>
             {% endif %}


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22657

*Description of changes:*
- Fixed the involuntary dissolution job stage 1 email output

Tested, new email output:
![image](https://github.com/user-attachments/assets/5cd48d59-98b6-47b4-b092-29ea3aa9a77d)

You can see the email in Mailhog as well.

The formatting now is correct: X, Y, and Z. Also, Quebec is not shown anymore. ONLY NWPTA jurisdictions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
