### PR TITLE
22889 - Added time to dissolutions in XML payloads

### DIFF
--- a/jobs/furnishings/src/furnishings-templates/gazette-notice.xml
+++ b/jobs/furnishings/src/furnishings-templates/gazette-notice.xml
@@ -18,7 +18,13 @@
                 {%- else -%}
                 <corp_num>{{ f.business_identifier[2:] }}</corp_num>
                 {%- endif %}
-                <text>{{ f.business_name }}</text>
+                <text>
+                    {% if furnishing['category'] == 'DISSOLUTIONS' -%}
+                    {{ f.business_name }} {{ processed_time }}
+                    {%- else -%}
+                    {{ f.business_name }}
+                    {%- endif %}
+                </text>
             </filing_detail>
             {%- endfor %}
         </filings>

--- a/jobs/furnishings/src/furnishings-templates/gazette-notice.xml
+++ b/jobs/furnishings/src/furnishings-templates/gazette-notice.xml
@@ -19,7 +19,7 @@
                 <corp_num>{{ f.business_identifier[2:] }}</corp_num>
                 {%- endif %}
                 <text>
-                    {% if furnishing['category'] == 'DISSOLUTIONS' -%}
+                    {% if furnishing['category'] == 'DISSOLUTIONS' or furnishing['category'] == 'REGISTRATIONS CANCELLED' -%}
                     {{ f.business_name }} {{ processed_time }}
                     {%- else -%}
                     {{ f.business_name }}

--- a/jobs/furnishings/src/furnishings/stage_processors/post_processor.py
+++ b/jobs/furnishings/src/furnishings/stage_processors/post_processor.py
@@ -84,7 +84,7 @@ class PostProcessor:
         self._format_furnishings()
         self._app.logger.debug('Formatted furnishing details presented in XML file')
         self._set_meta_info()
-        payload = self._build_xml_data(self._xml_data, self._processed_date.strftime('%-I:%M %p'))
+        payload = self._build_xml_data(self._xml_data, self._processed_date.strftime('%I:%M %p'))
         furnishing_group, _ = self._save_xml_payload(payload)
         self._app.logger.debug('Saved XML payload')
         # TODO: SFTP to BC Laws

--- a/jobs/furnishings/src/furnishings/stage_processors/post_processor.py
+++ b/jobs/furnishings/src/furnishings/stage_processors/post_processor.py
@@ -48,14 +48,14 @@ class PostProcessor:
             self._xml_data['furnishings'][name]['items'] = sorted(furnishings, key=lambda f: f.business_name)
 
     @staticmethod
-    def _build_xml_data(xml_data):
+    def _build_xml_data(xml_data, processed_time):
         """Build XML payload."""
         template = Path(
             f'{current_app.config.get("TEMPLATE_PATH")}/gazette-notice.xml'
         ).read_text()
         jinja_template = Template(template, autoescape=True)
 
-        return jinja_template.render(xml_data)
+        return jinja_template.render(xml_data, processed_time=processed_time)
 
     @staticmethod
     def _save_xml_payload(payload):
@@ -84,7 +84,7 @@ class PostProcessor:
         self._format_furnishings()
         self._app.logger.debug('Formatted furnishing details presented in XML file')
         self._set_meta_info()
-        payload = self._build_xml_data(self._xml_data)
+        payload = self._build_xml_data(self._xml_data, self._processed_date.strftime('%-I:%M %p'))
         furnishing_group, _ = self._save_xml_payload(payload)
         self._app.logger.debug('Saved XML payload')
         # TODO: SFTP to BC Laws


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22889

*Description of changes:*
- Added the time in the Dissolutions section in the XML Payloads

How I tested my change:
1. Went to DB and picked an entry in the batch_processing table that was in stage 1: 
![level 1 db](https://github.com/user-attachments/assets/0eb826f9-ee54-4ce4-907f-cf1c76f1b416)

2. Changed the trigger date to before today and ran the dissolutions job:
![level 2 db final](https://github.com/user-attachments/assets/6d11909e-ef20-47e5-b894-68135d3c4482)
This moved it to stage 2.

3. Ran the furnishings job. This created an intent to dissolve furnishings entry with an XML payload that resembles the same:
![intent to dissolve furnishings entry](https://github.com/user-attachments/assets/7255a18d-59b8-4d71-ad62-e0b739394ad1)
![xml payload intent to dissolve](https://github.com/user-attachments/assets/00d06912-d701-4d27-aff5-0034abaa430a)

4. Changed the trigger date again to before today and ran the dissolutions job again, this moved it to `DISSOLUTION`:
![completed dissolution](https://github.com/user-attachments/assets/74e8cad4-ead6-476e-bce1-ab9abdace339)

5. Ran the furnishings job again, this moved it to `CORP_DISSOLVED` and created an XML payload of DISSOLUTION:
![corp dissolved furnishings entry](https://github.com/user-attachments/assets/4cabb41c-5de2-4874-9925-14326e1ad3af)
![dissolutions xm](https://github.com/user-attachments/assets/85537780-194e-4014-889e-c7a5b29603de)

Now, if you look at the text node, you can see the processed time in 12 hour PM/AM format.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
