### PR TITLE
22011 - fix date range filtering issue

### DIFF
--- a/legal-api/src/legal_api/models/review.py
+++ b/legal-api/src/legal_api/models/review.py
@@ -89,10 +89,12 @@ class Review(db.Model):  # pylint: disable=too-many-instance-attributes
 
         if review_filter.start_date:
             start_date_utc = LegislationDatetime.as_utc_timezone_from_legislation_date_str(review_filter.start_date)
-            query = query.filter(Review.submission_date >= start_date_utc)
+            start_of_day = datetime.combine(start_date_utc, datetime.min.time())
+            query = query.filter(Review.submission_date >= start_of_day)
         if review_filter.end_date:
             end_date_utc = LegislationDatetime.as_utc_timezone_from_legislation_date_str(review_filter.end_date)
-            query = query.filter(Review.submission_date <= end_date_utc)
+            end_of_day = datetime.combine(end_date_utc, datetime.max.time())
+            query = query.filter(Review.submission_date <= end_of_day)
         if review_filter.nr_number:
             query = query.filter(Review.nr_number.ilike(f'%{review_filter.nr_number}%'))
         if review_filter.identifier:


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22011

*Description of changes:*
Issue: Results not returned if selected same date as start and end date for date submitted filter (e.g. Aug 22 - Aug 22)

Fixed filtering issue for same date range by checking start and end of the day (date is `datetime` field)

![image](https://github.com/user-attachments/assets/7f40c710-b203-4489-abea-cb1a62b68705)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
