### PR TITLE
22502 - legal api - update to use service class for furnishing documents generation

### DIFF
--- a/legal-api/report-templates/dissolutionCover.html
+++ b/legal-api/report-templates/dissolutionCover.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Cover for Dissolution/Cancellation Letter</title>
+    <meta charset="UTF-8">
+    <meta name="author" content="BC Registries and Online Services">
+    [[common/v2/styleMail.html]]
+  </head>
+  <body>
+    <div class="cover-container">
+        <div class="cover-header">
+            <span>Dissolution / Cancellation Letter<span>
+        </div>
+
+        <table class="cover-statistics">
+            <tr>
+                <td class="bold">Number of Letters:</td>
+                <td>{{ letterCount }}</td>
+            </tr>
+            <tr>
+                <td class="bold">Report Run Date:</td>
+                <td>{{ reportDate }}</td>
+            </tr>
+            <tr>
+                <td class="bold">Report Batch ID:</td>
+                <td>{{ customBatchId }}</td>
+            </tr>
+            <tr>
+                <td class="bold">Report Page Count:</td>
+                <td>{{ pageCount }}</td>
+            </tr>
+        </table>
+
+        <div class="cover-environment upper-text">
+            {{ environment }}
+        </div>
+    </div>
+  </body>
+</html>

--- a/legal-api/report-templates/template-parts/common/v2/styleMail.html
+++ b/legal-api/report-templates/template-parts/common/v2/styleMail.html
@@ -639,7 +639,7 @@
 		margin: 50px auto;
 		text-align: center;
 		color: #000000;
-		font-family: 'Calibri' !important;
+		font-family: 'Calibri'!important;
 		margin-top: 50px;
 		padding: 0;
 	}

--- a/legal-api/report-templates/template-parts/common/v2/styleMail.html
+++ b/legal-api/report-templates/template-parts/common/v2/styleMail.html
@@ -634,4 +634,46 @@
 	.letter-container {
 		margin-top: 4.75rem;
 	}
+
+	.cover-container {
+		margin: 50px auto;
+		text-align: center;
+		color: #000000;
+		font-family: 'Calibri' !important;
+		margin-top: 50px;
+		padding: 0;
+	}
+
+	.cover-header {
+		border-top: 1px solid black;
+		border-bottom: 1px solid black;
+		padding: 10px 0;
+	}
+
+	.cover-header span {
+		display: block;
+		font-size: 24px;
+		margin-top: 10px;
+		margin-bottom: 10px;
+		margin-left: 0;
+		margin-right: 0;
+	}
+
+	.cover-environment {
+		border-top: 2px dashed black;
+		border-bottom: 2px dashed black;
+		margin-top: 350px;
+		padding: 15px;
+		font-size: 36px;
+	}
+
+	.cover-statistics {
+		margin: 10px auto;
+		border-collapse: collapse;
+		text-align: left;
+	}
+	.cover-statistics td {
+		padding: 4px 8px;
+		font-size: 16px;
+	}
 </style>

--- a/legal-api/src/legal_api/reports/report_v2.py
+++ b/legal-api/src/legal_api/reports/report_v2.py
@@ -198,7 +198,7 @@ class ReportV2:
     def _get_report_files(self, data):
         """Get gotenberg report generation source file data."""
         if self._document_key == ReportTypes.DISSOLUTION_COVER:
-            return { 'index.html': self._get_html_from_data(data) }
+            return {'index.html': self._get_html_from_data(data)}
         title = self._report_data['title']
         files = copy.deepcopy(REPORT_FILES)
         files['index.html'] = self._get_html_from_data(data)

--- a/legal-api/src/legal_api/resources/v2/business/business_furnishings/furnishing_documents.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_furnishings/furnishing_documents.py
@@ -48,7 +48,7 @@ def get_furnishing_document(identifier: str, furnishing_id: int):
         ), HTTPStatus.NOT_FOUND
     if not (furnishing := Furnishing.find_by_id(furnishing_id)) or\
         furnishing.business_id != business.id or\
-        furnishing.furnishing_type == Furnishing.FurnishingType.GAZETTE:
+            furnishing.furnishing_type == Furnishing.FurnishingType.GAZETTE:
         return jsonify(
             message=get_error_message(ErrorCode.FURNISHING_NOT_FOUND,
                                       **{'furnishing_id': furnishing_id, 'identifier': identifier})

--- a/legal-api/src/legal_api/services/__init__.py
+++ b/legal-api/src/legal_api/services/__init__.py
@@ -20,20 +20,12 @@ from sentry_sdk import capture_message
 from legal_api.models import Business
 from legal_api.utils.datetime import datetime
 
-from .authz import (  # noqa: I001;
-    ACCOUNT_IDENTITY,
-    BASIC_USER,
-    COLIN_SVC_ROLE,
-    STAFF_ROLE,
-    SYSTEM_ROLE,
-    authorized,
-    has_roles,
-)  # noqa: I001;
 from .bootstrap import AccountService, RegistrationBootstrapService
 from .business_details_version import VersionedBusinessDetailsService
 from .digital_credentials import DigitalCredentialsService
 from .document_meta import DocumentMetaService
 from .flags import Flags
+from .furnishing_documents_service import FurnishingDocumentsService
 from .involuntary_dissolution import InvoluntaryDissolutionService
 from .minio import MinioService
 from .mras_service import MrasService
@@ -43,6 +35,17 @@ from .pdf_service import PdfService
 from .queue import QueueService
 from .warnings.business import check_business
 from .warnings.warning import check_warnings
+
+
+from .authz import (  # noqa: I001; noqa: I001;
+    ACCOUNT_IDENTITY,
+    BASIC_USER,
+    COLIN_SVC_ROLE,
+    STAFF_ROLE,
+    SYSTEM_ROLE,
+    authorized,
+    has_roles,
+)
 
 
 flags = Flags()  # pylint: disable=invalid-name; shared variables are lower case by Flask convention.

--- a/legal-api/src/legal_api/services/furnishing_documents_service.py
+++ b/legal-api/src/legal_api/services/furnishing_documents_service.py
@@ -1,0 +1,98 @@
+# Copyright © 2024 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This provides the service for furnishing documents."""
+import io
+from typing import Final
+
+import PyPDF2
+from flask import current_app
+
+from legal_api.models import Furnishing, db
+from legal_api.reports.report_v2 import ReportTypes, ReportV2
+
+
+COVER_REPORT_DATE_FORMAT: Final = '%B %d, %Y %I:%M:%S %p'
+
+
+class FurnishingDocumentsService():
+    """Provides services to get document(s) for furnishing entry."""
+
+    def __init__(self, document_key=None, variant=None):
+        """Create FurnishingDocumentsService instance."""
+        self._report = ReportV2(business=None, furnishing=None, document_key=document_key, variant=variant)
+
+    def get_furnishing_document(self, furnishing: Furnishing) -> bytes:
+        """Return a single furnishing document."""
+        self._report.set_report_data(business=furnishing.business, furnishing=furnishing)
+        return self._report.get_pdf()
+
+    def get_merged_furnishing_document(self, furnishings: list) -> bytes:
+        """Return a merged batch furnishing document with cover."""
+        pdfs = self._get_batch_furnishing_documents(furnishings)
+        cover = self._get_batch_cover(pdfs)
+        files = {
+            'cover': cover,
+            'contents': pdfs
+        }
+        return self._merge_documents(files)
+
+    def _get_batch_furnishing_documents(self, furnishings: list) -> list:
+        pdfs = []
+        for f in furnishings:
+            self._report.set_report_data(business=f.business, furnishing=f)
+            pdf = self._report.get_pdf()
+            if not pdf:
+                current_app.logger.error(
+                    f'Error generating PDF for furnishing {f.id}, business {f.business.id}, skip.'
+                )
+                continue
+            pdfs.append(pdf)
+        return pdfs
+
+    def _get_batch_cover(self, files: list) -> bytes:
+        self._report._document_key = ReportTypes.DISSOLUTION_COVER  # pylint: disable=protected-access
+        self._report._report_data = {  # pylint: disable=protected-access
+            'letterCount': len(files),
+            'reportDate': self._report._report_date_time.strftime(  # pylint: disable=protected-access
+                COVER_REPORT_DATE_FORMAT
+            ),
+            'customBatchId': self._get_batch_custom_identifier(),
+            'pageCount': len(files) * 2 + 1,
+            'environment': current_app.config.get('ENV')
+        }
+        cover = self._report.get_pdf()
+        if not cover:
+            current_app.logger.error('Error generating cover PDF.')
+        return cover
+
+    @staticmethod
+    def _merge_documents(files: dict) -> bytes:
+        try:
+            merger = PyPDF2.PdfFileMerger()
+            if files['cover']:
+                merger.append(io.BytesIO(files['cover']))
+            contents = files['contents']
+            for _, pdf in enumerate(contents):
+                merger.append(io.BytesIO(pdf))
+            writer_buffer = io.BytesIO()
+            merger.write(writer_buffer)
+            merger.close()
+            return writer_buffer.getvalue()
+        except Exception as e:
+            current_app.logger.error(f'Error merging PDF:{e}')
+            return None
+
+    @staticmethod
+    def _get_batch_custom_identifier() -> int:
+        return db.session.execute("SELECT nextval('batch_custom_identifier')").scalar()

--- a/legal-api/src/legal_api/services/furnishing_documents_service.py
+++ b/legal-api/src/legal_api/services/furnishing_documents_service.py
@@ -48,6 +48,7 @@ class FurnishingDocumentsService():
         return self._merge_documents(files)
 
     def _get_batch_furnishing_documents(self, furnishings: list) -> list:
+        self._report._document_key = ReportTypes.DISSOLUTION  # pylint: disable=protected-access
         pdfs = []
         for f in furnishings:
             self._report.set_report_data(business=f.business, furnishing=f)

--- a/legal-api/tests/unit/models/__init__.py
+++ b/legal-api/tests/unit/models/__init__.py
@@ -20,13 +20,11 @@ from datedelta import datedelta
 from freezegun import freeze_time
 from registry_schemas.example_data import ANNUAL_REPORT
 from sqlalchemy_continuum import versioning_manager
-from legal_api.exceptions.error_messages import ErrorCode
 
+from legal_api.exceptions.error_messages import ErrorCode
 from legal_api.models import (
     Address,
     Alias,
-    amalgamation,
-    amalgamating_business,
     Batch,
     BatchProcessing,
     Business,
@@ -40,6 +38,8 @@ from legal_api.models import (
     ShareClass,
     ShareSeries,
     User,
+    amalgamating_business,
+    amalgamation,
     db,
 )
 from legal_api.models.colin_event_id import ColinEventId
@@ -459,9 +459,9 @@ def factory_furnishing(business_id,
     return furnishing
 
 
-def factory_business_with_stage_one_furnishing(legal_type=None, furnishing_name=Furnishing.FurnishingName.DISSOLUTION_COMMENCEMENT_NO_AR):
+def factory_business_with_stage_one_furnishing(identifier='BC1234567', legal_type=None, furnishing_name=Furnishing.FurnishingName.DISSOLUTION_COMMENCEMENT_NO_AR):
     """Create a business with a stage one furnishing entry."""
-    business = factory_business(identifier='BC1234567', entity_type=legal_type)
+    business = factory_business(identifier=identifier, entity_type=legal_type)
     factory_business_mailing_address(business)
     batch = factory_batch()
     furnishing = factory_furnishing(business_id=business.id,

--- a/legal-api/tests/unit/resources/v2/test_business_furnishings/test_furnishing_documents.py
+++ b/legal-api/tests/unit/resources/v2/test_business_furnishings/test_furnishing_documents.py
@@ -31,7 +31,7 @@ def test_get_furnishing_document(session, client, jwt):
     """Assert that the endpoint is worked as expected."""
 
     business, furnishing = factory_business_with_stage_one_furnishing()
-    with patch.object(ReportV2, 'get_pdf', return_value=('', HTTPStatus.OK)):
+    with patch.object(ReportV2, 'get_pdf', return_value=b'TEST'):
         rv = client.get(f'/api/v2/businesses/{business.identifier}/furnishings/{furnishing.id}/document',
                         headers=create_header(jwt, [UserRoles.system, ], business.identifier, **{'accept': 'application/pdf'}))
         
@@ -87,7 +87,7 @@ def test_get_furnishing_document_missing_furnishing(session, client, jwt):
 )
 def test_get_furnishing_document_variant(session, client, jwt, test_name, variant, valid):
     business, furnishing = factory_business_with_stage_one_furnishing()
-    with patch.object(ReportV2, 'get_pdf', return_value=('', HTTPStatus.OK)):
+    with patch.object(ReportV2, 'get_pdf', return_value=b'TEST'):
         rv = client.get(f'/api/v2/businesses/{business.identifier}/furnishings/{furnishing.id}/document?variant={variant}',
                         headers=create_header(jwt, [UserRoles.system, ], business.identifier, **{'accept': 'application/pdf'}))
         

--- a/legal-api/tests/unit/services/test_furnishing_documents_service.py
+++ b/legal-api/tests/unit/services/test_furnishing_documents_service.py
@@ -1,0 +1,62 @@
+# Copyright © 2024 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests to assure the Furnishing Documents Service.
+
+Test-Suite to ensure that the Furnishing Documents Service is working as expected.
+"""
+from http import HTTPStatus
+from legal_api.models import Business
+from tests.unit.models import factory_business_with_stage_one_furnishing
+from unittest.mock import patch, MagicMock
+from legal_api.services import MrasService, FurnishingDocumentsService
+from legal_api.reports.report_v2 import ReportTypes
+import requests
+
+PDF_CONTENT = b'TEST'
+
+mock_response = MagicMock()
+mock_response.status_code = HTTPStatus.OK
+mock_response.content =  PDF_CONTENT
+
+
+def test_get_furnishing_document(session, app):
+    """Assert that a single furnishing document is returned."""
+    business, furnishing = factory_business_with_stage_one_furnishing(
+        legal_type=Business.LegalTypes.COMP.value
+    )
+    with patch.object(requests, 'post', return_value=mock_response):
+        with patch.object(MrasService, 'get_jurisdictions', return_value=[]):
+            service = FurnishingDocumentsService(ReportTypes.DISSOLUTION, 'default')
+            pdf = service.get_furnishing_document(furnishing)
+            assert pdf == PDF_CONTENT
+
+
+def test_get_merged_furnishing_document(session, app):
+    """Assert that a merged furnishing document with cover is returned."""
+    _, furnishing1 = factory_business_with_stage_one_furnishing(
+        identifier='BC1234567',
+        legal_type=Business.LegalTypes.COMP.value
+    )
+    _, furnishing2 = factory_business_with_stage_one_furnishing(
+        identifier='BC7654321',
+        legal_type=Business.LegalTypes.COMP.value
+    )
+    furnishings = [furnishing1, furnishing2]
+    with patch.object(requests, 'post', return_value=mock_response):
+        with patch.object(MrasService, 'get_jurisdictions', return_value=[]):
+            with patch.object(FurnishingDocumentsService, '_merge_documents', return_value=PDF_CONTENT) as mock_merge:
+                service = FurnishingDocumentsService(ReportTypes.DISSOLUTION, 'default')
+                pdf = service.get_merged_furnishing_document(furnishings)
+                assert pdf == PDF_CONTENT
+                assert mock_merge.assert_called()

--- a/legal-api/tests/unit/services/test_furnishing_documents_service.py
+++ b/legal-api/tests/unit/services/test_furnishing_documents_service.py
@@ -59,4 +59,4 @@ def test_get_merged_furnishing_document(session, app):
                 service = FurnishingDocumentsService(ReportTypes.DISSOLUTION, 'default')
                 pdf = service.get_merged_furnishing_document(furnishings)
                 assert pdf == PDF_CONTENT
-                assert mock_merge.assert_called()
+                mock_merge.assert_called()


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22502

*Description of changes:*

Note that this is the second PR of batch letter work. All the changes in this PR are only for legal-api. More changes in furnishings job will be in the following PR.
- create a service class for furnishing documents generation
- modify the `GET {{legal-api-base-url}}/businesses/:identifier/furnishings/:furnishing_id/document` endpoint to use service class
- add dissolution cover letter template
- modify `ReportV2` to support cover letter generation
- fix the bug in  bcgov/entity#22530
- add and update unit tests

*Local Testing*
- cover letter (with dummy data)
![Pasted image 20240829131319](https://github.com/user-attachments/assets/e7f87de7-7b9b-4946-ac88-9778e89e9305)
- merged batch letter with cover
![Pasted image 20240829131739](https://github.com/user-attachments/assets/180e88cd-8a42-48fe-a6b1-488e647d96f0)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
