### PR TITLE
22207 - update dissolution job to check furnishing data

### DIFF
--- a/jobs/involuntary-dissolutions/tests/unit/test_involuntary_dissolutions.py
+++ b/jobs/involuntary-dissolutions/tests/unit/test_involuntary_dissolutions.py
@@ -21,7 +21,7 @@ import pytest
 import pytz
 from datedelta import datedelta
 from legal_api.core.filing import Filing as CoreFiling
-from legal_api.models import Batch, BatchProcessing, Configuration, Filing
+from legal_api.models import Batch, BatchProcessing, Configuration, Filing, Furnishing
 from legal_api.services.filings.validations.dissolution import DissolutionTypes
 
 from involuntary_dissolutions import (
@@ -231,6 +231,15 @@ def test_stage_2_process_find_entry(app, session, test_name, batch_status, statu
         trigger_date=created_date+datedelta(days=42),
         last_modified=last_modified
     )
+    furnishing = Furnishing(
+        furnishing_type = Furnishing.FurnishingType.EMAIL,
+        furnishing_name = Furnishing.FurnishingName.DISSOLUTION_COMMENCEMENT_NO_AR,
+        batch_id = batch.id,
+        business_id = business.id,
+        business_identifier = business.identifier,
+        status = Furnishing.FurnishingStatus.PROCESSED,
+    )
+    furnishing.save()
 
     stage_2_process(app)
 
@@ -265,6 +274,15 @@ def test_stage_2_process_update_business(app, session, test_name, status, step):
         created_date=CREATED_DATE,
         trigger_date=TRIGGER_DATE
     )
+    furnishing = Furnishing(
+        furnishing_type = Furnishing.FurnishingType.EMAIL,
+        furnishing_name = Furnishing.FurnishingName.DISSOLUTION_COMMENCEMENT_NO_AR,
+        batch_id = batch.id,
+        business_id = business.id,
+        business_identifier = business.identifier,
+        status = Furnishing.FurnishingStatus.PROCESSED,
+    )
+    furnishing.save()
 
     if test_name == 'MOVE_BACK_2_GOOD_STANDING':
         business.last_ar_date = datetime.utcnow()

--- a/jobs/involuntary-dissolutions/tests/unit/test_involuntary_dissolutions.py
+++ b/jobs/involuntary-dissolutions/tests/unit/test_involuntary_dissolutions.py
@@ -327,7 +327,7 @@ async def test_stage_3_process(app, session, test_name, status, step):
     )
     furnishing = Furnishing(
         furnishing_type = Furnishing.FurnishingType.GAZETTE,
-        furnishing_name = Furnishing.FurnishingName.DISSOLUTION_COMMENCEMENT_NO_AR,
+        furnishing_name = Furnishing.FurnishingName.INTENT_TO_DISSOLVE,
         batch_id = batch.id,
         business_id = business.id,
         business_identifier = business.identifier,

--- a/jobs/involuntary-dissolutions/tests/unit/test_involuntary_dissolutions.py
+++ b/jobs/involuntary-dissolutions/tests/unit/test_involuntary_dissolutions.py
@@ -325,6 +325,15 @@ async def test_stage_3_process(app, session, test_name, status, step):
         created_date=CREATED_DATE,
         trigger_date=TRIGGER_DATE
     )
+    furnishing = Furnishing(
+        furnishing_type = Furnishing.FurnishingType.GAZETTE,
+        furnishing_name = Furnishing.FurnishingName.DISSOLUTION_COMMENCEMENT_NO_AR,
+        batch_id = batch.id,
+        business_id = business.id,
+        business_identifier = business.identifier,
+        status = Furnishing.FurnishingStatus.PROCESSED,
+    )
+    furnishing.save()
 
     if test_name == 'MOVE_BACK_TO_GOOD_STANDING':
         business.last_ar_date = datetime.utcnow()


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22207

*Description of changes:*
Updated the dissolution job to check furnishing data as required. Won't move to next step if furnishing entry hasn't completed.

How I tested:

### Scenario 1: Updated stage 2 logic to check if email or letter furnishing entry has been completed. If not, do not transition to stage 2 and update the batch_processing record

Here, we have a business in first stage + a status of processing
![processing entry](https://github.com/user-attachments/assets/5fa897e9-45b6-4c7f-8079-522f1fea42da)


Run furnishings job, get the email furnishing entry, set the status as QUEUED:
![furnishijng entry](https://github.com/user-attachments/assets/bf24212a-38ef-4133-97f4-83298e69ee4b)


Now, since the status is QUEUED not PROCESSED, if we run the dissolutions job again, this'll set the status to ERROR as we're checking now if the furnishing entry has completed.
![error batch processing](https://github.com/user-attachments/assets/4f3e766b-31d1-4c16-9eab-0b19dd743833)

Logger:
![logger](https://github.com/user-attachments/assets/78b962cf-1529-46d3-bb44-3f33b594b374)


### Scenario 2: Updated stage 3 logic to check if gazette entry has been completed. If not, do not transition to stage 3 and update the batch_processing record

Here, we have a business in second stage + a status of processing
![warning level 2](https://github.com/user-attachments/assets/f746b2f7-cccb-4aac-b57e-1904c018e654)

Run furnishings job, get the gazette furnishing entry, set the status as QUEUED:
![gazette queued](https://github.com/user-attachments/assets/b1db5585-d1a6-46ab-b515-0d55ad0abb59)

Now, since the status is QUEUED not PROCESSED, if we run the dissolutions job again, this'll set the status to ERROR as we're checking now if the furnishing gazette entry has completed.
![warning level 2 error](https://github.com/user-attachments/assets/ed122293-7322-4c15-a06e-2cd85eaa7d9c)

Logger:
![stage 3 dissolution job logging](https://github.com/user-attachments/assets/0bc28675-b90d-4203-a19e-7e7ae2ec64b7)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
