### PR TITLE
feat: add endpoint for Business AR to call to automatically update Co…

### DIFF
--- a/colin-api/src/colin_api/resources/filing.py
+++ b/colin-api/src/colin_api/resources/filing.py
@@ -237,14 +237,13 @@ class FilingInfo(Resource):
 @API.route('/<string:legal_type>/<string:identifier>/filings/reminder')
 # pylint: disable=too-few-public-methods
 class UpdateARStatus(Resource):
-    """Updates the corporation and set_ar_to_no tables after a AR Reminder email is sent"""
+    """Update the corporation and set_ar_to_no tables after a AR Reminder email is sent."""
 
     @staticmethod
     @cors.crossdomain(origin='*')
     @jwt.requires_roles([COLIN_SVC_ROLE])
     def post(identifier, **kwargs):
-        """Called by Business AR Reminder Batch job for each corporation after an email AR reminder is sent"""
-
+        """Trigger cleaning up data in Colin for the corporation after a Business AR Reminder email is sent."""
         # pylint: disable=unused-argument
         try:
             with DB.connection as con:
@@ -261,11 +260,17 @@ class UpdateARStatus(Resource):
                     # Return an error if corporation is not found or if the flag is already set to 'N'
                     if not result:
                         current_app.logger.warning(f'Corporation with identifier {identifier} not found.')
-                        return jsonify({'message': f'Corporation with identifier {identifier} not found.'}), HTTPStatus.NOT_FOUND
+                        return jsonify(
+                            {'message': f'Corporation with identifier {identifier} not found.'}
+                        ), HTTPStatus.NOT_FOUND
                     set_ar_ind_flag = result[0].strip()
                     if set_ar_ind_flag != 'Y':
-                        current_app.logger.warning(f'send_ar_ind for corporation {identifier} is not Y. Current value: {set_ar_ind_flag}')
-                        return jsonify({'message': f'send_ar_ind for corporation {identifier} must be Y, but it is {set_ar_ind_flag}.'}), HTTPStatus.BAD_REQUEST
+                        current_app.logger.warning(
+                            f'send_ar_ind for corporation {identifier} is not Y. Current value: {set_ar_ind_flag}'
+                        )
+                        return jsonify(
+                            {'message': f'send_ar_ind for corporation {identifier} must be Y.'}
+                        ), HTTPStatus.BAD_REQUEST
 
                     # Update the send_ar_ind flag to 'N' in the corporation table
                     update_corporation_query = """


### PR DESCRIPTION
**Ticket**: https://app.zenhub.com/workspaces/annual-report-filing-for-corporations-661483a4f4f833001637ec44/issues/gh/bcgov/business-ar/314

*Description of changes:*
Added an endpoint to the `colin-api` for Business AR to call. 
- Endpoint is called after Business AR batch job sends an email to an incorporation
- Endpoint returns an error and does nothing if corporation does not exist or if the `set_ar_ind` flag is already set to 'N'
- Else, updates this flag in the `corporation` table to `N` and inserts a record for the corporation into the `set_ar_to_no` table


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
