### PR TITLE
fix: corrected get last ar filed date method

### DIFF
--- a/colin-api/src/colin_api/models/filing.py
+++ b/colin-api/src/colin_api/models/filing.py
@@ -1297,10 +1297,17 @@ class Filing:  # pylint: disable=too-many-instance-attributes;
     @classmethod
     def _get_last_ar_filed_date(cls, header: dict, business: dict):
         filing_year = header.get('filingYear')
-        pacific_founding_date = convert_to_pacific_time(
-            datetime.datetime.fromisoformat(business['business']['foundingDate'])
+        founding_date_str = business.get('business').get('foundingDate')
+
+        # If the founding date has `-00:00`, replace it with `+00:00` before passing to the function
+        if '-00:00' in founding_date_str:
+            founding_date_str = founding_date_str.replace('-00:00', '+00:00')
+
+        pacific_founding_date = datetime.datetime.fromisoformat(
+            convert_to_pacific_time(founding_date_str)
         ).date()
-        last_ar_filed_dt = f'{filing_year}-{pacific_founding_date.month}-{pacific_founding_date.day}'
+
+        last_ar_filed_dt = f'{filing_year}-{pacific_founding_date.month:02}-{pacific_founding_date.day:02}'
         return last_ar_filed_dt
 
     @classmethod

--- a/colin-api/src/colin_api/models/filing.py
+++ b/colin-api/src/colin_api/models/filing.py
@@ -18,7 +18,6 @@ Currently this only provides API versioning information
 from __future__ import annotations
 
 import datetime
-import pytz
 from enum import Enum
 from http import HTTPStatus
 from typing import Dict, List, Optional
@@ -46,7 +45,7 @@ from colin_api.models import (  # noqa: I001
     ShareObject,  # noqa: I001
 )  # noqa: I001
 from colin_api.resources.db import DB
-from colin_api.utils import convert_to_json_date, convert_to_json_datetime, convert_to_snake
+from colin_api.utils import convert_to_json_date, convert_to_json_datetime, convert_to_snake, convert_to_pacific_time
 
 
 # Code smells:
@@ -1298,12 +1297,9 @@ class Filing:  # pylint: disable=too-many-instance-attributes;
     @classmethod
     def _get_last_ar_filed_date(cls, header: dict, business: dict):
         filing_year = header.get('filingYear')
-        pacific_founding_date = (
+        pacific_founding_date = convert_to_pacific_time(
             datetime.datetime.fromisoformat(business['business']['foundingDate'])
-            .astimezone(pytz.timezone('America/Los_Angeles'))
-            .date()
-        )
-
+        ).date()
         last_ar_filed_dt = f'{filing_year}-{pacific_founding_date.month}-{pacific_founding_date.day}'
         return last_ar_filed_dt
 

--- a/colin-api/src/colin_api/models/filing.py
+++ b/colin-api/src/colin_api/models/filing.py
@@ -45,7 +45,7 @@ from colin_api.models import (  # noqa: I001
     ShareObject,  # noqa: I001
 )  # noqa: I001
 from colin_api.resources.db import DB
-from colin_api.utils import convert_to_json_date, convert_to_json_datetime, convert_to_snake, convert_to_pacific_time
+from colin_api.utils import convert_to_json_date, convert_to_json_datetime, convert_to_pacific_time, convert_to_snake
 
 
 # Code smells:

--- a/colin-api/src/colin_api/models/filing.py
+++ b/colin-api/src/colin_api/models/filing.py
@@ -18,6 +18,7 @@ Currently this only provides API versioning information
 from __future__ import annotations
 
 import datetime
+import pytz
 from enum import Enum
 from http import HTTPStatus
 from typing import Dict, List, Optional
@@ -1297,8 +1298,13 @@ class Filing:  # pylint: disable=too-many-instance-attributes;
     @classmethod
     def _get_last_ar_filed_date(cls, header: dict, business: dict):
         filing_year = header.get('filingYear')
-        recognition_dt = datetime.datetime.fromisoformat(business.get('business').get('foundingDate')).date()
-        last_ar_filed_dt = f'{filing_year}-{recognition_dt.month}-{recognition_dt.day}'
+        pacific_founding_date = (
+            datetime.datetime.fromisoformat(business['business']['foundingDate'])
+            .astimezone(pytz.timezone('America/Los_Angeles'))
+            .date()
+        )
+
+        last_ar_filed_dt = f'{filing_year}-{pacific_founding_date.month}-{pacific_founding_date.day}'
         return last_ar_filed_dt
 
     @classmethod


### PR DESCRIPTION
*Issue #:* https://app.zenhub.com/workspaces/names-team-board-new-655554cbddd49510027dad2e/issues/gh/bcgov/business-ar/318

*Description of changes:*
When a Business AR filing is received from the new system, the corporation is looked up using `find_by_identifier`, which creates a founding_date based on the `recognition_date` (converted from Pacific Time to UTC).
https://github.com/bcgov/lear/blob/main/colin-api/src/colin_api/models/business.py#L327

When `_get_last_ar_filed_date` is called, it uses this founding_date by extracting the month and day. The issue was that the founding_date was not being converted back to Pacific Time. As a result, filings for businesses with a `recognition_date` after 5 PM local time were always showing a `last_ar_filed_date` one day ahead.

This PR fixes this by converting the `founding_date` back to pacific time before creating the `last_ar_filed_date`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
