### PR TITLE
Legal API Linting Fix

### DIFF
--- a/legal-api/Makefile
+++ b/legal-api/Makefile
@@ -64,7 +64,15 @@ install-dev: ## Install local application
 ci: lint flake8 test ## CI flow
 
 pylint: ## Linting with pylint
-	. venv/bin/activate && pylint --rcfile=setup.cfg  --load-plugins=pylint_flask src/$(PROJECT_NAME)
+	@. venv/bin/activate; \
+	PYLINT_VERSION=$$(pylint --version 2>&1 | grep -oP 'pylint \K(\d+\.\d+)'); \
+	if [ "$$PYLINT_VERSION" \> "3.3" ] || [ "$$PYLINT_VERSION" = "3.3" ]; then \
+		echo ". venv/bin/activate && pylint --rcfile=setup.cfg --load-plugins=pylint_flask --disable=too-many-positional-arguments src/$(PROJECT_NAME)";\
+		pylint --rcfile=setup.cfg --load-plugins=pylint_flask --disable=too-many-positional-arguments src/$(PROJECT_NAME); \
+	else \
+		echo ". venv/bin/activate && pylint --rcfile=setup.cfg --load-plugins=pylint_flask src/$(PROJECT_NAME)";\
+		pylint --rcfile=setup.cfg --load-plugins=pylint_flask src/$(PROJECT_NAME); \
+	fi
 
 flake8: ## Linting with flake8
 	. venv/bin/activate && flake8 src/$(PROJECT_NAME)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#23354

*Description of changes:*

This issue is mentioned in #3010. Trying to provide a temporary solution for it since `too-many-positional-arguments` is only available after version 3.3.0 and directly disabling it globally or locally will make pylint 3.2.x throw errors.

- make legal-api linting work for both pylint 3.2.x and pylint 3.3.x

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
