### PR TITLE
23349 - validation notice of withdrawal

### DIFF
--- a/legal-api/requirements.txt
+++ b/legal-api/requirements.txt
@@ -59,4 +59,4 @@ PyPDF2==1.26.0
 reportlab==3.6.12
 html-sanitizer==2.4.1
 lxml==5.2.2
-git+https://github.com/bcgov/business-schemas.git@2.18.28#egg=registry_schemas
+git+https://github.com/bcgov/business-schemas.git@2.18.30#egg=registry_schemas

--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
@@ -449,8 +449,9 @@ class ListFilingResource():  # pylint: disable=too-many-public-methods
         filing_type = json_input.get('filing', {}).get('header', {}).get('name')
         if not filing_type:
             return ({'message': 'filing/header/name is a required property'}, HTTPStatus.BAD_REQUEST)
-        
-        if filing_type not in CoreFiling.NEW_BUSINESS_FILING_TYPES and business is None and filing_type is not CoreFiling.FilingTypes.NOTICEOFWITHDRAWAL:
+
+        if filing_type not in CoreFiling.NEW_BUSINESS_FILING_TYPES and business is None \
+                and filing_type is not CoreFiling.FilingTypes.NOTICEOFWITHDRAWAL:
             return ({'message': 'A valid business is required.'}, HTTPStatus.BAD_REQUEST)
 
         return None, None

--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
@@ -450,8 +450,7 @@ class ListFilingResource():  # pylint: disable=too-many-public-methods
         if not filing_type:
             return ({'message': 'filing/header/name is a required property'}, HTTPStatus.BAD_REQUEST)
 
-        if filing_type not in CoreFiling.NEW_BUSINESS_FILING_TYPES and business is None \
-                and filing_type is not CoreFiling.FilingTypes.NOTICEOFWITHDRAWAL:
+        if filing_type not in CoreFiling.NEW_BUSINESS_FILING_TYPES and business is None:
             return ({'message': 'A valid business is required.'}, HTTPStatus.BAD_REQUEST)
 
         return None, None

--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
@@ -449,8 +449,8 @@ class ListFilingResource():  # pylint: disable=too-many-public-methods
         filing_type = json_input.get('filing', {}).get('header', {}).get('name')
         if not filing_type:
             return ({'message': 'filing/header/name is a required property'}, HTTPStatus.BAD_REQUEST)
-
-        if filing_type not in CoreFiling.NEW_BUSINESS_FILING_TYPES and business is None:
+        
+        if filing_type not in CoreFiling.NEW_BUSINESS_FILING_TYPES and business is None and filing_type is not CoreFiling.FilingTypes.NOTICEOFWITHDRAWAL:
             return ({'message': 'A valid business is required.'}, HTTPStatus.BAD_REQUEST)
 
         return None, None

--- a/legal-api/src/legal_api/services/filings/validations/notice_of_withdrawal.py
+++ b/legal-api/src/legal_api/services/filings/validations/notice_of_withdrawal.py
@@ -13,11 +13,15 @@
 # limitations under the License.
 """Validation for the Notice of Withdrawal filing."""
 from http import HTTPStatus
-from typing import Dict, Optional
+from typing import Dict, Optional, Final
 
 from flask_babel import _ as babel  # noqa: N813, I004, I001; importing camelcase '_' as a name
 # noqa: I003
 from legal_api.errors import Error
+from legal_api.services.utils import get_int
+
+from legal_api.models.db import db # noqa: I001
+from legal_api.models import Filing
 
 
 
@@ -27,3 +31,7 @@ def validate(filing: Dict) -> Optional[Error]:
         return Error(HTTPStatus.BAD_REQUEST, [{'error': babel('A valid filing is required.')}])
     
     msg = []
+
+    filing_id_path: Final = '/filing/noticeOfWithdrawal/filingId'
+    filing_id = get_int(filing, filing_id_path)
+

--- a/legal-api/src/legal_api/services/filings/validations/notice_of_withdrawal.py
+++ b/legal-api/src/legal_api/services/filings/validations/notice_of_withdrawal.py
@@ -1,0 +1,29 @@
+# Copyright © 2024 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validation for the Notice of Withdrawal filing."""
+from http import HTTPStatus
+from typing import Dict, Optional
+
+from flask_babel import _ as babel  # noqa: N813, I004, I001; importing camelcase '_' as a name
+# noqa: I003
+from legal_api.errors import Error
+
+
+
+def validate(filing: Dict) -> Optional[Error]:
+    """Validate the Notice of Withdrawal filing."""
+    if not filing:
+        return Error(HTTPStatus.BAD_REQUEST, [{'error': babel('A valid filing is required.')}])
+    
+    msg = []

--- a/legal-api/src/legal_api/services/filings/validations/notice_of_withdrawal.py
+++ b/legal-api/src/legal_api/services/filings/validations/notice_of_withdrawal.py
@@ -13,64 +13,60 @@
 # limitations under the License.
 """Validation for the Notice of Withdrawal filing."""
 from http import HTTPStatus
-from typing import Dict, Optional, Final
+from typing import Dict, Final, Optional
 
-from flask_babel import _ as babel  # noqa: N813, I004, I001; importing camelcase '_' as a name
-# noqa: I003
+from flask_babel import _ as babel  # noqa: N813, I004, I001, I003;
+
 from legal_api.errors import Error
-from legal_api.services.utils import get_int
-
-from legal_api.models.db import db # noqa: I001
 from legal_api.models import Filing
+from legal_api.models.db import db  # noqa: I001
+from legal_api.services.utils import get_int
 from legal_api.utils.datetime import datetime as dt
-
 
 
 def validate(filing: Dict) -> Optional[Error]:
     """Validate the Notice of Withdrawal filing."""
     if not filing:
         return Error(HTTPStatus.BAD_REQUEST, [{'error': babel('A valid filing is required.')}])
-    
+
     msg = []
 
     withdrawn_filing_id_path: Final = '/filing/noticeOfWithdrawal/filingId'
     withdrawn_filing_id = get_int(filing, withdrawn_filing_id_path)
     if not withdrawn_filing_id:
         msg.append({'error': babel('Filing Id is required.'), 'path': withdrawn_filing_id_path})
-        return msg # cannot continue validation without the to be withdrawn filing id
-    
+        return msg  # cannot continue validation without the to be withdrawn filing id
+
     err = validate_withdrawn_filing(withdrawn_filing_id)
     if err:
         msg.extend(err)
-    
+
     if msg:
         return Error(HTTPStatus.BAD_REQUEST, msg)
     return None
-    
 
 
 def validate_withdrawn_filing(withdrawn_filing_id: int):
-    """Validate the to be withdrawn filing id exists, the filing has a FED, the filing status is PAID """
+    """Validate the to be withdrawn filing id exists, the filing has a FED, the filing status is PAID."""
     msg = []
-    
     # check whether the filing ID exists
     withdrawn_filing = db.session.query(Filing). \
-                        filter(Filing.id == withdrawn_filing_id).one_or_none()
+        filter(Filing.id == withdrawn_filing_id).one_or_none()
     if not withdrawn_filing:
-        msg.append({'error':  babel('The filing to be withdrawn cannot be found.')})
-        return msg # cannot continue if the withdrawn filing doesn't exist
-    
+        msg.append({'error': babel('The filing to be withdrawn cannot be found.')})
+        return msg  # cannot continue if the withdrawn filing doesn't exist
+
     # check whether the filing has a Future Effective Date(FED)
     now = dt.utcnow()
     filing_effective_date = dt.fromisoformat(str(withdrawn_filing.effective_date))
     if filing_effective_date < now:
-        msg.append({'error': babel(f'Only filings with a future effective date can be withdrawn.')})
+        msg.append({'error': babel('Only filings with a future effective date can be withdrawn.')})
 
     # check the filing status
     filing_status = withdrawn_filing.status
     if filing_status != Filing.Status.PAID.value:
-        msg.append({'error': babel(f'Only paid filings with a future effective date can be withdrawn.')})
-    
+        msg.append({'error': babel('Only paid filings with a future effective date can be withdrawn.')})
+
     if msg:
         return msg
     return None

--- a/legal-api/src/legal_api/services/filings/validations/notice_of_withdrawal.py
+++ b/legal-api/src/legal_api/services/filings/validations/notice_of_withdrawal.py
@@ -54,7 +54,7 @@ def validate_withdrawn_filing(withdrawn_filing_id: int):
     msg = []
     
     # check whether the filing ID exists
-    withdrawn_filing:Filing = db.session.query(Filing). \
+    withdrawn_filing = db.session.query(Filing). \
                         filter(Filing.id == withdrawn_filing_id).one_or_none()
     if not withdrawn_filing:
         msg.append({'error':  babel('The filing to be withdrawn cannot be found.')})
@@ -62,13 +62,15 @@ def validate_withdrawn_filing(withdrawn_filing_id: int):
     
     # check whether the filing has a Future Effective Date(FED)
     now = dt.utcnow()
-    filing_effective_date = dt.fromisoformat(withdrawn_filing.effective_date)
+    filing_effective_date = dt.fromisoformat(str(withdrawn_filing.effective_date))
     if filing_effective_date < now:
-        msg.append({'error': babel('Only filings with a future effective date can be withdrawn.')})
+        msg.append({'error': babel(f'Only filings with a future effective date can be withdrawn.')})
 
     # check the filing status
     filing_status = withdrawn_filing.status
     if filing_status != Filing.Status.PAID.value:
-        msg.append({'error': babel('Only paid filings with a future effective date can be withdrawn')})
+        msg.append({'error': babel(f'Only paid filings with a future effective date can be withdrawn.')})
     
-    return msg
+    if msg:
+        return msg
+    return None

--- a/legal-api/src/legal_api/services/filings/validations/validation.py
+++ b/legal-api/src/legal_api/services/filings/validations/validation.py
@@ -40,6 +40,7 @@ from .court_order import validate as court_order_validate
 from .dissolution import DissolutionTypes
 from .dissolution import validate as dissolution_validate
 from .incorporation_application import validate as incorporation_application_validate
+from .notice_of_withdrawal import validate as notice_of_withdrawal_validate
 from .put_back_on import validate as put_back_on_validate
 from .registrars_notation import validate as registrars_notation_validate
 from .registrars_order import validate as registrars_order_validate
@@ -181,6 +182,9 @@ def validate(business: Business,  # pylint: disable=too-many-branches,too-many-s
 
                 elif k == Filing.FILINGS['continuationIn'].get('name'):
                     err = continuation_in_validate(filing_json)
+
+                elif k == Filing.FILINGS['noticeOfWithdrawal'].get('name'):
+                    err = notice_of_withdrawal_validate(filing_json)
 
                 if err:
                     return err

--- a/legal-api/tests/unit/services/filings/validations/test_notice_of_withdrawal.py
+++ b/legal-api/tests/unit/services/filings/validations/test_notice_of_withdrawal.py
@@ -1,0 +1,26 @@
+# Copyright © 2024 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test suite to ensure the Notice of Withdrawal filing is validated correctly."""
+import copy
+from datetime import date
+from http import HTTPStatus
+
+import pytest
+
+from legal_api.models import Filing
+from legal_api.services.filings import validate
+from legal_api.services.filings.validations.notice_of_withdrawal import validate_withdrawn_filing
+
+
+# setup

--- a/legal-api/tests/unit/services/filings/validations/test_notice_of_withdrawal.py
+++ b/legal-api/tests/unit/services/filings/validations/test_notice_of_withdrawal.py
@@ -13,14 +13,143 @@
 # limitations under the License.
 """Test suite to ensure the Notice of Withdrawal filing is validated correctly."""
 import copy
-from datetime import date
+from datetime import datetime, timedelta
 from http import HTTPStatus
 
 import pytest
 
-from legal_api.models import Filing
+from legal_api.models import Filing, RegistrationBootstrap
 from legal_api.services.filings import validate
-from legal_api.services.filings.validations.notice_of_withdrawal import validate_withdrawn_filing
+from legal_api.services.filings.validations.notice_of_withdrawal import (
+    validate_withdrawn_filing,
+    validate as validate_in_notice_of_withdrawal
+)
+from tests.unit.models import factory_pending_filing, factory_business
+from . import lists_are_equal
+
+from registry_schemas.example_data import FILING_HEADER, NOTICE_OF_WITHDRAWAL, DISSOLUTION, INCORPORATION
 
 
 # setup
+FILING_NOT_EXIST_MSG = {'error': 'The filing to be withdrawn cannot be found.'}
+FILING_NOT_FED_MSG = {'error': 'Only filings with a future effective date can be withdrawn.'}
+FILING_NOT_PAID_MSG = {'error': 'Only paid filings with a future effective date can be withdrawn.'}
+MISSING_FILING_DICT_MSG = {'error': 'A valid filing is required.'}
+
+
+# tests
+
+@pytest.mark.parametrize(
+        'test_name, is_filing_exist, withdrawn_filing_status, is_future_effective, has_filing_id, expected_code, expected_msg',[
+            ('SUCCESS', True, Filing.Status.PAID, True, True, None, None),
+            ('FAIL_NOT_PAID', True, Filing.Status.PENDING, True, True, HTTPStatus.BAD_REQUEST, [FILING_NOT_PAID_MSG]),
+            ('FAIL_NOT_FED', True, Filing.Status.PAID, False, True, HTTPStatus.BAD_REQUEST, [FILING_NOT_FED_MSG]),
+            ('FAIL_FILING_NOT_EXIST', False, Filing.Status.PAID, True, True, HTTPStatus.BAD_REQUEST, [FILING_NOT_EXIST_MSG]),
+            ('FAIL_MISS_FILING_ID', True, Filing.Status.PAID, True, False, HTTPStatus.UNPROCESSABLE_ENTITY, ''),
+            ('FAIL_NOT_PAID_NOT_FED', True, Filing.Status.PENDING, False, True, HTTPStatus.BAD_REQUEST, [FILING_NOT_FED_MSG, FILING_NOT_PAID_MSG])
+        ]
+)
+def test_validate_notice_of_withdrawal_exist_business(session, test_name, is_filing_exist, withdrawn_filing_status, is_future_effective, has_filing_id, expected_code, expected_msg):
+    """Assert that notice of withdrawal flings can be validated"""
+    identifier = 'BC1234567'
+    business = factory_business(identifier)
+    # file a voluntary dissolution with a FED
+    if is_filing_exist:
+        dissolution_filing_json = copy.deepcopy(FILING_HEADER)
+        dissolution_filing_json['filing']['header']['name'] = 'dissolution'
+        dissolution_filing_json['filing']['business']['legalType'] = 'BC'
+        dissolution_filing_json['filing']['dissolution'] = copy.deepcopy(DISSOLUTION)
+        today = datetime.utcnow().date()
+        future_effective_date = today + timedelta(days=5)
+        future_effective_date = future_effective_date.isoformat()
+        dissolution_filing_json['filing']['dissolution']['dissolutionDate'] = future_effective_date
+        dissolution_filing = factory_pending_filing(business, dissolution_filing_json)
+
+        if is_future_effective:
+            dissolution_filing.effective_date = future_effective_date
+        if withdrawn_filing_status == Filing.Status.PAID:
+            dissolution_filing.payment_completion_date = datetime.utcnow().isoformat()
+        dissolution_filing.save()
+        withdrawn_filing_id = dissolution_filing.id
+    
+    # create a notice of withdrawal filing json
+    filing_json = copy.deepcopy(FILING_HEADER)
+    filing_json['filing']['header']['name'] = 'noticeOfWithdrawal'
+    filing_json['filing']['business']['legalType'] = 'BC'
+    filing_json['filing']['noticeOfWithdrawal'] = copy.deepcopy(NOTICE_OF_WITHDRAWAL)
+    if has_filing_id:
+        if is_filing_exist:
+            filing_json['filing']['noticeOfWithdrawal']['filingId'] = withdrawn_filing_id
+    else:
+        del filing_json['filing']['noticeOfWithdrawal']['filingId']
+
+    err = validate(business, filing_json)
+    if expected_code:
+        assert err.code == expected_code
+        if has_filing_id: # otherwise, won't pass schema validation, and the error msg will be very long
+            assert lists_are_equal(err.msg, expected_msg)
+    else:
+        assert err is None
+    
+
+
+@pytest.mark.parametrize(
+        'test_name, is_filing_exist, withdrawn_filing_status, is_future_effective, has_filing_id, expected_code, expected_msg',[
+            ('SUCCESS', True, Filing.Status.PAID, True, True, None, None),
+            ('FAIL_NOT_PAID', True, Filing.Status.PENDING, True, True, HTTPStatus.BAD_REQUEST, [FILING_NOT_PAID_MSG]),
+            ('FAIL_NOT_FED', True, Filing.Status.PAID, False, True, HTTPStatus.BAD_REQUEST, [FILING_NOT_FED_MSG]),
+            ('FAIL_FILING_NOT_EXIST', False, Filing.Status.PAID, True, True, HTTPStatus.BAD_REQUEST, [FILING_NOT_EXIST_MSG]),
+            ('FAIL_MISS_FILING_ID', True, Filing.Status.PAID, True, False, HTTPStatus.UNPROCESSABLE_ENTITY, ''),
+            ('FAIL_NOT_PAID_NOT_FED', True, Filing.Status.PENDING, False, True, HTTPStatus.BAD_REQUEST, [FILING_NOT_FED_MSG, FILING_NOT_PAID_MSG])
+        ]
+)
+def test_validate_notice_of_withdrawal_new_business(session, test_name, is_filing_exist, withdrawn_filing_status, is_future_effective, has_filing_id, expected_code, expected_msg):
+    identifier = 'Tb31yQIuBw'
+    temp_bus = RegistrationBootstrap()
+    temp_bus._identifier = identifier
+    temp_bus.save()
+
+    # file an IA with a FED
+    ia_json = copy.deepcopy(FILING_HEADER)
+    ia_json['filing']['header']['name'] = 'incorporationApplication'
+    del ia_json['filing']['business']
+    ia_dict = copy.deepcopy(INCORPORATION)
+    ia_dict['nameRequest']['legalType'] = 'BC'
+    ia_json['filing']['incorporationApplication'] = ia_dict
+    ia_filing = factory_pending_filing(None, ia_json)
+    ia_filing.temp_reg = identifier
+    ia_filing.save()
+
+    if is_future_effective:
+        today = datetime.utcnow().date()
+        future_effective_date = today + timedelta(days=5)
+        future_effective_date = future_effective_date.isoformat()
+        ia_filing.effective_date = future_effective_date
+    if withdrawn_filing_status == Filing.Status.PAID:
+        ia_filing.payment_completion_date = datetime.utcnow().isoformat()
+    ia_filing.save()
+    ia_filing_id = ia_filing.id
+
+    # create a notice of withdrawal filing json
+    filing_json = copy.deepcopy(FILING_HEADER)
+    filing_json['filing']['header']['name'] = 'noticeOfWithdrawal'
+    temp_business_dict =  {
+        "legalType": "BC",
+        "identifier": identifier
+    }
+    filing_json['filing']['business'] = temp_business_dict
+    filing_json['filing']['noticeOfWithdrawal'] = copy.deepcopy(NOTICE_OF_WITHDRAWAL)
+
+    if has_filing_id:
+        if is_filing_exist:
+            filing_json['filing']['noticeOfWithdrawal']['filingId'] = ia_filing_id
+    else:
+        del filing_json['filing']['noticeOfWithdrawal']['filingId']   
+
+    err = validate(None, filing_json)
+    if expected_code:
+        assert err.code == expected_code
+        if has_filing_id: # otherwise, won't pass schema validation, and the error msg will be very long
+            assert lists_are_equal(err.msg, expected_msg)
+    else:
+        assert err is None

--- a/legal-api/tests/unit/services/filings/validations/test_notice_of_withdrawal.py
+++ b/legal-api/tests/unit/services/filings/validations/test_notice_of_withdrawal.py
@@ -40,38 +40,61 @@ MISSING_FILING_DICT_MSG = {'error': 'A valid filing is required.'}
 # tests
 
 @pytest.mark.parametrize(
-        'test_name, is_filing_exist, withdrawn_filing_status, is_future_effective, has_filing_id, expected_code, expected_msg',[
-            ('SUCCESS', True, Filing.Status.PAID, True, True, None, None),
-            ('FAIL_NOT_PAID', True, Filing.Status.PENDING, True, True, HTTPStatus.BAD_REQUEST, [FILING_NOT_PAID_MSG]),
-            ('FAIL_NOT_FED', True, Filing.Status.PAID, False, True, HTTPStatus.BAD_REQUEST, [FILING_NOT_FED_MSG]),
-            ('FAIL_FILING_NOT_EXIST', False, Filing.Status.PAID, True, True, HTTPStatus.BAD_REQUEST, [FILING_NOT_EXIST_MSG]),
-            ('FAIL_MISS_FILING_ID', True, Filing.Status.PAID, True, False, HTTPStatus.UNPROCESSABLE_ENTITY, ''),
-            ('FAIL_NOT_PAID_NOT_FED', True, Filing.Status.PENDING, False, True, HTTPStatus.BAD_REQUEST, [FILING_NOT_FED_MSG, FILING_NOT_PAID_MSG])
+        'test_name, is_temp_business, is_filing_exist, withdrawn_filing_status, is_future_effective, has_filing_id, expected_code, expected_msg',[
+            ('EXIST_BUSINESS_SUCCESS', False, True, Filing.Status.PAID, True, True, None, None),
+            ('EXIST_BUSINESS_FAIL_NOT_PAID', False, True, Filing.Status.PENDING, True, True, HTTPStatus.BAD_REQUEST, [FILING_NOT_PAID_MSG]),
+            ('EXIST_BUSINESS_FAIL_NOT_FED', False, True, Filing.Status.PAID, False, True, HTTPStatus.BAD_REQUEST, [FILING_NOT_FED_MSG]),
+            ('EXIST_BUSINESS_FAIL_FILING_NOT_EXIST', False, False, Filing.Status.PAID, True, True, HTTPStatus.BAD_REQUEST, [FILING_NOT_EXIST_MSG]),
+            ('EXIST_BUSINESS_FAIL_MISS_FILING_ID', False, True, Filing.Status.PAID, True, False, HTTPStatus.UNPROCESSABLE_ENTITY, ''),
+            ('EXIST_BUSINESS_FAIL_NOT_PAID_NOT_FED', False, True, Filing.Status.PENDING, False, True, HTTPStatus.BAD_REQUEST, [FILING_NOT_FED_MSG, FILING_NOT_PAID_MSG]),
+            ('NEW_BUSINESS_SUCCESS', True, True, Filing.Status.PAID, True, True, None, None),
+            ('NEW_BUSINESS_FAIL_NOT_PAID', True, True, Filing.Status.PENDING, True, True, HTTPStatus.BAD_REQUEST, [FILING_NOT_PAID_MSG]),
+            ('NEW_BUSINESS_FAIL_NOT_FED', True, True, Filing.Status.PAID, False, True, HTTPStatus.BAD_REQUEST, [FILING_NOT_FED_MSG]),
+            ('NEW_BUSINESS_FAIL_FILING_NOT_EXIST', True, False, Filing.Status.PAID, True, True, HTTPStatus.BAD_REQUEST, [FILING_NOT_EXIST_MSG]),
+            ('NEW_BUSINESS_FAIL_MISS_FILING_ID', True, True, Filing.Status.PAID, True, False, HTTPStatus.UNPROCESSABLE_ENTITY, ''),
+            ('NEW_BUSINESS_FAIL_NOT_PAID_NOT_FED', True, True, Filing.Status.PENDING, False, True, HTTPStatus.BAD_REQUEST, [FILING_NOT_FED_MSG, FILING_NOT_PAID_MSG])
         ]
 )
-def test_validate_notice_of_withdrawal_exist_business(session, test_name, is_filing_exist, withdrawn_filing_status, is_future_effective, has_filing_id, expected_code, expected_msg):
+def test_validate_notice_of_withdrawal(session, test_name, is_temp_business, is_filing_exist, withdrawn_filing_status, is_future_effective, has_filing_id, expected_code, expected_msg):
     """Assert that notice of withdrawal flings can be validated"""
-    identifier = 'BC1234567'
-    business = factory_business(identifier)
-    # file a voluntary dissolution with a FED
+    today = datetime.utcnow().date()
+    future_effective_date = today + timedelta(days=5)
+    future_effective_date = future_effective_date.isoformat()
+    if is_temp_business:
+        identifier = 'Tb31yQIuBw'
+        business = RegistrationBootstrap()
+        business._identifier = identifier
+        business.save()
+        # file an IA with a FED
+        if is_filing_exist:
+            withdrawn_json = copy.deepcopy(FILING_HEADER)
+            withdrawn_json['filing']['header']['name'] = 'incorporationApplication'
+            del withdrawn_json['filing']['business']
+            ia_dict = copy.deepcopy(INCORPORATION)
+            ia_dict['nameRequest']['legalType'] = 'BC'
+            withdrawn_json['filing']['incorporationApplication'] = ia_dict
+            withdrawn_filing = factory_pending_filing(None, withdrawn_json)
+            withdrawn_filing.temp_reg = identifier
+            withdrawn_filing.save()
+    else:
+        identifier = 'BC1234567'
+        business = factory_business(identifier)
+        # file a voluntary dissolution with a FED
+        if is_filing_exist:
+            withdrawn_json = copy.deepcopy(FILING_HEADER)
+            withdrawn_json['filing']['header']['name'] = 'dissolution'
+            withdrawn_json['filing']['business']['legalType'] = 'BC'
+            withdrawn_json['filing']['dissolution'] = copy.deepcopy(DISSOLUTION)
+            withdrawn_json['filing']['dissolution']['dissolutionDate'] = future_effective_date
+            withdrawn_filing = factory_pending_filing(business, withdrawn_json)
     if is_filing_exist:
-        dissolution_filing_json = copy.deepcopy(FILING_HEADER)
-        dissolution_filing_json['filing']['header']['name'] = 'dissolution'
-        dissolution_filing_json['filing']['business']['legalType'] = 'BC'
-        dissolution_filing_json['filing']['dissolution'] = copy.deepcopy(DISSOLUTION)
-        today = datetime.utcnow().date()
-        future_effective_date = today + timedelta(days=5)
-        future_effective_date = future_effective_date.isoformat()
-        dissolution_filing_json['filing']['dissolution']['dissolutionDate'] = future_effective_date
-        dissolution_filing = factory_pending_filing(business, dissolution_filing_json)
-
         if is_future_effective:
-            dissolution_filing.effective_date = future_effective_date
+            withdrawn_filing.effective_date = future_effective_date
         if withdrawn_filing_status == Filing.Status.PAID:
-            dissolution_filing.payment_completion_date = datetime.utcnow().isoformat()
-        dissolution_filing.save()
-        withdrawn_filing_id = dissolution_filing.id
-    
+            withdrawn_filing.payment_completion_date = datetime.utcnow().isoformat()
+        withdrawn_filing.save()
+        withdrawn_filing_id = withdrawn_filing.id
+
     # create a notice of withdrawal filing json
     filing_json = copy.deepcopy(FILING_HEADER)
     filing_json['filing']['header']['name'] = 'noticeOfWithdrawal'
@@ -91,65 +114,3 @@ def test_validate_notice_of_withdrawal_exist_business(session, test_name, is_fil
     else:
         assert err is None
     
-
-
-@pytest.mark.parametrize(
-        'test_name, is_filing_exist, withdrawn_filing_status, is_future_effective, has_filing_id, expected_code, expected_msg',[
-            ('SUCCESS', True, Filing.Status.PAID, True, True, None, None),
-            ('FAIL_NOT_PAID', True, Filing.Status.PENDING, True, True, HTTPStatus.BAD_REQUEST, [FILING_NOT_PAID_MSG]),
-            ('FAIL_NOT_FED', True, Filing.Status.PAID, False, True, HTTPStatus.BAD_REQUEST, [FILING_NOT_FED_MSG]),
-            ('FAIL_FILING_NOT_EXIST', False, Filing.Status.PAID, True, True, HTTPStatus.BAD_REQUEST, [FILING_NOT_EXIST_MSG]),
-            ('FAIL_MISS_FILING_ID', True, Filing.Status.PAID, True, False, HTTPStatus.UNPROCESSABLE_ENTITY, ''),
-            ('FAIL_NOT_PAID_NOT_FED', True, Filing.Status.PENDING, False, True, HTTPStatus.BAD_REQUEST, [FILING_NOT_FED_MSG, FILING_NOT_PAID_MSG])
-        ]
-)
-def test_validate_notice_of_withdrawal_new_business(session, test_name, is_filing_exist, withdrawn_filing_status, is_future_effective, has_filing_id, expected_code, expected_msg):
-    identifier = 'Tb31yQIuBw'
-    temp_bus = RegistrationBootstrap()
-    temp_bus._identifier = identifier
-    temp_bus.save()
-
-    # file an IA with a FED
-    ia_json = copy.deepcopy(FILING_HEADER)
-    ia_json['filing']['header']['name'] = 'incorporationApplication'
-    del ia_json['filing']['business']
-    ia_dict = copy.deepcopy(INCORPORATION)
-    ia_dict['nameRequest']['legalType'] = 'BC'
-    ia_json['filing']['incorporationApplication'] = ia_dict
-    ia_filing = factory_pending_filing(None, ia_json)
-    ia_filing.temp_reg = identifier
-    ia_filing.save()
-
-    if is_future_effective:
-        today = datetime.utcnow().date()
-        future_effective_date = today + timedelta(days=5)
-        future_effective_date = future_effective_date.isoformat()
-        ia_filing.effective_date = future_effective_date
-    if withdrawn_filing_status == Filing.Status.PAID:
-        ia_filing.payment_completion_date = datetime.utcnow().isoformat()
-    ia_filing.save()
-    ia_filing_id = ia_filing.id
-
-    # create a notice of withdrawal filing json
-    filing_json = copy.deepcopy(FILING_HEADER)
-    filing_json['filing']['header']['name'] = 'noticeOfWithdrawal'
-    temp_business_dict =  {
-        "legalType": "BC",
-        "identifier": identifier
-    }
-    filing_json['filing']['business'] = temp_business_dict
-    filing_json['filing']['noticeOfWithdrawal'] = copy.deepcopy(NOTICE_OF_WITHDRAWAL)
-
-    if has_filing_id:
-        if is_filing_exist:
-            filing_json['filing']['noticeOfWithdrawal']['filingId'] = ia_filing_id
-    else:
-        del filing_json['filing']['noticeOfWithdrawal']['filingId']   
-
-    err = validate(None, filing_json)
-    if expected_code:
-        assert err.code == expected_code
-        if has_filing_id: # otherwise, won't pass schema validation, and the error msg will be very long
-            assert lists_are_equal(err.msg, expected_msg)
-    else:
-        assert err is None

--- a/legal-api/tests/unit/services/filings/validations/test_notice_of_withdrawal.py
+++ b/legal-api/tests/unit/services/filings/validations/test_notice_of_withdrawal.py
@@ -98,7 +98,14 @@ def test_validate_notice_of_withdrawal(session, test_name, is_temp_business, is_
     # create a notice of withdrawal filing json
     filing_json = copy.deepcopy(FILING_HEADER)
     filing_json['filing']['header']['name'] = 'noticeOfWithdrawal'
-    filing_json['filing']['business']['legalType'] = 'BC'
+    if is_temp_business:
+        temp_business_dict = {
+            "legalType": "BC",
+            "identifier": identifier
+        }
+        filing_json['filing']['business'] = temp_business_dict
+    else:
+        filing_json['filing']['business']['legalType'] = 'BC'
     filing_json['filing']['noticeOfWithdrawal'] = copy.deepcopy(NOTICE_OF_WITHDRAWAL)
     if has_filing_id:
         if is_filing_exist:


### PR DESCRIPTION
*Issue #:* /bcgov/entity#23349

*Description of changes:*
- Added validation for Notice of Withdrawal filings, checking:
    - the to be withdrawn filing exist
    - it has a FED
    - its status is PAID
 - Added unit tests testing withdraw a filing from an existing business, as discussed, excluding the new business scenario.
 - Updated the Registry Schema version number
 
*Testing Results:*
- All unit tests passed
![Pasted image 20241004114510](https://github.com/user-attachments/assets/c36f0d84-ff44-4c9a-8bef-980579317f2b)
- Linting Cleared
![Pasted image 20241004134344](https://github.com/user-attachments/assets/fc7c62f3-a10a-4618-9a86-459f4ba04e79)
- Made a filing draft call in local environment (when testing, I commented out the authorization part to avoid the jwt staff check when running locally)
    - Draft
![Pasted image 20241004141806](https://github.com/user-attachments/assets/0e35a47b-69fe-45bf-8e67-7eb3c13f6def)
    - Validate
![image](https://github.com/user-attachments/assets/e0536515-58c9-49fe-be88-34fef45bf802)
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
