### PR TITLE
23608 - Update furnishing entries transferred to bc mail+

### DIFF
--- a/jobs/furnishings/src/furnishings/stage_processors/stage_one.py
+++ b/jobs/furnishings/src/furnishings/stage_processors/stage_one.py
@@ -126,6 +126,7 @@ class StageOneProcessor:
         for furnishing in furnishings_list:
             furnishing.notes = furnishing_notes
             furnishing.status = funishing_status
+            furnishing.processed_date = datetime.utcnow()
             furnishing.save()
 
     def process_paper_letters(self):
@@ -163,7 +164,7 @@ class StageOneProcessor:
                 with self._bcmail_sftp_connection as client:
                     resp = self.upload_to_sftp(client, self._xpro_letters, filename)
                 self.update_notes_and_status(
-                    self._bc_mail_furnishings,
+                    self._xpro_mail_furnishings,
                     Furnishing.FurnishingStatus.PROCESSED,
                     'SFTP of XPRO batch letter was a success.'
                 )

--- a/jobs/furnishings/tests/unit/stage_processors/test_stage_one.py
+++ b/jobs/furnishings/tests/unit/stage_processors/test_stage_one.py
@@ -329,3 +329,16 @@ async def test_process_paper_letters(app, session, sftpserver, sftpconnection, t
                 with sftpconnection as sftpclient:
                     uploaded_files = sftpclient.listdir(storage_directory)
                     assert len(uploaded_files) == 1
+
+                    # Fetch the updated furnishing
+                    updated_furnishing = Furnishing.find_by_id(mail_furnishing.id)
+
+                    # Assert the status is updated correctly
+                    assert updated_furnishing.status == Furnishing.FurnishingStatus.PROCESSED
+
+                    # Assert the processed_date is set
+                    assert updated_furnishing.processed_date is not None
+
+                    # Assert the correct note is added based on the entity type
+                    expected_note = 'SFTP of BC batch letter was a success' if entity_type == Business.LegalTypes.COMP.value else 'SFTP of XPRO batch letter was a success'
+                    assert expected_note in updated_furnishing.notes


### PR DESCRIPTION
*Issue #:* /bcgov/entity#23608

*Description of changes:*

- Fixed bugs related to the incorrect processed date, status, and notes population.
- Updated corresponding unit tests.

<img width="2114" alt="image" src="https://github.com/user-attachments/assets/e00ad355-6df4-499b-bcba-04bacb59fb64">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
