### PR TITLE
23697 - fix stage1 to stage2 dissolution transition bug

### DIFF
--- a/jobs/furnishings/flags.json
+++ b/jobs/furnishings/flags.json
@@ -1,5 +1,6 @@
 {
     "flagValues": {
-        "enable-involuntary-dissolution": true
+        "enable-involuntary-dissolution": true,
+        "disable-dissolution-sftp-bcmail": true
     }
 }

--- a/jobs/furnishings/flags.json
+++ b/jobs/furnishings/flags.json
@@ -1,6 +1,7 @@
 {
     "flagValues": {
         "enable-involuntary-dissolution": true,
-        "disable-dissolution-sftp-bcmail": true
+        "disable-dissolution-sftp-bcmail": true,
+        "disable-dissolution-sftp-bclaws": false
     }
 }

--- a/jobs/involuntary-dissolutions/flags.json
+++ b/jobs/involuntary-dissolutions/flags.json
@@ -1,5 +1,6 @@
 {
     "flagValues": {
-        "enable-involuntary-dissolution": true
+        "enable-involuntary-dissolution": true,
+        "disable-dissolution-sftp-bcmail": true
     }
 }

--- a/jobs/involuntary-dissolutions/flags.json
+++ b/jobs/involuntary-dissolutions/flags.json
@@ -1,6 +1,7 @@
 {
     "flagValues": {
         "enable-involuntary-dissolution": true,
-        "disable-dissolution-sftp-bcmail": true
+        "disable-dissolution-sftp-bcmail": true,
+        "disable-dissolution-sftp-bclaws": false
     }
 }

--- a/jobs/involuntary-dissolutions/flags.json
+++ b/jobs/involuntary-dissolutions/flags.json
@@ -1,7 +1,7 @@
 {
     "flagValues": {
         "enable-involuntary-dissolution": true,
-        "disable-dissolution-sftp-bcmail": true,
+        "disable-dissolution-sftp-bcmail": false,
         "disable-dissolution-sftp-bclaws": false
     }
 }

--- a/jobs/involuntary-dissolutions/involuntary_dissolutions.py
+++ b/jobs/involuntary-dissolutions/involuntary_dissolutions.py
@@ -253,13 +253,13 @@ def stage_2_process(app: Flask):
             for furnishing in furnishings
         )
         # if SFTP function is off, we expect the mail status will be QUEUED
-        expected_mail_status = Furnishing.FurnishingStatus.PROCESSED
+        expected_mail_status = [Furnishing.FurnishingStatus.PROCESSED]
         if flags.is_on('disable-dissolution-sftp-bcmail'):
-            expected_mail_status = Furnishing.FurnishingStatus.QUEUED
+            expected_mail_status.append(Furnishing.FurnishingStatus.QUEUED)
 
         mail_processed = any(
-            furnishing.furnishing_type == Furnishing.FurnishingType.MAIL
-            and furnishing.status == expected_mail_status
+            (furnishing.furnishing_type == Furnishing.FurnishingType.MAIL)
+            and (furnishing.status in expected_mail_status)
             for furnishing in furnishings
         )
         email_exists = any(furnishing.furnishing_type == Furnishing.FurnishingType.EMAIL for furnishing in furnishings)

--- a/jobs/involuntary-dissolutions/involuntary_dissolutions.py
+++ b/jobs/involuntary-dissolutions/involuntary_dissolutions.py
@@ -239,7 +239,7 @@ def stage_2_process(app: Flask):
     stage_2_delay = timedelta(days=app.config.get('STAGE_2_DELAY'))
 
     for batch_processing in batch_processings:
-        # check furnishing entries - 2 scenarios 
+        # check furnishing entries - 2 scenarios
         # - 1. if email processed, and mail processed(after 5 business days still not in GS)
         # - 2.only available to send mail out, and it's processed
         # If not, do not transition to stage 2.
@@ -256,16 +256,16 @@ def stage_2_process(app: Flask):
         expected_mail_status = Furnishing.FurnishingStatus.PROCESSED
         if flags.is_on('disable-dissolution-sftp-bcmail'):
             expected_mail_status = Furnishing.FurnishingStatus.QUEUED
-        
+
         mail_processed = any(
             furnishing.furnishing_type == Furnishing.FurnishingType.MAIL
             and furnishing.status == expected_mail_status
             for furnishing in furnishings
         )
-        email_exists = any(furnishing.furnishing_type == Furnishing.FurnishingType.EMAIL 
-        for furnishing in furnishings)
-    
-        furnishing_entry_completed = (email_exists and email_processed and mail_processed) or (not email_exists and mail_processed)
+        email_exists = any(furnishing.furnishing_type == Furnishing.FurnishingType.EMAIL for furnishing in furnishings)
+
+        furnishing_entry_completed = (email_exists and email_processed and mail_processed) \
+            or (not email_exists and mail_processed)
 
         if not furnishing_entry_completed:
             batch_processing.status = BatchProcessing.BatchProcessingStatus.ERROR

--- a/jobs/involuntary-dissolutions/involuntary_dissolutions.py
+++ b/jobs/involuntary-dissolutions/involuntary_dissolutions.py
@@ -239,16 +239,34 @@ def stage_2_process(app: Flask):
     stage_2_delay = timedelta(days=app.config.get('STAGE_2_DELAY'))
 
     for batch_processing in batch_processings:
-        # Check if email or letter furnishing entry has been completed. If not, do not transition to stage 2.
+        # check furnishing entries - 2 scenarios 
+        # - 1. if email processed, and mail processed(after 5 business days still not in GS)
+        # - 2.only available to send mail out, and it's processed
+        # If not, do not transition to stage 2.
         furnishings = Furnishing.find_by(
             batch_id=batch_processing.batch_id,
             business_id=batch_processing.business_id
         )
-        furnishing_entry_completed = any(
-            furnishing.furnishing_type in (Furnishing.FurnishingType.EMAIL, Furnishing.FurnishingType.MAIL)
+        email_processed = any(
+            furnishing.furnishing_type == Furnishing.FurnishingType.EMAIL
             and furnishing.status == Furnishing.FurnishingStatus.PROCESSED
             for furnishing in furnishings
         )
+        # if SFTP function is off, we expect the mail status will be QUEUED
+        expected_mail_status = Furnishing.FurnishingStatus.PROCESSED
+        if flags.is_on('disable-dissolution-sftp-bcmail'):
+            expected_mail_status = Furnishing.FurnishingStatus.QUEUED
+        
+        mail_processed = any(
+            furnishing.furnishing_type == Furnishing.FurnishingType.MAIL
+            and furnishing.status == expected_mail_status
+            for furnishing in furnishings
+        )
+        email_exists = any(furnishing.furnishing_type == Furnishing.FurnishingType.EMAIL 
+        for furnishing in furnishings)
+    
+        furnishing_entry_completed = (email_exists and email_processed and mail_processed) or (not email_exists and mail_processed)
+
         if not furnishing_entry_completed:
             batch_processing.status = BatchProcessing.BatchProcessingStatus.ERROR
             batch_processing.notes = 'stage 1 email or letter has not been sent'

--- a/jobs/involuntary-dissolutions/involuntary_dissolutions.py
+++ b/jobs/involuntary-dissolutions/involuntary_dissolutions.py
@@ -215,6 +215,33 @@ def stage_1_process(app: Flask):  # pylint: disable=redefined-outer-name,too-man
         app.logger.error(err)
 
 
+def _check_stage_1_furnishing_entries(furnishings):
+    """Check furnishing entries - 2 scenarios.
+
+    1. if email processed, and mail processed or queued(FF) (after 5 business days still not in GS).
+    2. only available to send mail out, and it's processed.
+    """
+    email_processed = any(
+            furnishing.furnishing_type == Furnishing.FurnishingType.EMAIL
+            and furnishing.status == Furnishing.FurnishingStatus.PROCESSED
+            for furnishing in furnishings
+        )
+
+    expected_mail_status = [Furnishing.FurnishingStatus.PROCESSED]
+    # if SFTP function is off, we expect the mail status will be QUEUED or PROCESSED
+    if flags.is_on('disable-dissolution-sftp-bcmail'):
+        expected_mail_status.append(Furnishing.FurnishingStatus.QUEUED)
+
+    mail_processed = any(
+        (furnishing.furnishing_type == Furnishing.FurnishingType.MAIL)
+        and (furnishing.status in expected_mail_status)
+        for furnishing in furnishings
+    )
+    email_exists = any(furnishing.furnishing_type == Furnishing.FurnishingType.EMAIL for furnishing in furnishings)
+    return (email_exists and email_processed and mail_processed) \
+        or (not email_exists and mail_processed)
+
+
 def stage_2_process(app: Flask):
     """Update batch processing data for previously created in_progress batches."""
     batch_processings = (
@@ -239,33 +266,12 @@ def stage_2_process(app: Flask):
     stage_2_delay = timedelta(days=app.config.get('STAGE_2_DELAY'))
 
     for batch_processing in batch_processings:
-        # check furnishing entries - 2 scenarios
-        # - 1. if email processed, and mail processed(after 5 business days still not in GS)
-        # - 2.only available to send mail out, and it's processed
-        # If not, do not transition to stage 2.
         furnishings = Furnishing.find_by(
             batch_id=batch_processing.batch_id,
             business_id=batch_processing.business_id
         )
-        email_processed = any(
-            furnishing.furnishing_type == Furnishing.FurnishingType.EMAIL
-            and furnishing.status == Furnishing.FurnishingStatus.PROCESSED
-            for furnishing in furnishings
-        )
-        # if SFTP function is off, we expect the mail status will be QUEUED
-        expected_mail_status = [Furnishing.FurnishingStatus.PROCESSED]
-        if flags.is_on('disable-dissolution-sftp-bcmail'):
-            expected_mail_status.append(Furnishing.FurnishingStatus.QUEUED)
 
-        mail_processed = any(
-            (furnishing.furnishing_type == Furnishing.FurnishingType.MAIL)
-            and (furnishing.status in expected_mail_status)
-            for furnishing in furnishings
-        )
-        email_exists = any(furnishing.furnishing_type == Furnishing.FurnishingType.EMAIL for furnishing in furnishings)
-
-        furnishing_entry_completed = (email_exists and email_processed and mail_processed) \
-            or (not email_exists and mail_processed)
+        furnishing_entry_completed = _check_stage_1_furnishing_entries(furnishings)
 
         if not furnishing_entry_completed:
             batch_processing.status = BatchProcessing.BatchProcessingStatus.ERROR

--- a/jobs/involuntary-dissolutions/tests/unit/test_involuntary_dissolutions.py
+++ b/jobs/involuntary-dissolutions/tests/unit/test_involuntary_dissolutions.py
@@ -173,11 +173,13 @@ def test_stage_1_process(app, session):
 
 
 @pytest.mark.parametrize(
-    'test_name, batch_status, status, step, created_date, found, has_email', [
+    'test_name, batch_status, status, email_status, mail_status, step, created_date, found, has_email', [
         (
             'FOUND_HAS_EMAIL',
             Batch.BatchStatus.PROCESSING,
             BatchProcessing.BatchProcessingStatus.PROCESSING,
+            Furnishing.FurnishingStatus.PROCESSED,
+            Furnishing.FurnishingStatus.PROCESSED,
             BatchProcessing.BatchProcessingStep.WARNING_LEVEL_1,
             CREATED_DATE,
             True,
@@ -187,6 +189,8 @@ def test_stage_1_process(app, session):
             'FOUND_MAIL_ONLY',
             Batch.BatchStatus.PROCESSING,
             BatchProcessing.BatchProcessingStatus.PROCESSING,
+            Furnishing.FurnishingStatus.PROCESSED,
+            Furnishing.FurnishingStatus.PROCESSED,
             BatchProcessing.BatchProcessingStep.WARNING_LEVEL_1,
             CREATED_DATE,
             True,
@@ -196,6 +200,8 @@ def test_stage_1_process(app, session):
             'NOT_FOUND_BATCH_STATUS',
             Batch.BatchStatus.HOLD,
             BatchProcessing.BatchProcessingStatus.PROCESSING,
+            Furnishing.FurnishingStatus.PROCESSED,
+            Furnishing.FurnishingStatus.PROCESSED,
             BatchProcessing.BatchProcessingStep.WARNING_LEVEL_1,
             CREATED_DATE,
             False,
@@ -205,6 +211,8 @@ def test_stage_1_process(app, session):
             'NOT_FOUND_BATCH_PROCESSING_STATUS',
             Batch.BatchStatus.PROCESSING,
             BatchProcessing.BatchProcessingStatus.HOLD,
+            Furnishing.FurnishingStatus.PROCESSED,
+            Furnishing.FurnishingStatus.PROCESSED,
             BatchProcessing.BatchProcessingStep.WARNING_LEVEL_1,
             CREATED_DATE,
             False,
@@ -214,6 +222,8 @@ def test_stage_1_process(app, session):
             'NOT_FOUND_STEP',
             Batch.BatchStatus.PROCESSING,
             BatchProcessing.BatchProcessingStatus.PROCESSING,
+            Furnishing.FurnishingStatus.PROCESSED,
+            Furnishing.FurnishingStatus.PROCESSED,
             BatchProcessing.BatchProcessingStep.WARNING_LEVEL_2,
             CREATED_DATE,
             False,
@@ -223,61 +233,111 @@ def test_stage_1_process(app, session):
             'NOT_FOUND_CREATED_DATE',
             Batch.BatchStatus.PROCESSING,
             BatchProcessing.BatchProcessingStatus.PROCESSING,
+            Furnishing.FurnishingStatus.PROCESSED,
+            Furnishing.FurnishingStatus.PROCESSED,
             BatchProcessing.BatchProcessingStep.WARNING_LEVEL_1,
             datetime.utcnow(),
             False,
             False
+        ),
+        (
+            'NOT_FOUND_EMAIL_NOT_PROCESSED',
+            Batch.BatchStatus.PROCESSING,
+            BatchProcessing.BatchProcessingStatus.PROCESSING,
+            Furnishing.FurnishingStatus.QUEUED,
+            Furnishing.FurnishingStatus.PROCESSED,
+            BatchProcessing.BatchProcessingStep.WARNING_LEVEL_1,
+            CREATED_DATE,
+            False,
+            True
+        ),
+        (
+            'NOT_FOUND_MAIL_FAILED',
+            Batch.BatchStatus.PROCESSING,
+            BatchProcessing.BatchProcessingStatus.PROCESSING,
+            Furnishing.FurnishingStatus.PROCESSED,
+            Furnishing.FurnishingStatus.FAILED,
+            BatchProcessing.BatchProcessingStep.WARNING_LEVEL_1,
+            CREATED_DATE,
+            False,
+            True
         )
     ]
 
 )
-def test_stage_2_process_find_entry(app, session, test_name, batch_status, status, step, created_date, found, has_email):
+def test_stage_2_process_find_entry(app, session, test_name, batch_status, status, email_status, mail_status, step, created_date, found, has_email):
     """Assert that only businesses that meet conditions can be processed for stage 2."""
-    business = factory_business(identifier='BC1234567')
+    # create 2 entries, so that if sftp bc mail FF is on, we can test both mail status PROCESSED and QUEUED
+    business1 = factory_business(identifier='BC1234567')
+    business2 = factory_business(identifier='BC7654321')
+    businesses = [business1, business2]
 
-    batch = factory_batch(status=batch_status)
+    batch1 = factory_batch(status=batch_status)
+    batch2 = factory_batch(status=batch_status)
+    batches = [batch1, batch2]
+    
     last_modified = CREATED_DATE
-    batch_processing = factory_batch_processing(
-        batch_id=batch.id,
-        business_id=business.id,
-        identifier=business.identifier,
-        status=status,
-        step=step,
-        created_date=created_date,
-        trigger_date=created_date+datedelta(days=42),
-        last_modified=last_modified
-    )
+    batch_processings = []
+    for i in range(2):
+        business = businesses[i]
+        batch = batches[i]
+        batch_processing = factory_batch_processing(
+            batch_id=batch.id,
+            business_id=business.id,
+            identifier=business.identifier,
+            status=status,
+            step=step,
+            created_date=created_date,
+            trigger_date=created_date+datedelta(days=42),
+            last_modified=last_modified
+        )
+        batch_processings.append(batch_processing)
+    batch_processing1, batch_processing2 = batch_processings
+
     if has_email:
-        furnishing_email = Furnishing(
-            furnishing_type = Furnishing.FurnishingType.EMAIL,
+        for i in range(2):
+            business = businesses[i]
+            batch = batches[i]
+            furnishing_email = Furnishing(
+                furnishing_type = Furnishing.FurnishingType.EMAIL,
+                furnishing_name = Furnishing.FurnishingName.DISSOLUTION_COMMENCEMENT_NO_AR,
+                batch_id = batch.id,
+                business_id = business.id,
+                business_identifier = business.identifier,
+                status = email_status,
+            )
+            furnishing_email.save()
+
+    furnishing_mails = []
+    for i in range(2):
+        business = businesses[i]
+        batch = batches[i]
+        furnishing_mail = Furnishing(
+            furnishing_type = Furnishing.FurnishingType.MAIL,
             furnishing_name = Furnishing.FurnishingName.DISSOLUTION_COMMENCEMENT_NO_AR,
             batch_id = batch.id,
             business_id = business.id,
             business_identifier = business.identifier,
-            status = Furnishing.FurnishingStatus.PROCESSED,
+            status = mail_status,
         )
-        furnishing_email.save()
-        
+        furnishing_mail.save()
+        furnishing_mails.append(furnishing_mail)
+    
     flags = Flags()
-    mail_status = Furnishing.FurnishingStatus.PROCESSED
-    if flags.is_on('disable-dissolution-sftp-bcmail'):
-        mail_status = Furnishing.FurnishingStatus.QUEUED
-    furnishing_mail = Furnishing(
-        furnishing_type = Furnishing.FurnishingType.MAIL,
-        furnishing_name = Furnishing.FurnishingName.DISSOLUTION_COMMENCEMENT_NO_AR,
-        batch_id = batch.id,
-        business_id = business.id,
-        business_identifier = business.identifier,
-        status = mail_status,
-    )
-    furnishing_mail.save()
+    # if sftp bc mail FF is on, test both mail status PROCESSED and QUEUED
+    if (flags.is_on('disable-dissolution-sftp-bcmail')) and (mail_status != Furnishing.FurnishingStatus.FAILED):
+        furnishing_mail2 = furnishing_mails[1]
+        furnishing_mail2.status = Furnishing.FurnishingStatus.QUEUED
+        furnishing_mail2.save()
 
     stage_2_process(app)
 
     if found:
-        assert batch_processing.last_modified != last_modified
+        assert batch_processing1.last_modified != last_modified
+        assert batch_processing2.last_modified != last_modified
     else:
-        assert batch_processing.last_modified == last_modified
+        assert batch_processing1.last_modified == last_modified
+        assert batch_processing2.last_modified == last_modified
 
 
 @pytest.mark.parametrize(
@@ -322,10 +382,7 @@ def test_stage_2_process_update_business(app, session, test_name, status, step, 
         status = furnishing_status,
     )
     furnishing_email.save()
-
-    flags = Flags()
-    if flags.is_on('disable-dissolution-sftp-bcmail') and furnishing_status == Furnishing.FurnishingStatus.PROCESSED:
-        furnishing_status = Furnishing.FurnishingStatus.QUEUED
+    
     furnishing_mail = Furnishing(
         furnishing_type = Furnishing.FurnishingType.MAIL,
         furnishing_name = Furnishing.FurnishingName.DISSOLUTION_COMMENCEMENT_NO_AR,
@@ -353,6 +410,7 @@ def test_stage_2_process_update_business(app, session, test_name, status, step, 
         assert batch_processing.meta_data['stage_2_date']
     else:
         assert batch_processing.trigger_date == TRIGGER_DATE
+
 
 @pytest.mark.parametrize(
     'test_name, status, step, furnishing_status', [

--- a/jobs/involuntary-dissolutions/tests/unit/test_involuntary_dissolutions.py
+++ b/jobs/involuntary-dissolutions/tests/unit/test_involuntary_dissolutions.py
@@ -324,7 +324,6 @@ def test_stage_1_process(app, session):
 def test_stage_2_process_find_entry(app, session, test_name, batch_status, status, email_status, mail_status, step, created_date, found, has_email, disable_dissolution_sftp_bcmail):
     """Assert that only businesses that meet conditions can be processed for stage 2."""
     with patch.object(flags, 'is_on', return_value=disable_dissolution_sftp_bcmail):
-        print(flags.is_on("disable-dissolution-sftp-bcmail"))
         # create 2 entries, so that if sftp bc mail FF is on, we can test both mail status PROCESSED and QUEUED
         business1 = factory_business(identifier='BC1234567')
         business2 = factory_business(identifier='BC7654321')


### PR DESCRIPTION
*Issue #:* /bcgov/entity#23697

*Description of changes:*
- Added the `disable-dissolution-sftp-bcmail` feature flag option in `flags.json`
- Updated the logic for furnishing entries check when moving from stage 1 to stage 2 of involuntary dissolution
    - check furnishing entries - 2 scenarios
        1. if email processed, and mail processed (after 5 business days still not in good standing)
        2. only has a mail entry, and it's processed
- Updated the check to support SFTP function FF

#### Local Test Results 
**Action**: Trying to move a business from stage 1 to stage 2 of involuntary dissolution

**Scenario 1** - ERROR and not moving to stage 2
_when this business has an email entry and haven't sent out a mail _
![Pasted image 20241011153110](https://github.com/user-attachments/assets/097513b1-36ab-4145-b118-6aa956503b39)
![Pasted image 20241011153047](https://github.com/user-attachments/assets/6a45bcfb-31ce-4d94-abcb-8406ece5125b)

**Scenario 2** - SUCCESS moving to stage 2
_when this business has an email entry and after 5 business days still not in good standing, a mail sent out_
![Pasted image 20241011153215](https://github.com/user-attachments/assets/f6d210b5-2cb5-493e-99f9-dd6e3d261361)
![Pasted image 20241011153238](https://github.com/user-attachments/assets/87aef4ce-53b3-48ff-bef2-7bdf8f6b3cfa)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
