### PR TITLE
23845 - Bumped version numbers up for release 23.2a

### DIFF
--- a/legal-api/src/legal_api/version.py
+++ b/legal-api/src/legal_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.129.0'  # pylint: disable=invalid-name
+__version__ = '2.130.0'  # pylint: disable=invalid-name

--- a/queue_services/entity-bn/src/entity_bn/version.py
+++ b/queue_services/entity-bn/src/entity_bn/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.129.0'  # pylint: disable=invalid-name
+__version__ = '2.130.0'  # pylint: disable=invalid-name

--- a/queue_services/entity-bn/src/entity_bn/version.py
+++ b/queue_services/entity-bn/src/entity_bn/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.128.0'  # pylint: disable=invalid-name
+__version__ = '2.129.0'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:* /bcgov/entity#23845

*Description of changes:*

- Legal API v2.130.0
- Entity-bn v2.129.0
- Furnishing jobs ( no version )
- Dissolution jobs ( no version )
- Business-pay ( no version )

[Release Report 
](https://app.zenhub.com/workspaces/entities---david-65af11a89e89f5043c2911f6/reports/release?release=Z2lkOi8vcmFwdG9yL1JlbGVhc2UvMTA1Mzgw)

[Github release](https://github.com/bcgov/lear/releases/edit/untagged-f33b7bef3d18e5741e2e)




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
