### PR TITLE
24153 fixes in colin sync

### DIFF
--- a/colin-api/src/colin_api/models/address.py
+++ b/colin-api/src/colin_api/models/address.py
@@ -168,15 +168,13 @@ class Address:  # pylint: disable=too-many-instance-attributes; need all these f
                                 :delivery_instructions)
                             """,
                            addr_id=addr_id,
-                           province=address_info['addressRegion'].upper(),
+                           province=(address_info.get('addressRegion') or '').upper(),
                            country_typ_cd=country_typ_cd,
                            postal_cd=address_info['postalCode'].upper(),
                            addr_line_1=address_info['streetAddress'].upper(),
-                           addr_line_2=address_info['streetAddressAdditional'].upper()
-                           if 'streetAddressAdditional' in address_info.keys() else '',
+                           addr_line_2=(address_info.get('streetAddressAdditional') or '').upper(),
                            city=address_info['addressCity'].upper(),
-                           delivery_instructions=address_info['deliveryInstructions'].upper()
-                           if 'deliveryInstructions' in address_info.keys() else ''
+                           delivery_instructions=(address_info.get('deliveryInstructions') or '').upper()
                            )
         except Exception as err:
             current_app.logger.error(f'Error in address: failed to insert new address: {address_info}')

--- a/colin-api/src/colin_api/models/business.py
+++ b/colin-api/src/colin_api/models/business.py
@@ -160,7 +160,7 @@ class Business:  # pylint: disable=too-many-instance-attributes, too-many-public
             cls.TypeCodes.ULC_COMP.value,
             cls.TypeCodes.CCC_COMP.value
         ] and lear_identifier.startswith('BC'):
-            return lear_identifier[-7:]
+            return lear_identifier[2:]
 
         return lear_identifier
 

--- a/colin-api/src/colin_api/models/corp_party.py
+++ b/colin-api/src/colin_api/models/corp_party.py
@@ -483,7 +483,7 @@ class Party:  # pylint: disable=too-many-instance-attributes; need all these fie
                         last_nme=party['officer']['lastName'],
                         middle_nme=party['officer'].get('middleInitial', ''),
                         first_nme=party['officer']['firstName'],
-                        email=party['officer']['email']
+                        email=party['officer'].get('email', '')
                     )
                 else:
                     cursor.execute(
@@ -493,7 +493,7 @@ class Party:  # pylint: disable=too-many-instance-attributes; need all these fie
                         last_nme=party['officer']['lastName'],
                         middle_nme=party['officer'].get('middleInitial', ''),
                         first_nme=party['officer']['firstName'],
-                        email=party['officer']['email']
+                        email=party['officer'].get('email', '')
                     )
             else:
                 date_format = '%Y-%m-%d'

--- a/colin-api/src/colin_api/models/filing.py
+++ b/colin-api/src/colin_api/models/filing.py
@@ -601,7 +601,7 @@ class Filing:  # pylint: disable=too-many-instance-attributes;
                     event_id=filing.event_id,
                     filing_type_code=filing_type_code,
                     effective_dt=filing.effective_date,
-                    filing_date=filing.filing_date
+                    filing_date=filing.filing_date[:10]
                 )
             elif filing_type_code in ['NOCAD', 'CRBIN', 'TRANS',
                                       'BEINC', 'ICORP', 'ICORU', 'ICORC',
@@ -1529,7 +1529,7 @@ class Filing:  # pylint: disable=too-many-instance-attributes;
             else:
                 # strip prefix BC
                 if identifier.startswith('BC'):
-                    identifier = identifier[-7:]
+                    identifier = identifier[2:]
                 corp_involved.corp_num = identifier
 
                 if amalgamating_business['role'] in ['holding', 'primary']:

--- a/colin-api/src/colin_api/resources/business.py
+++ b/colin-api/src/colin_api/resources/business.py
@@ -43,7 +43,7 @@ class BusinessPublicInfo(Resource):
         try:
             # strip prefix BC
             if identifier.startswith('BC'):
-                identifier = identifier[-7:]
+                identifier = identifier[2:]
 
             # get business
             business = Business.find_by_identifier(identifier)
@@ -172,7 +172,7 @@ class InternalBusinessInfo(Resource):
                 if not json_data or not json_data['identifiers']:
                     return jsonify({'message': 'No input data provided'}), HTTPStatus.BAD_REQUEST
                 # remove the BC prefix
-                identifiers = [x[-7:] if x.startswith('BC') else x
+                identifiers = [x[2:] if x.startswith('BC') else x
                                for x in json_data['identifiers']]
                 bn_15s = Business._get_bn_15s(  # pylint: disable = protected-access; internal call
                     cursor=cursor,

--- a/jobs/update-colin-filings/update_colin_filings.py
+++ b/jobs/update-colin-filings/update_colin_filings.py
@@ -16,7 +16,6 @@
 This module is the API for the Legal Entity system.
 """
 import logging
-import math
 import os
 
 import requests

--- a/jobs/update-colin-filings/update_colin_filings.py
+++ b/jobs/update-colin-filings/update_colin_filings.py
@@ -60,16 +60,16 @@ def register_shellcontext(app):
     app.shell_context_processor(shell_context)
 
 
-def get_filings(app: Flask, token, page, limit):
+def get_filings(app: Flask, token, limit, offset):
     """Get a filing with filing_id."""
     requests_timeout = int(app.config.get('ACCOUNT_SVC_TIMEOUT'))
-    req = requests.get(f'{app.config["LEGAL_API_URL"]}/businesses/internal/filings?page={page}&limit={limit}',
+    req = requests.get(f'{app.config["LEGAL_API_URL"]}/businesses/internal/filings?offset={offset}&limit={limit}',
                        headers={'Authorization': 'Bearer ' + token},
                        timeout=requests_timeout)
     if not req or req.status_code != 200:
         app.logger.error(f'Failed to collect filings from legal-api. {req} {req.json()} {req.status_code}')
         raise Exception  # pylint: disable=broad-exception-raised
-    return req.json()
+    return req.json().get('filings')
 
 
 def send_filing(app: Flask, token: str, filing: dict, filing_id: str):
@@ -148,26 +148,19 @@ def run():
     """Get filings that haven't been synced with colin and send them to the colin-api."""
     application = create_app()
     corps_with_failed_filing = []
+    failed_to_sync = 0
+    limit = 50
     with application.app_context():
         try:
             # get updater-job token
             token = get_bearer_token(application)
-
-            page = 1
-            limit = 50
-            pending_filings = None
-            while ((pending_filings is None or page <= math.ceil(pending_filings/limit)) and
-                   (results := get_filings(application, token, page, limit))):
-                page += 1
-                pending_filings = results.get('total')
-                if not (filings := results.get('filings')):
-                    # pylint: disable=no-member; false positive
-                    application.logger.debug('No completed filings to send to colin.')
+            while (filings := get_filings(application, token, limit, failed_to_sync)):
                 for filing in filings:
                     filing_id = filing['filingId']
                     identifier = filing['filing']['business']['identifier']
                     if identifier in corps_with_failed_filing:
                         # pylint: disable=no-member; false positive
+                        failed_to_sync += 1
                         application.logger.debug(f'Skipping filing {filing_id} for'
                                                  f' {filing["filing"]["business"]["identifier"]}.')
                     else:
@@ -178,11 +171,12 @@ def run():
                         if update:
                             # pylint: disable=no-member; false positive
                             application.logger.debug(f'Successfully updated filing {filing_id}')
-                            pending_filings -= 1
                         else:
+                            failed_to_sync += 1
                             corps_with_failed_filing.append(filing['filing']['business']['identifier'])
                             # pylint: disable=no-member; false positive
                             application.logger.error(f'Failed to update filing {filing_id} with colin event id.')
+            application.logger.debug('No more filings to send to colin.')
 
         except Exception as err:  # noqa: B902
             # pylint: disable=no-member; false positive

--- a/jobs/update-legal-filings/update_legal_filings.py
+++ b/jobs/update-legal-filings/update_legal_filings.py
@@ -81,10 +81,7 @@ def check_for_manual_filings(application: Flask = None, token: dict = None):
     colin_events = None
     legal_url = application.config['LEGAL_API_URL'] + '/businesses'
     colin_url = application.config['COLIN_URL']
-    corp_types = [Business.TypeCodes.COOP.value, Business.TypeCodes.BC_COMP.value,
-                  Business.TypeCodes.ULC_COMP.value, Business.TypeCodes.CCC_COMP.value]
-    no_corp_num_prefix_in_colin = [Business.TypeCodes.BC_COMP.value, Business.TypeCodes.ULC_COMP.value,
-                                   Business.TypeCodes.CCC_COMP.value]
+    corp_types = [Business.TypeCodes.COOP.value]
 
     # get max colin event_id from legal
     response = requests.get(f'{legal_url}/internal/filings/colin_id',
@@ -114,8 +111,6 @@ def check_for_manual_filings(application: Flask = None, token: dict = None):
                                             timeout=AccountService.timeout)
                     event_info = dict(response.json())
                     events = event_info.get('events')
-                    if corp_type in no_corp_num_prefix_in_colin:
-                        append_corp_num_prefixes(events, 'BC')
                     if colin_events:
                         colin_events.get('events').extend(events)
                     else:
@@ -159,13 +154,6 @@ def check_for_manual_filings(application: Flask = None, token: dict = None):
     return id_list
 
 
-def append_corp_num_prefixes(events, corp_num_prefix):
-    """Append corp num prefix to Colin corp num to make Lear compatible."""
-    for event in events:
-        event['corp_num'] = corp_num_prefix + event['corp_num']
-
-
-# pylint: disable=redefined-outer-name
 def get_filing(event_info: dict = None, application: Flask = None, token: dict = None):
     """Get filing created by previous event."""
     # call the colin api for the filing

--- a/jobs/update-legal-filings/update_legal_filings.py
+++ b/jobs/update-legal-filings/update_legal_filings.py
@@ -47,31 +47,31 @@ CONTENT_TYPE_JSON = 'application/json'
 
 def create_app(run_mode=os.getenv('FLASK_ENV', 'production')):
     """Return a configured Flask App using the Factory method."""
-    app = Flask(__name__)
-    app.config.from_object(config.CONFIGURATION[run_mode])
+    application = Flask(__name__)
+    application.config.from_object(config.CONFIGURATION[run_mode])
     # Configure Sentry
-    if app.config.get('SENTRY_DSN', None):
+    if application.config.get('SENTRY_DSN', None):
         sentry_sdk.init(
-            dsn=app.config.get('SENTRY_DSN'),
+            dsn=application.config.get('SENTRY_DSN'),
             integrations=[SENTRY_LOGGING]
         )
 
-    register_shellcontext(app)
+    register_shellcontext(application)
 
     # Static class load the variables while importing the class for the first time,
     # By then config is not loaded, so it never get the config value
-    AccountService.timeout = int(app.config.get('ACCOUNT_SVC_TIMEOUT'))
+    AccountService.timeout = int(application.config.get('ACCOUNT_SVC_TIMEOUT'))
 
-    return app
+    return application
 
 
-def register_shellcontext(app):
+def register_shellcontext(application):
     """Register shell context objects."""
     def shell_context():
         """Shell context objects."""
-        return {'app': app}
+        return {'app': application}
 
-    app.shell_context_processor(shell_context)
+    application.shell_context_processor(shell_context)
 
 
 def check_for_manual_filings(application: Flask = None, token: dict = None):
@@ -357,9 +357,9 @@ async def update_business_nos(application, qsm):  # pylint: disable=redefined-ou
 
 
 if __name__ == '__main__':
-    application = create_app()
-    with application.app_context():
-        update_filings(application)
+    app = create_app()
+    with app.app_context():
+        update_filings(app)
         event_loop = asyncio.get_event_loop()
-        qsm = QueueService(app=application, loop=event_loop)
-        event_loop.run_until_complete(update_business_nos(application, qsm))
+        qsm = QueueService(app=app, loop=event_loop)
+        event_loop.run_until_complete(update_business_nos(app, qsm))

--- a/legal-api/src/legal_api/models/business.py
+++ b/legal-api/src/legal_api/models/business.py
@@ -665,7 +665,11 @@ class Business(db.Model, Versioned):  # pylint: disable=too-many-instance-attrib
             Business.LegalTypes.SOLE_PROP.value,
             Business.LegalTypes.PARTNERSHIP.value,
         ]
-        businesses = cls.query.filter(~Business.legal_type.in_(no_tax_id_types)).filter_by(tax_id=None).all()
+        businesses = (db.session.query(Business.identifier)
+                      .filter(
+                          ~Business.legal_type.in_(no_tax_id_types),
+                           Business.tax_id == None)  # pylint: disable=singleton-comparison # noqa: E711;
+                      .all())
         return businesses
 
     @classmethod

--- a/legal-api/src/legal_api/models/business.py
+++ b/legal-api/src/legal_api/models/business.py
@@ -668,7 +668,7 @@ class Business(db.Model, Versioned):  # pylint: disable=too-many-instance-attrib
         businesses = (db.session.query(Business.identifier)
                       .filter(
                           ~Business.legal_type.in_(no_tax_id_types),
-                           Business.tax_id == None)  # pylint: disable=singleton-comparison # noqa: E711;
+                          Business.tax_id == None)  # pylint: disable=singleton-comparison # noqa: E711;
                       .all())
         return businesses
 

--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -998,10 +998,10 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
         return filing.first()
 
     @staticmethod
-    def get_completed_filings_for_colin(page=1, limit=20):
-        """Return the filings with statuses in the status array input."""
+    def get_completed_filings_for_colin(limit=20, offset=0):
+        """Return the filings based on limit and offset."""
         from .business import Business  # noqa: F401; pylint: disable=import-outside-toplevel
-        excluded_filings = ['adminFreeze', 'courtOrder', 'registrarsNotation', 'registrarsOrder']
+        excluded_filings = ['lear_epoch', 'adminFreeze', 'courtOrder', 'registrarsNotation', 'registrarsOrder']
         excluded_businesses = [Business.LegalTypes.SOLE_PROP.value, Business.LegalTypes.PARTNERSHIP.value]
         filings = db.session.query(Filing).join(Business). \
             filter(
@@ -1010,15 +1010,9 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
                 Filing.colin_event_ids == None,  # pylint: disable=singleton-comparison # noqa: E711;
                 Filing._status == Filing.Status.COMPLETED.value,
                 Filing.effective_date != None   # pylint: disable=singleton-comparison # noqa: E711;
-            ).order_by(Filing.filing_date).paginate(per_page=limit, page=page)
+            ).order_by(Filing.effective_date).limit(limit).offset(offset).all()
 
-        return {
-            'page': page,
-            'limit': limit,
-            'filings': filings.items,
-            'pages': filings.pages,
-            'total': filings.total
-        }
+        return filings
 
     @staticmethod
     def get_future_effective_filing_ids() -> List[int]:

--- a/legal-api/src/legal_api/resources/v1/business/business_filings.py
+++ b/legal-api/src/legal_api/resources/v1/business/business_filings.py
@@ -867,7 +867,7 @@ class InternalFilings(Resource):
 
         if status is None:
             pending_filings = Filing.get_completed_filings_for_colin()
-            for filing in pending_filings.get('filings'):
+            for filing in pending_filings:
                 filing_json = filing.filing_json
                 business = Business.find_by_internal_id(filing.business_id)
                 if filing_json and filing.filing_type != 'lear_epoch' and \

--- a/legal-api/tests/unit/models/test_filing.py
+++ b/legal-api/tests/unit/models/test_filing.py
@@ -541,7 +541,6 @@ def test_get_internal_filings(session, client, jwt):
     filing.colin_event_ids.append(colin_event_id)
     filing.save()
     filings = Filing.get_completed_filings_for_colin()
-    filings = filings.get('filings')
 
     # test method
     # assert doesn't return completed filing with colin_event_ids set
@@ -550,7 +549,6 @@ def test_get_internal_filings(session, client, jwt):
     filing.colin_event_ids.clear()
     filing.save()
     filings = Filing.get_completed_filings_for_colin()
-    filings = filings.get('filings')
     assert len(filings) == 1
     assert filing.id == filings[0].json['filing']['header']['filingId']
     assert filings[0].json['filing']['header']['colinIds'] == []
@@ -559,7 +557,6 @@ def test_get_internal_filings(session, client, jwt):
     filing.save()
     assert filing.status != Filing.Status.COMPLETED.value
     filings = Filing.get_completed_filings_for_colin()
-    filings = filings.get('filings')
     assert len(filings) == 0
 
 

--- a/legal-api/tests/unit/resources/v1/test_business_filings/test_internal.py
+++ b/legal-api/tests/unit/resources/v1/test_business_filings/test_internal.py
@@ -279,31 +279,6 @@ def test_get_internal_filings(session, client, jwt):
     assert rv.json[0]['filingId'] == filing1.id
 
 
-@pytest.mark.parametrize('identifier, base_filing, corrected_filing, colin_id', [
-        ('BC1234567', CORRECTION_INCORPORATION, INCORPORATION_FILING_TEMPLATE, 1234),
-        ('BC1234568', CORRECTION_INCORPORATION, INCORPORATION_FILING_TEMPLATE, None),
-    ])
-def test_get_bcomp_corrections(session, client, jwt, identifier, base_filing, corrected_filing, colin_id):
-    """Assert that the internal filings get endpoint returns corrections for bcomps."""
-    # setup
-    b = factory_business(identifier=identifier, entity_type=Business.LegalTypes.BCOMP.value)
-    factory_business_mailing_address(b)
-
-    incorp_filing = factory_completed_filing(business=b, data_dict=corrected_filing, colin_id=colin_id)
-    correction_filing = copy.deepcopy(base_filing)
-    correction_filing['filing']['correction']['correctedFilingId'] = incorp_filing.id
-    filing = factory_completed_filing(b, correction_filing)
-
-    # test endpoint returns filing
-    rv = client.get('/api/v1/businesses/internal/filings')
-    assert rv.status_code == HTTPStatus.OK
-    assert len(rv.json) == 1
-    if colin_id:
-        assert rv.json[0]['filingId'] == filing.id
-    else:
-        assert rv.json[0]['filingId'] == incorp_filing.id
-
-
 def test_patch_internal_filings(session, client, jwt):
     """Assert that the internal filings patch endpoint updates the colin_event_id."""
     from legal_api.models.colin_event_id import ColinEventId

--- a/legal-api/tests/unit/resources/v2/test_colin_sync.py
+++ b/legal-api/tests/unit/resources/v2/test_colin_sync.py
@@ -76,7 +76,7 @@ def test_get_internal_filings(session, client, jwt):
     assert rv.status_code == HTTPStatus.OK
     filings = rv.json.get('filings')
     assert len(filings) == 2
-    assert filings[0]['filingId'] == filing1.id
+    assert filings[0]['filingId'] in [filing1.id, filing6.id]
 
 
 def test_patch_internal_filings(session, client, jwt):

--- a/legal-api/tests/unit/resources/v2/test_colin_sync.py
+++ b/legal-api/tests/unit/resources/v2/test_colin_sync.py
@@ -75,7 +75,7 @@ def test_get_internal_filings(session, client, jwt):
                     headers=create_header(jwt, [COLIN_SVC_ROLE]))
     assert rv.status_code == HTTPStatus.OK
     filings = rv.json.get('filings')
-    assert len(filings) == 1
+    assert len(filings) == 2
     assert filings[0]['filingId'] == filing1.id
 
 

--- a/legal-api/tests/unit/resources/v2/test_colin_sync.py
+++ b/legal-api/tests/unit/resources/v2/test_colin_sync.py
@@ -79,33 +79,6 @@ def test_get_internal_filings(session, client, jwt):
     assert filings[0]['filingId'] == filing1.id
 
 
-@pytest.mark.parametrize('identifier, base_filing, corrected_filing, colin_id', [
-    ('BC1234567', CORRECTION_INCORPORATION, INCORPORATION_FILING_TEMPLATE, 1234),
-    ('BC1234568', CORRECTION_INCORPORATION, INCORPORATION_FILING_TEMPLATE, None),
-])
-def test_get_bcomp_corrections(session, client, jwt, identifier, base_filing, corrected_filing, colin_id):
-    """Assert that the internal filings get endpoint returns corrections for bcomps."""
-    # setup
-    b = factory_business(identifier=identifier, entity_type=Business.LegalTypes.BCOMP.value)
-    factory_business_mailing_address(b)
-
-    incorp_filing = factory_completed_filing(business=b, data_dict=corrected_filing, colin_id=colin_id)
-    correction_filing = copy.deepcopy(base_filing)
-    correction_filing['filing']['correction']['correctedFilingId'] = incorp_filing.id
-    filing = factory_completed_filing(b, correction_filing)
-
-    # test endpoint returns filing
-    rv = client.get('/api/v2/businesses/internal/filings',
-                    headers=create_header(jwt, [COLIN_SVC_ROLE]))
-    assert rv.status_code == HTTPStatus.OK
-    filings = rv.json.get('filings')
-    assert len(filings) == 1
-    if colin_id:
-        assert filings[0]['filingId'] == filing.id
-    else:
-        assert filings[0]['filingId'] == incorp_filing.id
-
-
 def test_patch_internal_filings(session, client, jwt):
     """Assert that the internal filings patch endpoint updates the colin_event_id."""
     from legal_api.models.colin_event_id import ColinEventId


### PR DESCRIPTION
*Issue #:* /bcgov/entity#24153

*Description of changes:*
  - Fixed `ORA-01830: date format picture ends before converting entire input string` (COD filing_date)
  - Fixed `'NoneType' object has no attribute 'upper'`
  - Handled optional fields 
  - `update-colin-filings` changed logic of fetching filings with offset instead of paginate (to avoid calculation)
  - `update_legal_filings` removed sync of CORPS from colin -> lear (this is not accepted anymore). Still have logic for COOP's, seems like it may be in use. Not in a position to work on COOP's

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
