### PR TITLE
24164 Update legacy database extract script

### DIFF
--- a/data-tool/scripts/README_COLIN_Corps_Extract.md
+++ b/data-tool/scripts/README_COLIN_Corps_Extract.md
@@ -4,14 +4,31 @@
 1. Create empty postgres extract db
    `createdb -h localhost -p 5432 -U postgres -T template0 colin-mig-corps-data-test`
 2. Create COLIN corps postgres extract table structure via ddl in `/data-tool/scripts/colin_corps_extract_postgres_ddl`
-3. Install dbshell -  [DbShell | Free Universal SQL Command-Line Client](https://dbschema.com/dbshell.html)  More general info around configuration and data transfer can be found at [DbShell | Multi-Database SQL Command Line Client](https://dbschema.com/documentation/dbshell.html)
-4. Add `/Applications/DbShell` to path
-5. Register extract source db by adding db connection in  `~/.DbSchema/dbshell/init.sql`
-   e.g. `connection cprd Oracle "user=<some_user> password=<some_password> host=<host_name> db=<SID>"`
-5. Register extract target db by adding db connection in  `~/.DbSchema/dbshell/init.sql`
-   e.g. `connection cprd_pg PostgreSql "user=postgres password=<some_password> host=localhost db=colin-mig-corps-data-test"`
-6. Disable triggers in target extract db using sql snippet found in `misc_extract_corps_queries.sql`
-7. Transfer data `dbshell <lear-repo-base-path>/data-tool/scripts/transfer_cprd_corps.sql`
+```
+# create empty db for the first time
+createdb -h localhost -p 5432 -U postgres -T template0 colin-mig-corps-data-test && \
+psql -h localhost -p 5432 -U postgres -d colin-mig-corps-test -f <lear-repo-base-path>/data-tool/scripts/colin_corps_extract_postgres_ddl
+
+# kill connection & recreate empty db
+psql -h localhost -p 5432 -U postgres -d colin-mig-corps-data-test -c "SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE datname = 'colin-mig-corps-data-test' AND pid <> pg_backend_pid();" && \
+dropdb -h localhost -p 5432 -U postgres colin-mig-corps-data-test && \
+createdb -h localhost -p 5432 -U postgres -T template0 colin-mig-corps-data-test && \
+psql -h localhost -p 5432 -U postgres -d colin-mig-corps-test -f <lear-repo-base-path>/data-tool/scripts/colin_corps_extract_postgres_ddl
+```
+3. Install DbSchemaCLI (previously named DbShell) -  [DbSchemaCLI | Free Universal SQL Command-Line Client](https://dbschema.com/dbschemacli.html). More general info around configuration and data transfer can be found at [DbSchemaCLI | Universal Command Line Client](https://dbschema.com/documentation/dbschemacli.html)
+4. Add `/Applications/DbSchema` to path
+5. Register Oracle driver and extract source db in `~/.DbSchema/cli/init.sql`
+```
+register driver Oracle oracle.jdbc.OracleDriver jdbc:oracle:thin:@<host>:<port>:<db> "port=1521"
+connection cprd -d Oracle -u <some_user> -p <some_password> -h <host_name> -P <port> -D <database_name>
+```
+5. Register PostgreSQL driver and extract target db in  `~/.DbSchema/cli/init.sql`
+```
+register driver PostgreSql org.postgresql.Driver jdbc:postgresql://<host>:<port>/<db> "port=5432"
+connection cprd_pg -d PostgreSql -u postgres -p <some_password> -h localhost -P <port> -D colin-mig-corps-test
+```
+6. (No longer required) ~~Disable triggers in target extract db using sql snippet found in `misc_extract_corps_queries.sql`~~
+7. Transfer data `dbschemacli <lear-repo-base-path>/data-tool/scripts/transfer_cprd_corps.sql`
 8. Successful output will look something like following:
 ```
 argus@Argus-Mac ~/h3/git/bcreg/lear/data-tool/scripts $ dbshell /Users/argus/h3/git/bcreg/lear/data-tool/scripts/transfer_cprd_corps.sql
@@ -30,8 +47,11 @@ Transfer using 4 thread(s) filing_user ...                          5 rows in 00
 Transfer using 4 thread(s) office ...                               5 rows in 00:01. Reader waited 00:00, writer 00:04.
 ...
 ```
-8. Re-enable triggers in target extract db using sql snippet found in `misc_extract_corps_queries.sql`
+8. (No longer required) ~~Re-enable triggers in target extract db using sql snippet found in `misc_extract_corps_queries.sql`~~
 9. Re-index target extract db.
+10. Use "count overview" SQL snippet in `misc_extract_corps_queries.sql` to verify the db changes.
 
 
-Notes: Update number of threads(`vset transfer.threads=4`) to use as appropriate in `transfer_cprd_corps.sql`.   
+Notes:
+1. Update number of threads (e.g. `vset cli.settings.transfer_threads=4`) to use as appropriate in `transfer_cprd_corps.sql`.
+2. As of November 4, 2024, the database extract script runs without error using DbSchemaCLI 9.4.3

--- a/data-tool/scripts/README_COLIN_Corps_Extract.md
+++ b/data-tool/scripts/README_COLIN_Corps_Extract.md
@@ -22,12 +22,11 @@ psql -h localhost -p 5432 -U postgres -d colin-mig-corps-test -f <lear-repo-base
 register driver Oracle oracle.jdbc.OracleDriver jdbc:oracle:thin:@<host>:<port>:<db> "port=1521"
 connection cprd -d Oracle -u <some_user> -p <some_password> -h <host_name> -P <port> -D <database_name>
 ```
-5. Register PostgreSQL driver and extract target db in  `~/.DbSchema/cli/init.sql`
+6. Register PostgreSQL driver and extract target db in  `~/.DbSchema/cli/init.sql`
 ```
 register driver PostgreSql org.postgresql.Driver jdbc:postgresql://<host>:<port>/<db> "port=5432"
 connection cprd_pg -d PostgreSql -u postgres -p <some_password> -h localhost -P <port> -D colin-mig-corps-test
 ```
-6. (No longer required) ~~Disable triggers in target extract db using sql snippet found in `misc_extract_corps_queries.sql`~~
 7. Transfer data `dbschemacli <lear-repo-base-path>/data-tool/scripts/transfer_cprd_corps.sql`
 8. Successful output will look something like following:
 ```
@@ -47,7 +46,6 @@ Transfer using 4 thread(s) filing_user ...                          5 rows in 00
 Transfer using 4 thread(s) office ...                               5 rows in 00:01. Reader waited 00:00, writer 00:04.
 ...
 ```
-8. (No longer required) ~~Re-enable triggers in target extract db using sql snippet found in `misc_extract_corps_queries.sql`~~
 9. Re-index target extract db.
 10. Use "count overview" SQL snippet in `misc_extract_corps_queries.sql` to verify the db changes.
 

--- a/data-tool/scripts/misc_extract_corps_queries.sql
+++ b/data-tool/scripts/misc_extract_corps_queries.sql
@@ -68,8 +68,8 @@ ALTER TABLE party_notification ENABLE TRIGGER ALL;
 
 
 -- count overview
-select (select count(*) from event)       as events,
-       (select count(*) from corporation) as corps,
+select (select count(*) from corporation) as corps,
+	   (select count(*) from event)       as events,
        (select count(*) from corp_name) as corp_names,
        (select count(*) from corp_state) as corp_states,
        (select count(*) from filing)      as filings,
@@ -93,9 +93,9 @@ select (select count(*) from event)       as events,
        (select count(*) from correction) as corrections,
        (select count(*) from jurisdiction) as jurisdiction,
        (select count(*) from resolution) as resolutions,
-       (select count(*) from share_series) as share_series,
        (select count(*) from share_struct) as share_structs,
        (select count(*) from share_struct_cls) as share_structs_cls,
+	   (select count(*) from share_series) as share_series,
        (select count(*) from notification) as notifications,
        (select count(*) from notification_resend) as notification_resends,
        (select count(*) from party_notification) as party_notifications

--- a/data-tool/scripts/misc_extract_corps_queries.sql
+++ b/data-tool/scripts/misc_extract_corps_queries.sql
@@ -95,7 +95,7 @@ select (select count(*) from corporation) as corps,
        (select count(*) from resolution) as resolutions,
        (select count(*) from share_struct) as share_structs,
        (select count(*) from share_struct_cls) as share_structs_cls,
-	(select count(*) from share_series) as share_series,
+       (select count(*) from share_series) as share_series,
        (select count(*) from notification) as notifications,
        (select count(*) from notification_resend) as notification_resends,
        (select count(*) from party_notification) as party_notifications

--- a/data-tool/scripts/misc_extract_corps_queries.sql
+++ b/data-tool/scripts/misc_extract_corps_queries.sql
@@ -69,7 +69,7 @@ ALTER TABLE party_notification ENABLE TRIGGER ALL;
 
 -- count overview
 select (select count(*) from corporation) as corps,
-	   (select count(*) from event)       as events,
+	(select count(*) from event)       as events,
        (select count(*) from corp_name) as corp_names,
        (select count(*) from corp_state) as corp_states,
        (select count(*) from filing)      as filings,
@@ -95,7 +95,7 @@ select (select count(*) from corporation) as corps,
        (select count(*) from resolution) as resolutions,
        (select count(*) from share_struct) as share_structs,
        (select count(*) from share_struct_cls) as share_structs_cls,
-	   (select count(*) from share_series) as share_series,
+	(select count(*) from share_series) as share_series,
        (select count(*) from notification) as notifications,
        (select count(*) from notification_resend) as notification_resends,
        (select count(*) from party_notification) as party_notifications

--- a/data-tool/scripts/transfer_cprd_corps.sql
+++ b/data-tool/scripts/transfer_cprd_corps.sql
@@ -7,6 +7,58 @@ connect cprd_pg;
 
 learn schema public;
 
+
+-- disable triggers
+ALTER TABLE corporation DISABLE TRIGGER ALL;
+ALTER TABLE corp_name DISABLE TRIGGER ALL;
+ALTER TABLE corp_state DISABLE TRIGGER ALL;
+ALTER TABLE event DISABLE TRIGGER ALL;
+ALTER TABLE filing DISABLE TRIGGER ALL;
+ALTER TABLE filing_user DISABLE TRIGGER ALL;
+ALTER TABLE office DISABLE TRIGGER ALL;
+ALTER TABLE address DISABLE TRIGGER ALL;
+ALTER TABLE corp_comments DISABLE TRIGGER ALL;
+ALTER TABLE ledger_text DISABLE TRIGGER ALL;
+ALTER TABLE corp_party DISABLE TRIGGER ALL;
+ALTER TABLE corp_party_relationship DISABLE TRIGGER ALL;
+ALTER TABLE offices_held DISABLE TRIGGER ALL;
+ALTER TABLE completing_party DISABLE TRIGGER ALL;
+ALTER TABLE submitting_party DISABLE TRIGGER ALL;
+ALTER TABLE corp_flag DISABLE TRIGGER ALL;
+ALTER TABLE cont_out DISABLE TRIGGER ALL;
+ALTER TABLE conv_event DISABLE TRIGGER ALL;
+ALTER TABLE conv_ledger DISABLE TRIGGER ALL;
+ALTER TABLE corp_involved_amalgamating DISABLE TRIGGER ALL;
+ALTER TABLE corp_involved_cont_in DISABLE TRIGGER ALL;
+ALTER TABLE corp_restriction DISABLE TRIGGER ALL;
+ALTER TABLE correction DISABLE TRIGGER ALL;
+ALTER TABLE jurisdiction DISABLE TRIGGER ALL;
+ALTER TABLE resolution DISABLE TRIGGER ALL;
+ALTER TABLE share_series DISABLE TRIGGER ALL;
+ALTER TABLE share_struct DISABLE TRIGGER ALL;
+ALTER TABLE share_struct_cls DISABLE TRIGGER ALL;
+ALTER TABLE notification DISABLE TRIGGER ALL;
+ALTER TABLE notification_resend DISABLE TRIGGER ALL;
+ALTER TABLE party_notification DISABLE TRIGGER ALL;
+
+
+-- alter tables
+alter table corporation alter column send_ar_ind type integer using send_ar_ind::integer;
+alter table filing
+   alter column arrangement_ind type integer using arrangement_ind::integer,
+   alter column court_appr_ind type integer using court_appr_ind::integer;
+alter table share_struct_cls
+   alter column max_share_ind type integer using max_share_ind::integer,
+   alter column spec_rights_ind type integer using spec_rights_ind::integer,
+   alter column par_value_ind type integer using par_value_ind::integer;
+alter table conv_event alter report_corp_ind type integer using report_corp_ind::integer;
+alter table corp_involved_amalgamating alter adopted_corp_ind type integer using adopted_corp_ind::integer;
+alter table corp_restriction alter restriction_ind type integer using restriction_ind::integer;
+alter table share_series
+   alter column max_share_ind type integer using max_share_ind::integer,
+   alter column spec_right_ind type integer using spec_right_ind::integer;
+
+
 -- corporation
 transfer public.corporation from cprd using
 select case
@@ -174,15 +226,15 @@ where o.corp_num = c.corp_num
 order by c.corp_num, start_event_id;
 
 
-vset transfer.threads=3
+vset cli.settings.transfer_threads=3
 -- address
 transfer public.address from cprd using
 select distinct ADDR_ID,
                 PROVINCE,
                 COUNTRY_TYP_CD,
-                POSTAL_CD,
+                replace(POSTAL_CD, CHR(0), '') as POSTAL_CD,
                 ADDR_LINE_1,
-                ADDR_LINE_2,
+                replace(ADDR_LINE_2, CHR(0), '') as ADDR_LINE_2,
                 ADDR_LINE_3,
                 CITY
 from (select a.*
@@ -256,7 +308,7 @@ from (select a.*
 order by addr_id;
 
 
-vset transfer.threads=8
+vset cli.settings.transfer_threads=8
 -- corp_comments
 transfer public.corp_comments from cprd using
 select cc.comment_dts,
@@ -687,7 +739,7 @@ select case
            else c.CORP_NUM
        end CORP_NUM,
        ssc.SHARE_CLASS_ID,
-       ssc.CLASS_NME,
+       replace(ssc.CLASS_NME, CHR(0), '') as CLASS_NME,
        ssc.CURRENCY_TYP_CD,
        case ssc.MAX_SHARE_IND
            when 'N' then 0
@@ -816,3 +868,54 @@ where cp.CORP_PARTY_ID = pn.party_id
   -- and c.corp_num in ('1396310', '1396309', '1396308', '1396307', '1396306', '1396890', '1396889', '1396885', '1396883', '1396878','1396597', '1396143', '1395925', '1395116', '1394990', '1246445', '1216743', '1396508', '1396505', '1396488', '1396401', '1396387', '1396957', '1355943', '1340611', '1335427', '1327193', '1393945', '1208648', '1117024', '1120292', '1127373', '1135492')
   -- and rownum <= 5
 order by c.corp_num;
+
+
+-- alter tables
+alter table corporation alter column send_ar_ind type boolean using send_ar_ind::boolean;
+alter table filing
+   alter column arrangement_ind type boolean using arrangement_ind::boolean,
+   alter column court_appr_ind type boolean using court_appr_ind::boolean;
+alter table share_struct_cls
+   alter column max_share_ind type boolean using max_share_ind::boolean,
+   alter column spec_rights_ind type boolean using spec_rights_ind::boolean,
+   alter column par_value_ind type boolean using par_value_ind::boolean;
+alter table conv_event alter report_corp_ind type boolean using report_corp_ind::boolean;
+alter table corp_involved_amalgamating alter adopted_corp_ind type boolean using adopted_corp_ind::boolean;
+alter table corp_restriction alter restriction_ind type boolean using restriction_ind::boolean;
+alter table share_series
+   alter column max_share_ind type boolean using max_share_ind::boolean,
+   alter column spec_right_ind type boolean using spec_right_ind::boolean;
+
+
+-- enable triggers
+ALTER TABLE corporation ENABLE TRIGGER ALL;
+ALTER TABLE corp_name ENABLE TRIGGER ALL;
+ALTER TABLE corp_state ENABLE TRIGGER ALL;
+ALTER TABLE event ENABLE TRIGGER ALL;
+ALTER TABLE filing ENABLE TRIGGER ALL;
+ALTER TABLE filing_user ENABLE TRIGGER ALL;
+ALTER TABLE office ENABLE TRIGGER ALL;
+ALTER TABLE address ENABLE TRIGGER ALL;
+ALTER TABLE corp_comments ENABLE TRIGGER ALL;
+ALTER TABLE ledger_text ENABLE TRIGGER ALL;
+ALTER TABLE corp_party ENABLE TRIGGER ALL;
+ALTER TABLE corp_party_relationship ENABLE TRIGGER ALL;
+ALTER TABLE offices_held ENABLE TRIGGER ALL;
+ALTER TABLE completing_party ENABLE TRIGGER ALL;
+ALTER TABLE submitting_party ENABLE TRIGGER ALL;
+ALTER TABLE corp_flag ENABLE TRIGGER ALL;
+ALTER TABLE cont_out ENABLE TRIGGER ALL;
+ALTER TABLE conv_event ENABLE TRIGGER ALL;
+ALTER TABLE conv_ledger ENABLE TRIGGER ALL;
+ALTER TABLE corp_involved_amalgamating ENABLE TRIGGER ALL;
+ALTER TABLE corp_involved_cont_in ENABLE TRIGGER ALL;
+ALTER TABLE corp_restriction ENABLE TRIGGER ALL;
+ALTER TABLE correction ENABLE TRIGGER ALL;
+ALTER TABLE jurisdiction ENABLE TRIGGER ALL;
+ALTER TABLE resolution ENABLE TRIGGER ALL;
+ALTER TABLE share_series ENABLE TRIGGER ALL;
+ALTER TABLE share_struct ENABLE TRIGGER ALL;
+ALTER TABLE share_struct_cls ENABLE TRIGGER ALL;
+ALTER TABLE notification ENABLE TRIGGER ALL;
+ALTER TABLE notification_resend ENABLE TRIGGER ALL;
+ALTER TABLE party_notification ENABLE TRIGGER ALL;


### PR DESCRIPTION
*Issue #:* /bcgov/entity#24164

*Description of changes:*
- Update extract script
    - resolve errors (mainly 2)
        - incompatible type between boolean and numeric
        - NULL byte (0x00)
    - add disable/enable-trigger snippets
- Update `README_COLIN_Corps_Extract.md`
- dbschema version = 9.4.3

*Local Testing*
- transfer legacy dev db data to local extract db
- execution time:  14m40s
- results shown as follows

screenshot 1: outputs of dbschemacli
![image](https://github.com/user-attachments/assets/9521e5d9-ce88-4361-a9f9-f608f13d5c19)


screenshot 2: results of db query
![image](https://github.com/user-attachments/assets/21150117-f482-4fc1-88f0-f01ae6780f9c)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
