### PR TITLE
Fix validation rules for filing, add a could file detection for if th…

### DIFF
--- a/legal-api/Makefile
+++ b/legal-api/Makefile
@@ -147,6 +147,11 @@ tag: push ## tag image
 run: ## Run the project in local
 	. venv/bin/activate && python -m flask run -p 5000
 
+db:
+	. venv/bin/activate && python -m flask db init
+	. venv/bin/activate && python -m flask db migrate
+	. venv/bin/activate && python -m flask db upgrade
+
 #################################################################################
 # Self Documenting Commands                                                     #
 #################################################################################

--- a/legal-api/Makefile
+++ b/legal-api/Makefile
@@ -147,11 +147,6 @@ tag: push ## tag image
 run: ## Run the project in local
 	. venv/bin/activate && python -m flask run -p 5000
 
-db:
-	. venv/bin/activate && python -m flask db init
-	. venv/bin/activate && python -m flask db migrate
-	. venv/bin/activate && python -m flask db upgrade
-
 #################################################################################
 # Self Documenting Commands                                                     #
 #################################################################################

--- a/legal-api/src/legal_api/resources/v2/business/business.py
+++ b/legal-api/src/legal_api/resources/v2/business/business.py
@@ -225,6 +225,11 @@ def get_allowable_for_business_type(business_type: str, business_state: str):
     business_type = business_type.upper()
     if business_type.startswith('T'):
         return {'message': babel('No information on temp registrations.')}, 200
+    
+    bs_state = getattr(Business.State, business_state, False)
+    bs_type = getattr(Business.LegalTypes, business_type, False)
+    if not bs_state or not bs_type:
+        return {'message': babel('Invalid business type or state.')}, 400
 
     could_file = get_could_files(jwt, business_type, business_state)
 

--- a/legal-api/src/legal_api/resources/v2/business/business.py
+++ b/legal-api/src/legal_api/resources/v2/business/business.py
@@ -223,7 +223,7 @@ def get_allowable_for_business_type(business_type: str, business_state: str):
     """Return a JSON object with information about what a user could theoretically file for a business type."""
     business_state = business_state.upper()
     business_type = business_type.upper()
-    
+
     bs_state = getattr(Business.State, business_state, False)
     bs_type = getattr(Business.LegalTypes, business_type, False)
     if not bs_state or not bs_type:

--- a/legal-api/src/legal_api/resources/v2/business/business.py
+++ b/legal-api/src/legal_api/resources/v2/business/business.py
@@ -223,8 +223,6 @@ def get_allowable_for_business_type(business_type: str, business_state: str):
     """Return a JSON object with information about what a user could theoretically file for a business type."""
     business_state = business_state.upper()
     business_type = business_type.upper()
-    if business_type.startswith('T'):
-        return {'message': babel('No information on temp registrations.')}, 200
     
     bs_state = getattr(Business.State, business_state, False)
     bs_type = getattr(Business.LegalTypes, business_type, False)

--- a/legal-api/src/legal_api/resources/v2/business/business.py
+++ b/legal-api/src/legal_api/resources/v2/business/business.py
@@ -34,7 +34,7 @@ from legal_api.services import (  # noqa: I001;
     RegistrationBootstrapService,
     check_warnings,
 )  # noqa: I001;
-from legal_api.services.authz import get_allowable_actions, get_allowed
+from legal_api.services.authz import get_allowable_actions, get_allowed, get_could_files
 from legal_api.utils.auth import jwt
 
 from .bp import bp
@@ -64,6 +64,7 @@ def get_businesses(identifier: str):
         business_json = business.json(slim=True)
         # need to add the alternateNames array here because it is not a part of slim JSON
         business_json['alternateNames'] = business.get_alternate_names()
+
         return jsonify(business=business_json)
 
     warnings = check_warnings(business)
@@ -75,6 +76,10 @@ def get_businesses(identifier: str):
     business.allowable_actions = allowable_actions
 
     business_json = business.json()
+
+    could_file = get_could_files(jwt, business)
+    business_json['couldFile'] = could_file
+
     recent_filing_json = CoreFiling.get_most_recent_filing_json(business.id, None, jwt)
     if recent_filing_json:
         business_json['submitter'] = recent_filing_json['filing']['header']['submitter']

--- a/legal-api/src/legal_api/resources/v2/business/business.py
+++ b/legal-api/src/legal_api/resources/v2/business/business.py
@@ -225,9 +225,13 @@ def get_allowable_for_business_type(business_type: str, business_state: str):
     business_type = business_type.upper()
 
     bs_state = getattr(Business.State, business_state, False)
-    bs_type = getattr(Business.LegalTypes, business_type, False)
-    if not bs_state or not bs_type:
-        return {'message': babel('Invalid business type or state.')}, 400
+    if not bs_state:
+        return {'message': babel('Invalid business state.')}, 400
+
+    try:
+        _ = Business.LegalTypes(business_type)
+    except ValueError:
+        return {'message': babel('Invalid business type.')}, 400
 
     could_file = get_could_files(jwt, business_type, business_state)
 

--- a/legal-api/src/legal_api/resources/v2/business/business.py
+++ b/legal-api/src/legal_api/resources/v2/business/business.py
@@ -226,12 +226,12 @@ def get_allowable_for_business_type(business_type: str, business_state: str):
 
     bs_state = getattr(Business.State, business_state, False)
     if not bs_state:
-        return {'message': babel('Invalid business state.')}, 400
+        return {'message': babel('Invalid business state.')}, HTTPStatus.BAD_REQUEST
 
     try:
         _ = Business.LegalTypes(business_type)
     except ValueError:
-        return {'message': babel('Invalid business type.')}, 400
+        return {'message': babel('Invalid business type.')}, HTTPStatus.BAD_REQUEST
 
     could_file = get_could_files(jwt, business_type, business_state)
 

--- a/legal-api/src/legal_api/services/authz.py
+++ b/legal-api/src/legal_api/services/authz.py
@@ -57,19 +57,6 @@ class BusinessBlocker(str, Enum):
     FILING_WITHDRAWAL = 'FILING_WITHDRAWAL'
 
 
-class BusinessConditionalBlocker():
-    """Define the conditional checks."""
-
-    def sp_gp_missing_required_business_info(self, business, blocker_checks):
-        """If business is GP or SP enforce missing required info otherwise skip."""
-        if business.legal_type in (Business.LegalTypes.SOLE_PROP, Business.LegalTypes.PARTNERSHIP):
-            checks = {
-                'warningTypes': [WarningType.MISSING_REQUIRED_BUSINESS_INFO]
-            }
-            return has_blocker_warning_filing(business.warnings, checks)
-        return False
-
-
 class BusinessRequirement(str, Enum):
     """Define an enum for business requirement scenarios."""
 
@@ -186,7 +173,7 @@ def get_allowable_filings_dict():
                     'regular': {
                         'legalTypes': ['BEN', 'BC', 'ULC', 'CC', 'C', 'CBEN', 'CUL', 'CCC'],
                         'blockerChecks': {
-                            'business': [BusinessBlocker.BUSINESS_FROZEN,
+                            'business': [BusinessBlocker.DEFAULT,
                                          BusinessBlocker.NOT_IN_GOOD_STANDING,
                                          BusinessBlocker.IN_DISSOLUTION],
                             'futureEffectiveFilings': [filing_types_compact.DISSOLUTION_VOLUNTARY,
@@ -196,7 +183,7 @@ def get_allowable_filings_dict():
                     'vertical': {
                         'legalTypes': ['BEN', 'BC', 'ULC', 'CC', 'C', 'CBEN', 'CUL', 'CCC'],
                         'blockerChecks': {
-                            'business': [BusinessBlocker.BUSINESS_FROZEN,
+                            'business': [BusinessBlocker.DEFAULT,
                                          BusinessBlocker.NOT_IN_GOOD_STANDING,
                                          BusinessBlocker.IN_DISSOLUTION],
                             'futureEffectiveFilings': [filing_types_compact.DISSOLUTION_VOLUNTARY,
@@ -235,11 +222,12 @@ def get_allowable_filings_dict():
                 'changeOfRegistration': {
                     'legalTypes': ['SP', 'GP'],
                     'blockerChecks': {
+                        'warningTypes': [WarningType.MISSING_REQUIRED_BUSINESS_INFO],
                         'business': [BusinessBlocker.DEFAULT]
                     }
                 },
                 'continuationIn': {
-                    'legalTypes': ['BEN', 'BC', 'ULC', 'CC', 'C', 'CBEN', 'CUL', 'CCC'],
+                    'legalTypes': ['C', 'CBEN', 'CUL', 'CCC'],
                     # only show filing when providing allowable filings not specific to a business
                     'businessRequirement': BusinessRequirement.NOT_EXIST
                 },
@@ -262,8 +250,8 @@ def get_allowable_filings_dict():
                 'correction': {
                     'legalTypes': ['CP', 'BEN', 'SP', 'GP', 'BC', 'ULC', 'CC', 'C', 'CBEN', 'CUL', 'CCC'],
                     'blockerChecks': {
-                        'business': [BusinessBlocker.DEFAULT],
-                        'conditionalChecks': [BusinessConditionalBlocker.sp_gp_missing_required_business_info]
+                        'warningTypes': [WarningType.MISSING_REQUIRED_BUSINESS_INFO],
+                        'business': [BusinessBlocker.DEFAULT]
                     }
                 },
                 'courtOrder': {
@@ -273,7 +261,7 @@ def get_allowable_filings_dict():
                     'voluntary': {
                         'legalTypes': ['CP', 'BC', 'BEN', 'CC', 'ULC', 'SP', 'GP', 'C', 'CBEN', 'CUL', 'CCC'],
                         'blockerChecks': {
-                            'conditionalChecks': [BusinessConditionalBlocker.sp_gp_missing_required_business_info],
+                            'warningTypes': [WarningType.MISSING_REQUIRED_BUSINESS_INFO],
                             'business': [BusinessBlocker.DEFAULT,
                                          BusinessBlocker.NOT_IN_GOOD_STANDING,
                                          BusinessBlocker.IN_DISSOLUTION]
@@ -282,7 +270,7 @@ def get_allowable_filings_dict():
                     'administrative': {
                         'legalTypes': ['CP', 'BC', 'BEN', 'CC', 'ULC', 'SP', 'GP', 'C', 'CBEN', 'CUL', 'CCC'],
                         'blockerChecks': {
-                            'conditionalChecks': [BusinessConditionalBlocker.sp_gp_missing_required_business_info],
+                            'warningTypes': [WarningType.MISSING_REQUIRED_BUSINESS_INFO],
                             'business': [BusinessBlocker.DRAFT_PENDING]
                         }
                     }
@@ -333,7 +321,7 @@ def get_allowable_filings_dict():
                 'noticeOfWithdrawal': {
                     'legalTypes': ['BC', 'BEN', 'CC', 'ULC', 'C', 'CBEN', 'CUL', 'CCC'],
                     'blockerChecks': {
-                        'business': [BusinessBlocker.DEFAULT, BusinessBlocker.FILING_WITHDRAWAL]
+                        'business': [BusinessBlocker.FILING_WITHDRAWAL]
                     }
                 }
             },
@@ -343,10 +331,6 @@ def get_allowable_filings_dict():
                 },
                 'putBackOn': {
                     'legalTypes': ['SP', 'GP', 'BEN', 'CP', 'BC', 'CC', 'ULC', 'C', 'CBEN', 'CUL', 'CCC'],
-                    'blockerChecks': {
-                        'invalidStateFilings': ['amalgamationApplication', 'administrative'],
-                    },
-                    'futureEffectiveFilings': [filing_types_compact.DISSOLUTION_ADMINISTRATIVE]
                 },
                 'registrarsNotation': {
                     'legalTypes': ['SP', 'GP', 'CP', 'BC', 'BEN', 'CC', 'ULC', 'C', 'CBEN', 'CUL', 'CCC']
@@ -358,14 +342,14 @@ def get_allowable_filings_dict():
                     'fullRestoration': {
                         'legalTypes': ['BC', 'BEN', 'CC', 'ULC', 'C', 'CBEN', 'CUL', 'CCC'],
                         'blockerChecks': {
-                            'invalidStateFilings': ['continuationOut', 'continuationIn'],
+                            'invalidStateFilings': ['continuationOut'],
                             'business': [BusinessBlocker.AMALGAMATING_BUSINESS]
                         }
                     },
                     'limitedRestoration': {
                         'legalTypes': ['BC', 'BEN', 'CC', 'ULC', 'C', 'CBEN', 'CUL', 'CCC'],
                         'blockerChecks': {
-                            'invalidStateFilings': ['continuationOut', 'continuationIn'],
+                            'invalidStateFilings': ['continuationOut'],
                             'business': [BusinessBlocker.AMALGAMATING_BUSINESS]
                         }
                     }
@@ -399,7 +383,7 @@ def get_allowable_filings_dict():
                     'regular': {
                         'legalTypes': ['BEN', 'BC', 'ULC', 'CC', 'C', 'CBEN', 'CUL', 'CCC'],
                         'blockerChecks': {
-                            'business': [BusinessBlocker.BUSINESS_FROZEN,
+                            'business': [BusinessBlocker.DEFAULT,
                                          BusinessBlocker.NOT_IN_GOOD_STANDING,
                                          BusinessBlocker.IN_DISSOLUTION],
                             'futureEffectiveFilings': [filing_types_compact.DISSOLUTION_VOLUNTARY,
@@ -459,7 +443,7 @@ def get_allowable_filings_dict():
                     }
                 },
                 'continuationIn': {
-                    'legalTypes': ['BEN', 'BC', 'ULC', 'CC', 'C', 'CBEN', 'CUL', 'CCC'],
+                    'legalTypes': ['C', 'CBEN', 'CUL', 'CCC'],
                     # only show filing when providing allowable filings not specific to a business
                     'businessRequirement': BusinessRequirement.NOT_EXIST
                 },
@@ -467,7 +451,7 @@ def get_allowable_filings_dict():
                     'voluntary': {
                         'legalTypes': ['CP', 'BC', 'BEN', 'CC', 'ULC', 'SP', 'GP', 'C', 'CBEN', 'CUL', 'CCC'],
                         'blockerChecks': {
-                            'conditionalChecks': [BusinessConditionalBlocker.sp_gp_missing_required_business_info],
+                            'warningTypes': [WarningType.MISSING_REQUIRED_BUSINESS_INFO],
                             'business': [BusinessBlocker.DEFAULT,
                                          BusinessBlocker.NOT_IN_GOOD_STANDING,
                                          BusinessBlocker.IN_DISSOLUTION]
@@ -724,11 +708,6 @@ def has_blocker(business: Business, state_filing: Filing, allowable_filing: dict
 
     if has_blocker_warning_filing(business.warnings, blocker_checks):
         return True
-
-    conditional_checks = blocker_checks.get('conditionalChecks', [])
-    for conditional_function in conditional_checks:
-        if conditional_function(business, blocker_checks):
-            return True
 
     return False
 

--- a/legal-api/tests/unit/resources/v2/test_business.py
+++ b/legal-api/tests/unit/resources/v2/test_business.py
@@ -549,7 +549,7 @@ def test_post_affiliated_businesses_invalid(session, client, jwt):
 def test_get_could_file(session, client, jwt):
     """Assert that the cold file is returned."""
     identifier = 'BC0000001'
-    rv = client.get(f'/api/v2/businesses/allowable/BC/ACTIVE',
+    rv = client.get('/api/v2/businesses/allowable/BC/ACTIVE',
                     headers=create_header(jwt, [STAFF_ROLE], identifier))
     
     expected = [

--- a/legal-api/tests/unit/resources/v2/test_business.py
+++ b/legal-api/tests/unit/resources/v2/test_business.py
@@ -544,3 +544,119 @@ def test_post_affiliated_businesses_invalid(session, client, jwt):
                      json={},
                      headers=create_header(jwt, [SYSTEM_ROLE]))
     assert rv.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_get_could_file(session, client, jwt):
+    """Assert that the cold file is returned."""
+    identifier = 'BC0000001'
+    rv = client.get(f'/api/v2/businesses/allowable/BC/ACTIVE',
+                    headers=create_header(jwt, [STAFF_ROLE], identifier))
+    
+    expected = [
+        {
+            "displayName": "Admin Freeze",
+            "name": "adminFreeze"
+        },
+        {
+            "displayName": "Request for AGM Extension",
+            "name": "agmExtension"
+        },
+        {
+            "displayName": "AGM Location Change",
+            "name": "agmLocationChange"
+        },
+        {
+            "displayName": "Alteration",
+            "name": "alteration"
+        },
+        {
+            "displayName": "Amalgamation Application (Regular)",
+            "name": "amalgamationApplication",
+            "type": "regular"
+        },
+        {
+            "displayName": "Amalgamation Application Short-form (Vertical)",
+            "name": "amalgamationApplication",
+            "type": "vertical"
+        },
+        {
+            "displayName": "Amalgamation Application Short-form (Horizontal)",
+            "name": "amalgamationApplication",
+            "type": "horizontal"
+        },
+        {
+            "displayName": "Annual Report",
+            "name": "annualReport"
+        },
+        {
+            "displayName": "Address Change",
+            "name": "changeOfAddress"
+        },
+        {
+            "displayName": "Director Change",
+            "name": "changeOfDirectors"
+        },
+        {
+            "displayName": "6-Month Consent to Continue Out",
+            "name": "consentContinuationOut"
+        },
+        {
+            "displayName": "Continuation Out",
+            "name": "continuationOut"
+        },
+        {
+            "displayName": "Register Correction Application",
+            "name": "correction"
+        },
+        {
+            "displayName": "Court Order",
+            "name": "courtOrder"
+        },
+        {
+            "displayName": "Voluntary Dissolution",
+            "name": "dissolution",
+            "type": "voluntary"
+        },
+        {
+            "displayName": "Administrative Dissolution",
+            "name": "dissolution",
+            "type": "administrative"
+        },
+        {
+            "displayName": "BC Limited Company Incorporation Application",
+            "name": "incorporationApplication"
+        },
+        {
+            "displayName": "Registrar's Notation",
+            "name": "registrarsNotation"
+        },
+        {
+            "displayName": "Registrar's Order",
+            "name": "registrarsOrder"
+        },
+        {
+            "displayName": "Transition Application",
+            "name": "transition"
+        },
+        {
+            "displayName": "Limited Restoration Extension Application",
+            "name": "restoration",
+            "type": "limitedRestorationExtension"
+        },
+        {
+            "displayName": "Conversion to Full Restoration Application",
+            "name": "restoration",
+            "type": "limitedRestorationToFull"
+        },
+        {
+            "displayName": "Notice of Withdrawal",
+            "name": "noticeOfWithdrawal"
+        }
+    ]
+
+    assert rv.status_code == HTTPStatus.OK
+    assert rv.json['couldFile']
+    assert rv.json['couldFile']['filing']
+    assert rv.json['couldFile']['filing']['filingTypes']
+    assert len(rv.json['couldFile']['filing']['filingTypes']) > 0
+    assert rv.json['couldFile']['filing']['filingTypes'] == expected


### PR DESCRIPTION
…e user is allowed to do something to a legal type, fix flake violations in continuation_in

*Issue #:* /bcgov/entity#22051

*Description of changes:*
Fixed differences between api and spreadsheet (see below). Also added a could file which just returns if a user could do a filing on a business of the type to the get endpoint.

Differences
Staff
Amalgamation - Regular/Horizontal/Vertical — were additionally blocked on pending filings
Put back on was allowed when it had 'amalgamationApplication' or ’administrative' filings or a future effective dissolution filing
Full Restoration was allowed when there was a continuation in filing
Limited Restoration was allowed when there was a continuation in filing
Change of Registration - was blocked for staff when required info was missing and shouldn’t be
Continuation In didn’t support any of the types in the spreadsheet
Correction required no missing info always not just on SP/GP
Voluntary Dissolution required no missing info always not just on SP/GP
Administrative Dissolution required no missing info always not just on SP/GP
Notice of withdrawal was allowed when business was frozen or had a pending filing

General
Amalgamation - Regular/Horizontal/Vertical — were additionally blocked on pending filings
Continuation In didn’t support any of the types in the spreadsheet
Voluntary Dissolution required no missing info always not just on SP/GP

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
