### PR TITLE
24318 - fix missing voluntary dissolution pdf in email attachment

### DIFF
--- a/queue_services/entity-emailer/src/entity_emailer/email_processors/dissolution_notification.py
+++ b/queue_services/entity-emailer/src/entity_emailer/email_processors/dissolution_notification.py
@@ -54,7 +54,7 @@ def _get_pdfs(
     if status == Filing.Status.PAID.value:
         # add filing pdf
         if legal_type not in ['SP', 'GP']:
-            filing_pdf_type = 'voluntaryDissolution'
+            filing_pdf_type = 'dissolution'
             filing_pdf_encoded = get_filing_document(business['identifier'], filing.id, filing_pdf_type, token)
             if filing_pdf_encoded:
                 pdfs.append(


### PR DESCRIPTION
*Issue #:* /bcgov/entity#24318

*Description of changes:*
- The root cause of consistently not getting `Voluntary Dissolution Application.pdf` attachment is due to passing the wrong document_type to legal_api's GET document endpoint (supposed to be `dissolution` but was `voluntaryDissolution`

**Note:** This PR is to solve the consistently missing `Voluntary Dissolution Application.pdf` attachment in the email issue.
The intermittently missing one PDF issue is still under investigation. _So, after this PR, the ticket will still be open until all issues are resolved._

**Log on DEV - Before:**
```log
2024-11-13 18:24:31,380 - legal_api - INFO in report:report.py:94 - _get_report: Sending report request - Filing: 151945, Type: voluntaryDissolution
2024-11-13 18:24:37,749 - legal_api - ERROR in report:report.py:102 - _get_report: Report error - Filing: 151945, Duration: 6368ms, Status: 500, Content: b'{"message": "Internal server error"}\n', Time: 2024-11-13T18:24:37.749779
```

**Log on DEV - After fix:**
```log
2024-11-13 18:30:53,813 - legal_api - INFO in report:report.py:94 - _get_report: Sending report request - Filing: 151476, Type: dissolution
2024-11-13 18:30:59,809 - legal_api - INFO in report:report.py:109 - _get_report: Report success - Filing: 151476, Duration: 5995ms
```

### A quick way to validate / reproduce the issue
In Postman, call the business_document endpoint in legal-api using the 2 different type:

- Results ✅ using: `{{url}}/api/v2/businesses/:identifier/filings/:filing_id/documents/dissolution`
![image](https://github.com/user-attachments/assets/bc7a9146-3641-4c19-813f-9097dd41ccb9)

- Results ❌ using: `{{url}}/api/v2/businesses/:identifier/filings/:filing_id/documents/voluntaryDissolution`
![image](https://github.com/user-attachments/assets/cc4704e2-320a-4460-abb2-910f7521f523)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
