### PR TITLE
24361 - fix missing pdf continuation application

### DIFF
--- a/queue_services/entity-emailer/src/entity_emailer/email_processors/amalgamation_notification.py
+++ b/queue_services/entity-emailer/src/entity_emailer/email_processors/amalgamation_notification.py
@@ -66,7 +66,11 @@ def _get_pdfs(
             )
             attach_order += 1
 
-        corp_name = business.get('legalName')
+        # add receipt
+        if not (corp_name := business.get('legalName')):  # pylint: disable=superfluous-parens
+            legal_type = business.get('legalType')
+            corp_name = Business.BUSINESSES.get(legal_type, {}).get('numberedDescription')
+
         receipt = requests.post(
             f'{current_app.config.get("PAY_API_URL")}/{filing.payment_token}/receipts',
             json={

--- a/queue_services/entity-emailer/src/entity_emailer/email_processors/continuation_in_notification.py
+++ b/queue_services/entity-emailer/src/entity_emailer/email_processors/continuation_in_notification.py
@@ -67,7 +67,9 @@ def _get_pdfs(
             attach_order += 1
 
         # add receipt
-        corp_name = filing.filing_json['filing']['continuationIn']['nameRequest'].get('legalName', 'Numbered Company')
+        if not (corp_name := business.get('legalName')):
+            legal_type = business.get('legalType')
+            corp_name = Business.BUSINESSES.get(legal_type, {}).get('numberedDescription')
 
         # Debugging logger for #24361, will have another PR before closing the ticket to remove it
         current_app.logger.debug(

--- a/queue_services/entity-emailer/src/entity_emailer/email_processors/continuation_in_notification.py
+++ b/queue_services/entity-emailer/src/entity_emailer/email_processors/continuation_in_notification.py
@@ -69,9 +69,9 @@ def _get_pdfs(
         # add receipt
         corp_name = business.get('legalName')
 
-        ############## Debugging logger for #24361, will remove later ##########
+        # Debugging logger for #24361, will remove later
         current_app.logger.debug(
-            f"\U0001F4D2 - Business: {business}\n"
+            f'\U0001F4D2 - Business: {business}\n'
             f"""\U0001F4D2 - Payload to get receipt: json:
                 corpName: {corp_name if corp_name else ''},
                 filingDateTime: {filing_date_time},
@@ -80,7 +80,7 @@ def _get_pdfs(
                 businessNumber: {business.get('taxId', '')}
             """
             )
-        #########################################################################
+        # debugging logger end
 
         receipt = requests.post(
             f'{current_app.config.get("PAY_API_URL")}/{filing.payment_token}/receipts',
@@ -94,9 +94,9 @@ def _get_pdfs(
             headers=headers
         )
         if receipt.status_code != HTTPStatus.CREATED:
-            ##################### Debugging logger for #24361, will remove later ###############################
-            current_app.logger.debug(f"\U0001F4D2 - Error getting receipt, when PAID Response: {receipt.text}")
-            ####################################################################################################
+            # Debugging logger for #24361, will remove later
+            current_app.logger.debug(f'\U0001F4D2 - Error getting receipt, when PAID Response: {receipt.text}')
+            # debugging logger end
             logger.error('Failed to get receipt pdf for filing: %s', filing.id)
         else:
             receipt_encoded = base64.b64encode(receipt.content)
@@ -139,7 +139,7 @@ def _get_pdfs(
                 }
             )
             attach_order += 1
-        
+
         # add certificate of continuation
         certificate_pdf_type = 'certificateOfContinuation'
         certificate_encoded = get_filing_document(business['identifier'], filing.id, certificate_pdf_type, token)
@@ -183,9 +183,9 @@ def _get_pdfs(
             headers=headers
         )
         if receipt.status_code != HTTPStatus.CREATED:
-            ##################### Debugging logger for #24361, will remove later ###############################
-            current_app.logger.debug(f"\U0001F4D2 - Error getting receipt, when COMPLETED Response: {receipt.text}")
-            ####################################################################################################
+            # Debugging logger for #24361, will remove later
+            current_app.logger.debug(f'\U0001F4D2 - Error getting receipt, when COMPLETED Response: {receipt.text}')
+            # debugging logger end
             logger.error('Failed to get receipt pdf for filing: %s', filing.id)
         else:
             receipt_encoded = base64.b64encode(receipt.content)

--- a/queue_services/entity-emailer/src/entity_emailer/email_processors/continuation_in_notification.py
+++ b/queue_services/entity-emailer/src/entity_emailer/email_processors/continuation_in_notification.py
@@ -67,13 +67,13 @@ def _get_pdfs(
             attach_order += 1
 
         # add receipt
-        corp_name = business.get('legalName')
+        corp_name = filing.filing_json['filing']['continuationIn']['nameRequest'].get('legalName', 'Numbered Company')
 
         # Debugging logger for #24361, will remove later
         current_app.logger.debug(
             f'\U0001F4D2 - Business: {business}\n'
             f"""\U0001F4D2 - Payload to get receipt: json:
-                corpName: {corp_name if corp_name else ''},
+                corpName: {corp_name},
                 filingDateTime: {filing_date_time},
                 effectiveDateTime: {effective_date if effective_date != filing_date_time else ''},
                 filingIdentifier: {str(filing.id)},
@@ -85,7 +85,7 @@ def _get_pdfs(
         receipt = requests.post(
             f'{current_app.config.get("PAY_API_URL")}/{filing.payment_token}/receipts',
             json={
-                'corpName': corp_name if corp_name else '',
+                'corpName': corp_name,
                 'filingDateTime': filing_date_time,
                 'effectiveDateTime': effective_date if effective_date != filing_date_time else '',
                 'filingIdentifier': str(filing.id),
@@ -174,7 +174,7 @@ def _get_pdfs(
         receipt = requests.post(
             f'{current_app.config.get("PAY_API_URL")}/{filing.payment_token}/receipts',
             json={
-                'corpName': corp_name if corp_name else '',
+                'corpName': corp_name,
                 'filingDateTime': filing_date_time,
                 'effectiveDateTime': effective_date if effective_date != filing_date_time else '',
                 'filingIdentifier': str(filing.id),

--- a/queue_services/entity-emailer/src/entity_emailer/email_processors/continuation_in_notification.py
+++ b/queue_services/entity-emailer/src/entity_emailer/email_processors/continuation_in_notification.py
@@ -67,10 +67,9 @@ def _get_pdfs(
             attach_order += 1
 
         # add receipt
-        if not (corp_name := business.get('legalName')):
+        if not (corp_name := business.get('legalName')):  # pylint: disable=superfluous-parens
             legal_type = business.get('legalType')
             corp_name = Business.BUSINESSES.get(legal_type, {}).get('numberedDescription')
-
         # Debugging logger for #24361, will have another PR before closing the ticket to remove it
         current_app.logger.debug(
             f'\U0001F4D2 - Business: {business}\n'

--- a/queue_services/entity-emailer/src/entity_emailer/email_processors/filing_notification.py
+++ b/queue_services/entity-emailer/src/entity_emailer/email_processors/filing_notification.py
@@ -79,12 +79,11 @@ def _get_pdfs(
                 }
             )
             attach_order += 1
+
         # add receipt pdf
-        if filing.filing_type == 'incorporationApplication':
-            corp_name = filing.filing_json['filing']['incorporationApplication']['nameRequest'].get(
-                'legalName', 'Numbered Company')
-        else:
-            corp_name = business.get('legalName')
+        if not (corp_name := business.get('legalName')):  # pylint: disable=superfluous-parens
+            legal_type = business.get('legalType')
+            corp_name = Business.BUSINESSES.get(legal_type, {}).get('numberedDescription')
 
         receipt = requests.post(
             f'{current_app.config.get("PAY_API_URL")}/{filing.payment_token}/receipts',

--- a/queue_services/entity-emailer/src/entity_emailer/email_templates/CONT-IN-COMPLETED.html
+++ b/queue_services/entity-emailer/src/entity_emailer/email_templates/CONT-IN-COMPLETED.html
@@ -33,10 +33,8 @@
             </ul>
             {% else %}
             <ul class="outputs">
-              <li>Continuation Application</li>
               <li>Notice of Articles</li>
               <li>Certificate of Continuation</li>
-              <li>Receipt</li>
             </ul>
             {% endif %}
 

--- a/queue_services/entity-emailer/src/entity_emailer/worker.py
+++ b/queue_services/entity-emailer/src/entity_emailer/worker.py
@@ -123,6 +123,10 @@ def process_email(email_msg: dict, flask_app: Flask):  # pylint: disable=too-man
     """Process the email contained in the submission."""
     if not flask_app:
         raise QueueException('Flask App not available.')
+    
+    ############## Debugging logger for #24361, will remove later ############
+    flask_app.logger.debug(f"\U0001F4D2 email_msg: {email_msg}")
+    ##########################################################################
 
     with flask_app.app_context():
         logger.debug('Attempting to process email: %s', email_msg)

--- a/queue_services/entity-emailer/src/entity_emailer/worker.py
+++ b/queue_services/entity-emailer/src/entity_emailer/worker.py
@@ -123,11 +123,9 @@ def process_email(email_msg: dict, flask_app: Flask):  # pylint: disable=too-man
     """Process the email contained in the submission."""
     if not flask_app:
         raise QueueException('Flask App not available.')
-    
-    ############## Debugging logger for #24361, will remove later ############
-    flask_app.logger.debug(f"\U0001F4D2 email_msg: {email_msg}")
-    ##########################################################################
-
+    # Debugging logger for #24361, will remove later
+    flask_app.logger.debug(f'\U0001F4D2 email_msg: {email_msg}')
+    # debugging logger end
     with flask_app.app_context():
         logger.debug('Attempting to process email: %s', email_msg)
         token = AccountService.get_bearer_token()

--- a/queue_services/entity-emailer/src/entity_emailer/worker.py
+++ b/queue_services/entity-emailer/src/entity_emailer/worker.py
@@ -123,7 +123,7 @@ def process_email(email_msg: dict, flask_app: Flask):  # pylint: disable=too-man
     """Process the email contained in the submission."""
     if not flask_app:
         raise QueueException('Flask App not available.')
-    # Debugging logger for #24361, will remove later
+    # Debugging logger for #24361, will have another PR before closing the ticket to remove it
     flask_app.logger.debug(f'\U0001F4D2 email_msg: {email_msg}')
     # debugging logger end
     with flask_app.app_context():


### PR DESCRIPTION
*Issue #:* /bcgov/entity#24361

*Description of changes:*
**For missing the `receipt.pdf` in the first email (continuation application received):**
- Found the root cause for not getting the receipt when the filing status is PAID due to a wrong data type in the payload when running emailer in local environment. To fix this, reformatted the payload to meet the requirement
```
📒 - Payload to get receipt: json:
                corpName: None,
                filingDateTime: November 13, 2024 at 6:11 pm Pacific time,
                effectiveDateTime: ,
                filingIdentifier: 152418,
                businessNumber: 

continuation_in_notification.py:99-_get_pdfs:📒 - Response: {"type": "INVALID_REQUEST", "title": "Invalid Request", "detail": "Invalid Request", "invalidParams": ["None is not of type 'string'"]}
```

**For missing the `continuation application.pdf` and `receipt.pdf` in the second email (continuation in successful):**
As per discussion https://github.com/bcgov/lear/pull/3078#discussion_r1844381297, updated the email template and not attaching them.

_Also, added some debugging logger to monitor the behaviours when merged to DEV, and will have another PR to remove these debugging logger code afterwards._

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
