### PR TITLE
22943 update models to use new db_versioning

### DIFF
--- a/legal-api/flags.json
+++ b/legal-api/flags.json
@@ -11,7 +11,7 @@
             "exclude-accounts": []
         },
         "db-versioning": {
-            "legal-api": false,
+            "legal-api": true,
             "emailer": false,
             "filer": false,
             "entity-bn": false,

--- a/legal-api/src/legal_api/models/amalgamating_business.py
+++ b/legal-api/src/legal_api/models/amalgamating_business.py
@@ -20,10 +20,9 @@ from enum import auto
 
 from sql_versioning import Versioned
 from sqlalchemy import or_
-from sqlalchemy_continuum import version_class
 
 from ..utils.base import BaseEnum
-from .db import db
+from .db import db, VersioningProxy  # noqa: I001
 
 
 class AmalgamatingBusiness(db.Model, Versioned):  # pylint: disable=too-many-instance-attributes
@@ -62,7 +61,7 @@ class AmalgamatingBusiness(db.Model, Versioned):  # pylint: disable=too-many-ins
     def get_revision(cls, transaction_id, amalgamation_id):
         """Get amalgamating businesses for the given transaction id."""
         # pylint: disable=singleton-comparison;
-        amalgamating_businesses_version = version_class(AmalgamatingBusiness)
+        amalgamating_businesses_version = VersioningProxy.version_class(db.session(), AmalgamatingBusiness)
         amalgamating_businesses = db.session.query(amalgamating_businesses_version) \
             .filter(amalgamating_businesses_version.transaction_id <= transaction_id) \
             .filter(amalgamating_businesses_version.operation_type == 0) \
@@ -84,7 +83,7 @@ class AmalgamatingBusiness(db.Model, Versioned):  # pylint: disable=too-many-ins
 
         In this case T1 is involved in 2 amalgamation
         """
-        amalgamating_businesses_version = version_class(AmalgamatingBusiness)
+        amalgamating_businesses_version = VersioningProxy.version_class(db.session(), AmalgamatingBusiness)
         amalgamating_businesses = db.session.query(amalgamating_businesses_version) \
             .filter(amalgamating_businesses_version.operation_type == 0) \
             .filter(amalgamating_businesses_version.business_id == business_id) \

--- a/legal-api/src/legal_api/models/amalgamation.py
+++ b/legal-api/src/legal_api/models/amalgamation.py
@@ -21,10 +21,9 @@ from enum import auto
 
 from sql_versioning import Versioned
 from sqlalchemy import or_
-from sqlalchemy_continuum import version_class
 
 from ..utils.base import BaseEnum
-from .db import db
+from .db import db, VersioningProxy  # noqa: I001
 
 
 class Amalgamation(db.Model, Versioned):  # pylint: disable=too-many-instance-attributes
@@ -83,7 +82,7 @@ class Amalgamation(db.Model, Versioned):  # pylint: disable=too-many-instance-at
     def get_revision_by_id(cls, transaction_id, amalgamation_id):
         """Get amalgamation for the given id."""
         # pylint: disable=singleton-comparison;
-        amalgamation_version = version_class(Amalgamation)
+        amalgamation_version = VersioningProxy.version_class(db.session(), Amalgamation)
         amalgamation = db.session.query(amalgamation_version) \
             .filter(amalgamation_version.transaction_id <= transaction_id) \
             .filter(amalgamation_version.operation_type == 0) \
@@ -97,7 +96,7 @@ class Amalgamation(db.Model, Versioned):  # pylint: disable=too-many-instance-at
     def get_revision(cls, transaction_id, business_id):
         """Get amalgamation for the given transaction id."""
         # pylint: disable=singleton-comparison;
-        amalgamation_version = version_class(Amalgamation)
+        amalgamation_version = VersioningProxy.version_class(db.session(), Amalgamation)
         amalgamation = db.session.query(amalgamation_version) \
             .filter(amalgamation_version.transaction_id <= transaction_id) \
             .filter(amalgamation_version.operation_type == 0) \

--- a/legal-api/src/legal_api/models/business.py
+++ b/legal-api/src/legal_api/models/business.py
@@ -27,7 +27,6 @@ from sqlalchemy.exc import OperationalError, ResourceClosedError
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import aliased, backref
 from sqlalchemy.sql import and_, exists, func, not_, text
-from sqlalchemy_continuum import version_class
 
 from legal_api.exceptions import BusinessException
 from legal_api.utils.base import BaseEnum
@@ -37,7 +36,7 @@ from legal_api.utils.legislation_datetime import LegislationDatetime
 from .amalgamation import Amalgamation  # noqa: F401, I001, I003 pylint: disable=unused-import
 from .batch import Batch  # noqa: F401, I001, I003 pylint: disable=unused-import
 from .batch_processing import BatchProcessing  # noqa: F401, I001, I003 pylint: disable=unused-import
-from .db import db  # noqa: I001
+from .db import db, VersioningProxy  # noqa: I001
 from .party import Party
 from .share_class import ShareClass  # noqa: F401,I001,I003 pylint: disable=unused-import
 
@@ -693,7 +692,7 @@ class Business(db.Model, Versioned):  # pylint: disable=too-many-instance-attrib
         alternate_names = []
 
         # Fetch aliases and related filings in a single query
-        alias_version = version_class(Alias)
+        alias_version = VersioningProxy.version_class(db.session(), Alias)
         filing_alias = aliased(Filing)
         aliases_query = db.session.query(
             alias_version.alias,

--- a/legal-api/src/legal_api/models/db.py
+++ b/legal-api/src/legal_api/models/db.py
@@ -288,6 +288,6 @@ def setup_versioning():
 
 # TODO: enable versioning switching
 # it should be called before data model initialzed, otherwise, old versioning doesn't work properly
-# setup_versioning()
+setup_versioning()
 
-make_versioned(user_cls=None, manager=versioning_manager)
+# make_versioned(user_cls=None, manager=versioning_manager)

--- a/legal-api/src/legal_api/resources/v2/business/colin_sync.py
+++ b/legal-api/src/legal_api/resources/v2/business/colin_sync.py
@@ -21,7 +21,6 @@ from http import HTTPStatus
 from flask import current_app, jsonify, request
 from flask_cors import cross_origin
 from sqlalchemy import or_
-from sqlalchemy_continuum import version_class
 
 from legal_api.exceptions import BusinessException
 from legal_api.models import (
@@ -42,6 +41,7 @@ from legal_api.models import (
     db,
 )
 from legal_api.models.colin_event_id import ColinEventId
+from legal_api.models.db import VersioningProxy
 from legal_api.services.business_details_version import VersionedBusinessDetailsService
 from legal_api.utils.auth import jwt
 from legal_api.utils.legislation_datetime import LegislationDatetime
@@ -135,7 +135,7 @@ def set_correction_flags(filing_json, filing: Filing):
 
 def has_alias_changed(filing) -> bool:
     """Has alias changed in the given filing."""
-    alias_version = version_class(Alias)
+    alias_version = VersioningProxy.version_class(db.session(), Alias)
     aliases_query = (db.session.query(alias_version)
                      .filter(or_(alias_version.transaction_id == filing.transaction_id,
                                  alias_version.end_transaction_id == filing.transaction_id))
@@ -148,7 +148,7 @@ def has_office_changed(filing) -> bool:
     """Has office changed in the given filing."""
     offices = db.session.query(Office).filter(Office.business_id == filing.business_id).all()
 
-    address_version = version_class(Address)
+    address_version = VersioningProxy.version_class(db.session(), Address)
     addresses_query = (db.session.query(address_version)
                        .filter(or_(address_version.transaction_id == filing.transaction_id,
                                    address_version.end_transaction_id == filing.transaction_id))
@@ -160,7 +160,7 @@ def has_office_changed(filing) -> bool:
 
 def has_party_changed(filing: Filing) -> bool:
     """Has party changed in the given filing."""
-    party_role_version = version_class(PartyRole)
+    party_role_version = VersioningProxy.version_class(db.session(), PartyRole)
     party_roles_query = (db.session.query(party_role_version)
                          .filter(or_(party_role_version.transaction_id == filing.transaction_id,
                                      party_role_version.end_transaction_id == filing.transaction_id))
@@ -175,7 +175,7 @@ def has_party_changed(filing: Filing) -> bool:
                                                                           filing.business_id,
                                                                           role=PartyRole.RoleTypes.DIRECTOR.value)
 
-    party_version = version_class(Party)
+    party_version = VersioningProxy.version_class(db.session(), Party)
     for party_role in party_roles:
         parties_query = (db.session.query(party_version)
                          .filter(or_(party_version.transaction_id == filing.transaction_id,
@@ -186,7 +186,7 @@ def has_party_changed(filing: Filing) -> bool:
             return True
 
         party = VersionedBusinessDetailsService.get_party_revision(filing.transaction_id, party_role['id'])
-        address_version = version_class(Address)
+        address_version = VersioningProxy.version_class(db.session(), Address)
         # Has party delivery/mailing address modified
         address_query = (db.session.query(address_version)
                          .filter(or_(address_version.transaction_id == filing.transaction_id,
@@ -201,7 +201,7 @@ def has_party_changed(filing: Filing) -> bool:
 
 def has_resolution_changed(filing: Filing) -> bool:
     """Has resolution changed in the given filing."""
-    resolution_version = version_class(Resolution)
+    resolution_version = VersioningProxy.version_class(db.session(), Resolution)
     resolution_query = (db.session.query(resolution_version)
                         .filter(or_(resolution_version.transaction_id == filing.transaction_id,
                                     resolution_version.end_transaction_id == filing.transaction_id))
@@ -212,7 +212,7 @@ def has_resolution_changed(filing: Filing) -> bool:
 
 def has_share_changed(filing: Filing) -> bool:
     """Has share changed in the given filing."""
-    share_class_version = version_class(ShareClass)
+    share_class_version = VersioningProxy.version_class(db.session(), ShareClass)
     share_class_query = (db.session.query(share_class_version)
                          .filter(or_(share_class_version.transaction_id == filing.transaction_id,
                                      share_class_version.end_transaction_id == filing.transaction_id))
@@ -222,7 +222,7 @@ def has_share_changed(filing: Filing) -> bool:
         return True
 
     share_classes = VersionedBusinessDetailsService.get_share_class_revision(filing.transaction_id, filing.business_id)
-    series_version = version_class(ShareSeries)
+    series_version = VersioningProxy.version_class(db.session(), ShareSeries)
     share_series_query = (db.session.query(series_version)
                           .filter(or_(series_version.transaction_id == filing.transaction_id,
                                       series_version.end_transaction_id == filing.transaction_id))

--- a/legal-api/src/legal_api/services/business_details_version.py
+++ b/legal-api/src/legal_api/services/business_details_version.py
@@ -18,7 +18,6 @@ from datetime import datetime
 
 import pycountry
 from sqlalchemy import or_
-from sqlalchemy_continuum import version_class
 
 from legal_api.models import (
     Address,
@@ -33,6 +32,7 @@ from legal_api.models import (
     ShareSeries,
     db,
 )
+from legal_api.models.db import VersioningProxy
 from legal_api.utils.legislation_datetime import LegislationDatetime
 
 
@@ -210,7 +210,7 @@ class VersionedBusinessDetailsService:  # pylint: disable=too-many-public-method
     @staticmethod
     def get_business_revision(transaction_id, business) -> dict:
         """Consolidates the business info as of a particular transaction."""
-        business_version = version_class(Business)
+        business_version = VersioningProxy.version_class(db.session(), Business)
         business_revision = db.session.query(business_version) \
             .filter(business_version.transaction_id <= transaction_id) \
             .filter(business_version.operation_type != 2) \
@@ -223,7 +223,7 @@ class VersionedBusinessDetailsService:  # pylint: disable=too-many-public-method
     @staticmethod
     def get_business_revision_obj(transaction_id, business_id):
         """Return business version object associated with a given transaction id for a business."""
-        business_version = version_class(Business)
+        business_version = VersioningProxy.version_class(db.session(), Business)
         business_revision = db.session.query(business_version) \
             .filter(business_version.transaction_id <= transaction_id) \
             .filter(business_version.operation_type != 2) \
@@ -238,7 +238,7 @@ class VersionedBusinessDetailsService:  # pylint: disable=too-many-public-method
                                                is_dissolution_date=False,
                                                is_restoration_expiry_date=False) -> dict:
         """Get business info with last value of dissolution_date or restoration_expiry_date."""
-        business_version = version_class(Business)
+        business_version = VersioningProxy.version_class(db.session(), Business)
         query = db.session.query(business_version) \
             .filter(business_version.transaction_id < transaction_id) \
             .filter(business_version.operation_type != 2) \
@@ -255,7 +255,7 @@ class VersionedBusinessDetailsService:  # pylint: disable=too-many-public-method
         """Consolidates the business info as of a particular transaction."""
         business = Business.find_by_internal_id(business_id)
         filing = Filing.find_by_id(filing_id)
-        business_version = version_class(Business)
+        business_version = VersioningProxy.version_class(db.session(), Business)
         business_revision = db.session.query(business_version) \
             .filter(business_version.transaction_id > filing.transaction_id) \
             .filter(business_version.operation_type != 2) \
@@ -267,8 +267,8 @@ class VersionedBusinessDetailsService:  # pylint: disable=too-many-public-method
     def get_office_revision(transaction_id, business_id) -> dict:
         """Consolidates all office changes upto the given transaction id."""
         offices_json = {}
-        address_version = version_class(Address)
-        offices_version = version_class(Office)
+        address_version = VersioningProxy.version_class(db.session(), Address)
+        offices_version = VersioningProxy.version_class(db.session(), Office)
 
         offices = db.session.query(offices_version) \
             .filter(offices_version.transaction_id <= transaction_id) \
@@ -296,7 +296,7 @@ class VersionedBusinessDetailsService:  # pylint: disable=too-many-public-method
     @staticmethod
     def get_party_role_revision(transaction_id, business_id, is_ia_or_after=False, role=None) -> dict:
         """Consolidates all party changes upto the given transaction id."""
-        party_role_version = version_class(PartyRole)
+        party_role_version = VersioningProxy.version_class(db.session(), PartyRole)
         party_roles = db.session.query(party_role_version)\
             .filter(party_role_version.transaction_id <= transaction_id) \
             .filter(party_role_version.operation_type != 2) \
@@ -322,7 +322,7 @@ class VersionedBusinessDetailsService:  # pylint: disable=too-many-public-method
     @staticmethod
     def get_share_class_revision(transaction_id, business_id) -> dict:
         """Consolidates all share classes upto the given transaction id."""
-        share_class_version = version_class(ShareClass)
+        share_class_version = VersioningProxy.version_class(db.session(), ShareClass)
         share_classes_list = db.session.query(share_class_version) \
             .filter(share_class_version.transaction_id <= transaction_id) \
             .filter(share_class_version.operation_type != 2) \
@@ -343,7 +343,7 @@ class VersionedBusinessDetailsService:  # pylint: disable=too-many-public-method
     @staticmethod
     def get_share_series_revision(transaction_id, share_class_id) -> dict:
         """Consolidates all share series under the share class upto the given transaction id."""
-        share_series_version = version_class(ShareSeries)
+        share_series_version = VersioningProxy.version_class(db.session(), ShareSeries)
         share_series_list = db.session.query(share_series_version) \
             .filter(share_series_version.transaction_id <= transaction_id) \
             .filter(share_series_version.operation_type != 2) \
@@ -362,7 +362,7 @@ class VersionedBusinessDetailsService:  # pylint: disable=too-many-public-method
     @staticmethod
     def get_name_translations_revision(transaction_id, business_id) -> dict:
         """Consolidates all name translations upto the given transaction id."""
-        name_translations_version = version_class(Alias)
+        name_translations_version = VersioningProxy.version_class(db.session(), Alias)
         name_translations_list = db.session.query(name_translations_version) \
             .filter(name_translations_version.transaction_id <= transaction_id) \
             .filter(name_translations_version.operation_type != 2) \
@@ -380,7 +380,7 @@ class VersionedBusinessDetailsService:  # pylint: disable=too-many-public-method
     @staticmethod
     def get_name_translations_before_revision(transaction_id, business_id) -> dict:
         """Consolidates all name translations before deletion given a transaction id."""
-        name_translations_version = version_class(Alias)
+        name_translations_version = VersioningProxy.version_class(db.session(), Alias)
         name_translations_list = db.session.query(name_translations_version) \
             .filter(name_translations_version.transaction_id <= transaction_id) \
             .filter(name_translations_version.operation_type != 2) \
@@ -396,7 +396,7 @@ class VersionedBusinessDetailsService:  # pylint: disable=too-many-public-method
     @staticmethod
     def get_resolution_dates_revision(transaction_id, business_id) -> dict:
         """Consolidates all resolutions upto the given transaction id."""
-        resolution_version = version_class(Resolution)
+        resolution_version = VersioningProxy.version_class(db.session(), Resolution)
         resolution_list = db.session.query(resolution_version) \
             .filter(resolution_version.transaction_id <= transaction_id) \
             .filter(resolution_version.operation_type != 2) \
@@ -439,7 +439,7 @@ class VersionedBusinessDetailsService:  # pylint: disable=too-many-public-method
     @staticmethod
     def get_party_revision(transaction_id, party_id) -> dict:
         """Consolidates all party changes upto the given transaction id."""
-        party_version = version_class(Party)
+        party_version = VersioningProxy.version_class(db.session(), Party)
         party = db.session.query(party_version) \
             .filter(party_version.transaction_id <= transaction_id) \
             .filter(party_version.operation_type != 2) \
@@ -500,9 +500,8 @@ class VersionedBusinessDetailsService:  # pylint: disable=too-many-public-method
             if 'addressType' in member_mailing_address:
                 del member_mailing_address['addressType']
             member['mailingAddress'] = member_mailing_address
-        else:
-            if party_revision.delivery_address:
-                member['mailingAddress'] = member['deliveryAddress']
+        elif party_revision.delivery_address_id:
+            member['mailingAddress'] = member['deliveryAddress']
 
         if is_ia_or_after:
             member['officer']['id'] = str(party_revision.id)
@@ -514,7 +513,7 @@ class VersionedBusinessDetailsService:  # pylint: disable=too-many-public-method
     @staticmethod
     def get_address_revision(transaction_id, address_id) -> dict:
         """Consolidates all party changes upto the given transaction id."""
-        address_version = version_class(Address)
+        address_version = VersioningProxy.version_class(db.session(), Address)
         address = db.session.query(address_version) \
             .filter(address_version.transaction_id <= transaction_id) \
             .filter(address_version.operation_type != 2) \

--- a/legal-api/tests/unit/models/__init__.py
+++ b/legal-api/tests/unit/models/__init__.py
@@ -42,7 +42,7 @@ from legal_api.models import (
     db,
 )
 from legal_api.models.colin_event_id import ColinEventId
-from legal_api.models.db import versioning_manager
+from legal_api.models.db import VersioningProxy
 from legal_api.utils.datetime import datetime, timezone
 from tests import EPOCH_DATETIME, FROZEN_DATETIME
 
@@ -160,8 +160,7 @@ def factory_business(identifier,
                         no_dissolution=no_dissolution)
 
     # Versioning business
-    uow = versioning_manager.unit_of_work(db.session)
-    uow.create_transaction(db.session)
+    VersioningProxy.get_transaction_id(db.session())
 
     business.save()
     return business
@@ -245,9 +244,8 @@ def factory_completed_filing(business,
             filing._filing_sub_type = filing_sub_type
         filing.save()
 
-        uow = versioning_manager.unit_of_work(db.session)
-        transaction = uow.create_transaction(db.session)
-        filing.transaction_id = transaction.id
+        transaction_id = VersioningProxy.get_transaction_id(db.session())
+        filing.transaction_id = transaction_id
         filing.payment_token = payment_token
         filing.effective_date = filing_date
         filing.payment_completion_date = filing_date
@@ -287,9 +285,8 @@ def factory_epoch_filing(business, filing_date=FROZEN_DATETIME):
     """Create an error filing."""
     filing = Filing()
     filing.business_id = business.id
-    uow = versioning_manager.unit_of_work(db.session)
-    transaction = uow.create_transaction(db.session)
-    filing.transaction_id = transaction.id
+    transaction_id = VersioningProxy.get_transaction_id(db.session())
+    filing.transaction_id = transaction_id
     filing.filing_date = filing_date
     filing.filing_json = {'filing': {'header': {'name': 'lear_epoch'}}}
     filing.save()

--- a/legal-api/tests/unit/models/test_business.py
+++ b/legal-api/tests/unit/models/test_business.py
@@ -37,7 +37,7 @@ from legal_api.models import (
     PartyRole,
     db,
 )
-from legal_api.models.db import versioning_manager
+from legal_api.models.db import VersioningProxy
 from legal_api.services import flags
 from legal_api.utils.legislation_datetime import LegislationDatetime
 from tests import EPOCH_DATETIME, TIMEZONE_OFFSET
@@ -721,8 +721,7 @@ def test_amalgamated_into_business_json(session, test_name, existing_business_st
         filing.save()
 
         # Versioning business
-        uow = versioning_manager.unit_of_work(db.session)
-        transaction = uow.create_transaction(db.session)
+        transaction_id = VersioningProxy.get_transaction_id(session())
 
         business = Business(
             legal_name='Test - Legal Name',
@@ -749,7 +748,7 @@ def test_amalgamated_into_business_json(session, test_name, existing_business_st
         db.session.add(existing_business)
         db.session.commit()
 
-        filing.transaction_id = transaction.id
+        filing.transaction_id = transaction_id
         filing.business_id = business.id
         filing.save()
 

--- a/legal-api/tests/unit/reports/test_report.py
+++ b/legal-api/tests/unit/reports/test_report.py
@@ -37,7 +37,7 @@ from registry_schemas.example_data import (
 )
 
 from legal_api.models import db  # noqa:I001
-from legal_api.models.db import versioning_manager
+from legal_api.models.db import VersioningProxy
 from legal_api.reports.report import Report  # noqa:I001
 from legal_api.services import VersionedBusinessDetailsService  # noqa:I001
 from tests.unit.models import factory_business, factory_completed_filing  # noqa:E501,I001
@@ -244,8 +244,7 @@ def test_alteration_name_change(session):
 
 def update_business_legal_name(business, legal_name):
     """Update business legal name."""
-    uow = versioning_manager.unit_of_work(db.session)
-    uow.create_transaction(db.session)
+    VersioningProxy.get_transaction_id(db.session())
     business.legal_name = legal_name
     business.save()
 

--- a/python/common/sql-versioning/sql_versioning/versioning.py
+++ b/python/common/sql-versioning/sql_versioning/versioning.py
@@ -93,7 +93,7 @@ def _create_version(session, target, operation_type):
         return
 
     transaction_manager = TransactionManager(session)
-    transaction_id = transaction_manager.create_transaction()
+    transaction_id = transaction_manager.get_current_transaction_id()
 
     if transaction_id is None:
         print(f'\033[31mError - Unable to create transaction for {target.__class__.__name__} (id={target.id})\033[0m')
@@ -119,15 +119,18 @@ def _create_version(session, target, operation_type):
         'operation_type': {'I': 0, 'U': 1, 'D': 2}.get(operation_type, 1)
     }
 
-    for column in inspect(target.__class__).columns:
+    mapper = inspect(target.__class__)
+
+    for column in mapper.columns:
         if column.name not in ['transaction_id', 'end_transaction_id', 'operation_type']:
-            if hasattr(target, column.name):
-                new_version_data[column.name] = getattr(target, column.name)
+            property_name = mapper.get_property_by_column(column).key
+            if hasattr(target, property_name):
+                new_version_data[column.name] = getattr(target, property_name)
 
     if existing_version:
         # Update the existing version
         session.execute(
-            update(VersionClass).
+            update(VersionClass.__table__).
             where(and_(
                 VersionClass.id == target.id,
                 VersionClass.transaction_id == transaction_id
@@ -136,11 +139,11 @@ def _create_version(session, target, operation_type):
         )
     else:
         # Insert a new version
-        session.execute(insert(VersionClass).values(new_version_data))
+        session.execute(insert(VersionClass.__table__).values(new_version_data))
 
     # Close any open versions
     session.execute(
-        update(VersionClass).
+        update(VersionClass.__table__).
         where(and_(
             VersionClass.id == target.id,
             VersionClass.end_transaction_id.is_(None),
@@ -197,14 +200,14 @@ class TransactionManager:
 
     @debug
     def create_transaction(self):
-        """Create a new transaction or reuses the existing one in the session.
+        """Create a new transaction in the session.
 
-        :return: The ID of the created or reused transaction.
+        :return: The ID of the created transaction.
         """
 
         if 'current_transaction_id' in self.session.info:
-            print(f"\033[32mReusing existing transaction: {self.session.info['current_transaction_id']}\033[0m")
-            return self.session.info['current_transaction_id']
+            print(f"\033[32mPoping out existing transaction: {self.session.info['current_transaction_id']}\033[0m")
+            self.session.info.pop('current_transaction_id', None)
 
         # Use insert().returning() to get the ID and issued_at without committing
         stmt = insert(self.transaction_model).values(
@@ -224,7 +227,10 @@ class TransactionManager:
         
         :return: The current transaction ID in the session.
         """
-        return self.session.info.get('current_transaction_id')
+        if 'current_transaction_id' in self.session.info:
+            return self.session.info.get('current_transaction_id')
+        else:
+            return self.create_transaction()
 
     @debug
     def clear_current_transaction(self):
@@ -232,6 +238,9 @@ class TransactionManager:
         
         :return: None
         """
+        if self.session.transaction.nested:
+            print(f"\033[32mSkip clearing nested transaction\033[0m")
+            return
         print(f"\033[32mClearing current transaction: {self.session.info.get('current_transaction_id')}\033[0m")
         self.session.info.pop('current_transaction_id', None)
 
@@ -244,8 +253,13 @@ def _before_flush(session, flush_context, instances):
         if not _is_session_modified(session):
             print('\033[31mThere is no modified versioned object in this session.\033[0m')
             return
-        transaction_manager = TransactionManager(session)
-        transaction_manager.create_transaction()
+        
+        if 'current_transaction_id' in session.info:
+            print(f"\033[31mtransaction_id={session.info['current_transaction_id']} exists before flush.\033[0m")
+        else:
+            print('\033[31mCreating transaction before flush.\033[0m')
+            transaction_manager = TransactionManager(session)
+            transaction_manager.create_transaction()
 
     except Exception as e:
         raise e
@@ -344,10 +358,13 @@ class Versioned:
         if hasattr(cls, '_pending_version_classes'):
             for pending_cls in cls._pending_version_classes:
                 version_cls = pending_cls._version_cls
+                mapper = inspect(pending_cls)
                 # Now add columns from the original table
-                for c in pending_cls.__table__.columns:
-                    if not hasattr(version_cls, c.name):
-                        setattr(version_cls, c.name, Column(c.type))
+                for c in mapper.columns:
+                    # Make sure table's column name and class's property name can be different
+                    property_name = mapper.get_property_by_column(c).key
+                    if not hasattr(version_cls, property_name):
+                        setattr(version_cls, property_name, Column(c.name, c.type))
             delattr(cls, '_pending_version_classes')
 
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22943
*Issue #:* /bcgov/entity#22942

*Description of changes:*

Update the models and VersionedBusinessDetailsService to use the new DB versioning.

- ***Get the Versioning DB***
Old: `amalgamating_businesses_version = version_class(AmalgamatingBusiness)`
New: `amalgamating_businesses_version = VersioningProxy.version_class(db.session(), AmalgamatingBusiness)`

- ***Get the transaction in the Test***
Old: `uow = versioning_manager.unit_of_work(session).  transaction = uow.create_transaction(session)`
New: `transaction_id = VersioningProxy.get_transaction_id(session())`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
