### PR TITLE
22952 update furnishing job use versioning proxy

### DIFF
--- a/jobs/furnishings/flags.json
+++ b/jobs/furnishings/flags.json
@@ -10,7 +10,7 @@
             "entity-bn": false,
             "digital-credentials": false,
             "dissolutions-job": false,
-            "furnishings-job": false,
+            "furnishings-job": true,
             "emailer-reminder-job": false,
             "future-effective-job": false,
             "update-colin-filings-job": false,

--- a/jobs/furnishings/flags.json
+++ b/jobs/furnishings/flags.json
@@ -2,6 +2,19 @@
     "flagValues": {
         "enable-involuntary-dissolution": true,
         "disable-dissolution-sftp-bcmail": true,
-        "disable-dissolution-sftp-bclaws": false
+        "disable-dissolution-sftp-bclaws": false,
+        "db-versioning": {
+            "legal-api": true,
+            "emailer": false,
+            "filer": false,
+            "entity-bn": false,
+            "digital-credentials": false,
+            "dissolutions-job": false,
+            "furnishings-job": false,
+            "emailer-reminder-job": false,
+            "future-effective-job": false,
+            "update-colin-filings-job": false,
+            "update-legal-filings-job": false
+        }
     }
 }

--- a/jobs/furnishings/requirements.txt
+++ b/jobs/furnishings/requirements.txt
@@ -31,6 +31,9 @@ six==1.15.0
 urllib3==1.26.11
 requests==2.25.1
 cachelib==0.9.0
-git+https://github.com/bcgov/lear.git#egg=legal_api&subdirectory=legal-api
+# install updated legal-api from feature branch for development, 
+# TODO - change it back when the db versioning feature branch merged to main
+git+https://github.com/bcgov/lear.git@feature-db-versioning#egg=legal_api&subdirectory=legal-api
+# git+https://github.com/bcgov/lear.git#egg=legal_api&subdirectory=legal-api
 git+https://github.com/bcgov/business-schemas.git@2.15.38#egg=registry_schemas
 git+https://github.com/bcgov/lear.git#egg=sql-versioning&subdirectory=python/common/sql-versioning

--- a/jobs/furnishings/src/furnishings/config.py
+++ b/jobs/furnishings/src/furnishings/config.py
@@ -45,6 +45,8 @@ def get_named_config(config_name: str = 'production'):
 class _Config:  # pylint: disable=too-few-public-methods
     """Base class configuration."""
 
+    # used to identify versioning flag
+    SERVICE_NAME = 'furnishings-job'
     PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
     SENTRY_DSN = os.getenv('SENTRY_DSN') or ''

--- a/jobs/furnishings/src/furnishings/worker.py
+++ b/jobs/furnishings/src/furnishings/worker.py
@@ -20,7 +20,8 @@ import pytz
 import sentry_sdk  # noqa: I001, E501; pylint: disable=ungrouped-imports; conflicts with Flake8
 from croniter import croniter
 from flask import Flask
-from legal_api.models import Configuration, db
+from legal_api import init_db
+from legal_api.models import Configuration
 from legal_api.services.flags import Flags
 from legal_api.services.queue import QueueService
 from sentry_sdk.integrations.logging import LoggingIntegration
@@ -44,7 +45,7 @@ def create_app(run_mode=os.getenv('FLASK_ENV', 'production')):
     """Return a configured Flask App using the Factory method."""
     app = Flask(__name__)
     app.config.from_object(get_named_config(run_mode))
-    db.init_app(app)
+    init_db(app)
 
     # Configure Sentry
     if app.config.get('SENTRY_DSN', None):

--- a/jobs/furnishings/tests/unit/__init__.py
+++ b/jobs/furnishings/tests/unit/__init__.py
@@ -21,7 +21,7 @@ from freezegun import freeze_time
 
 from legal_api.models import Address, Batch, BatchProcessing, Business, Filing, Furnishing, db
 from legal_api.models.colin_event_id import ColinEventId
-from legal_api.models.db import versioning_manager
+from legal_api.models.db import VersioningProxy
 
 
 EPOCH_DATETIME = datetime.datetime.utcfromtimestamp(0).replace(tzinfo=datetime.timezone.utc)
@@ -115,9 +115,8 @@ def factory_completed_filing(business,
             filing._filing_sub_type = filing_sub_type
         filing.save()
 
-        uow = versioning_manager.unit_of_work(db.session)
-        transaction = uow.create_transaction(db.session)
-        filing.transaction_id = transaction.id
+        transaction_id = VersioningProxy.get_transaction_id(db.session())
+        filing.transaction_id = transaction_id
         filing.payment_token = payment_token
         filing.effective_date = filing_date
         filing.payment_completion_date = filing_date

--- a/legal-api/flags.json
+++ b/legal-api/flags.json
@@ -17,7 +17,7 @@
             "entity-bn": true,
             "digital-credentials": false,
             "dissolutions-job": false,
-            "furnishings-job": false,
+            "furnishings-job": true,
             "emailer-reminder-job": false,
             "future-effective-job": false,
             "update-colin-filings-job": false,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22952

*Description of changes:*

1. Replaced the code to initialize and use the new db versioning
2. Updated configuration to support feature flags
3. Added flags.json file
4. Updated requirements.txt with necessary dependencies


5. Switch the versioning Proxy
- Flag is on
<img width="1382" alt="Screenshot 2024-11-29 at 11 33 39 AM" src="https://github.com/user-attachments/assets/8e3d12ea-2c69-4e49-92ac-1300b9f60209">


- Flag is off
<img width="1425" alt="Screenshot 2024-11-29 at 11 43 01 AM" src="https://github.com/user-attachments/assets/d24a4139-d7e7-4f28-936e-51943675bbad">


6. Unit Test
- legal: True, furnishings: True
<img width="1376" alt="Screenshot 2024-11-29 at 11 45 10 AM" src="https://github.com/user-attachments/assets/08a3ca6d-c03d-4b68-9d35-ca9cd68ae661">


- legal: True, furnishings: False
<img width="1400" alt="Screenshot 2024-11-29 at 11 46 53 AM" src="https://github.com/user-attachments/assets/b9683861-9d9a-4603-bf5f-c273b2504413">


- legal: False, furnishings: True
<img width="1413" alt="Screenshot 2024-11-29 at 11 47 48 AM" src="https://github.com/user-attachments/assets/c5c5329e-ece5-4ea9-8d0b-c10ce6bce99c">


- legal: False, furnishings: False
<img width="1438" alt="Screenshot 2024-11-29 at 11 48 09 AM" src="https://github.com/user-attachments/assets/3cab638d-e122-493d-a140-773d71047121">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
