### PR TITLE
24477 Add auth logic for creating and affiliating entities to tombstone pipeline

### DIFF
--- a/data-tool/flows/common/auth_service.py
+++ b/data-tool/flows/common/auth_service.py
@@ -1,0 +1,204 @@
+import json
+from http import HTTPStatus
+from typing import Dict
+
+import requests
+
+
+class AuthService:
+    """Wrapper to call Authentication Services.
+    """
+
+    BEARER: str = 'Bearer '
+    CONTENT_TYPE_JSON = {'Content-Type': 'application/json'}
+
+    @classmethod
+    def get_time_out(cls, config):
+        try:
+            timeout = int(config.ACCOUNT_SVC_TIMEOUT, 20)
+        except Exception:
+            timeout = 20
+
+    @classmethod
+    def get_bearer_token(cls, config):
+        """Get a valid Bearer token for the service to use."""
+        token_url = config.ACCOUNT_SVC_AUTH_URL
+        client_id = config.ACCOUNT_SVC_CLIENT_ID
+        client_secret = config.ACCOUNT_SVC_CLIENT_SECRET
+
+        data = 'grant_type=client_credentials'
+
+        # get service account token
+        res = requests.post(url=token_url,
+                             data=data,
+                             headers={'content-type': 'application/x-www-form-urlencoded'},
+                             auth=(client_id, client_secret),
+                             timeout=cls.get_time_out(config))
+
+        try:
+            return res.json().get('access_token')
+        except Exception:
+            return None
+
+
+    # pylint: disable=too-many-arguments, too-many-locals disable=invalid-name;
+    @classmethod
+    def create_affiliation(cls,
+                           config,
+                           account: int,
+                           business_registration: str,
+                           business_name: str = None,
+                           corp_type_code: str = 'TMP',
+                           corp_sub_type_code: str = None,
+                           pass_code: str = '',
+                           details: dict = None):
+        """Affiliate a business to an account."""
+        auth_url = config.AUTH_SVC_URL
+        account_svc_entity_url = f'{auth_url}/entities'
+        account_svc_affiliate_url = f'{auth_url}/orgs/{account}/affiliations'
+
+        token = cls.get_bearer_token(config)
+
+        if not token:
+            return HTTPStatus.UNAUTHORIZED
+
+        # Create an entity record
+        entity_data = {
+            'businessIdentifier': business_registration,
+            'corpTypeCode': corp_type_code,
+            'name': business_name or business_registration
+        }
+        if corp_sub_type_code:
+            entity_data['corpSubTypeCode'] = corp_sub_type_code
+
+        entity_record = requests.post(
+            url=account_svc_entity_url,
+            headers={**cls.CONTENT_TYPE_JSON,
+                     'Authorization': cls.BEARER + token},
+            data=json.dumps(entity_data),
+            timeout=cls.get_time_out(config)
+        )
+
+        # Create an account:business affiliation
+        affiliate_data = {
+            'businessIdentifier': business_registration,
+            'passCode': pass_code
+        }
+        if details:
+            affiliate_data['entityDetails'] = details
+        affiliate = requests.post(
+            url=account_svc_affiliate_url,
+            headers={**cls.CONTENT_TYPE_JSON,
+                     'Authorization': cls.BEARER + token},
+            data=json.dumps(affiliate_data),
+            timeout=cls.get_time_out(config)
+        )
+
+        # @TODO delete affiliation and entity record next sprint when affiliation service is updated
+        if affiliate.status_code != HTTPStatus.CREATED or entity_record.status_code != HTTPStatus.CREATED:
+            return HTTPStatus.BAD_REQUEST
+        return HTTPStatus.OK
+
+    @classmethod
+    def create_entity(cls,
+                      config,
+                      business_registration: str,
+                      business_name: str,
+                      corp_type_code: str):
+        """Update an entity."""
+        auth_url = config.AUTH_SVC_URL
+        account_svc_entity_url = f'{auth_url}/entities'
+
+        token = cls.get_bearer_token(config)
+
+        if not token:
+            return HTTPStatus.UNAUTHORIZED
+
+        # Create an entity record
+        entity_data = {
+            'businessIdentifier': business_registration,
+            'corpTypeCode': corp_type_code,
+            'name': business_name
+        }
+
+        entity_record = requests.post(
+            url=account_svc_entity_url,
+            headers={**cls.CONTENT_TYPE_JSON,
+                     'Authorization': cls.BEARER + token},
+            data=json.dumps(entity_data),
+            timeout=cls.get_time_out(config)
+        )
+
+        if entity_record.status_code != HTTPStatus.OK:
+            return HTTPStatus.BAD_REQUEST
+        return HTTPStatus.OK
+
+
+    @classmethod
+    def update_entity(cls,
+                      config,
+                      business_registration: str,
+                      business_name: str,
+                      corp_type_code: str,
+                      state: str = None):
+        """Update an entity."""
+        auth_url = config.AUTH_SVC_URL
+        account_svc_entity_url = f'{auth_url}/entities'
+
+        token = cls.get_bearer_token(config)
+
+        if not token:
+            return HTTPStatus.UNAUTHORIZED
+
+        # Create an entity record
+        entity_data = {
+            'businessIdentifier': business_registration,
+            'corpTypeCode': corp_type_code,
+            'name': business_name
+        }
+        if state:
+            entity_data['state'] = state
+
+        entity_record = requests.patch(
+            url=account_svc_entity_url + '/' + business_registration,
+            headers={**cls.CONTENT_TYPE_JSON,
+                     'Authorization': cls.BEARER + token},
+            data=json.dumps(entity_data),
+            timeout=cls.get_time_out(config)
+        )
+
+        if entity_record.status_code != HTTPStatus.OK:
+            return HTTPStatus.BAD_REQUEST
+        return HTTPStatus.OK
+
+    @classmethod
+    def delete_affiliation(cls, config, account: int, business_registration: str) -> Dict:
+        """Affiliate a business to an account.
+
+        @TODO Update this when account affiliation is changed next sprint.
+        """
+        auth_url = config.AUTH_SVC_URL
+        account_svc_entity_url = f'{auth_url}/entities'
+        account_svc_affiliate_url = f'{auth_url}/orgs/{account}/affiliations'
+
+        token = cls.get_bearer_token(config)
+
+        # Delete an account:business affiliation
+        affiliate = requests.delete(
+            url=account_svc_affiliate_url + '/' + business_registration,
+            headers={**cls.CONTENT_TYPE_JSON,
+                     'Authorization': cls.BEARER + token},
+            timeout=cls.get_time_out(config)
+        )
+        # Delete an entity record
+        entity_record = requests.delete(
+            url=account_svc_entity_url + '/' + business_registration,
+            headers={**cls.CONTENT_TYPE_JSON,
+                     'Authorization': cls.BEARER + token},
+            timeout=cls.get_time_out(config)
+        )
+
+        if affiliate.status_code != HTTPStatus.OK \
+                or entity_record.status_code not in (HTTPStatus.OK, HTTPStatus.NO_CONTENT):
+            return HTTPStatus.BAD_REQUEST
+        return HTTPStatus.OK

--- a/data-tool/flows/tombstone/tombstone_queries.py
+++ b/data-tool/flows/tombstone/tombstone_queries.py
@@ -20,6 +20,8 @@ def get_unprocessed_corps_query(flow_name, environment, batch_size):
 --    and c.corp_num = 'BC0043406' -- lots of directors
 --    and c.corp_num in ('BC0326163', 'BC0395512', 'BC0883637') -- TODO: re-migrate issue (can be solved by adding tracking)
 --    and c.corp_num = 'BC0870626' -- lots of filings - IA, CoDs, ARs
+--    and c.corp_num = 'BC0004969' -- lots of filings - IA, ARs, transition, alteration, COD, COA
+--    and c.corp_num = 'BC0002567' -- lots of filings - IA, ARs, transition, COD
 --    and c.corp_num in ('BC0068889', 'BC0441359') -- test users mapping
 --    and c.corp_num in ('BC0326163', 'BC0046540', 'BC0883637', 'BC0043406', 'BC0068889', 'BC0441359')
     and c.corp_type_cd in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE') -- TODO: update transfer script


### PR DESCRIPTION
*Issue #:* /bcgov/entity#24477

*Description of changes:*

* Added `update_auth` task in `migrate_tombstone` task .  This new task contains logic that supports entity creation and affiliation in auth.  `UPDATE_ENTITY`, `AFFILIATE_ENTITY` and `AFFILIATE_ENTITY_ACCOUNT_ID`  config i values can be used to test the added auth logic.  
* Added `auth_service.py`.  This was added as the tombstone pipeline wasn't updated to support LEAR version of sqlalchemy like `migrate_corps_flow.py`.  As such, it causes issues with importing legal api dependencies.  This is ok for now as we mainly use raw sql and don't have much need for direct sqlachemy model access so far.  But we may need to revisit this later and refactor to support legal api models if it becomes any issue in downstream work.

**Testing notes from loading BC0004969 into Dev with auth entity creation + affiliation turned on**

**Before BC0004969 is created in Dev**

Confirmed no entity in auth
![image](https://github.com/user-attachments/assets/3fd16ccd-232d-46c1-aca6-655f49553bd1)

**After BC0004969 is created in Dev**

```
# .env config for Dev
UPDATE_ENTITY=True
AFFILIATE_ENTITY=True
AFFILIATE_ENTITY_ACCOUNT_ID=2596
```

Confirmed entity + affiliation exists in auth
![image](https://github.com/user-attachments/assets/cdeebf41-1af1-4110-abc6-59be516b6bbc)

Confirmed flow run succeeds for update-auth task
![image](https://github.com/user-attachments/assets/c66fd99a-5cf7-4d32-a32f-7c7a8f916146)

Confirmed affiliated account shows business in MBR
![image](https://github.com/user-attachments/assets/00127db4-dfa3-4d70-9705-0a8bf6a369b0)

Confirmed business loads under affiliated account
![image](https://github.com/user-attachments/assets/70293afe-b1a6-4a00-a6d3-d88d8abe1064)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
