### PR TITLE
Add details for parValue and maxNumberOfShares fields

### DIFF
--- a/docs/business.yaml
+++ b/docs/business.yaml
@@ -6733,11 +6733,11 @@ components:
         maxNumberOfShares:
           type: number
           title: 'Maximum number of shares in the class. '
-          description: The maximum number of shares that a corporation can issue to the investors called authorized shares.
+          description: 'The maximum number of shares that a corporation can issue to the investors called authorized shares. If hasMaximumShares is false, set this field to null.'
         parValue:
           type: number
           title: 'Initial value of each share. '
-          description: 'The value of a single common share as set by a corporation''s charter. '
+          description: 'The value of a single common share as set by a corporation''s charter. If hasMaximumShares is false, set this field to null.'
         currency:
           type: string
           description: The currency in which the Share is traded on the Exchange.

--- a/docs/business.yaml
+++ b/docs/business.yaml
@@ -6737,7 +6737,7 @@ components:
         parValue:
           type: number
           title: 'Initial value of each share. '
-          description: 'The value of a single common share as set by a corporation''s charter. If hasMaximumShares is false, set this field to null.'
+          description: 'The value of a single common share as set by a corporation''s charter. If hasParValue is false, set this field to null.'
         currency:
           type: string
           description: The currency in which the Share is traded on the Exchange.


### PR DESCRIPTION
*Issue #:* /bcgov/entity###  No ticket number for this

*Description of changes:*
As per discussion with Leo and Dave, made a quick update to add information about set relevant fields to `null` in certain scenarios, so that API users would be able to put correct value for the fields.

#### Before:
![image](https://github.com/user-attachments/assets/6825aa51-9a35-4d0a-a2b7-10072f6a416c)

#### After:
![image](https://github.com/user-attachments/assets/0760f1ac-c5db-4e0a-998e-96f193cc4f00)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
