### PR TITLE
22956 - Verify update legal filings job to use new db versioning

### DIFF
--- a/jobs/update-legal-filings/requirements.txt
+++ b/jobs/update-legal-filings/requirements.txt
@@ -28,6 +28,11 @@ asyncio-nats-streaming==0.4.0
 nest_asyncio
 protobuf==3.15.8
 git+https://github.com/bcgov/lear.git#subdirectory=colin-api
-git+https://github.com/bcgov/lear.git#egg=legal_api&subdirectory=legal-api
+
+# install updated legal-api from feature branch for development, 
+# TODO - change it back when the db versioning feature branch merged to main
+git+https://github.com/bcgov/lear.git@feature-db-versioning#egg=legal_api&subdirectory=legal-api
+# git+https://github.com/bcgov/lear.git#egg=legal_api&subdirectory=legal-api
+
 git+https://github.com/bcgov/lear.git#egg=sql-versioning&subdirectory=python/common/sql-versioning
-git+https://github.com/bcgov/business-schemas.git@2.5.12#egg=registry_schemas
+git+https://github.com/bcgov/business-schemas.git@2.18.27#egg=registry_schemas

--- a/legal-api/flags.json
+++ b/legal-api/flags.json
@@ -20,8 +20,7 @@
             "furnishings-job": false,
             "emailer-reminder-job": false,
             "future-effective-job": false,
-            "update-colin-filings-job": false,
-            "update-legal-filings-job": false
+            "update-colin-filings-job": false
         }
     }
 }

--- a/queue_services/entity-bn/flags.json
+++ b/queue_services/entity-bn/flags.json
@@ -10,8 +10,7 @@
             "furnishings-job": false,
             "emailer-reminder-job": false,
             "future-effective-job": false,
-            "update-colin-filings-job": false,
-            "update-legal-filings-job": false
+            "update-colin-filings-job": false
         }
     }
 }

--- a/queue_services/entity-emailer/flags.json
+++ b/queue_services/entity-emailer/flags.json
@@ -11,8 +11,7 @@
             "furnishings-job": false,
             "emailer-reminder-job": false,
             "future-effective-job": false,
-            "update-colin-filings-job": false,
-            "update-legal-filings-job": false
+            "update-colin-filings-job": false
         }
     }
 }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22956

*Description of changes:*
update-legal-filings-job doesn't directly operate in lear db, instead, it's calling legal-api and colin-api endpoints. And there isn't any existing code initialize a db instance in this job. As per discussion I have removed FF for update-legal-filings in multiple flags.json files.

### Verification 1 - Running local legal-api and check behaviours
Keep the local lear-db's colin_last_update table remain the same for 3 runs in different scenarios.
In summary, there is no behaviour differences between these 3 scenarios:
1. Not using new db versioning
![Not using new db versioning](https://github.com/user-attachments/assets/6307a43f-0cbd-4d94-97ad-fa6cf0357037)
2. Using new db versioning and FF on
![FF-on](https://github.com/user-attachments/assets/ed7052f4-3303-47c9-a60d-67def3704b19)
3. Using new db versioning and FF off
![FF-off](https://github.com/user-attachments/assets/400ed0e7-026b-457b-ae01-837e3e62bb8b)

### Verification 2 - Running local legal-api and verify the endpoints the job used
1. get max colin event_id from lear-db `{{url}}/api/v2/businesses/internal/filings/colin_id`
![Pasted image 20241203095542](https://github.com/user-attachments/assets/da9a2190-10e1-4a71-bf95-58e726985df2)
2. Pick an event_ids greater than the max id returned -- `105911836`
3. Get business info in lear-db: `{{url}}/api/v2/businesses/:identifier`
![Pasted image 20241203101654](https://github.com/user-attachments/assets/798b4de2-e6c8-4721-93e7-c46501ccf4d5)
4. Check whether that event has been updated to lear-db or not: `{{url}}/api/v2/businesses/internal/filings/colin_id/:event_id`
As this event/filing is not yet updated, it's not found in lear-db
![Pasted image 20241203103005](https://github.com/user-attachments/assets/0e886173-c0ed-4044-bf56-e98ec0e9379b)
5. Update it in lear: `{{url}}/api/v2/businesses/:identifier/filings`
After fixing the data-type for `goodStanding` and `adminFreeze`
![Pasted image 20241203104455](https://github.com/user-attachments/assets/9eb8f5eb-eee1-4230-8273-18ad4bbd9ea6)
6. Update the new max_event_id: `{{url}}/api/v2/businesses/internal/filings/colin_id/:new_max_event_id`
![Pasted image 20241203104635](https://github.com/user-attachments/assets/c1474707-6af6-468b-885e-30f5741f53e0)
![Pasted image 20241203104656](https://github.com/user-attachments/assets/4d9ade3b-395b-4287-a81d-98ef6646e9b9)
7. Check again (prev check in step-4): `{{url}}/api/v2/businesses/internal/filings/colin_id/:event_id`
And since it's updated to lear-db now, we can find it
![image](https://github.com/user-attachments/assets/828baacd-cac1-459a-84d5-cea45082a8b6)

### Other findings
Found this job is already not really working properly, and might be like this for a while. I left some details here: https://github.com/bcgov/entity/issues/22956#issuecomment-2508692615
May need to cut another ticket to address this issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
