### PR TITLE
22955 - Verify update-colin-filings job to use new db versioning

### DIFF
--- a/jobs/furnishings/flags.json
+++ b/jobs/furnishings/flags.json
@@ -12,8 +12,6 @@
             "dissolutions-job": false,
             "furnishings-job": true,
             "emailer-reminder-job": false,
-            "future-effective-job": false,
-            "update-colin-filings-job": false,
             "update-legal-filings-job": false
         }
     }

--- a/legal-api/flags.json
+++ b/legal-api/flags.json
@@ -18,8 +18,7 @@
             "digital-credentials": false,
             "dissolutions-job": false,
             "furnishings-job": true,
-            "emailer-reminder-job": false,
-            "update-colin-filings-job": false
+            "emailer-reminder-job": false
         }
     }
 }

--- a/legal-api/src/legal_api/models/resolution.py
+++ b/legal-api/src/legal_api/models/resolution.py
@@ -90,3 +90,8 @@ class Resolution(db.Model, Versioned):  # pylint: disable=too-many-instance-attr
             filter(Resolution.resolution_type == resolution_type). \
             all()
         return resolutions
+
+    @classmethod
+    def get_resolution_by_business_id(cls, business_id: int):
+        """Get all resolutions for a business."""
+        return cls.query.filter_by(business_id=business_id).all()

--- a/legal-api/src/legal_api/resources/v2/business/colin_sync.py
+++ b/legal-api/src/legal_api/resources/v2/business/colin_sync.py
@@ -287,7 +287,8 @@ def _set_shares(primary_or_holding_business, amalgamation_filing, transaction_id
     share_classes = VersionedBusinessDetailsService.get_share_class_revision(transaction_id,
                                                                              primary_or_holding_business.id)
     amalgamation_filing['shareStructure'] = {'shareClasses': share_classes}
-    business_dates = [item.resolution_date.isoformat() for item in primary_or_holding_business.resolutions]
+    resolutions = Resolution.get_resolution_by_business_id(primary_or_holding_business.id)
+    business_dates = [item.resolution_date.isoformat() for item in resolutions]
     if business_dates:
         amalgamation_filing['shareStructure']['resolutionDates'] = business_dates
 

--- a/queue_services/entity-bn/flags.json
+++ b/queue_services/entity-bn/flags.json
@@ -8,8 +8,7 @@
             "digital-credentials": false,
             "dissolutions-job": false,
             "furnishings-job": false,
-            "emailer-reminder-job": false,
-            "update-colin-filings-job": false
+            "emailer-reminder-job": false
         }
     }
 }

--- a/queue_services/entity-emailer/flags.json
+++ b/queue_services/entity-emailer/flags.json
@@ -9,8 +9,7 @@
             "digital-credentials": false,
             "dissolutions-job": false,
             "furnishings-job": false,
-            "emailer-reminder-job": false,
-            "update-colin-filings-job": false
+            "emailer-reminder-job": false
         }
     }
 }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22955

*Description of changes:*

1. Investigated the job's functionality:

    - Job only handles API calls from legal-api and colin-api
    - No direct DB operations
    - No legal-api and db versioning package usage

2. Conclusions:

    - No changes needed in db versioning setup
    - Remove the update-colin-filings flag in legal-api's flags.json

3. Findings of db versioning relationship issue:
   - Found versioned objects (BusinessVersion) missing relationship attributes (`Resolutions`)
   - Root cause:       
       - Our db versioning only copies table columns but misses the relationship mappings
      - When versioning is enabled, `BusinessVersion` lacks the `resolutions` relationship that exists in the original Business model
   - Solutions:
       - Added direct Resolution query to replace relationship access
       - Updated `_set_shares` method to handle both versioned and non-versioned cases
       - Code changes:
      ```python
      # Before
      business_dates = [item.resolution_date.isoformat() for item in primary_or_holding_business.resolutions]
      
      # After
      resolutions = Resolution.get_resolution_by_business_id(primary_or_holding_business.id)
      business_dates = [item.resolution_date.isoformat() for item in resolutions]
      ```
 
![image](https://github.com/user-attachments/assets/fb2ae404-51cc-409a-a7a1-a6f50ded2024)
    
  - Debug logs showing the issue:
    
    When the FF is ON:
    ![image](https://github.com/user-attachments/assets/2bed63c1-69d5-4a49-85d3-58994579adc0)
    ![image](https://github.com/user-attachments/assets/8cbb0700-8e7a-4044-a61d-3ec5ee33b640)

    When the FF is OFF:
    ![image](https://github.com/user-attachments/assets/b4023d33-c4d2-460b-8b12-73624bce05ec)
    ![image](https://github.com/user-attachments/assets/a26bc714-7054-448f-b005-143e719afb94)
  

4. Verification steps:

    - Tested legal-api with feature flags ON & OFF
    - Verified update-colin-filings job functionality
    - Confirmed queue message processing works correctly in the local environment
    - All unit tests passed successfully
    - Verified resolution dates are correctly retrieved in both versioned and non-versioned scenarios


ScreenShots:
* Legal-API OFF
   - Job works successfully in the local environment

![image](https://github.com/user-attachments/assets/6cc9c855-18ae-4e2e-8ff1-d81d820120e5)

* Legal-API ON
1.  Created a new FED filing (Change of Address) - Filing ID: 151265
![image](https://github.com/user-attachments/assets/1b2cc14d-087a-4c26-bcc7-f425974dcb42)
2. Verified filing exists in the local DB
![image](https://github.com/user-attachments/assets/6d70738a-a66b-4e99-a070-0c4648003c0c)

3. Updated filing status to COMPLETED for testing
![image](https://github.com/user-attachments/assets/12fe7bb1-1a05-4357-a804-4c931128e598)
4. Then run the job locally again and confirm the filing(Filing ID: 151265) was successfully updated
![image](https://github.com/user-attachments/assets/9b708a33-638f-4414-aa08-e1150d4ca3fc)
5. Verified passed all unit test
![image](https://github.com/user-attachments/assets/891acfff-6835-4051-a8cc-be219e1f649f)
![image](https://github.com/user-attachments/assets/7719e689-3c74-4407-aacf-b1f2c291767a)

 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
