### PR TITLE
22945 Filer - Updated to use new db versioning

### DIFF
--- a/legal-api/flags.json
+++ b/legal-api/flags.json
@@ -13,7 +13,7 @@
         "db-versioning": {
             "legal-api": true,
             "emailer": true,
-            "filer": false,
+            "filer": true,
             "entity-bn": true,
             "digital-credentials": false,
             "dissolutions-job": true,

--- a/queue_services/entity-filer/flags.json
+++ b/queue_services/entity-filer/flags.json
@@ -11,9 +11,7 @@
             "dissolutions-job": false,
             "furnishings-job": false,
             "emailer-reminder-job": false,
-            "future-effective-job": false,
             "update-colin-filings-job": false,
-            "update-legal-filings-job": false
         }
     }
 }

--- a/queue_services/entity-filer/flags.json
+++ b/queue_services/entity-filer/flags.json
@@ -11,7 +11,7 @@
             "dissolutions-job": false,
             "furnishings-job": false,
             "emailer-reminder-job": false,
-            "update-colin-filings-job": false,
+            "update-colin-filings-job": false
         }
     }
 }

--- a/queue_services/entity-filer/flags.json
+++ b/queue_services/entity-filer/flags.json
@@ -1,6 +1,19 @@
 {
     "flagValues": {
         "enable-involuntary-dissolution": true,
-        "namex-nro-decommissioned": true
+        "namex-nro-decommissioned": true,
+        "db-versioning": {
+            "legal-api": true,
+            "emailer": false,
+            "filer": true,
+            "entity-bn": false,
+            "digital-credentials": false,
+            "dissolutions-job": false,
+            "furnishings-job": false,
+            "emailer-reminder-job": false,
+            "future-effective-job": false,
+            "update-colin-filings-job": false,
+            "update-legal-filings-job": false
+        }
     }
 }

--- a/queue_services/entity-filer/flags.json
+++ b/queue_services/entity-filer/flags.json
@@ -10,8 +10,7 @@
             "digital-credentials": false,
             "dissolutions-job": false,
             "furnishings-job": false,
-            "emailer-reminder-job": false,
-            "update-colin-filings-job": false
+            "emailer-reminder-job": false
         }
     }
 }

--- a/queue_services/entity-filer/requirements.txt
+++ b/queue_services/entity-filer/requirements.txt
@@ -26,5 +26,7 @@ reportlab==3.6.12
 git+https://github.com/bcgov/sbc-connect-common.git#egg=gcp-queue&subdirectory=python/gcp-queue
 git+https://github.com/bcgov/business-schemas.git@2.18.27#egg=registry_schemas
 git+https://github.com/bcgov/lear.git#egg=entity_queue_common&subdirectory=queue_services/common
-git+https://github.com/bcgov/lear.git#egg=legal_api&subdirectory=legal-api
+#git+https://github.com/bcgov/lear.git#egg=legal_api&subdirectory=legal-api
+# fetch legal api's updates from the feature-db-versioning branch, need to change to the main branch later
+git+https://github.com/bcgov/lear.git@feature-db-versioning#egg=legal_api&subdirectory=legal-api
 git+https://github.com/bcgov/lear.git#egg=sql-versioning&subdirectory=python/common/sql-versioning

--- a/queue_services/entity-filer/src/entity_filer/config.py
+++ b/queue_services/entity-filer/src/entity_filer/config.py
@@ -58,6 +58,7 @@ class _Config():  # pylint: disable=too-few-public-methods
     Used as the base for all the other configurations.
     """
 
+    SERVICE_NAME = 'filer'
     PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
     PAYMENT_SVC_URL = os.getenv('PAYMENT_SVC_URL', '')

--- a/queue_services/entity-filer/src/entity_filer/worker.py
+++ b/queue_services/entity-filer/src/entity_filer/worker.py
@@ -36,10 +36,10 @@ from entity_queue_common.service import QueueServiceManager
 from entity_queue_common.service_utils import FilingException, QueueException, logger
 from flask import Flask
 from gcp_queue import GcpQueue, SimpleCloudEvent, to_queue_message
-from legal_api import db
+from legal_api import init_db
 from legal_api.core import Filing as FilingCore
-from legal_api.models import Business, Filing
-from legal_api.models.db import init_db, versioning_manager
+from legal_api.models import Business, Filing, db
+from legal_api.models.db import VersioningProxy
 from legal_api.services import Flags
 from legal_api.utils.datetime import datetime, timezone
 from sentry_sdk import capture_message
@@ -224,8 +224,7 @@ async def process_filing(filing_msg: Dict, flask_app: Flask):  # pylint: disable
         is_correction = filing_core_submission.filing_type == FilingCore.FilingTypes.CORRECTION
 
         if legal_filings := filing_core_submission.legal_filings():
-            uow = versioning_manager.unit_of_work(db.session)
-            transaction = uow.create_transaction(db.session)
+            VersioningProxy.get_transaction_id(db.session())
 
             business = Business.find_by_internal_id(filing_submission.business_id)
 
@@ -334,7 +333,8 @@ async def process_filing(filing_msg: Dict, flask_app: Flask):  # pylint: disable
                 if filing.get('specialResolution'):
                     special_resolution.process(business, filing, filing_submission)
 
-            filing_submission.transaction_id = transaction.id
+            transaction_id = VersioningProxy.get_transaction_id(db.session())
+            filing_submission.transaction_id = transaction_id
 
             business_type = business.legal_type if business else filing_submission['business']['legal_type']
             filing_submission.set_processed(business_type)

--- a/queue_services/entity-filer/tests/unit/__init__.py
+++ b/queue_services/entity-filer/tests/unit/__init__.py
@@ -22,7 +22,7 @@ from freezegun import freeze_time
 
 from legal_api.models import Batch, BatchProcessing, Filing, Resolution, ShareClass, ShareSeries, db
 from legal_api.models.colin_event_id import ColinEventId
-from legal_api.models.db import versioning_manager
+from legal_api.models.db import VersioningProxy
 from legal_api.utils.datetime import datetime, timezone
 from tests import EPOCH_DATETIME, FROZEN_DATETIME
 
@@ -589,9 +589,8 @@ def factory_completed_filing(business, data_dict, filing_date=FROZEN_DATETIME, p
         filing.filing_json = data_dict
         filing.save()
 
-        uow = versioning_manager.unit_of_work(db.session)
-        transaction = uow.create_transaction(db.session)
-        filing.transaction_id = transaction.id
+        transaction_id = VersioningProxy.get_transaction_id(db.session())
+        filing.transaction_id = transaction_id
         filing.payment_token = payment_token
         filing.effective_date = filing_date
         filing.payment_completion_date = filing_date


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22945

*Description of changes:*
- Updated filer to use new db versioning

### Unit Tests
_Note: the 2 failed tests are because I did not have my NATS server running, but the rest of the tests pass._
![Screenshot 2024-12-04 at 4 12 23 PM](https://github.com/user-attachments/assets/8d367db2-323f-47b9-926f-25268e3b719c)
<img width="1153" alt="Screenshot 2024-12-05 at 8 43 44 AM" src="https://github.com/user-attachments/assets/a849283c-2575-4404-8c70-c8fbe0ea6095">

### Local Testing
Running the filer and legal api with FFs off results in a business_version with id=58116 and transaction_id=1077830
![Screenshot 2024-12-06 at 10 38 59 AM](https://github.com/user-attachments/assets/7ba06d62-dcc5-49db-b043-a8cb76560f79)
![Screenshot 2024-12-06 at 10 40 27 AM](https://github.com/user-attachments/assets/b56c607d-f1d0-4fad-b62e-ce6ff5f4762c)

Running the filer and legal api with FFs on results in a business_version with id=58116 and transaction_id=1077831. The different transaction ids between test runs are because I used the same db instance and manually adjusted the test data, so it grabbed the next transaction_id in the sequence. However, we can see the new versioning working correctly here.
![Screenshot 2024-12-06 at 10 07 58 AM](https://github.com/user-attachments/assets/13ecd835-8950-47e4-afe6-f2f817db90ca)
![Screenshot 2024-12-06 at 10 11 20 AM](https://github.com/user-attachments/assets/a8edb76d-1ba4-469a-ba99-57e7614b2b1e)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
