### PR TITLE
24478 Add corp processing logic to tombstone pipeline

### DIFF
--- a/data-tool/flows/common/auth_service.py
+++ b/data-tool/flows/common/auth_service.py
@@ -94,7 +94,6 @@ class AuthService:
             timeout=cls.get_time_out(config)
         )
 
-        # @TODO delete affiliation and entity record next sprint when affiliation service is updated
         if affiliate.status_code != HTTPStatus.CREATED or entity_record.status_code != HTTPStatus.CREATED:
             return HTTPStatus.BAD_REQUEST
         return HTTPStatus.OK
@@ -175,7 +174,6 @@ class AuthService:
     def delete_affiliation(cls, config, account: int, business_registration: str) -> Dict:
         """Affiliate a business to an account.
 
-        @TODO Update this when account affiliation is changed next sprint.
         """
         auth_url = config.AUTH_SVC_URL
         account_svc_entity_url = f'{auth_url}/entities'

--- a/data-tool/flows/common/corp_processing_queue_service.py
+++ b/data-tool/flows/common/corp_processing_queue_service.py
@@ -1,0 +1,173 @@
+from enum import Enum
+from typing import List
+from sqlalchemy import text
+import logging
+
+class ProcessingStatuses(str, Enum):
+    PENDING = 'PENDING'
+    PROCESSING = 'PROCESSING'
+    COMPLETED = 'COMPLETED'
+    FAILED = 'FAILED'
+
+class CorpProcessingQueueService:
+    def __init__(self, environment: str, db_engine, flow_name: str):
+        self.data_load_env = environment
+        self.db_engine = db_engine
+        self.flow_name = flow_name
+        self.logger = logging.getLogger(__name__)
+
+    def reserve_for_flow(self, base_query: str, flow_run_id: str) -> int:
+        """Reserve corporations for processing in a specific flow run.
+
+        Args:
+            base_query: SQL query that selects corps to be processed
+            flow_run_id: Unique identifier for this flow run
+
+        Returns:
+            Number of corporations successfully reserved for this flow
+        """
+        init_query = f"""
+        WITH candidate_corps AS ({base_query}),
+        available_corps AS (
+            SELECT corp_num, corp_type_cd
+            FROM candidate_corps
+            FOR UPDATE SKIP LOCKED
+        )
+        INSERT INTO corp_processing (
+            corp_num,
+            corp_type_cd,
+            flow_name,
+            processed_status,
+            environment,
+            flow_run_id,
+            create_date,
+            last_modified,
+            claimed_at
+        )
+        SELECT 
+            corp_num,
+            corp_type_cd,
+            :flow_name,
+            :status,
+            :environment,
+            :flow_run_id,
+            NOW(),
+            NOW(),
+            NULL
+        FROM available_corps
+        ON CONFLICT (corp_num, flow_name, environment) 
+        DO NOTHING
+        RETURNING corp_num
+        """
+
+        with self.db_engine.connect() as conn:
+            with conn.begin():
+                result = conn.execute(
+                    text(init_query),
+                    {
+                        'flow_name': self.flow_name,
+                        'status': ProcessingStatuses.PENDING,
+                        'environment': self.data_load_env,
+                        'flow_run_id': flow_run_id
+                    }
+                )
+                count = len(result.fetchall())
+                self.logger.info(f"Initialized {count} corps for flow run {flow_run_id}")
+                return count
+
+    def claim_batch(self, flow_run_id: str, batch_size: int) -> List[str]:
+        """Claim a batch of corporations for immediate processing within a flow run.
+
+        Args:
+            flow_run_id: Unique identifier for this flow run
+            batch_size: Maximum number of corps to claim
+
+        Returns:
+            List of corporation numbers that were successfully claimed for processing
+        """
+        query = """
+        WITH claimable AS (
+            SELECT corp_num
+            FROM corp_processing
+            WHERE processed_status = :pending_status
+            AND environment = :environment
+            AND flow_name = :flow_name
+            AND flow_run_id = :flow_run_id
+            AND claimed_at IS NULL
+            LIMIT :batch_size
+            FOR UPDATE SKIP LOCKED
+        )
+        UPDATE corp_processing
+        SET processed_status = :processing_status,
+            claimed_at = NOW(),
+            last_modified = NOW()
+        FROM claimable
+        WHERE corp_processing.corp_num = claimable.corp_num
+        RETURNING corp_processing.corp_num, corp_processing.claimed_at
+        """
+
+        with self.db_engine.connect() as conn:
+            with conn.begin():
+                result = conn.execute(
+                    text(query),
+                    {
+                        'pending_status': ProcessingStatuses.PENDING,
+                        'processing_status': ProcessingStatuses.PROCESSING,
+                        'environment': self.data_load_env,
+                        'flow_name': self.flow_name,
+                        'flow_run_id': flow_run_id,
+                        'batch_size': batch_size
+                    }
+                )
+                claimed = result.fetchall()
+                claimed_corps = [row[0] for row in claimed]
+                if claimed_corps:
+                    self.logger.info(f"Claimed {len(claimed_corps)} corps for flow {flow_run_id}")
+                    self.logger.info(f"Corps: {', '.join(claimed_corps[:5])}...")
+                    for corp, claimed_at in claimed:
+                        self.logger.debug(f"  {corp} claimed at {claimed_at}")
+                return claimed_corps
+
+    def update_corp_status(
+        self,
+        flow_run_id: str,
+        corp_num: str,
+        status: ProcessingStatuses,
+        error: str = None
+    ) -> bool:
+        """Update status for a corp."""
+        query = """
+        UPDATE corp_processing
+        SET processed_status = :status,
+            last_modified = NOW(),
+            last_error = CASE 
+                WHEN :error IS NOT NULL THEN :error 
+                ELSE last_error 
+            END
+        WHERE corp_num = :corp_num
+        AND flow_run_id = :flow_run_id
+        AND environment = :environment
+        AND flow_name = :flow_name
+        RETURNING corp_num
+        """
+
+        with self.db_engine.connect() as conn:
+            with conn.begin():
+                result = conn.execute(
+                    text(query),
+                    {
+                        'status': status,
+                        'error': error,
+                        'corp_num': corp_num,
+                        'flow_run_id': flow_run_id,
+                        'environment': self.data_load_env,
+                        'flow_name': self.flow_name
+                    }
+                )
+                success = result.rowcount > 0
+                if not success:
+                    self.logger.warning(
+                        f"Failed to update {corp_num} to {status} "
+                        f"(flow_run_id={flow_run_id})"
+                    )
+                return success

--- a/data-tool/flows/corps_tombstone_flow.py
+++ b/data-tool/flows/corps_tombstone_flow.py
@@ -1,13 +1,16 @@
 import math
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from common.init_utils import colin_init, get_config, lear_init
 from common.query_utils import convert_result_set_to_dict
 from common.auth_service import AuthService
-from prefect import flow, task
+from prefect import flow, task, serve
 from prefect.futures import wait
+from prefect.context import get_run_context
 from sqlalchemy import Connection, text
 from sqlalchemy.engine import Engine
+
+from common.corp_processing_queue_service import CorpProcessingQueueService as CorpProcessingService, ProcessingStatuses
 from tombstone.tombstone_queries import (get_corp_snapshot_filings_queries,
                                          get_corp_users_query,
                                          get_total_unprocessed_count_query,
@@ -20,20 +23,21 @@ from tombstone.tombstone_utils import (build_epoch_filing, format_users_data,
 
 
 @task
-def get_unprocessed_corps(config, colin_engine: Engine) -> list:
-    """Get unprocessed corp numbers."""
-    query = get_unprocessed_corps_query(
-        'local',
-        config.DATA_LOAD_ENV,
-        config.TOMBSTONE_BATCH_SIZE
-    )
-    sql_text = text(query)
+def reserve_unprocessed_corps(config, processing_service, flow_run_id, num_corps) -> list:
+    """Reserve corps for a given flow run.
 
-    with colin_engine.connect() as conn:
-        rs = conn.execute(sql_text)
-        raw_data_dict = convert_result_set_to_dict(rs)
-        corp_nums = [x.get('corp_num') for x in raw_data_dict]
-        return corp_nums
+    Note that this is not same as claiming them for processing which will be done in some subsequent steps.  This step
+    is done to avoid parallel flows from trying to compete for the same corps.
+    """
+    base_query = get_unprocessed_corps_query(
+        'tombstone-flow',
+        config.DATA_LOAD_ENV,
+        num_corps  # Pass the total number we want to process
+    )
+
+    # reserve corps
+    reserved = processing_service.reserve_for_flow(base_query, flow_run_id)
+    return reserved
 
 
 @task
@@ -200,8 +204,8 @@ def load_placeholder_filings(conn: Connection, tombstone_data: dict, business_id
 @task(name='3.3-Update-Auth-Task')
 def update_auth(conn: Connection, config, corp_num: str, tombstone_data: dict):
     """Create auth entity and affiliate as required."""
-    # TODO affiliation to an account does not need to happen.  only entity creation in auth is req'd.
-    #  used for testing purposes to see how things look in entity dashboard - remove when done testing
+    # Note: affiliation to an account does not need to happen.  only entity creation in auth is req'd.
+    #  used for testing purposes to see how things look in entity dashboard
     if config.AFFILIATE_ENTITY:
         business_data = tombstone_data['businesses']
         account_id = config.AFFILIATE_ENTITY_ACCOUNT_ID
@@ -287,6 +291,8 @@ def tombstone_flow():
         config = get_config()
         colin_engine = colin_init(config)
         lear_engine = lear_init(config)
+        flow_run_id = get_run_context().flow_run.id
+        processing_service = CorpProcessingService(config.DATA_LOAD_ENV, colin_engine, 'tombstone-flow')
 
         total = get_unprocessed_count(config, colin_engine)
 
@@ -297,12 +303,21 @@ def tombstone_flow():
         batch_size = config.TOMBSTONE_BATCH_SIZE
         batches = min(math.ceil(total/batch_size), config.TOMBSTONE_BATCHES)
 
+        # Calculate max corps to initialize
+        max_corps = min(total, config.TOMBSTONE_BATCHES * config.TOMBSTONE_BATCH_SIZE)
+        print(f'max_corps: {max_corps}')
+        reserved_corps = reserve_unprocessed_corps(config, processing_service, flow_run_id, max_corps)
+        print(f'👷 Reserved {reserved_corps} corps for processing')
         print(f'👷 Going to migrate {total} corps with batch size of {batch_size}')
 
         cnt = 0
         migrated_cnt = 0
         while cnt < batches:
-            corp_nums = get_unprocessed_corps(config, colin_engine)
+            # Claim next batch of reserved corps for current flow
+            corp_nums = processing_service.claim_batch(flow_run_id, batch_size)
+            if not corp_nums:
+                print("No more corps available to claim")
+                break
 
             print(f'👷 Start processing {len(corp_nums)} corps: {", ".join(corp_nums[:5])}...')
 
@@ -327,6 +342,11 @@ def tombstone_flow():
                     corp_futures.append(
                         migrate_tombstone.submit(config, lear_engine, corp_num, clean_data, users_mapper)
                     )
+                    processing_service.update_corp_status(
+                        flow_run_id,
+                        corp_num,
+                        ProcessingStatuses.COMPLETED
+                    )
                 else:
                     skipped += 1
                     print(f'❗ Skip migrating {corp_num} due to data collection error.')
@@ -347,3 +367,13 @@ def tombstone_flow():
 
 if __name__ == "__main__":
     tombstone_flow()
+
+    # # Create deployment - only intended to test locally for parallel flows
+    # deployment = tombstone_flow.to_deployment(
+    #     name="tombstone-deployment",
+    #     interval=timedelta(seconds=8),  # Run every x seconds
+    #     tags=["tombstone-migration"]
+    # )
+    #
+    # # Start serving the deployment
+    # serve(deployment)

--- a/data-tool/flows/tombstone/tombstone_queries.py
+++ b/data-tool/flows/tombstone/tombstone_queries.py
@@ -20,14 +20,16 @@ def get_unprocessed_corps_query(flow_name, environment, batch_size):
 --    and c.corp_num = 'BC0043406' -- lots of directors
 --    and c.corp_num in ('BC0326163', 'BC0395512', 'BC0883637') -- TODO: re-migrate issue (can be solved by adding tracking)
 --    and c.corp_num = 'BC0870626' -- lots of filings - IA, CoDs, ARs
---    and c.corp_num = 'BC0004969' -- lots of filings - IA, ARs, transition, alteration, COD, COA
+--      and c.corp_num = 'BC0004969' -- lots of filings - IA, ARs, transition, alteration, COD, COA
 --    and c.corp_num = 'BC0002567' -- lots of filings - IA, ARs, transition, COD
 --    and c.corp_num in ('BC0068889', 'BC0441359') -- test users mapping
 --    and c.corp_num in ('BC0326163', 'BC0046540', 'BC0883637', 'BC0043406', 'BC0068889', 'BC0441359')
 --    and c.corp_num in ('BC0472301', 'BC0649417', 'BC0808085', 'BC0803411', 'BC0756111', 'BC0511226', 'BC0833000', 'BC0343855', 'BC0149266') -- dissolution
     and c.corp_type_cd in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE') -- TODO: update transfer script
     and cs.end_event_id is null
-    and ((cp.processed_status is null or cp.processed_status != 'COMPLETED'))
+--    and ((cp.processed_status is null or cp.processed_status != 'COMPLETED'))
+      and cp.processed_status is null
+      and cp.flow_run_id is null
 --    and cs.state_type_cd = 'ACT'
 --    order by random()
     limit {batch_size}

--- a/data-tool/scripts/colin_corps_extract_postgres_ddl
+++ b/data-tool/scripts/colin_corps_extract_postgres_ddl
@@ -629,6 +629,8 @@ create table if not exists corp_processing
     create_date             timestamp with time zone,
     last_modified           timestamp with time zone,
     last_error              varchar(1000),
+    claimed_at              timestamp with time zone,
+    flow_run_id             uuid,
     constraint unq_corp_processing
         unique (corp_num, flow_name, environment)
 );


### PR DESCRIPTION
*Issue #:* /bcgov/entity#24478

*Description of changes:*

* Add `claimed_at` and `flow_run_id` fields to `corp_processing` table
* Add `CorpProcessingQueueService`.  This differs a bit from what we had done previously for firms and old corps pipeline.  The underlying `corp_processing` table is still fully intact but this service has been re-implemented to handle parallel flows.  In particular a concept of reserving corps for a given flow run and claiming a batch of reserved corps has been introduced.  It hasn't been fully implemented but enough to handle the general flow of loading a tombstone corp from start to finish.  Error handling corp processing status updates still needs to be handled.  This work will take place in the future.  The batch logic in tombstone flow is also still a bit messy so this will need to be refactored a bit in future work as well.
* Misc comment updates
* Addition of commented deployment code to test parallel flows easily locally.  Will use prefect.yaml to do real deployments if we host prefect infra in GCP
* Update `get_unprocessed_corps_query` to take into account `flow_run_id` when determining unprocessed corps

**Below is example data and info from a local test run that tested multiple parallel flows at a time**

.env values
```
TOMBSTONE_BATCHES=5
TOMBSTONE_BATCH_SIZE=10
```

used following in `if __name__ == "__main__":` to simulate parallel flows
```
    # Create deployment - only intended to test locally for parallel flows
    deployment = tombstone_flow.to_deployment(
        name="tombstone-deployment",
        interval=timedelta(seconds=8),  # Run every x seconds
        tags=["tombstone-migration"]
    )

    # Start serving the deployment
    serve(deployment)
```

Multiple parallel flows
![image](https://github.com/user-attachments/assets/035d4ac0-8ff5-46c9-966f-b37fb5d7829b)

Where to find prefect flow run id
![image](https://github.com/user-attachments/assets/dde57a3d-3627-420e-ba44-b33688dc9eae)

Query to show flow run data and businesses processed for flows
```sql
select flow_name, flow_run_id, create_date, processed_status, count(*) as cnt
from corp_processing
where 1 = 1
  and flow_name = 'tombstone-flow'
group by flow_name, flow_run_id, create_date, processed_status
order by create_date desc
;
```
![image](https://github.com/user-attachments/assets/267d87f9-bb29-4374-a7dc-5e6edd38ca95)

Query to show batches are claimed properly for a given flow run via the claimed_at field
```sql
select flow_name, flow_run_id, claimed_at, processed_status, count(*) as cnt
from corp_processing
where 1 = 1
  and flow_name = 'tombstone-flow'
group by flow_name, flow_run_id, claimed_at, processed_status
order by flow_run_id, claimed_at desc
;
```
![image](https://github.com/user-attachments/assets/23c8f688-c4b2-4554-9984-19f2a9ddabb6)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
