### PR TITLE
24826 - Disable publishing to emailer when sandbox FF is on

### DIFF
--- a/queue_services/business-pay/src/business_pay/resources/pay_filer.py
+++ b/queue_services/business-pay/src/business_pay/resources/pay_filer.py
@@ -207,6 +207,10 @@ def publish_to_filer(filing: Filing, payment_token: PaymentToken):
 def publish_to_emailer(filing: Filing):
     """Publish a queue message to entity-emailer once the filing has been marked as PAID."""
     with suppress(Exception):
+        # skip publishing NATS message
+        if flags.is_on("enable-sandbox"):
+            logger.debug("Skip publishing to emailer.")
+            return
         mail_topic = current_app.config["EMAIL_PUBLISH_OPTIONS"]["subject"]
         email_msg = create_email_msg(filing.id, filing.filing_type)
         # await queue.publish(subject=mail_topic, msg=email_msg)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#24826

*Description of changes:*
- Disable publishing to emailer to avoid too many NATS error messages in GCP logs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
