### PR TITLE
24764 - Bump version up for 23.5b release

### DIFF
--- a/queue_services/entity-filer/src/entity_filer/version.py
+++ b/queue_services/entity-filer/src/entity_filer/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.132.0'  # pylint: disable=invalid-name
+__version__ = '2.135.0'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:* /bcgov/entity#24764

*Description of changes:*
* Updated the version number of entity_filier for 23.5b release

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
