### PR TITLE
24830-5 Tweak status code to avoid infinite retries before message is expired

### DIFF
--- a/queue_services/entity-filer/src/entity_filer/resources/worker.py
+++ b/queue_services/entity-filer/src/entity_filer/resources/worker.py
@@ -91,9 +91,9 @@ def worker():
     # 2. Get filing_message information
     # ##
     if not (filing_message := get_filing_message(ce)):
-        # no filing_message info, error off Q
+        # no filing_message info, take off Q
         logger.debug(f'no filing_message info in: {ce}')
-        return {'error': 'no filing info in cloud event'}, HTTPStatus.BAD_REQUEST
+        return {'message': 'no filing info in cloud event'}, HTTPStatus.OK
     logger.info(f'Incoming filing_message: {filing_message}')
 
     # 3. Process Filing
@@ -102,7 +102,7 @@ def worker():
         loop.run_until_complete(process_filing(filing_message, current_app))
     except Exception as err:  # pylint: disable=broad-exception-caught
         logger.error(f'Error processing filing {filing_message}: {err}')
-        return {'error': f'Unable to process filing: {filing_message}'}, HTTPStatus.BAD_REQUEST
+        return {'error': f'Unable to process filing: {filing_message}'}, HTTPStatus.INTERNAL_SERVER_ERROR
 
     logger.info(f'completed ce: {str(ce)}')
     return {}, HTTPStatus.OK


### PR DESCRIPTION
*Issue #:* /bcgov/entity#24830

*Description of changes:*
- Found an issue that the message is pushed back to filer infinitely in retention duration, even after the retry policy and dead letter topic are configured in GCP. This PR is trying to solve this issue.
- Let me know if you have any better thoughts ⭐ 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
