### PR TITLE
24952 - Fix not allow to update NoW draft issue

### DIFF
--- a/legal-api/src/legal_api/services/authz.py
+++ b/legal-api/src/legal_api/services/authz.py
@@ -876,7 +876,7 @@ def has_notice_of_withdrawal_filing_blocker(business: Business):
     """Check if there are any blockers specific to Notice of Withdrawal."""
     if business.admin_freeze:
         return True
-    
+
     # Get request method and filing id from request context
     is_update = request.method == 'PUT'
     filing_id = request.view_args.get('filing_id') if is_update else None


### PR DESCRIPTION
*Issue #:* /bcgov/entity#24952

*Description of changes:*
Updated the logic for allowable actions to enable update Notice of Withdrawal draft. This change is only within scope for regular/existing businesses. The support of allowable actions for temporary business will be done in https://github.com/bcgov/entity/issues/24987

#### Issue Before
- Can file NoW and NoW draft
- But cannot update the draft using `PUT` method with endpoint `/api/v2/businesses/:identifier/filings/:filing_id?draft=true`

#### After Update
Able to update NoW draft using the endpoint and method mentioned above.
- Create a Draft
![image](https://github.com/user-attachments/assets/1d2754af-0b0d-4f14-aaca-6b90b5a9bfd7)
- Update this Draft
![image](https://github.com/user-attachments/assets/3ca7068a-11b0-49d3-9859-00698a7714ed)

#### Other Verifications
- Allowable Actions: there is no NoW or NoW draft, NoW filing is allowed
![image](https://github.com/user-attachments/assets/7d86e1ea-ee1b-4d84-b94a-f772ddf0d5ca)
- Allowable Action: after a NoW draft is created, NoW filing is not allowed anymore
![image](https://github.com/user-attachments/assets/cb3a7677-a1b8-4e12-95b2-93d40e57c79b)
- Try to create the **second** draft when there is already a draft exist is now allowed
![image](https://github.com/user-attachments/assets/8b1a4a1d-e7b8-49e3-afe8-aaa00571fa1e)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
