### PR TITLE
25040 - Filer put back off

### DIFF
--- a/queue_services/entity-filer/requirements.txt
+++ b/queue_services/entity-filer/requirements.txt
@@ -24,7 +24,7 @@ minio==7.0.2
 PyPDF2==1.26.0
 reportlab==3.6.12
 git+https://github.com/bcgov/sbc-connect-common.git#egg=gcp-queue&subdirectory=python/gcp-queue
-git+https://github.com/bcgov/business-schemas.git@2.18.27#egg=registry_schemas
+git+https://github.com/bcgov/business-schemas.git@2.18.32#egg=registry_schemas
 git+https://github.com/bcgov/lear.git#egg=entity_queue_common&subdirectory=queue_services/common
 git+https://github.com/bcgov/lear.git#egg=legal_api&subdirectory=legal-api
 git+https://github.com/bcgov/lear.git#egg=sql-versioning&subdirectory=python/common/sql-versioning

--- a/queue_services/entity-filer/requirements/bcregistry-libraries.txt
+++ b/queue_services/entity-filer/requirements/bcregistry-libraries.txt
@@ -1,5 +1,5 @@
 git+https://github.com/bcgov/sbc-connect-common.git#egg=gcp-queue&subdirectory=python/gcp-queue
-git+https://github.com/bcgov/business-schemas.git@2.18.27#egg=registry_schemas
+git+https://github.com/bcgov/business-schemas.git@2.18.32#egg=registry_schemas
 git+https://github.com/bcgov/lear.git#egg=legal_api&subdirectory=legal-api
 git+https://github.com/bcgov/lear.git#egg=sql-versioning&subdirectory=python/common/sql-versioning
 git+https://github.com/bcgov/lear.git#egg=entity_queue_common&subdirectory=queue_services/common

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/business_profile.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/business_profile.py
@@ -149,7 +149,7 @@ def update_affiliation(business: Business, filing: Filing):
 def update_entity(business: Business, filing_type: str):
     """Update an entity in auth with the latest change."""
     state = None
-    if filing_type in ['dissolution', 'putBackOn', 'restoration']:
+    if filing_type in ['dissolution', 'putBackOn', 'putBackOff', 'restoration']:
         state = business.state.name  # state changed to HISTORICAL/ACTIVE
 
     AccountService.update_entity(

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/put_back_off.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/put_back_off.py
@@ -1,0 +1,44 @@
+# Copyright © 2025 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""File processing rules and actions for the put back off filing."""
+
+from contextlib import suppress
+from typing import Dict
+
+import dpath
+from entity_queue_common.service_utils import QueueException, logger
+from legal_api.models import Business, Filing
+
+from entity_filer.filing_meta import FilingMeta
+from entity_filer.filing_processors.filing_components import filings
+
+
+def process(business: Business, filing: Dict, filing_rec: Filing, filing_meta: FilingMeta):
+    """Render the put back off filing unto the model objects."""
+    if not (put_back_off_filing := filing.get('putBackOff')):
+        logger.error('Could not find putBackOff in: %s', filing)
+        raise QueueException(f'legal_filing:putBackOff missing from {filing}')
+
+    logger.debug('processing putBackOff: %s', filing)
+
+    # update court order, if any is present
+    with suppress(IndexError, KeyError, TypeError):
+        court_order_json = dpath.util.get(put_back_off_filing, '/courtOrder')
+        filings.update_filing_court_order(filing_rec, court_order_json)
+
+    filing_rec.order_details = put_back_off_filing.get('details')
+
+    # change business state to historical
+    business.state = Business.State.HISTORICAL
+    business.state_filing_id = filing_rec.id

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/put_back_off.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/put_back_off.py
@@ -42,3 +42,4 @@ def process(business: Business, filing: Dict, filing_rec: Filing, filing_meta: F
     # change business state to historical
     business.state = Business.State.HISTORICAL
     business.state_filing_id = filing_rec.id
+    business.restoration_expiry_date = None

--- a/queue_services/entity-filer/src/entity_filer/worker.py
+++ b/queue_services/entity-filer/src/entity_filer/worker.py
@@ -66,6 +66,7 @@ from entity_filer.filing_processors import (
     court_order,
     dissolution,
     incorporation_filing,
+    put_back_off,
     put_back_on,
     registrars_notation,
     registrars_order,
@@ -296,6 +297,9 @@ async def process_filing(filing_msg: Dict, flask_app: Flask):  # pylint: disable
                 elif filing.get('changeOfRegistration'):
                     change_of_registration.process(business, filing_submission, filing, filing_meta)
 
+                elif filing.get('putBackOff'):
+                    put_back_off.process(business, filing, filing_submission, filing_meta)
+
                 elif filing.get('putBackOn'):
                     put_back_on.process(business, filing, filing_submission, filing_meta)
 
@@ -376,6 +380,7 @@ async def process_filing(filing_msg: Dict, flask_app: Flask):  # pylint: disable
                         FilingCore.FilingTypes.CHANGEOFREGISTRATION,
                         FilingCore.FilingTypes.CORRECTION,
                         FilingCore.FilingTypes.DISSOLUTION,
+                        FilingCore.FilingTypes.PUTBACKOFF,
                         FilingCore.FilingTypes.PUTBACKON,
                         FilingCore.FilingTypes.RESTORATION
                     ]:

--- a/queue_services/entity-filer/tests/unit/filing_processors/test_annual_report.py
+++ b/queue_services/entity-filer/tests/unit/filing_processors/test_annual_report.py
@@ -18,6 +18,7 @@ import pytest
 import random
 from unittest.mock import patch
 
+from dateutil.relativedelta import relativedelta
 from freezegun import freeze_time
 from legal_api.models import BatchProcessing, Business, Filing
 from registry_schemas.example_data import ANNUAL_REPORT
@@ -60,11 +61,11 @@ def test_process_ar_filing_involuntary_dissolution(app, session, test_name, flag
     now = datetime.datetime.utcnow()
     if eligibility:
         # setup ar_date to """INTERVAL '26 MONTHS'"" to make the businees is eligibility
-        ar_date = datetime.date(year=now.year-4, month=now.month-1, day=now.day)
-        agm_date = datetime.date(year=now.year-4, month=now.month-2, day=now.day)
+        ar_date = (now - relativedelta(years=4, months=1)).date()
+        agm_date = (now - relativedelta(years=4, months=2)).date()
     else:
-        ar_date = datetime.date(year=now.year, month=now.month-1, day=now.day)
-        agm_date = datetime.date(year=now.year, month=now.month-2, day=now.day)
+        ar_date = (now - relativedelta(months=1)).date()
+        agm_date = (now - relativedelta(months=2)).date()
 
     ar = copy.deepcopy(ANNUAL_REPORT)
     ar['filing']['business']['identifier'] = identifier

--- a/queue_services/entity-filer/tests/unit/filing_processors/test_put_back_off.py
+++ b/queue_services/entity-filer/tests/unit/filing_processors/test_put_back_off.py
@@ -1,0 +1,51 @@
+# Copyright © 2025 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The Unit Tests for the Put Back Off filing."""
+import copy
+import random
+
+from legal_api.models import Business, Filing
+from registry_schemas.example_data import FILING_HEADER, PUT_BACK_OFF
+
+from entity_filer.filing_meta import FilingMeta
+from entity_filer.filing_processors import put_back_off
+from tests.unit import create_business, create_filing
+
+
+def test_worker_put_back_off(session):
+    """Assert that the put back off filing processes correctly."""
+    # Setup
+    identifier = 'BC1234567'
+    business = create_business(identifier, legal_type='BC')
+    
+    # Create filing
+    filing_json = copy.deepcopy(FILING_HEADER)
+    filing_json['filing']['business']['identifier'] = identifier
+    filing_json['filing']['putBackOff'] = copy.deepcopy(PUT_BACK_OFF)
+    
+    payment_id = str(random.SystemRandom().getrandbits(0x58))
+    filing = create_filing(payment_id, filing_json, business_id=business.id)
+    
+    filing_meta = FilingMeta()
+    
+    # Test
+    put_back_off.process(business, filing_json['filing'], filing, filing_meta)
+    business.save()
+    
+    # Check results
+    final_filing = Filing.find_by_id(filing.id)
+    
+    assert business.state == Business.State.HISTORICAL
+    assert business.state_filing_id == filing.id
+    assert filing.order_details == final_filing.order_details

--- a/queue_services/entity-filer/tests/unit/filing_processors/test_put_back_off.py
+++ b/queue_services/entity-filer/tests/unit/filing_processors/test_put_back_off.py
@@ -48,4 +48,5 @@ def test_worker_put_back_off(session):
     
     assert business.state == Business.State.HISTORICAL
     assert business.state_filing_id == filing.id
+    assert business.restoration_expiry_date is None
     assert filing.order_details == final_filing.order_details


### PR DESCRIPTION
*Issue #:* /bcgov/entity#25040

*Description of changes:*
- Added put back off filing processor to handle expired limited restoration filings
- Implemented unit tests for put back off filing processor

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
