### PR TITLE
25159 - Update NoW filing not Saving temp_reg for T business

### DIFF
--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
@@ -633,6 +633,8 @@ class ListFilingResource():  # pylint: disable=too-many-public-methods
 
             if filing.filing_type == Filing.FILINGS['noticeOfWithdrawal']['name']:
                 ListFilingResource.link_now_and_withdrawn_filing(filing)
+                if bootstrap:
+                    filing.temp_reg = None
             filing.save()
         except BusinessException as err:
             return None, None, {'error': err.error}, err.status_code

--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
@@ -633,7 +633,7 @@ class ListFilingResource():  # pylint: disable=too-many-public-methods
 
             if filing.filing_type == Filing.FILINGS['noticeOfWithdrawal']['name']:
                 ListFilingResource.link_now_and_withdrawn_filing(filing)
-                if bootstrap:
+                if business_identifier.startswith('T'):
                     filing.temp_reg = None
             filing.save()
         except BusinessException as err:
@@ -835,7 +835,7 @@ class ListFilingResource():  # pylint: disable=too-many-public-methods
         """Set the withdrawal pending flag to False when a NoW is deleted."""
         withdrawn_filing = ListFilingResource.get_withdrawn_filing(filing)
         withdrawn_filing.withdrawal_pending = False
-        withdrawn_filing.save()
+        withdrawn_filing.save()    
 
     @staticmethod
     def create_invoice(business: Business,  # pylint: disable=too-many-locals,too-many-branches,too-many-statements

--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
@@ -835,7 +835,7 @@ class ListFilingResource():  # pylint: disable=too-many-public-methods
         """Set the withdrawal pending flag to False when a NoW is deleted."""
         withdrawn_filing = ListFilingResource.get_withdrawn_filing(filing)
         withdrawn_filing.withdrawal_pending = False
-        withdrawn_filing.save()    
+        withdrawn_filing.save()
 
     @staticmethod
     def create_invoice(business: Business,  # pylint: disable=too-many-locals,too-many-branches,too-many-statements

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filings.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filings.py
@@ -1608,8 +1608,8 @@ def test_resubmit_filing_failed(session, client, jwt, filing_status, review_stat
             ('REGULAR-BUSINESS-DISSOLUTION', 'CBEN', 'dissolution', DISSOLUTION, False)
         ]
 )
-def test_notice_of_withdraw_filing(session, client, jwt, test_name, legal_type, filing_type, filing_json, is_temp):
-    """Assert that notice of withdraw for new business filings can be filed"""
+def test_notice_of_withdrawal_filing(session, client, jwt, test_name, legal_type, filing_type, filing_json, is_temp):
+    """Assert that notice of withdrawal for new business filings can be filed"""
     today = datetime.utcnow().date()
     future_effective_date = today + timedelta(days=5)
     future_effective_date = future_effective_date.isoformat()
@@ -1702,3 +1702,5 @@ def test_notice_of_withdraw_filing(session, client, jwt, test_name, legal_type, 
     now_filing = (Filing.find_by_id(rv_draft.json['filing']['header']['filingId']))
     assert now_filing.withdrawn_filing_id == withdrawn_filing.id
     assert now_filing.withdrawal_pending == False
+    if is_temp:
+        assert now_filing.temp_reg == None


### PR DESCRIPTION
*Issue #:* /bcgov/entity#25159

*Description of changes:*
This is a small change to avoid fill `temp_reg` field when we create a Notice of Withdrawal filing for a T business ([discussion link](https://teams.microsoft.com/l/message/19:cc93369433d341e7b5aa42b5ff78f7e0@thread.tacv2/1736275096889?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&groupId=00bd6377-9feb-44be-bbc8-19c3752a67b2&parentMessageId=1736270467592&teamName=External%3A%20SBC%20REG%20Modernization&channelName=Entities%20-%20Olga&createdTime=1736275096889))

#### Screenshots from local tests
File a NoW for a T business
![image](https://github.com/user-attachments/assets/64f261e9-0729-4fc2-8a94-4c09fbda3e91)

After change, the `temp_reg` field is not filled when filing NoW for a T business:
![image](https://github.com/user-attachments/assets/34aa3358-0374-4f24-aa81-85bd1605d4cf)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
