### PR TITLE
24820 - Return embedded NoW filing for withdrawn bootstrap filing

### DIFF
--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -859,14 +859,6 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
             filing = cls.query.filter_by(id=filing_id).one_or_none()
         return filing
 
-    @classmethod
-    def get_notice_of_withdrawal(cls, filing_id: str = None):
-        """Return a NoW by the withdrawn filing id."""
-        filing = None
-        if filing_id:
-            filing = cls.query.filter_by(withdrawn_filing_id=filing_id).one_or_none()
-        return filing
-
     @staticmethod
     def get_temp_reg_filing(temp_reg_id: str, filing_id: str = None):
         """Return a Filing by it's payment token."""

--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -859,6 +859,14 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
             filing = cls.query.filter_by(id=filing_id).one_or_none()
         return filing
 
+    @classmethod
+    def get_notice_of_withdrawal(cls, withdrawn_id: str = None):
+        """Return a NoW by the withdrawn filing id."""
+        filing = None
+        if withdrawn_id:
+            filing = cls.query.filter_by(withdrawn_filing_id=withdrawn_id).one_or_none()
+        return filing
+
     @staticmethod
     def get_temp_reg_filing(temp_reg_id: str, filing_id: str = None):
         """Return a Filing by it's payment token."""

--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -860,11 +860,11 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
         return filing
 
     @classmethod
-    def get_notice_of_withdrawal(cls, withdrawn_id: str = None):
+    def get_notice_of_withdrawal(cls, filing_id: str = None):
         """Return a NoW by the withdrawn filing id."""
         filing = None
-        if withdrawn_id:
-            filing = cls.query.filter_by(withdrawn_filing_id=withdrawn_id).one_or_none()
+        if filing_id:
+            filing = cls.query.filter_by(withdrawn_filing_id=filing_id).one_or_none()
         return filing
 
     @staticmethod

--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
@@ -308,7 +308,7 @@ class ListFilingResource():  # pylint: disable=too-many-public-methods
         if rv.status == Filing.Status.PENDING.value:
             ListFilingResource.get_payment_update(filing_json)
         if rv.status == Filing.Status.WITHDRAWN.value:
-            now_filing = Filing.get_notice_of_withdrawal(filing_json['filing']['header']['filingId'])
+            now_filing = ListFilingResource.get_notice_of_withdrawal(filing_json['filing']['header']['filingId'])
             filing_json['filing']['noticeOfWithdrawal'] = now_filing.json
         elif (rv.status in [Filing.Status.CHANGE_REQUESTED.value,
                             Filing.Status.APPROVED.value,
@@ -466,6 +466,16 @@ class ListFilingResource():  # pylint: disable=too-many-public-methods
         else:
             business = Business.find_by_identifier(identifier)
         return business, filing
+    
+    @staticmethod
+    def get_notice_of_withdrawal(filing_id: str = None):
+        """Return a NoW by the withdrawn filing id."""
+        filing = None
+        q = db.session.query(Filing). \
+            filter(Filing.withdrawn_filing_id == filing_id)
+
+        filing = q.one_or_none()
+        return filing
 
     @staticmethod
     def put_basic_checks(identifier, filing, client_request, business) -> Tuple[dict, int]:

--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
@@ -307,7 +307,7 @@ class ListFilingResource():  # pylint: disable=too-many-public-methods
         filing_json = rv.json
         if rv.status == Filing.Status.PENDING.value:
             ListFilingResource.get_payment_update(filing_json)
-        if rv.status == Filing.Status.WITHDRAWN.value:
+        if rv.status == Filing.Status.WITHDRAWN.value and identifier.startswith('T'):
             now_filing = ListFilingResource.get_notice_of_withdrawal(filing_json['filing']['header']['filingId'])
             filing_json['filing']['noticeOfWithdrawal'] = now_filing.json
         elif (rv.status in [Filing.Status.CHANGE_REQUESTED.value,

--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
@@ -307,6 +307,9 @@ class ListFilingResource():  # pylint: disable=too-many-public-methods
         filing_json = rv.json
         if rv.status == Filing.Status.PENDING.value:
             ListFilingResource.get_payment_update(filing_json)
+        if rv.status == Filing.Status.WITHDRAWN.value:
+            withdrawn_filing = Filing.get_notice_of_withdrawal(filing_json['filing']['header']['filingId'])
+            filing_json['filing']['noticeOfWithdrawal'] = withdrawn_filing.json
         elif (rv.status in [Filing.Status.CHANGE_REQUESTED.value,
                             Filing.Status.APPROVED.value,
                             Filing.Status.REJECTED.value] and

--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
@@ -466,7 +466,7 @@ class ListFilingResource():  # pylint: disable=too-many-public-methods
         else:
             business = Business.find_by_identifier(identifier)
         return business, filing
-    
+
     @staticmethod
     def get_notice_of_withdrawal(filing_id: str = None):
         """Return a NoW by the withdrawn filing id."""

--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
@@ -470,11 +470,9 @@ class ListFilingResource():  # pylint: disable=too-many-public-methods
     @staticmethod
     def get_notice_of_withdrawal(filing_id: str = None):
         """Return a NoW by the withdrawn filing id."""
-        filing = None
-        q = db.session.query(Filing). \
-            filter(Filing.withdrawn_filing_id == filing_id)
+        filing = db.session.query(Filing). \
+            filter(Filing.withdrawn_filing_id == filing_id).one_or_none()
 
-        filing = q.one_or_none()
         return filing
 
     @staticmethod

--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
@@ -308,8 +308,8 @@ class ListFilingResource():  # pylint: disable=too-many-public-methods
         if rv.status == Filing.Status.PENDING.value:
             ListFilingResource.get_payment_update(filing_json)
         if rv.status == Filing.Status.WITHDRAWN.value:
-            withdrawn_filing = Filing.get_notice_of_withdrawal(filing_json['filing']['header']['filingId'])
-            filing_json['filing']['noticeOfWithdrawal'] = withdrawn_filing.json
+            now_filing = Filing.get_notice_of_withdrawal(filing_json['filing']['header']['filingId'])
+            filing_json['filing']['noticeOfWithdrawal'] = now_filing.json
         elif (rv.status in [Filing.Status.CHANGE_REQUESTED.value,
                             Filing.Status.APPROVED.value,
                             Filing.Status.REJECTED.value] and


### PR DESCRIPTION
*Issue #:* /bcgov/entity#24820

*Description of changes:*
- Embed NoW in the withdrawn bootstrap filing if the filing status = WITHDRAWN
- Add unit tests

1. Boostrap FE IA Status = PAID:
![image](https://github.com/user-attachments/assets/e57480d7-143f-4b21-9a0e-f367ef943fd1)

NoW is not embedded:
![image](https://github.com/user-attachments/assets/9342790f-bc0a-4ef2-8017-fe5554c24bd6)

2. Boostrap FE IA Status = WITHDRAWN:
![image](https://github.com/user-attachments/assets/04c46180-3bc4-4976-87f0-237ad6a57aba)

NoW is now embedded:
![image](https://github.com/user-attachments/assets/c2d24d26-61eb-490d-ae99-8d91a0a125f7)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
