### PR TITLE
25387-Add Filings with Withdrawn Status to Ledger

### DIFF
--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
@@ -371,7 +371,8 @@ class ListFilingResource():  # pylint: disable=too-many-public-methods
 
         filings = CoreFiling.ledger(business.id,
                                     jwt=user_jwt,
-                                    statuses=[Filing.Status.COMPLETED.value, Filing.Status.PAID.value],
+                                    statuses=[Filing.Status.COMPLETED.value, Filing.Status.PAID.value,
+                                              Filing.Status.WITHDRAWN.value],
                                     start=ledger_start,
                                     size=ledger_size,
                                     effective_date=effective_date)

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filings_ledger.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filings_ledger.py
@@ -177,6 +177,45 @@ def test_ledger_comment_count(session, client, jwt):
     # validate
     assert rv.json['filings'][0]['commentsCount'] == number_of_comments
 
+@pytest.mark.parametrize('test_name, filing_status, expected', [
+    ('filing-status-Completed', Filing.Status.COMPLETED.value, 1),
+    ('filing-status-Corrected',Filing.Status.CORRECTED.value, 0),
+    ('filing-status-Draft', Filing.Status.DRAFT.value, 0),
+    ('filing-status-Epoch', Filing.Status.EPOCH.value, 0),
+    ('filing-status-Error', Filing.Status.ERROR.value, 0),
+    ('filing-status-Paid', Filing.Status.PAID.value, 1),
+    ('filing-status-Pending', Filing.Status.PENDING.value, 0),
+    ('filing-status-PaperOnly', Filing.Status.PAPER_ONLY.value, 0),
+    ('filing-status-PendingCorrection', Filing.Status.PENDING_CORRECTION.value, 0),
+    ('filing-status-Withdrawn', Filing.Status.WITHDRAWN.value, 1),
+])    
+
+def test_get_all_business_filings_permitted_statuses(session, client, jwt, test_name, filing_status, expected):
+    """Assert that the ledger only shows filings with permitted statuses."""
+    # setup
+    identifier = 'BC1234567'
+    today = date.today().isoformat()
+    alteration_meta = {'alteration': {
+        'fromLegalType': 'BC',
+        'toLegalType': 'BEN'
+    }}
+    meta_data = {**{'applicationDate': today}, **alteration_meta}
+
+    business, filing_storage = ledger_element_setup_help(identifier, 'alteration')
+    filing_storage._meta_data = meta_data
+
+    # set filing status
+    filing_storage._status = filing_status
+    filing_storage.skip_status_listener = True
+    filing_storage.save()
+
+    # test
+    rv = client.get(f'/api/v2/businesses/{identifier}/filings',
+                    headers=create_header(jwt, [UserRoles.system], identifier))
+
+    # validate
+    assert len(rv.json.get('filings')) == expected    
+
 
 @pytest.mark.parametrize('test_name, file_number, order_date, effect_of_order, order_details, expected', [
     ('all_elements', 'ABC123', datetime.utcnow(), 'effect', 'details',


### PR DESCRIPTION
*Issue #:* /bcgov/entity#25387

*Description of changes:*
- Add "WITHDRAWN" status to allowable statuses for filing history ledger fetched for regular businesses

Withdrawn Filing Status = WITHDRAWN
![image](https://github.com/user-attachments/assets/bc932ed6-77e0-4d4c-a099-37c048d5d03d)
![image](https://github.com/user-attachments/assets/658f4e77-bcc8-4076-9210-26b746f1e770)




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
