### PR TITLE
25446 - add check for lear businesses before freezing corps

### DIFF
--- a/colin-api/devops/vaults.json
+++ b/colin-api/devops/vaults.json
@@ -6,7 +6,8 @@
             "test-oracle",
             "sentry",
             "jwt",
-            "launchdarkly"
+            "launchdarkly",
+            "entity-service-account"
         ]
     }
 ]

--- a/colin-api/src/colin_api/config.py
+++ b/colin-api/src/colin_api/config.py
@@ -93,6 +93,15 @@ class _Config:  # pylint: disable=too-few-public-methods
     except (TypeError, ValueError):
         JWT_OIDC_JWKS_CACHE_TIMEOUT = 300
 
+    # legal api
+    LEGAL_API_URL = os.getenv('LEGAL_API_URL')
+
+    # service accounts
+    ACCOUNT_SVC_AUTH_URL = os.getenv('ACCOUNT_SVC_AUTH_URL')
+    ACCOUNT_SVC_CLIENT_ID = os.getenv('ACCOUNT_SVC_CLIENT_ID')
+    ACCOUNT_SVC_CLIENT_SECRET = os.getenv('ACCOUNT_SVC_CLIENT_SECRET')
+    ACCOUNT_SVC_TIMEOUT = os.getenv('ACCOUNT_SVC_TIMEOUT')
+
     TESTING = False
     DEBUG = False
 

--- a/colin-api/src/colin_api/models/filing.py
+++ b/colin-api/src/colin_api/models/filing.py
@@ -1403,8 +1403,8 @@ class Filing:  # pylint: disable=too-many-instance-attributes;
             # call to legal-api to check if business exists in lear
             response = LegalApiService.query_business(bc_identifier)
 
-            # Freeze all entities if found in LEAR and if 'enable-bc-ccc-ulc' flag is on else just freeze BEN
-            # exclude CP at all times
+            # Check business exists in lear
+            # If found in LEAR, freeze entities except CP if 'enable-bc-ccc-ulc' flag is on else just freeze BEN
             if response.status_code == HTTPStatus.OK:
                 is_frozen_condition = (
                     flags.is_on('enable-bc-ccc-ulc') and

--- a/colin-api/src/colin_api/models/filing.py
+++ b/colin-api/src/colin_api/models/filing.py
@@ -1397,6 +1397,7 @@ class Filing:  # pylint: disable=too-many-instance-attributes;
                                                 Business.TypeCodes.BCOMP_CONTINUE_IN.value,
                                             ])
             is_business_in_lear = cls.is_business_in_lear(lear_identifier)
+            current_app.logger.debug(f'Business {lear_identifier}, is_business_in_lear:{is_business_in_lear}')
 
             # Freeze all entities except CP if business exists in lear and
             # 'enable-bc-ccc-ulc' flag is on else just freeze BEN
@@ -1405,7 +1406,6 @@ class Filing:  # pylint: disable=too-many-instance-attributes;
                 business['business']['legalType'] != Business.TypeCodes.COOP.value and
                 is_business_in_lear
             )
-
             current_app.logger.debug(f'Business {lear_identifier}, is_frozen_condition:{is_frozen_condition}')
 
             is_new_or_altered_ben = is_new_ben or is_new_cben or is_alteration_to_ben_or_cben

--- a/colin-api/src/colin_api/models/filing.py
+++ b/colin-api/src/colin_api/models/filing.py
@@ -46,6 +46,7 @@ from colin_api.models import (  # noqa: I001
 )  # noqa: I001
 from colin_api.resources.db import DB
 from colin_api.services import flags
+from colin_api.services.legal import LegalApiService
 from colin_api.utils import convert_to_json_date, convert_to_json_datetime, convert_to_pacific_time, convert_to_snake
 
 
@@ -1240,7 +1241,7 @@ class Filing:  # pylint: disable=too-many-instance-attributes;
 
     # pylint: disable=too-many-locals,too-many-statements,too-many-branches,too-many-nested-blocks;
     @classmethod
-    def add_filing(cls, con, filing: Filing) -> int:
+    def add_filing(cls, con, filing: Filing, bc_identifier: str) -> int:
         """Add new filing to COLIN tables."""
         try:
             if filing.filing_type not in ['agmExtension', 'agmLocationChange', 'alteration',
@@ -1396,11 +1397,19 @@ class Filing:  # pylint: disable=too-many-instance-attributes;
                                                 Business.TypeCodes.BCOMP_CONTINUE_IN.value,
                                             ])
 
-            # Freeze all entities except CP if 'enable-bc-ccc-ulc' flag is on else just freeze BEN
-            is_frozen_condition = (
-                flags.is_on('enable-bc-ccc-ulc') and
-                business['business']['legalType'] != Business.TypeCodes.COOP.value
-            )
+            # default value set to False
+            is_frozen_condition = False
+
+            # call to legal-api to check if business exists in lear
+            response = LegalApiService.query_business(bc_identifier)
+
+            # Freeze all entities if found in LEAR and if 'enable-bc-ccc-ulc' flag is on else just freeze BEN
+            # exclude CP at all times
+            if response.status_code == HTTPStatus.OK:
+                is_frozen_condition = (
+                    flags.is_on('enable-bc-ccc-ulc') and
+                    business['business']['legalType'] != Business.TypeCodes.COOP.value
+                )
 
             is_new_or_altered_ben = is_new_ben or is_new_cben or is_alteration_to_ben_or_cben
 

--- a/colin-api/src/colin_api/resources/filing.py
+++ b/colin-api/src/colin_api/resources/filing.py
@@ -118,7 +118,7 @@ class FilingInfo(Resource):
                 ), HTTPStatus.BAD_REQUEST
 
             # setting this for lear business check as identifier is converted from lear to colin below
-            bc_identifier = identifier
+            lear_identifier = identifier
 
             # convert identifier if BC legal_type
             identifier = Business.get_colin_identifier(identifier, legal_type)
@@ -180,7 +180,7 @@ class FilingInfo(Resource):
                         }
                     }), HTTPStatus.CREATED
 
-                filings_added = FilingInfo._add_filings(con, json_data, filing_list, identifier, bc_identifier)
+                filings_added = FilingInfo._add_filings(con, json_data, filing_list, identifier, lear_identifier)
 
                 # success! commit the db changes
                 con.commit()
@@ -205,7 +205,7 @@ class FilingInfo(Resource):
             }), HTTPStatus.INTERNAL_SERVER_ERROR
 
     @staticmethod
-    def _add_filings(con, json_data: dict, filing_list: list, identifier: str, bc_identifier: str) -> list:
+    def _add_filings(con, json_data: dict, filing_list: list, identifier: str, lear_identifier: str) -> list:
         """Process all parts of the filing."""
         filings_added = []
         for filing_type in filing_list:
@@ -227,7 +227,7 @@ class FilingInfo(Resource):
             if filing_type == 'correction':
                 filings_added.extend(Filing.add_correction_filings(con, filing))
             else:
-                event_id = Filing.add_filing(con, filing, bc_identifier)
+                event_id = Filing.add_filing(con, filing, lear_identifier)
                 filings_added.append({'event_id': event_id,
                                       'filing_type': filing_type,
                                       'filing_sub_type': filing.filing_sub_type})

--- a/colin-api/src/colin_api/resources/filing.py
+++ b/colin-api/src/colin_api/resources/filing.py
@@ -117,6 +117,9 @@ class FilingInfo(Resource):
                     {'message': 'Error: Identifier in URL does not match identifier in filing data'}
                 ), HTTPStatus.BAD_REQUEST
 
+            # setting this for lear business check as identifier is converted from lear to colin below
+            bc_identifier = identifier
+
             # convert identifier if BC legal_type
             identifier = Business.get_colin_identifier(identifier, legal_type)
 
@@ -177,7 +180,7 @@ class FilingInfo(Resource):
                         }
                     }), HTTPStatus.CREATED
 
-                filings_added = FilingInfo._add_filings(con, json_data, filing_list, identifier)
+                filings_added = FilingInfo._add_filings(con, json_data, filing_list, identifier, bc_identifier)
 
                 # success! commit the db changes
                 con.commit()
@@ -202,7 +205,7 @@ class FilingInfo(Resource):
             }), HTTPStatus.INTERNAL_SERVER_ERROR
 
     @staticmethod
-    def _add_filings(con, json_data: dict, filing_list: list, identifier: str) -> list:
+    def _add_filings(con, json_data: dict, filing_list: list, identifier: str, bc_identifier: str) -> list:
         """Process all parts of the filing."""
         filings_added = []
         for filing_type in filing_list:
@@ -224,7 +227,7 @@ class FilingInfo(Resource):
             if filing_type == 'correction':
                 filings_added.extend(Filing.add_correction_filings(con, filing))
             else:
-                event_id = Filing.add_filing(con, filing)
+                event_id = Filing.add_filing(con, filing, bc_identifier)
                 filings_added.append({'event_id': event_id,
                                       'filing_type': filing_type,
                                       'filing_sub_type': filing.filing_sub_type})

--- a/colin-api/src/colin_api/services/account.py
+++ b/colin-api/src/colin_api/services/account.py
@@ -1,0 +1,52 @@
+# Copyright © 2025 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This class provides the service for auth calls."""
+
+import requests
+from flask import current_app
+
+
+# pylint: disable=too-few-public-methods
+class AccountService:
+    """Provides service to call Authentication Services."""
+
+    BEARER: str = 'Bearer '
+    CONTENT_TYPE_JSON = {'Content-Type': 'application/json'}
+
+    try:
+        timeout = int(current_app.config.get('ACCOUNT_SVC_TIMEOUT', 20))
+    except Exception:  # pylint: disable=broad-except
+        timeout = 20
+
+    @classmethod
+    def get_bearer_token(cls):
+        """Get a valid Bearer token for the service to use."""
+        token_url = current_app.config.get('ACCOUNT_SVC_AUTH_URL')
+        client_id = current_app.config.get('ACCOUNT_SVC_CLIENT_ID')
+        client_secret = current_app.config.get('ACCOUNT_SVC_CLIENT_SECRET')
+
+        data = 'grant_type=client_credentials'
+
+        # get service account token
+        res = requests.post(url=token_url,
+                            data=data,
+                            headers={'content-type': 'application/x-www-form-urlencoded'},
+                            auth=(client_id, client_secret),
+                            timeout=cls.timeout)
+
+        try:
+            return res.json().get('access_token')
+        except Exception:  # pylint: disable=broad-except
+            return None

--- a/colin-api/src/colin_api/services/legal.py
+++ b/colin-api/src/colin_api/services/legal.py
@@ -28,15 +28,17 @@ class LegalApiService():
         """Return a JSON object with business information."""
         timeout = int(current_app.config.get('ACCOUNT_SVC_TIMEOUT'))
         legal_api_url = current_app.config.get('LEGAL_API_URL')
-
         token = AccountService.get_bearer_token()
 
-        # Perform proxy call using the input identifier (e.g. BC 123456)
-        response = requests.get(legal_api_url + '/businesses/' + identifier,
-                                headers={'Content-Type': 'application/json', 'Authorization': 'Bearer ' + token},
-                                timeout=timeout
-                                )
         try:
-            return response
-        except Exception:  # pylint: disable=broad-except
-            return None
+            # Perform proxy call using the input identifier (e.g. BC 123456)
+            response = requests.get(legal_api_url + '/businesses/' + identifier,
+                                    headers={'Content-Type': 'application/json', 'Authorization': 'Bearer ' + token},
+                                    timeout=timeout
+                                    )
+            # If the status code is 200 or 404, return the response
+            if response.status_code in (200, 404):
+                return response
+        except requests.exceptions.RequestException as err:
+            current_app.logger.error(err, exc_info=True)
+            return None, str(err)

--- a/colin-api/src/colin_api/services/legal.py
+++ b/colin-api/src/colin_api/services/legal.py
@@ -1,0 +1,42 @@
+# Copyright © 2025 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This class provides the service for legal-api calls."""
+import requests
+from flask import current_app
+
+from colin_api.services.account import AccountService
+
+
+# pylint: disable=too-few-public-methods
+class LegalApiService():
+    """Provides service to call the legal-api."""
+
+    @staticmethod
+    def query_business(identifier: str):
+        """Return a JSON object with business information."""
+        timeout = int(current_app.config.get('ACCOUNT_SVC_TIMEOUT'))
+        legal_api_url = current_app.config.get('LEGAL_API_URL')
+
+        token = AccountService.get_bearer_token()
+
+        # Perform proxy call using the input identifier (e.g. BC 123456)
+        response = requests.get(legal_api_url + '/businesses/' + identifier,
+                                headers={'Content-Type': 'application/json', 'Authorization': 'Bearer ' + token},
+                                timeout=timeout
+                                )
+        try:
+            return response
+        except Exception:  # pylint: disable=broad-except
+            return None

--- a/colin-api/src/colin_api/services/legal.py
+++ b/colin-api/src/colin_api/services/legal.py
@@ -41,7 +41,6 @@ class LegalApiService():
                 return response
             response.raise_for_status()
 
-        except requests.exceptions.RequestException as e:
-            # Log the error and raise an exception up the chain
-            current_app.logger.error(f'Request failed: {e}, URL: {legal_api_url}')
-            raise Exception(f'Request failed: {e}, URL: {legal_api_url}') from e
+        except Exception as err:  # pylint: disable=broad-except:
+            current_app.logger.error(err, exc_info=True)
+            raise  # re-throw the exception after logging

--- a/colin-api/src/colin_api/services/legal.py
+++ b/colin-api/src/colin_api/services/legal.py
@@ -42,3 +42,4 @@ class LegalApiService():
         except requests.exceptions.RequestException as err:
             current_app.logger.error(err, exc_info=True)
             return None, str(err)
+        return None

--- a/colin-api/src/colin_api/services/legal.py
+++ b/colin-api/src/colin_api/services/legal.py
@@ -39,7 +39,9 @@ class LegalApiService():
             # If the status code is 200 or 404, return the response
             if response.status_code in (200, 404):
                 return response
-        except requests.exceptions.RequestException as err:
-            current_app.logger.error(err, exc_info=True)
-            return None, str(err)
-        return None
+            response.raise_for_status()
+
+        except requests.exceptions.RequestException as e:
+            # Log the error and raise an exception up the chain
+            current_app.logger.error(f'Request failed: {e}, URL: {legal_api_url}')
+            raise Exception(f'Request failed: {e}, URL: {legal_api_url}') from e


### PR DESCRIPTION
*Issue #:* /bcgov/entity#25446

*Description of changes:*

freeze a business if it exists only in LEAR

Branched off from https://github.com/bcgov/lear/tree/release-2.136.0 (Sev created this yesterday)

- add service to call legal-api business endpoint
- add logic to freeze a business only if found in LEAR

BC Limited company created in in DEV:
https://dev.business-dashboard.bcregistry.gov.bc.ca/BC0887528/?accountid=3040

Record in CDEV after COLIN sync was complete:
![image](https://github.com/user-attachments/assets/d8200665-45c6-446e-902a-97b23b2b23aa)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
