### PR TITLE
25419 - Tombstone - support staff comments

### DIFF
--- a/data-tool/flows/tombstone/tombstone_base_data.py
+++ b/data-tool/flows/tombstone/tombstone_base_data.py
@@ -17,6 +17,28 @@ BUSINESS = {
 }
 
 
+# ======== user ========
+USER = {
+    'username': None,
+    'firstname': None,
+    'middlename': None,
+    'lastname': None,
+    'email': None,
+    'creation_date': None
+}
+
+
+# ======== comment ========
+COMMENT = {
+    'comment': None,
+    'timestamp': None,
+    # FK
+    'business_id': None,
+    'staff_id': None,
+    'filing_id': None
+}
+
+
 # ======== address ========
 ADDRESS = {
     'address_type': None,  # mailing or delivery
@@ -146,15 +168,6 @@ JURISDICTION = {
 
 
 # ======== filing ========
-USER = {
-    'username': None,
-    'firstname': None,
-    'middlename': None,
-    'lastname': None,
-    'email': None,
-    'creation_date': None
-}
-
 FILING_JSON = {
     'filing': {
         'header': {}
@@ -185,7 +198,8 @@ FILING = {
         'submitter_roles': None,
     },
     'jurisdiction': None,  # optional
-    'amalgamations': None  # optional
+    'amalgamations': None,  # optional
+    'comments': None  # optional
 }
 
 FILING_COMBINED = {

--- a/data-tool/flows/tombstone/tombstone_queries.py
+++ b/data-tool/flows/tombstone/tombstone_queries.py
@@ -553,7 +553,9 @@ def get_jurisdictions_query(corp_num):
         j.xpro_typ_cd       as j_xpro_typ_cd,
         j.home_company_nme  as j_home_company_nme,
         j.home_juris_num    as j_home_juris_num,
-        to_char(j.home_recogn_dt, 'YYYY-MM-DD') as j_home_recogn_dt,
+        to_char(
+            j.home_recogn_dt::timestamp at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SSTZH:TZM'
+        )                   as j_home_recogn_dt,
         j.othr_juris_desc   as j_othr_juris_desc,
         j.bc_xpro_num       as j_bc_xpro_num
     from jurisdiction j

--- a/data-tool/flows/tombstone/tombstone_utils.py
+++ b/data-tool/flows/tombstone/tombstone_utils.py
@@ -25,10 +25,11 @@ def format_business_data(data: dict) -> dict:
     state = business_data['state']
     business_data['state'] = 'ACTIVE' if state == 'ACT' else 'HISTORICAL'
 
-    if not (last_ar_date := business_data['last_ar_date']):
-        last_ar_date = business_data['founding_date']
-    
-    last_ar_year = int(last_ar_date.split('-')[0])
+    if last_ar_date := business_data['last_ar_date']:
+        last_ar_year = int(last_ar_date.split('-')[0])
+    else:
+        last_ar_date = None
+        last_ar_year = None
 
     formatted_business = {
         **business_data,

--- a/legal-api/report-templates/template-parts/common/businessDetails.html
+++ b/legal-api/report-templates/template-parts/common/businessDetails.html
@@ -43,7 +43,7 @@
                  <div class="pt-2">{{report_date_time}}</div>
                  <div class="pt-2">
                    <span class="capitalize-text">{{business.state}}</span>
-                   {% if business.state in ('HISTORICAL', 'LIQUIDATION') %}
+                   {% if business.state in ('HISTORICAL', 'LIQUIDATION')  and stateFilings %}
                     <span> - </span>
                     {% if business.legalType in ['GP', 'SP'] and business.state == 'HISTORICAL' %}
                         <span>Dissolved</span>

--- a/legal-api/src/legal_api/models/comment.py
+++ b/legal-api/src/legal_api/models/comment.py
@@ -52,15 +52,16 @@ class Comment(db.Model):
     @property
     def json(self):
         """Return the json repressentation of a comment."""
+        from legal_api.core.constants import REDACTED_STAFF_SUBMITTER  # pylint: disable=import-outside-toplevel
         user = User.find_by_id(self.staff_id)
         return {
             'comment': {
                 'id': self.id,
-                'submitterDisplayName': user.display_name if user else None,
+                'submitterDisplayName': user.display_name if user else REDACTED_STAFF_SUBMITTER,
                 'comment': self.comment,
                 'filingId': self.filing_id,
                 'businessId': self.business_id,
-                'timestamp': self.timestamp.isoformat()
+                'timestamp': self.timestamp.isoformat() if self.timestamp else None
             }
         }
 

--- a/legal-api/tests/unit/models/test_comments.py
+++ b/legal-api/tests/unit/models/test_comments.py
@@ -75,7 +75,7 @@ def test_filing_comment_dump_json(session):
         assert c.json == {
             'comment': {
                 'id': c.id,
-                'submitterDisplayName': None,
+                'submitterDisplayName': 'Registry Staff',
                 'comment': 'a comment',
                 'filingId': f.id,
                 'businessId': None,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#25419
*Side Issue #:* /bcgov/entity#25508  /bcgov/entity#25504

*Description of changes:*
- Load users for comments
- Load staff comments at business level
- Load staff comments at filing level
   - Two types
       - general filing comment
       - filing comment coming with conversion ledger
   - Note that conversion ledger may have two types of filing comments at the same time
 - Some fix in legal-api for this work
 - Update TODOs
 
_Testing_
The following businesses are loaded in dev and affiliated to account `3446`, but some are not properly displayed due to legal-api error. Since conversion ledger work is in progress, I used name `Conversion Ledger` as placholder for this filing and make this category display in UI when I loaded data into dev.
```python
BC0000921  # multiple comments at business level
BC0047143  # multiple comments at filing level
BC0637102  # two types of comments at filing level for conversion ledger


BC1318351  # for issue 25508
C1316402   # for issue 25504
C1318533   # for issue 25504
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
