### PR TITLE
25393 - Suppress emails for system file BEN Corrections Statement

### DIFF
--- a/queue_services/entity-filer/src/entity_filer/worker.py
+++ b/queue_services/entity-filer/src/entity_filer/worker.py
@@ -200,7 +200,7 @@ async def publish_mras_email(filing: Filing):
 
 
 async def process_filing(filing_msg: Dict,
-                         flask_app: Flask):  # pylint: disable=too-many-branches,too-many-statements, R0914
+                         flask_app: Flask):  # pylint: disable=too-many-branches,too-many-statements, too-many-locals
     """Render the filings contained in the submission.
 
     Start the migration to using core/Filing

--- a/queue_services/entity-filer/src/entity_filer/worker.py
+++ b/queue_services/entity-filer/src/entity_filer/worker.py
@@ -199,8 +199,8 @@ async def publish_mras_email(filing: Filing):
             )
 
 
-async def process_filing(filing_msg: Dict,
-                         flask_app: Flask):  # pylint: disable=too-many-branches,too-many-statements, too-many-locals
+async def process_filing(filing_msg: Dict,  # pylint: disable=too-many-branches,too-many-statements,too-many-locals
+                         flask_app: Flask):
     """Render the filings contained in the submission.
 
     Start the migration to using core/Filing

--- a/queue_services/entity-filer/src/entity_filer/worker.py
+++ b/queue_services/entity-filer/src/entity_filer/worker.py
@@ -400,9 +400,6 @@ async def process_filing(filing_msg: Dict, flask_app: Flask):  # pylint: disable
                         if filing_type != FilingCore.FilingTypes.CHANGEOFNAME:
                             business_profile.update_business_profile(business, filing_submission, filing_type)
 
-            # This will be True only in the case where filing is filed by Jupyter notebook for BEN corrections
-            is_system_filed_correction = is_correction and is_system_filed_filing(filing_submission)
-            
             if not is_system_filed_correction:
                 try:
                     await publish_email_message(
@@ -437,15 +434,17 @@ async def process_filing(filing_msg: Dict, flask_app: Flask):  # pylint: disable
                     level='error'
                 )
 
-              
-def is_system_filed_filing(filing_submission) -> bool:
+
+# This will be True only in the case where filing is filed by Jupyter notebook for BEN corrections
+def is_system_filed_correction(filing_submission, filing_type) -> bool:
     """Check if filing is filed by system.
-    
+
     Filing filed using Jupyter Notebook will have 'certified_by' field = 'system'.
-    
+
     """
+    is_correction = filing_type == FilingCore.FilingTypes.CORRECTION
     certified_by = filing_submission.json['filing']['header']['certifiedBy']
-    return certified_by == 'system' if certified_by else False
+    return is_correction and certified_by == 'system' and certified_by is not None
 
 
 async def cb_subscription_handler(msg: nats.aio.client.Msg):

--- a/queue_services/entity-filer/src/entity_filer/worker.py
+++ b/queue_services/entity-filer/src/entity_filer/worker.py
@@ -404,7 +404,7 @@ async def process_filing(filing_msg: Dict,
             # This will be True only in the case where filing is filed by Jupyter notebook for BEN corrections
             is_system_filed_correction = is_correction and is_system_filed_filing(filing_submission)
 
-            if not is_system_filed_correction(filing_submission):
+            if not is_system_filed_correction:
                 try:
                     await publish_email_message(
                         qsm, APP_CONFIG.EMAIL_PUBLISH_OPTIONS['subject'], filing_submission, filing_submission.status)

--- a/queue_services/entity-filer/tests/unit/test_worker/test_correction_bcia.py
+++ b/queue_services/entity-filer/tests/unit/test_worker/test_correction_bcia.py
@@ -228,13 +228,7 @@ BC_CORRECTION_SHORT = {
             'details': 'First correction',
             'correctedFilingId': '123456',
             'correctedFilingType': 'incorporationApplication',
-            'comment': f'''Correction for Incorporation Application filed on 2025-01-01 \n
-                        BC benefit company statement contained in notice of articles as required under section 
-                        51.992 of the Business Corporations Act corrected from “This company is a benefit company 
-                        and, as such, has purposes that include conducting its business in a responsible and 
-                        sustainable manner and promoting one or more public benefits” to 
-                        “This company is a benefit company and, as such, is committed to conducting its business in 
-                        a responsible and sustainable manner and promoting one or more public benefits”.'''
+            'comment': 'Correction for Incorporation Application filed on 2025-01-01 by system'
         }
     }
 }
@@ -884,7 +878,6 @@ async def test_correction_ben_statement(app, session, mocker):
     await process_filing(filing_msg, app)
     
     final_filing = Filing.find_by_id(filing_id)
-    business = Business.find_by_internal_id(business_id)
 
     filing_comments = final_filing.comments.all()
     assert len(filing_comments) == 1

--- a/queue_services/entity-filer/tests/unit/test_worker/test_correction_bcia.py
+++ b/queue_services/entity-filer/tests/unit/test_worker/test_correction_bcia.py
@@ -856,7 +856,7 @@ async def test_worker_share_class_and_series_change(app, session, mocker, test_n
         assert [item.json for item in business.share_classes.all()[0].series] == share_class_json2['series']
         
 
-async def test_correction_ben_statement(app, mocker):
+async def test_correction_ben_statement(app, session, mocker):
     """Assert the worker process calls the BEN correction statement correctly."""
     
     identifier = 'BC1234567'

--- a/queue_services/entity-filer/tests/unit/test_worker/test_correction_bcia.py
+++ b/queue_services/entity-filer/tests/unit/test_worker/test_correction_bcia.py
@@ -213,6 +213,32 @@ BC_CORRECTION = {
     }
 }
 
+BC_CORRECTION_SHORT = {
+    'filing': {
+        'header': {
+            'name': 'correction',
+            'date': '2025-01-01',
+            'certifiedBy': 'system'
+        },
+        'business': {
+            'identifier': 'BC1234567',
+            'legalType': 'BC'
+        },
+        'correction': {
+            'details': 'First correction',
+            'correctedFilingId': '123456',
+            'correctedFilingType': 'incorporationApplication',
+            'comment': f'''Correction for Incorporation Application filed on 2025-01-01 \n
+                        BC benefit company statement contained in notice of articles as required under section 
+                        51.992 of the Business Corporations Act corrected from “This company is a benefit company 
+                        and, as such, has purposes that include conducting its business in a responsible and 
+                        sustainable manner and promoting one or more public benefits” to 
+                        “This company is a benefit company and, as such, is committed to conducting its business in 
+                        a responsible and sustainable manner and promoting one or more public benefits”.'''
+        }
+    }
+}
+
 BC_CORRECTION_APPLICATION = BC_CORRECTION
 
 naics_response = {
@@ -828,3 +854,38 @@ async def test_worker_share_class_and_series_change(app, session, mocker, test_n
         assert business.share_classes.all()[0].par_value == share_class_json2['parValue']
         assert business.share_classes.all()[0].currency == share_class_json2['currency']
         assert [item.json for item in business.share_classes.all()[0].series] == share_class_json2['series']
+        
+
+async def test_correction_ben_statement(app, mocker):
+    """Assert the worker process calls the BEN correction statement correctly."""
+    
+    identifier = 'BC1234567'
+    business = create_entity(identifier, 'BEN', 'ABC test inc.')
+    business.save()
+    business_id = business.id
+
+    filing = copy.deepcopy(BC_CORRECTION_SHORT)
+    
+    corrected_filing_id = factory_completed_filing(business, BC_CORRECTION_SHORT).id
+    filing['filing']['correction']['correctedFilingId'] = corrected_filing_id
+    
+    payment_id = str(random.SystemRandom().getrandbits(0x58))
+
+    filing_id = (create_filing(payment_id, filing, business_id=business_id)).id
+    filing_msg = {'filing': {'id': filing_id}}
+    
+    # mock out the email sender and event publishing
+    mocker.patch('entity_filer.worker.publish_event', return_value=None)
+    mocker.patch('entity_filer.filing_processors.filing_components.name_request.consume_nr', return_value=None)
+    mocker.patch('entity_filer.filing_processors.filing_components.business_profile.update_business_profile',
+                 return_value=None)
+    mocker.patch('legal_api.services.bootstrap.AccountService.update_entity', return_value=None)
+
+    await process_filing(filing_msg, app)
+    
+    final_filing = Filing.find_by_id(filing_id)
+    business = Business.find_by_internal_id(business_id)
+
+    filing_comments = final_filing.comments.all()
+    assert len(filing_comments) == 1
+    assert filing_comments[0].comment == filing['filing']['correction']['comment']


### PR DESCRIPTION
*Issue #:* /bcgov/entity#25393

*Description of changes:*

A little bit of background for this change.
We worked on a Jupyter Notebook to run Corrections for BEN statements. This will be a system file Correction filing with No Fee. This just adds a correction statement as Comment. We need to suppress any emails generated for such Corrections filing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
