### PR TITLE
Bumped Legal API version to 2.138.0

### DIFF
--- a/legal-api/src/legal_api/version.py
+++ b/legal-api/src/legal_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.137.0'  # pylint: disable=invalid-name
+__version__ = '2.138.0'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:* N/A

*Description of changes:*
- bumped up the Legal API version before deployment to Test (only Legal API has changed since the last deployment)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
