### PR TITLE
25578 - Expose WithdrawalPending Property in CommonLedgerItems for FE 

### DIFF
--- a/legal-api/src/legal_api/core/filing.py
+++ b/legal-api/src/legal_api/core/filing.py
@@ -454,6 +454,7 @@ class Filing:  # pylint: disable=too-many-public-methods
             filing_storage.filing_type not in no_output_filing_types else None,
             'filingLink': f'{base_url}/{business_identifier}/filings/{filing_storage.id}',
             'isFutureEffective': filing.is_future_effective,
+            'withdrawalPending': filing_storage.withdrawal_pending
         }
 
     @staticmethod

--- a/legal-api/tests/unit/core/test_filing_ledger.py
+++ b/legal-api/tests/unit/core/test_filing_ledger.py
@@ -70,7 +70,7 @@ def test_simple_ledger_search(session):
     alteration = next((f for f in ledger if f.get('name') == 'alteration'), None)
 
     assert alteration
-    assert 16 == len(alteration.keys())
+    assert 17 == len(alteration.keys())
     assert 'availableOnPaperOnly' in alteration
     assert 'effectiveDate' in alteration
     assert 'filingId' in alteration
@@ -80,6 +80,7 @@ def test_simple_ledger_search(session):
     assert 'submittedDate' in alteration
     assert 'submitter' in alteration
     assert 'displayLedger' in alteration
+    assert 'withdrawalPending' in alteration
     # assert alteration['commentsLink']
     # assert alteration['correctionLink']
     # assert alteration['filingLink']
@@ -119,3 +120,7 @@ def test_common_ledger_items(session):
         factory_completed_filing(business, filing, filing_date=founding_date + datedelta.datedelta(months=1), filing_type='adminFreeze')
     common_ledger_items = CoreFiling.common_ledger_items(identifier, completed_filing)
     assert common_ledger_items['displayLedger'] is False
+
+    completed_filing.withdrawal_pending = True
+    common_ledger_items = CoreFiling.common_ledger_items(identifier, completed_filing)
+    assert common_ledger_items['withdrawalPending'] is True

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filings_ledger.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filings_ledger.py
@@ -135,6 +135,7 @@ def test_ledger_search(session, client, jwt):
     assert 'submittedDate' in alteration
     assert 'submitter' in alteration
     assert 'displayLedger' in alteration
+    assert 'withdrawalPending' in alteration
     # assert alteration['commentsLink']
     # assert alteration['correctionLink']
     # assert alteration['filingLink']

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filings_ledger.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filings_ledger.py
@@ -125,7 +125,7 @@ def test_ledger_search(session, client, jwt):
     alteration = next((f for f in ledger['filings'] if f.get('name') == 'alteration'), None)
 
     assert alteration
-    assert 16 == len(alteration.keys())
+    assert 17 == len(alteration.keys())
     assert 'availableOnPaperOnly' in alteration
     assert 'effectiveDate' in alteration
     assert 'filingId' in alteration


### PR DESCRIPTION
*Issue #:* /bcgov/entity#25578 

*Description of changes:*
- Add withdrawalPending property to commonLedgerItems

![image](https://github.com/user-attachments/assets/73254148-415f-4b75-b2e4-a030ad8e1188)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
