### PR TITLE
25641 - Update NoW Embedding Conditions

### DIFF
--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
@@ -307,7 +307,7 @@ class ListFilingResource():  # pylint: disable=too-many-public-methods
         filing_json = rv.json
         if rv.status == Filing.Status.PENDING.value:
             ListFilingResource.get_payment_update(filing_json)
-        if rv.status == Filing.Status.WITHDRAWN.value and identifier.startswith('T'):
+        if (rv.status == Filing.Status.WITHDRAWN.value or rv.storage.withdrawal_pending) and identifier.startswith('T'):
             now_filing = ListFilingResource.get_notice_of_withdrawal(filing_json['filing']['header']['filingId'])
             filing_json['filing']['noticeOfWithdrawal'] = now_filing.json
         elif (rv.status in [Filing.Status.CHANGE_REQUESTED.value,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#25641 

*Description of changes:*
- Previously we were only embedding the NoW once the bootstrap filing was processed and `status == WITHDRAWN`, now we also want to display the NoW when boostrap filing is pending and waiting to be processed (i.e. `withdrawal_pending == True`)
- Updated the conditions to also embed a NoW when `withdrawal_pending == True`  
- Updated unit tests

`withdrawal_pending == True` 
![image](https://github.com/user-attachments/assets/071c17ed-05d8-4c6b-a8ee-9ca898ec2662)
![image](https://github.com/user-attachments/assets/9ce8120f-2fce-478c-817b-9a028e4d5484)

`withdrawal_pending == False` but `status == WITHDRAWN`
![image](https://github.com/user-attachments/assets/f94461e7-f92f-4174-8427-8c0b4ac749ba)
![image](https://github.com/user-attachments/assets/e770e48e-86af-4b2e-9f0b-17d2b3f3c7eb)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
