### PR TITLE
25678 Tombstone - Updates for involuntary dissolution

### DIFF
--- a/data-tool/.corps.env.sample
+++ b/data-tool/.corps.env.sample
@@ -72,6 +72,3 @@ DELETE_BATCH_SIZE=300
 ## delete corps record in auth db, corp_processing of colin extract
 DELETE_AUTH_RECORDS=False
 DELETE_CORP_PROCESSING_RECORDS=True
-
-## tombstone dissolution threshold in timestamp with time zone format
-TOMBSTONE_DISSOLUTION_TS=2025-02-11 07:00:00+00

--- a/data-tool/.corps.env.sample
+++ b/data-tool/.corps.env.sample
@@ -72,3 +72,6 @@ DELETE_BATCH_SIZE=300
 ## delete corps record in auth db, corp_processing of colin extract
 DELETE_AUTH_RECORDS=False
 DELETE_CORP_PROCESSING_RECORDS=True
+
+## tombstone dissolution threshold in timestamp with time zone format
+TOMBSTONE_DISSOLUTION_TS=2025-02-11 07:00:00+00

--- a/data-tool/flows/batch_delete_flow.py
+++ b/data-tool/flows/batch_delete_flow.py
@@ -15,6 +15,7 @@ SELECT COUNT(*) FROM businesses
 WHERE 1 = 1
 AND legal_type IN ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
 AND legal_name LIKE '%' || :corp_name_suffix
+AND identifier IN ('BC0588870', 'BC0546050', 'BC0550140', 'BC0670410', 'BC0600187')
 """
 
 identifiers_query = """
@@ -22,6 +23,7 @@ SELECT id, identifier FROM businesses
 WHERE 1 = 1 
 AND legal_type IN ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
 AND legal_name LIKE '%' || :corp_name_suffix
+AND identifier IN ('BC0588870', 'BC0546050', 'BC0550140', 'BC0670410', 'BC0600187')
 LIMIT :batch_size
 """
 

--- a/data-tool/flows/batch_delete_flow.py
+++ b/data-tool/flows/batch_delete_flow.py
@@ -15,7 +15,6 @@ SELECT COUNT(*) FROM businesses
 WHERE 1 = 1
 AND legal_type IN ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
 AND legal_name LIKE '%' || :corp_name_suffix
-AND identifier IN ('BC0588870', 'BC0546050', 'BC0550140', 'BC0670410', 'BC0600187')
 """
 
 identifiers_query = """
@@ -23,7 +22,6 @@ SELECT id, identifier FROM businesses
 WHERE 1 = 1 
 AND legal_type IN ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
 AND legal_name LIKE '%' || :corp_name_suffix
-AND identifier IN ('BC0588870', 'BC0546050', 'BC0550140', 'BC0670410', 'BC0600187')
 LIMIT :batch_size
 """
 

--- a/data-tool/flows/batch_delete_flow.py
+++ b/data-tool/flows/batch_delete_flow.py
@@ -231,6 +231,10 @@ def lear_delete_versioned(conn: Connection, business_ids: list):
                     'source': 'comments',
                     'params': {'filing_id': filing_ids},
                 },
+                {
+                    'source': 'furnishings',
+                    'params': {'business_id': business_ids},
+                },
                 # there're some Comment records saved by legal-api directly instead of filer
                 # some of them are linked via business_id
                 {

--- a/data-tool/flows/config.py
+++ b/data-tool/flows/config.py
@@ -138,6 +138,7 @@ class _Config():  # pylint: disable=too-few-public-methods
     TOMBSTONE_BATCHES = int(TOMBSTONE_BATCHES) if TOMBSTONE_BATCHES.isnumeric() else 0
     TOMBSTONE_BATCH_SIZE = os.getenv('TOMBSTONE_BATCH_SIZE')
     TOMBSTONE_BATCH_SIZE = int(TOMBSTONE_BATCH_SIZE) if TOMBSTONE_BATCH_SIZE.isnumeric() else 0
+    TOMBSTONE_DISSOLUTION_TS = os.getenv('TOMBSTONE_DISSOLUTION_TS')
 
     TESTING = False
     DEBUG = False

--- a/data-tool/flows/config.py
+++ b/data-tool/flows/config.py
@@ -138,7 +138,6 @@ class _Config():  # pylint: disable=too-few-public-methods
     TOMBSTONE_BATCHES = int(TOMBSTONE_BATCHES) if TOMBSTONE_BATCHES.isnumeric() else 0
     TOMBSTONE_BATCH_SIZE = os.getenv('TOMBSTONE_BATCH_SIZE')
     TOMBSTONE_BATCH_SIZE = int(TOMBSTONE_BATCH_SIZE) if TOMBSTONE_BATCH_SIZE.isnumeric() else 0
-    TOMBSTONE_DISSOLUTION_TS = os.getenv('TOMBSTONE_DISSOLUTION_TS')
 
     TESTING = False
     DEBUG = False

--- a/data-tool/flows/corps_tombstone_flow.py
+++ b/data-tool/flows/corps_tombstone_flow.py
@@ -123,7 +123,7 @@ def load_corp_snapshot(conn: Connection, tombstone_data: dict, users_mapper: dic
     # Note: The business info is partially loaded for businesses table now. And it will be fully
     # updated by the following placeholder historical filings migration. But it depends on the
     # implementation of next step.
-    business_id = load_data(conn, 'businesses', tombstone_data['businesses'], 'identifier')
+    business_id = load_data(conn, 'businesses', tombstone_data['businesses'])
 
     for office in tombstone_data['offices']:
         office['offices']['business_id'] = business_id
@@ -176,6 +176,20 @@ def load_corp_snapshot(conn: Connection, tombstone_data: dict, users_mapper: dic
         staff_id = users_mapper.get(username)
         comment['staff_id'] = staff_id
         load_data(conn, 'comments', comment)
+
+    if in_dissolution := tombstone_data['in_dissolution']:
+        batch = in_dissolution['batches']
+        batch_id = load_data(conn, 'batches', batch)
+        batch_processing = in_dissolution['batch_processing']
+
+        batch_processing['batch_id'] = batch_id
+        batch_processing['business_id'] = business_id
+        load_data(conn, 'batch_processing', batch_processing)
+
+        furnishing = in_dissolution['furnishings']
+        furnishing['batch_id'] = batch_id
+        furnishing['business_id'] = business_id
+        load_data(conn, 'furnishings', furnishing)
 
     return business_id
 

--- a/data-tool/flows/corps_tombstone_flow.py
+++ b/data-tool/flows/corps_tombstone_flow.py
@@ -123,7 +123,7 @@ def load_corp_snapshot(conn: Connection, tombstone_data: dict, users_mapper: dic
     # Note: The business info is partially loaded for businesses table now. And it will be fully
     # updated by the following placeholder historical filings migration. But it depends on the
     # implementation of next step.
-    business_id = load_data(conn, 'businesses', tombstone_data['businesses'])
+    business_id = load_data(conn, 'businesses', tombstone_data['businesses'], 'identifier', conflict_error=True)
 
     for office in tombstone_data['offices']:
         office['offices']['business_id'] = business_id

--- a/data-tool/flows/tombstone/tombstone_base_data.py
+++ b/data-tool/flows/tombstone/tombstone_base_data.py
@@ -235,6 +235,54 @@ AMALGAMTING_BUSINESS = {
     'amalgamation_id': None,
 }
 
+
+# ======== in_dissoluion ========
+BATCH = {
+    'batch_type': 'INVOLUNTARY_DISSOLUTION',
+    'status': 'PROCESSING',
+    'size': 1,
+    'max_size': 1,
+    'start_date': None,  # timestamptz, required
+    'notes': 'Import from COLIN',
+}
+
+BATCH_PROCESSING = {
+    'business_identifier': None,
+    'step': None,
+    'meta_data': None,
+    'created_date': None,  # timestamptz, required
+    'last_modified': None,  # timestamptz, required
+    'trigger_date': None,  # timestamptz
+    'status': 'PROCESSING',
+    'notes': 'Import from COLIN',
+    # FK
+    'batch_id': None,
+    'business_id': None,
+}
+
+FURNISHING = {
+    'business_identifier': None,
+    'furnishing_type': None,
+    'furnishing_name': None,
+    'meta_data': None,
+    'created_date': None,  # timestamptz, required
+    'last_modified': None,  # timestamptz, required
+    'processed_date': None,  # timestamptz
+    'status': 'PROCESSED',
+    'notes': 'Import from COLIN',
+    # FK
+    'batch_id': None,
+    'business_id': None,
+
+}
+
+IN_DISSOLUTION = {
+    'batches': BATCH,
+    'batch_processing': BATCH_PROCESSING,
+    'furnishings': FURNISHING,
+}
+
+
 # ======== tombstone example ========
 TOMBSTONE = {
     'businesses': BUSINESS,
@@ -244,6 +292,8 @@ TOMBSTONE = {
     'aliases': [ALIAS],
     'resolutions': [RESOLUTION],
     'filings': [FILING],
+    'comments': [COMMENT],
+    'in_dissolution': IN_DISSOLUTION,
     'updates': {
         'businesses': BUSINESS,
         'state_filing_index': -1

--- a/data-tool/flows/tombstone/tombstone_mappings.py
+++ b/data-tool/flows/tombstone/tombstone_mappings.py
@@ -216,8 +216,8 @@ EVENT_FILING_LEAR_TARGET_MAPPING = {
     EventFilings.CONVDSL_NULL: 'conversion',  # TODO: liquidation
     EventFilings.CONVDSO_NULL: ['conversion', ('dissolution', 'unknown')],
     EventFilings.CONVICORP_NULL: 'conversion',
-    EventFilings.CONVID1_NULL: 'conversion',  # TODO: related to invol dissolution
-    EventFilings.CONVID2_NULL: 'conversion',  # TODO: related to invol dissolution
+    EventFilings.CONVID1_NULL: ['conversion', 'putBackOn'],  # TODO: to confirm
+    EventFilings.CONVID2_NULL: ['conversion', 'putBackOn'],  # TODO: to confirm
     EventFilings.CONVILIQ_NULL: 'conversion',  # TODO: liquidation
     EventFilings.CONVLRSTR_NULL: ['conversion', ('restoration', 'limitedRestoration')],
     EventFilings.CONVNC_NULL: ['conversion', 'changeOfName'],

--- a/data-tool/flows/tombstone/tombstone_queries.py
+++ b/data-tool/flows/tombstone/tombstone_queries.py
@@ -720,7 +720,7 @@ def get_filing_comments_query(corp_num):
     return query
 
 
-def get_in_dissolution_query(corp_num, threshold_timestamp):
+def get_in_dissolution_query(corp_num):
     query = f"""
     select
         cs.corp_num         as cs_corp_num,
@@ -736,7 +736,6 @@ def get_in_dissolution_query(corp_num, threshold_timestamp):
     and cs.corp_num = '{corp_num}'
     and cs.end_event_id is null
     and cs.state_type_cd in ('D1F', 'D2F', 'D1T', 'D2T')
-    and e.trigger_dts > '{threshold_timestamp}' :: timestamptz
     """
     return query
 
@@ -754,8 +753,7 @@ def get_corp_snapshot_filings_queries(config, corp_num):
         'amalgamations': get_amalgamation_query(corp_num),
         'business_comments': get_business_comments_query(corp_num),
         'filing_comments': get_filing_comments_query(corp_num),
-        'in_dissolution': get_in_dissolution_query(
-            corp_num, config.TOMBSTONE_DISSOLUTION_TS),
+        'in_dissolution': get_in_dissolution_query(corp_num),
     }
 
     return queries

--- a/data-tool/flows/tombstone/tombstone_queries.py
+++ b/data-tool/flows/tombstone/tombstone_queries.py
@@ -720,6 +720,27 @@ def get_filing_comments_query(corp_num):
     return query
 
 
+def get_in_dissolution_query(corp_num, threshold_timestamp):
+    query = f"""
+    select
+        cs.corp_num         as cs_corp_num,
+        cs.state_type_cd    as cs_state_type_cd,
+        e.event_id          as e_event_id,
+        e.event_type_cd     as e_event_type_cd,
+        to_char(
+            e.trigger_dts::timestamp at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SSTZH:TZM'
+        )                   as e_trigger_dts_str
+    from corp_state cs
+    join event e on e.event_id = cs.start_event_id
+    where 1 = 1
+    and cs.corp_num = '{corp_num}'
+    and cs.end_event_id is null
+    and cs.state_type_cd in ('D1F', 'D2F', 'D1T', 'D2T')
+    and e.trigger_dts > '{threshold_timestamp}' :: timestamptz
+    """
+    return query
+
+
 def get_corp_snapshot_filings_queries(config, corp_num):
     queries = {
         'businesses': get_business_query(corp_num, config.CORP_NAME_SUFFIX),
@@ -732,7 +753,9 @@ def get_corp_snapshot_filings_queries(config, corp_num):
         'filings': get_filings_query(corp_num),
         'amalgamations': get_amalgamation_query(corp_num),
         'business_comments': get_business_comments_query(corp_num),
-        'filing_comments': get_filing_comments_query(corp_num)
+        'filing_comments': get_filing_comments_query(corp_num),
+        'in_dissolution': get_in_dissolution_query(
+            corp_num, config.TOMBSTONE_DISSOLUTION_TS),
     }
 
     return queries

--- a/data-tool/flows/tombstone/tombstone_utils.py
+++ b/data-tool/flows/tombstone/tombstone_utils.py
@@ -761,6 +761,7 @@ def load_data(conn: Connection,
               table_name: str,
               data: dict,
               conflict_column: str = None,
+              conflict_error = False,
               expecting_id: bool = True) -> Optional[int]:
     columns = ', '.join(data.keys())
     values = ', '.join([format_value(v) for v in data.values()])
@@ -770,7 +771,10 @@ def load_data(conn: Connection,
         check_query = f"select id from {table_name} where {conflict_column} = {conflict_value}"
         check_result = conn.execute(text(check_query)).scalar()
         if check_result:
-            return check_result
+            if not conflict_error:
+                return check_result
+            else:
+                raise Exception('Trying to reload corp existing in db, run delete script first')
 
     query = f"""insert into {table_name} ({columns}) values ({values})"""
     if expecting_id:

--- a/data-tool/flows/tombstone/tombstone_utils.py
+++ b/data-tool/flows/tombstone/tombstone_utils.py
@@ -628,7 +628,8 @@ def get_business_update_value(key: str, effective_date: str, trigger_date: str, 
 def build_filing_json_meta_data(raw_filing_type: str, filing_type: str, filing_subtype: str, effective_date: str, data: dict) -> tuple[dict, dict]:
     filing_json = copy.deepcopy(FILING_JSON)
     filing_json['filing'][raw_filing_type] = {}
-    if raw_filing_type != filing_type:
+    # if conversion has conv filing type, set filing_json
+    if raw_filing_type != filing_type and filing_type:
         filing_json['filing'][filing_type] = {}
 
     meta_data = {

--- a/legal-api/src/legal_api/reports/business_document.py
+++ b/legal-api/src/legal_api/reports/business_document.py
@@ -330,6 +330,7 @@ class BusinessDocument:
         # TODO: add conv liquidation etc. in the future work
         for filing in Filing.get_conversion_filings_by_conv_types(self._business.id, ['dissolution',
                                                                                       'continuationOut',
+                                                                                      'putBackOn',
                                                                                       'restoration']):
             state_filings.append(self._format_state_filing(filing))
 

--- a/legal-api/src/legal_api/services/warnings/business/business_checks/involuntary_dissolution.py
+++ b/legal-api/src/legal_api/services/warnings/business/business_checks/involuntary_dissolution.py
@@ -52,6 +52,11 @@ def check_business(business: Business) -> list:
                 exclude_in_dissolution=False, exclude_future_effective_filing=True
             )
         )
+
+        # dis_details is None when the account is not included in FF filter
+        if not dis_details:
+            return result
+
         if dis_details.transition_overdue:
             result.append(transition_warning)
         elif dis_details.ar_overdue:


### PR DESCRIPTION
*Issue #:* /bcgov/entity#25678 /bcgov/entity#25672

*Description of changes:*
- Add in-dissolution information in tombstone data set
- Updates for conversion involuntary dissolution
- Update delete script
- Misc fix

Testing
The following businesses are loaded in dev and affiliated to account `3446` (add this account into involuntary dissolution filter so that things work, but the legal-api is buggy somewhere)
```python
# D1F
BC0588870 # by SYSD1
BC0546050 # by DISD1 (delay of dissolution 1)
BC0550140 # by DISD2 (delay of dissolution 2)
BC0670410 # by ADCORP
BC0600187 # by FILE (change of address)

# D2F
BC0585930 # by SYSD2
BC0703023 # by DISD1 (delay of dissolution 1)
BC0576833 # by DISD2 (delay of dissolution 2)
BC0927679 # by ADCORP
BC0546311 # by FILE (change of address)

# no records for D1T and D2T
```

```python
# CONVID1
BC0617448 # active
BC0618432 # historical

# CONVID2
BC0617257 # active
BC0618459 # historical
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
