### PR TITLE
Enable feature branch "push" directly to Test

### DIFF
--- a/.github/workflows/legal-api-cd.yml
+++ b/.github/workflows/legal-api-cd.yml
@@ -1,17 +1,12 @@
 name: Legal API CD
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "legal-api/**"
   workflow_dispatch:
     inputs:
       environment:
-        description: "Environment (dev/test/prod)"
+        description: "Environment (test/prod)"
         required: true
-        default: "dev"
+        default: "test"
 
 defaults:
   run:
@@ -20,15 +15,15 @@ defaults:
 
 env:
   APP_NAME: "legal-api"
-  TAG_NAME: "dev"
+  TAG_NAME: "test"
 
 jobs:
   legal-api-cd-by-push:
     runs-on: ubuntu-20.04
 
-    if: github.event_name == 'push' && github.repository == 'bcgov/lear'
+    if: github.event.inputs.environment == 'test' && github.repository == 'bcgov/lear'
     environment:
-      name: "dev"
+      name: "test"
 
     steps:
       - uses: actions/checkout@v3
@@ -69,9 +64,9 @@ jobs:
   legal-api-cd-by-dispatch:
     runs-on: ubuntu-20.04
 
-    if: github.event_name == 'workflow_dispatch' && github.repository == 'bcgov/lear'
+    if: github.event.inputs.environment == 'prod' && github.repository == 'bcgov/lear'
     environment:
-      name: "${{ github.event.inputs.environment }}"
+      name: "prod"
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
*Issue #:* None

*Goals:*
- to enable release branch to deploy directly to Test (ie, skip over Dev)
- to retain the ability to deploy Test -> Prod

*Description of changes:*
- remove auto-push from main branch
- enable entity-filer-cd-by-push job for test only
- enable legal-api-cd-by-dispatch job for prod only

It's my observation that normal deployments to Dev only run the 'entity-filer-cd-by-push' job:

![image](https://github.com/user-attachments/assets/97f647f3-069c-4167-9ad3-4763ef860d4a)

While normal deployments to Test only run the 'legal-api-cd-by-dispatch' job:

![image](https://github.com/user-attachments/assets/41d63fae-6d93-4cf5-92b3-2973fcb3093f)

Therefore, the changes to the CD file specifically apply the 'push' job for deployments to Test and the 'dispatch' job for deployements to Prod.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).