### PR TITLE
24628 Get remove() function working for db versioned relationships

### DIFF
--- a/legal-api/src/legal_api/models/business.py
+++ b/legal-api/src/legal_api/models/business.py
@@ -268,7 +268,8 @@ class Business(db.Model, Versioned):  # pylint: disable=too-many-instance-attrib
     filings = db.relationship('Filing', lazy='dynamic')
     offices = db.relationship('Office', backref='business', lazy='dynamic', cascade='all, delete, delete-orphan')
     party_roles = db.relationship('PartyRole', lazy='dynamic')
-    share_classes = db.relationship('ShareClass', backref='business', lazy='dynamic', cascade='all, delete, delete-orphan')
+    share_classes = db.relationship('ShareClass', backref='business', lazy='dynamic',
+                                    cascade='all, delete, delete-orphan')
     aliases = db.relationship('Alias', lazy='dynamic')
     resolutions = db.relationship('Resolution', lazy='dynamic')
     documents = db.relationship('Document', lazy='dynamic')

--- a/legal-api/src/legal_api/models/business.py
+++ b/legal-api/src/legal_api/models/business.py
@@ -266,9 +266,9 @@ class Business(db.Model, Versioned):  # pylint: disable=too-many-instance-attrib
 
     # relationships
     filings = db.relationship('Filing', lazy='dynamic')
-    offices = db.relationship('Office', lazy='dynamic', cascade='all, delete, delete-orphan')
+    offices = db.relationship('Office', backref='business', lazy='dynamic', cascade='all, delete, delete-orphan')
     party_roles = db.relationship('PartyRole', lazy='dynamic')
-    share_classes = db.relationship('ShareClass', lazy='dynamic', cascade='all, delete, delete-orphan')
+    share_classes = db.relationship('ShareClass', backref='business', lazy='dynamic', cascade='all, delete, delete-orphan')
     aliases = db.relationship('Alias', lazy='dynamic')
     resolutions = db.relationship('Resolution', lazy='dynamic')
     documents = db.relationship('Document', lazy='dynamic')

--- a/legal-api/src/legal_api/models/office.py
+++ b/legal-api/src/legal_api/models/office.py
@@ -34,7 +34,7 @@ class Office(db.Model, Versioned):  # pylint: disable=too-few-public-methods
     id = db.Column(db.Integer, primary_key=True)
     office_type = db.Column('office_type', db.String(75), db.ForeignKey('office_types.identifier'))
     business_id = db.Column('business_id', db.Integer, db.ForeignKey('businesses.id'), index=True)
-    addresses = db.relationship('Address', lazy='dynamic', cascade='all, delete, delete-orphan')
+    addresses = db.relationship('Address', backref='office', lazy='dynamic', cascade='all, delete, delete-orphan')
     deactivated_date = db.Column('deactivated_date', db.DateTime(timezone=True), default=None)
 
     # relationships

--- a/python/common/sql-versioning/sql_versioning/versioning.py
+++ b/python/common/sql-versioning/sql_versioning/versioning.py
@@ -82,7 +82,7 @@ def _is_session_modified(session):
     return False
 
 
-def _get_operation_type(session, obj, delete_orphan: False):
+def _get_operation_type(session, obj, delete_orphan=False):
     """Return the operation type for the given object within the session.
     
     :param session: The database session instance.

--- a/python/common/sql-versioning/sql_versioning/versioning.py
+++ b/python/common/sql-versioning/sql_versioning/versioning.py
@@ -47,6 +47,27 @@ def _is_obj_modified(obj):
     return False
 
 
+def _should_relationship_delete_orphan(session, obj):
+    """
+    Checks if:
+        1. This relationship is a many-to-one relationship
+        2. If the opposite direction one-to-many relationship parent object has changes
+        3. If the opposite direction one-to-many relationship has cascade=delete-orphan
+        
+    :param session: The database session instance.
+    :param obj: The object to inspect for changes.
+    :return: True if the above checks pass, otherwise False.
+    """
+    should_delete = False
+    for r in inspect(obj.__class__).relationships:
+        if r.direction.name == 'MANYTOONE' and r._reverse_property:
+            reverse_rel, *_ = r._reverse_property
+            parent_obj = inspect(obj).committed_state.get(reverse_rel.backref, None)
+            if parent_obj in session.dirty:
+                should_delete = should_delete or "delete-orphan" in inspect(reverse_rel)._cascade
+    return should_delete
+
+
 def _is_session_modified(session):
     """Check if the session contains modified versioned objects.
     
@@ -61,19 +82,20 @@ def _is_session_modified(session):
     return False
 
 
-def _get_operation_type(session, obj):
+def _get_operation_type(session, obj, delete_orphan: False):
     """Return the operation type for the given object within the session.
     
     :param session: The database session instance.
     :param obj: The object to determine the operation type.
     :return: The operation type ('I' for insert, 'U' for update, 'D' for delete), or None if unchanged.
     """
+    is_orphaned = inspect(obj)._orphaned_outside_of_session
     if obj in session.new:
         return 'I'
+    elif obj in session.deleted or (is_orphaned and delete_orphan):
+        return 'D'
     elif obj in session.dirty:
         return 'U' if _is_obj_modified(obj) else None
-    elif obj in session.deleted:
-        return 'D'
     return None
 
 
@@ -270,7 +292,8 @@ def _after_flush(session, flush_context):
     """Trigger after a flush operation to create version records for changed objects."""
     try:
         for obj in versioned_objects(session):
-            operation_type = _get_operation_type(session, obj)
+            should_delete_orphan = _should_relationship_delete_orphan(session, obj)
+            operation_type = _get_operation_type(session, obj, should_delete_orphan)
             if operation_type:
                 _create_version(session, obj, operation_type)
     except Exception as e:

--- a/python/common/sql-versioning/tests/__init__.py
+++ b/python/common/sql-versioning/tests/__init__.py
@@ -41,9 +41,9 @@ class User(Base, Versioned):
     # One-to-one non-versioned relationship
     location = orm.relationship('Location', backref='user', uselist=False)
     # One-to-many versioned relationship
-    emails = orm.relationship('Email', backref='user', lazy='dynamic')
+    emails = orm.relationship('Email', backref='user', lazy='dynamic', cascade='all, delete, delete-orphan')
     # One-to-many non versioned relationship
-    items = orm.relationship('Item', backref='user', lazy='dynamic')
+    items = orm.relationship('Item', backref='user', lazy='dynamic', cascade='all, delete, delete-orphan')
 
 class Address(Base, Versioned):
     __tablename__ = 'addresses'

--- a/queue_services/entity-filer/tests/unit/filing_processors/filing_components/test_shares.py
+++ b/queue_services/entity-filer/tests/unit/filing_processors/filing_components/test_shares.py
@@ -14,6 +14,7 @@
 """The Unit Tests for the business filing component processors."""
 import pytest
 from legal_api.models import Business
+from sql_versioning import version_class
 
 from entity_filer.filing_processors.filing_components import shares
 from tests import strip_keys_from_dict
@@ -119,5 +120,13 @@ def test_manage_share_structure__delete_shares(app, session):
     # check
     check_business = Business.find_by_internal_id(business_id)
     share_classes = check_business.share_classes.all()
-
     assert not share_classes
+
+    share_classes = session.query(ShareClass).all()
+    assert not share_classes
+
+    share_class_version = version_class(ShareClass)
+    share_class_versions = session.query(share_class_version).all()
+    assert len(share_class_versions) == 5
+    for scv in share_class_versions:
+        assert scv.operation_type == 2


### PR DESCRIPTION
*Issue #:* /bcgov/entity#24628

*Description of changes:*
This fix ended up needing 3 things:
1. In order to use `<parent>.remove(<child>)` and have the child be deleted from the table, the relationship needs `cascade='delete-orphan'`. This is already the case for resolutions, but I added it to the versioning tests as well.
2. For whatever reason, the parent side of the relationship also needs `backref=<parent>`, otherwise we always get `operation_type=0` (created). This however results in the child version entries that were removed getting `operation_type=1` (updated).
3. In order to properly assign `operation_type=2` on cascade deleted orphans I needed to add some custom logic to versioning.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
