### PR TITLE
24628 - update a work around to get resolution versioning data

### DIFF
--- a/legal-api/src/legal_api/resources/v2/business/colin_sync.py
+++ b/legal-api/src/legal_api/resources/v2/business/colin_sync.py
@@ -45,6 +45,7 @@ from legal_api.models.db import VersioningProxy
 from legal_api.services.business_details_version import VersionedBusinessDetailsService
 from legal_api.utils.auth import jwt
 from legal_api.utils.legislation_datetime import LegislationDatetime
+from legal_api.models.db import VersioningProxy
 
 from .bp import bp
 
@@ -109,7 +110,6 @@ def get_completed_filings_for_colin():
                 current_app.logger.error(f'dissolution: filingId={filing.id}, missing batch processing info')
                 # to skip this filing and block subsequent filing from syncing in update-colin-filings
                 filing_json['filing']['header']['name'] = None
-
         filings.append(filing_json)
     return jsonify({'filings': filings}), HTTPStatus.OK
 
@@ -285,11 +285,28 @@ def _set_offices(primary_or_holding_business, amalgamation_filing, transaction_i
 
 
 def _set_shares(primary_or_holding_business, amalgamation_filing, transaction_id):
-    # copy shares
+    """Set shares from holding/primary business."""
+    # Copy shares
     share_classes = VersionedBusinessDetailsService.get_share_class_revision(transaction_id,
-                                                                             primary_or_holding_business.id)
+                                                                           primary_or_holding_business.id)
     amalgamation_filing['shareStructure'] = {'shareClasses': share_classes}
-    business_dates = [item.resolution_date.isoformat() for item in primary_or_holding_business.resolutions]
+    
+    # Get resolution dates using versioned query
+    resolution_version = VersioningProxy.version_class(db.session(), Resolution)
+    resolutions_query = (
+        db.session.query(resolution_version.resolution_date)
+        .filter(resolution_version.transaction_id <= transaction_id)  # Get records valid at or before the transaction
+        .filter(resolution_version.operation_type != 2)  # Exclude deleted records
+        .filter(resolution_version.business_id == primary_or_holding_business.id)
+        .filter(or_(
+            resolution_version.end_transaction_id.is_(None),  # Records not yet ended
+            resolution_version.end_transaction_id > transaction_id  # Records ended after our transaction
+        ))
+        .order_by(resolution_version.transaction_id)
+        .all()
+    )
+    
+    business_dates = [res.resolution_date.isoformat() for res in resolutions_query]
     if business_dates:
         amalgamation_filing['shareStructure']['resolutionDates'] = business_dates
 

--- a/legal-api/src/legal_api/resources/v2/business/colin_sync.py
+++ b/legal-api/src/legal_api/resources/v2/business/colin_sync.py
@@ -45,7 +45,6 @@ from legal_api.models.db import VersioningProxy
 from legal_api.services.business_details_version import VersionedBusinessDetailsService
 from legal_api.utils.auth import jwt
 from legal_api.utils.legislation_datetime import LegislationDatetime
-from legal_api.models.db import VersioningProxy
 
 from .bp import bp
 
@@ -288,9 +287,9 @@ def _set_shares(primary_or_holding_business, amalgamation_filing, transaction_id
     """Set shares from holding/primary business."""
     # Copy shares
     share_classes = VersionedBusinessDetailsService.get_share_class_revision(transaction_id,
-                                                                           primary_or_holding_business.id)
+                                                                             primary_or_holding_business.id)
     amalgamation_filing['shareStructure'] = {'shareClasses': share_classes}
-    
+
     # Get resolution dates using versioned query
     resolution_version = VersioningProxy.version_class(db.session(), Resolution)
     resolutions_query = (
@@ -305,7 +304,7 @@ def _set_shares(primary_or_holding_business, amalgamation_filing, transaction_id
         .order_by(resolution_version.transaction_id)
         .all()
     )
-    
+
     business_dates = [res.resolution_date.isoformat() for res in resolutions_query]
     if business_dates:
         amalgamation_filing['shareStructure']['resolutionDates'] = business_dates


### PR DESCRIPTION
*Issue #:* /bcgov/entity#24628

*Description of changes:*
In Colin Sync, update to use a work around to fix the issue when trying to get amalgamation filings sync to colin.

**Before -- when running `update-colin-filings` job**
Log from the job:
![image](https://github.com/user-attachments/assets/828dd1d6-e36d-43f7-b196-18a71aadec3a)

Corresponding log from legal-api:
![image](https://github.com/user-attachments/assets/110368b6-71a8-4dce-8f9b-a83fa9e88aeb)

**After change:**
![image](https://github.com/user-attachments/assets/006e2bd2-df31-4365-8602-7ef88d308771)

Local Run = Local db + Local legal-api + Local update-colin-filing job + DEV colin-api

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
