### PR TITLE
26028 - Show blank recognition date/time if the application was withdrawn/not come to pass

### DIFF
--- a/legal-api/report-templates/template-parts/common/businessDetails.html
+++ b/legal-api/report-templates/template-parts/common/businessDetails.html
@@ -70,8 +70,8 @@
                   <div>{{business.identifier}}</div>
                {% endif %}
                <div class="pt-2">{{effective_date_time}}</div>
-               {% if header.isFutureEffective %}
-                  <div class="pt-2">{{effective_date_time}}</div>
+               {% if not business or business.identifier.startswith('T') %}
+                  <div class="pt-2">&nbsp;</div>
                {% elif header.status == 'COMPLETED' %}
                   <div class="pt-2">{{recognition_date_time}}</div>
                {% endif %}
@@ -132,8 +132,8 @@
                   <div>{{business.identifier}}</div>
                {% endif %}
                <div class="pt-2">{{filing_date_time}}</div>
-               {% if header.isFutureEffective %}
-                  <div class="pt-2">{{effective_date_time}}</div> 
+               {% if not business or business.identifier.startswith('T') %}
+                  <div class="pt-2">&nbsp;</div> 
                {% elif header.status == 'COMPLETED' %}
                   <div class="pt-2">{{recognition_date_time}}</div>
                {% endif %}
@@ -342,7 +342,7 @@
             <td>
                {% if not business or business.identifier.startswith('T') %}
                   <div>{{ filing_date_time }}</div>
-                  <div class="pt-2">{{ effective_date_time }}</div>
+                  <div class="pt-2">&nbsp;</div>
                {% else %}
                   <div>{{business.identifier}}</div>
                   <div class="pt-2">{{ filing_date_time }}</div>


### PR DESCRIPTION
*Issue #:* /bcgov/entity#26028

*Description of changes:*
- For NoW for temp business output, Show blank recognition date/time, because the application was withdrawn
- For IA/Amagl/ContIn output, Show blank recognition date/time, when the time not come to pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
