### PR TITLE
23001 - Reduce DB Versioning Debugging Logs to Minimal

### DIFF
--- a/legal-api/src/legal_api/models/db.py
+++ b/legal-api/src/legal_api/models/db.py
@@ -195,7 +195,6 @@ class VersioningProxy:
         :param transaction: The transaction associated with the session.
         :return: None
         """
-
         if '_versioning_locked' in session.info and '_transactions_locked' in session.info:
             session.info['_transactions_locked'].remove(transaction)
 

--- a/python/common/sql-versioning/sql_versioning/utils.py
+++ b/python/common/sql-versioning/sql_versioning/utils.py
@@ -23,7 +23,6 @@ def version_class(obj):
     """
     with suppress(Exception):
         versioned_class = obj.__versioned_cls__
-        print(f'\033[32mVersioned Class={versioned_class}\033[0m')
         return versioned_class
     return None
 

--- a/python/common/sql-versioning/sql_versioning/versioning.py
+++ b/python/common/sql-versioning/sql_versioning/versioning.py
@@ -20,7 +20,6 @@ from sqlalchemy import (BigInteger, Column, DateTime, Integer, SmallInteger,
 from sqlalchemy.ext.declarative import declarative_base, declared_attr
 from sqlalchemy.orm import Session, mapper, relationships
 
-from .debugging import debug
 from .relationship_builder import RelationshipBuilder
 
 Base = declarative_base()
@@ -220,7 +219,6 @@ class TransactionManager:
         self.session = session
         self.transaction_model = TransactionFactory.create_transaction_model()
 
-    @debug
     def create_transaction(self):
         """Create a new transaction in the session.
 
@@ -254,7 +252,6 @@ class TransactionManager:
         else:
             return self.create_transaction()
 
-    @debug
     def clear_current_transaction(self):
         """Clear the current transaction_id stored in the session.
         
@@ -268,7 +265,6 @@ class TransactionManager:
 
 
 # ---------- Event Listeners ----------
-@debug
 def _before_flush(session, flush_context, instances):
     """Trigger before a flush operation to ensure a transaction is created."""
     try:
@@ -287,7 +283,6 @@ def _before_flush(session, flush_context, instances):
         raise e
 
 
-@debug
 def _after_flush(session, flush_context):
     """Trigger after a flush operation to create version records for changed objects."""
     try:
@@ -300,7 +295,6 @@ def _after_flush(session, flush_context):
         raise e
 
 
-@debug
 def _clear_transaction(session):
     """Clears the current transaction from the session after commit or rollback."""
     try:
@@ -410,7 +404,6 @@ def versioned_objects(session):
             yield obj
 
 
-@debug
 def enable_versioning(transaction_cls=None):
     """Enable versioning. It registers listeners.
 
@@ -426,7 +419,6 @@ def enable_versioning(transaction_cls=None):
         raise e
 
 
-@debug
 def disable_versioning():
     """Disable versioning. It removes listeners.
     


### PR DESCRIPTION
*Issue #:* /bcgov/entity#23001 

*Description of changes:*
- Reduce DB Versioning Debugging Logs to Minimal
    - Only keep showing the current db-versioning type (new / old) to help us quickly identify whether FF switching works or not)

**For a same API call:**
**Before**
![Pasted image 20250226083535](https://github.com/user-attachments/assets/80ac513c-f76c-4637-bbd1-2b4a795884a4)

**After**
![Pasted image 20250226094534](https://github.com/user-attachments/assets/cb5a6163-58f5-4c7f-a83b-ce67f8cfa4f3)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
