### PR TITLE
25940 - Fix the Filing History Bug after withdraw a VD

### DIFF
--- a/legal-api/src/legal_api/core/meta/filing.py
+++ b/legal-api/src/legal_api/core/meta/filing.py
@@ -748,8 +748,9 @@ class FilingMeta:  # pylint: disable=too-few-public-methods
                 # overriden with the latest correction, which cause loosing the previous correction link.
                 name = FilingMeta.get_corrected_filing_name(filing, business_revision, name)
 
-        elif filing.filing_type in ('dissolution') and filing.meta_data:
-            if filing.meta_data['dissolution'].get('dissolutionType') == 'administrative':
+        elif filing.filing_type in ('dissolution'):
+            dissolution_data = filing.meta_data.get('dissolution') if filing.meta_data else None
+            if dissolution_data and dissolution_data.get('dissolutionType') == 'administrative':
                 name = 'Administrative Dissolution'
 
         elif filing.filing_type in ('adminFreeze') and filing.meta_data:


### PR DESCRIPTION
*Issue #:* /bcgov/entity#25940

*Description of changes:*
- The bug is: file a NoW for a Voluntary Dissolution -> the Filing History is empty
- Cause: there is a key error when read filing.meta_data[dissolution]
- Fixed: add a check 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
