### PR TITLE
25870 Tombstone - Extract updates & filing submitter and staff user info updates

### DIFF
--- a/data-tool/scripts/colin_corps_extract_postgres_ddl
+++ b/data-tool/scripts/colin_corps_extract_postgres_ddl
@@ -772,6 +772,17 @@ comment on table corp_involved_cont_in is 'new table\n\n"Optionally, a ""Continu
 alter table corp_involved_cont_in
     owner to postgres;
 
+create table if not exists payment
+(
+    event_id numeric(9)  not null
+        constraint fk_payment
+            references event (event_id),
+    payment_typ_cd varchar(4) not null,
+    cc_holder_nme varchar(80)
+);
+
+alter table payment
+    owner to postgres;
 
 CREATE INDEX if not exists ix_conv_event_event_id ON conv_event (event_id);
 
@@ -864,6 +875,8 @@ CREATE INDEX if not exists ix_office_end_event_id ON office (end_event_id);
 CREATE INDEX if not exists ix_office_mailing_addr_id ON office (mailing_addr_id);
 
 CREATE INDEX if not exists ix_office_delivery_addr_id ON office (delivery_addr_id);
+
+CREATE INDEX if not exists ix_payment_event_id ON payment (event_id);
 
 CREATE INDEX if not exists ix_resolution_corp_num ON resolution (corp_num);
 

--- a/data-tool/scripts/transfer_cprd_corps.sql
+++ b/data-tool/scripts/transfer_cprd_corps.sql
@@ -66,7 +66,10 @@ select case
            else c.CORP_NUM
        end CORP_NUM,
        CORP_FROZEN_TYP_CD as corp_frozen_type_cd,
-       CORP_TYP_CD as CORP_TYPE_CD,
+       case
+           when c.CORP_TYP_CD in ('QA', 'QB', 'QC', 'QD', 'QE') then 'BC'
+           else c.CORP_TYP_CD
+       end CORP_TYPE_CD,
        RECOGNITION_DTS,
        BN_9,
        bn_15,
@@ -887,6 +890,22 @@ where cp.CORP_PARTY_ID = pn.party_id
   -- and c.corp_num in ('1396310', '1396309', '1396308', '1396307', '1396306', '1396890', '1396889', '1396885', '1396883', '1396878','1396597', '1396143', '1395925', '1395116', '1394990', '1246445', '1216743', '1396508', '1396505', '1396488', '1396401', '1396387', '1396957', '1355943', '1340611', '1335427', '1327193', '1393945', '1208648', '1117024', '1120292', '1127373', '1135492')
   -- and rownum <= 5
 order by c.corp_num;
+
+
+
+-- payment
+transfer public.payment from cprd using
+select p.event_id,
+       p.payment_typ_cd,
+       p.cc_holder_nme
+from payment p
+   , event e
+   , corporation c
+where p.event_id = e.event_id
+and e.corp_num = c.corp_num
+and c.corp_typ_cd in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+order by e.event_id;
+
 
 
 -- alter tables


### PR DESCRIPTION
*Issue #:* /bcgov/entity#25870

*Description of changes:*
- Update extract to include payment info
- Update extract for Q* type to merge them into BC (revert [previous changes](https://github.com/bcgov/lear/pull/3177))
- Update user info formatting for filing submitter and business comment staff (There's one exception of filing comment where staff is BCOMPS and we haven't looked into it. But no bad impact in this work)

_Testing_
load the following businesses are loaded in dev and affiliated to account `3446`
```python
# test different user roles in COLIN
BC0642190 # null, anon
BC0935488 # bcol, anon, staff
BC1283244 # reg
# other user role not found

# test corp in ticket description
BC1235881

# test of user info colliding
BC0820915
BC0503592
BC0672944

# test users of staff comments
BC0000921
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
