### PR TITLE
Bump db versioning component versions to 2.143.0

### DIFF
--- a/queue_services/entity-bn/src/entity_bn/version.py
+++ b/queue_services/entity-bn/src/entity_bn/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.142.0'  # pylint: disable=invalid-name
+__version__ = '2.143.0'  # pylint: disable=invalid-name

--- a/queue_services/entity-digital-credentials/src/entity_digital_credentials/version.py
+++ b/queue_services/entity-digital-credentials/src/entity_digital_credentials/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.142.0'  # pylint: disable=invalid-name
+__version__ = '2.143.0'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:* /bcgov/entity#25779

*Description of changes:*
- entity-bn v2.142.0
- entity-digital-credentials v2.142.0
- Other component versions already bumped during release branch merge https://github.com/bcgov/lear/pull/3251

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
