### PR TITLE
26262 - Minimize DB Versioning Logging

### DIFF
--- a/legal-api/src/legal_api/models/db.py
+++ b/legal-api/src/legal_api/models/db.py
@@ -35,6 +35,7 @@ from sqlalchemy_continuum.manager import VersioningManager
 db = SQLAlchemy()  # pylint: disable=invalid-name
 IS_LOGGED = False
 
+
 class Transaction(db.Model):
     """This class manages the transaction."""
 
@@ -51,16 +52,17 @@ class Transaction(db.Model):
 
 
 def print_versioning_info():
-    """Print the current versioning status if not already printed.
+    """
+    Print the current versioning status if not already printed.
+
     This should only be called within an application context.
     """
-    global IS_LOGGED
-    
+    global IS_LOGGED  # pylint: disable=global-statement
+
     if not IS_LOGGED:
         try:
-            from legal_api.services import flags as flag_service
-            from flask import current_app
-            
+            from legal_api.services import flags as flag_service  # pylint: disable=import-outside-toplevel
+
             current_service = current_app.config.get('SERVICE_NAME')
             if current_service:
                 db_versioning = flag_service.value('db-versioning')
@@ -276,8 +278,10 @@ def setup_versioning():
     _new_enable_versioning(transaction_cls=Transaction)
     make_versioned(user_cls=None, manager=versioning_manager)
 
+
 # TODO: enable versioning switching
 # it should be called before data model initialized, otherwise, old versioning doesn't work properly
 setup_versioning()
+
 
 # make_versioned(user_cls=None, manager=versioning_manager)

--- a/legal-api/src/legal_api/models/db.py
+++ b/legal-api/src/legal_api/models/db.py
@@ -33,7 +33,7 @@ from sqlalchemy_continuum.manager import VersioningManager
 # by convention in the Flask community these are lower case,
 # whereas pylint wants them upper case
 db = SQLAlchemy()  # pylint: disable=invalid-name
-
+IS_LOGGED = False
 
 class Transaction(db.Model):
     """This class manages the transaction."""
@@ -50,6 +50,29 @@ class Transaction(db.Model):
     issued_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=True)
 
 
+def print_versioning_info():
+    """Print the current versioning status if not already printed.
+    This should only be called within an application context.
+    """
+    global IS_LOGGED
+    
+    if not IS_LOGGED:
+        try:
+            from legal_api.services import flags as flag_service
+            from flask import current_app
+            
+            current_service = current_app.config.get('SERVICE_NAME')
+            if current_service:
+                db_versioning = flag_service.value('db-versioning')
+                use_new_versioning = (bool(db_versioning) and bool(db_versioning.get(current_service)))
+                current_versioning = 'new' if use_new_versioning else 'old'
+                print(f'\033[31mService: {current_service}, db versioning={current_versioning}\033[0m')
+                IS_LOGGED = True
+        except Exception as err:
+            # Don't crash if something goes wrong
+            print(f'\033[31mUnable to determine versioning type: {err}\033[0m')
+
+
 def init_db(app):
     """Initialize database using flask app and configure db mappers.
 
@@ -58,6 +81,9 @@ def init_db(app):
     """
     db.init_app(app)
     orm.configure_mappers()
+
+    with app.app_context():
+        print_versioning_info()
 
 
 # TODO: remove versioning switching logic
@@ -136,7 +162,6 @@ class VersioningProxy:
         db_versioning = flags.value('db-versioning')
         use_new_versioning = (bool(db_versioning) and bool(db_versioning.get(current_service)))
         cls._current_versioning = 'new' if use_new_versioning else 'old'
-        print(f'\033[31mCurrent versioning={cls._current_versioning}\033[0m')
 
     @classmethod
     def _initialize_versioning(cls):
@@ -159,6 +184,8 @@ class VersioningProxy:
         """
         cls._versioning_control[previous]['disable']()
         cls._versioning_control[current]['enable']()
+        # Print when versioning changes
+        print(f'\033[31mVersioning changed: {previous} -> {current}\033[0m')
 
     @classmethod
     def lock_versioning(cls, session, transaction):
@@ -248,7 +275,6 @@ def setup_versioning():
 
     _new_enable_versioning(transaction_cls=Transaction)
     make_versioned(user_cls=None, manager=versioning_manager)
-
 
 # TODO: enable versioning switching
 # it should be called before data model initialized, otherwise, old versioning doesn't work properly

--- a/legal-api/src/legal_api/models/db.py
+++ b/legal-api/src/legal_api/models/db.py
@@ -33,7 +33,6 @@ from sqlalchemy_continuum.manager import VersioningManager
 # by convention in the Flask community these are lower case,
 # whereas pylint wants them upper case
 db = SQLAlchemy()  # pylint: disable=invalid-name
-IS_LOGGED = False
 
 
 class Transaction(db.Model):
@@ -57,22 +56,18 @@ def print_versioning_info():
 
     This should only be called within an application context.
     """
-    global IS_LOGGED  # pylint: disable=global-statement
+    try:
+        from legal_api.services import flags as flag_service  # pylint: disable=import-outside-toplevel
 
-    if not IS_LOGGED:
-        try:
-            from legal_api.services import flags as flag_service  # pylint: disable=import-outside-toplevel
-
-            current_service = current_app.config.get('SERVICE_NAME')
-            if current_service:
-                db_versioning = flag_service.value('db-versioning')
-                use_new_versioning = (bool(db_versioning) and bool(db_versioning.get(current_service)))
-                current_versioning = 'new' if use_new_versioning else 'old'
-                print(f'\033[31mService: {current_service}, db versioning={current_versioning}\033[0m')
-                IS_LOGGED = True
-        except Exception as err:
-            # Don't crash if something goes wrong
-            print(f'\033[31mUnable to determine versioning type: {err}\033[0m')
+        current_service = current_app.config.get('SERVICE_NAME')
+        if current_service:
+            db_versioning = flag_service.value('db-versioning')
+            use_new_versioning = (bool(db_versioning) and bool(db_versioning.get(current_service)))
+            current_versioning = 'new' if use_new_versioning else 'old'
+            print(f'\033[31mService: {current_service}, db versioning={current_versioning}\033[0m')
+    except Exception as err:
+        # Don't crash if something goes wrong
+        print(f'\033[31mUnable to determine versioning type: {err}\033[0m')
 
 
 def init_db(app):

--- a/python/common/sql-versioning/sql_versioning/__init__.py
+++ b/python/common/sql-versioning/sql_versioning/__init__.py
@@ -21,7 +21,6 @@ __all__ = (
     "TransactionFactory",
     "TransactionManager",
     "Versioned",
-    "debug",
     "disable_versioning",
     "enable_versioning",
     "version_class"


### PR DESCRIPTION
*Issue #:* /bcgov/entity#26262

*Description of changes:*
- Removed the remaining `debug` in `__all__`
- Change logging to only print out when a service initialized, and when switching versioning

**Screenshots after change:**
Legal-API:
![Pasted image 20250228121225](https://github.com/user-attachments/assets/edfb3c30-36fe-4064-8e88-a8c83d29f26b)

Emailer:
![Pasted image 20250228122223](https://github.com/user-attachments/assets/d5249a4a-6cef-46c6-a840-756f8cc4c0e9)

Filer:
![Pasted image 20250228140011](https://github.com/user-attachments/assets/b44e4d78-0a3e-4b35-b500-475bcfbeddad)

**Local Linting and Testing Results**
Since we currently have some issues in the legal-api CI, here are screenshots for local linting and testings resutls
![image](https://github.com/user-attachments/assets/bb14d84c-6f29-4923-a848-d777a56613a0)
![image](https://github.com/user-attachments/assets/8bb76541-2542-4feb-86f4-55723fe5dd91)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
