### PR TITLE
26204 try setup-python v5

### DIFF
--- a/.github/workflows/legal-api-ci.yml
+++ b/.github/workflows/legal-api-ci.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -86,7 +86,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install docker-compose


### PR DESCRIPTION
*Issue #:* bcgov/entity#26204

*Description:*

This is a test to resolve this error:

![image](https://github.com/user-attachments/assets/b595976e-559b-4c40-bf7f-bf74eb7396f9)

It is related to the recent update of the GitHub runner for this script -- Ubuntu-24.04 (instead of previous 20.04).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).