### PR TITLE
26262 - change init_db importing approach

### DIFF
--- a/jobs/email-reminder/email_reminder.py
+++ b/jobs/email-reminder/email_reminder.py
@@ -20,8 +20,8 @@ import sys
 import requests
 import sentry_sdk  # noqa: I001, E501; pylint: disable=ungrouped-imports; conflicts with Flake8
 from flask import Flask
-from legal_api import init_db
 from legal_api.models import Business, Filing, db  # noqa: I001
+from legal_api.models.db import init_db
 from legal_api.services.bootstrap import AccountService
 from legal_api.services.flags import Flags
 from legal_api.services.queue import QueueService

--- a/jobs/furnishings/src/furnishings/worker.py
+++ b/jobs/furnishings/src/furnishings/worker.py
@@ -20,8 +20,8 @@ import pytz
 import sentry_sdk  # noqa: I001, E501; pylint: disable=ungrouped-imports; conflicts with Flake8
 from croniter import croniter
 from flask import Flask
-from legal_api import init_db
 from legal_api.models import Configuration
+from legal_api.models.db import init_db
 from legal_api.services.flags import Flags
 from legal_api.services.queue import QueueService
 from sentry_sdk.integrations.logging import LoggingIntegration

--- a/jobs/involuntary-dissolutions/involuntary_dissolutions.py
+++ b/jobs/involuntary-dissolutions/involuntary_dissolutions.py
@@ -21,9 +21,9 @@ import pytz
 import sentry_sdk  # noqa: I001, E501; pylint: disable=ungrouped-imports; conflicts with Flake8
 from croniter import croniter
 from flask import Flask
-from legal_api import init_db
 from legal_api.core.filing import Filing as CoreFiling
 from legal_api.models import Batch, BatchProcessing, Business, Configuration, Filing, Furnishing, db  # noqa: I001
+from legal_api.models.db import init_db
 from legal_api.services.filings.validations.dissolution import DissolutionTypes
 from legal_api.services.flags import Flags
 from legal_api.services.involuntary_dissolution import InvoluntaryDissolutionService

--- a/queue_services/entity-bn/src/entity_bn/worker.py
+++ b/queue_services/entity-bn/src/entity_bn/worker.py
@@ -32,9 +32,9 @@ from typing import Dict
 import nats
 from entity_queue_common.service_utils import QueueException, logger
 from flask import Flask
-from legal_api import init_db
 from legal_api.core import Filing as FilingCore
 from legal_api.models import Business
+from legal_api.models.db import init_db
 from legal_api.services.flags import Flags
 from sentry_sdk import capture_message
 from sqlalchemy.exc import OperationalError

--- a/queue_services/entity-digital-credentials/src/entity_digital_credentials/worker.py
+++ b/queue_services/entity-digital-credentials/src/entity_digital_credentials/worker.py
@@ -33,9 +33,9 @@ import nats
 from entity_queue_common.service import QueueServiceManager
 from entity_queue_common.service_utils import QueueException, logger
 from flask import Flask
-from legal_api import init_db
 from legal_api.core import Filing as FilingCore
 from legal_api.models import Business
+from legal_api.models.db import init_db
 from legal_api.services import digital_credentials, flags
 from sqlalchemy.exc import OperationalError
 

--- a/queue_services/entity-emailer/src/entity_emailer/worker.py
+++ b/queue_services/entity-emailer/src/entity_emailer/worker.py
@@ -34,8 +34,9 @@ import requests
 from entity_queue_common.service import QueueServiceManager
 from entity_queue_common.service_utils import EmailException, QueueException, logger
 from flask import Flask
-from legal_api import db, init_db  # noqa:F401,I001;pylint:disable=unused-import;
+from legal_api import db  # noqa:F401,I001;pylint:disable=unused-import;
 from legal_api.models import Filing, Furnishing
+from legal_api.models.db import init_db
 from legal_api.services.bootstrap import AccountService
 from legal_api.services.flags import Flags
 from sqlalchemy.exc import OperationalError

--- a/queue_services/entity-filer/src/entity_filer/worker.py
+++ b/queue_services/entity-filer/src/entity_filer/worker.py
@@ -36,10 +36,9 @@ from entity_queue_common.service import QueueServiceManager
 from entity_queue_common.service_utils import FilingException, QueueException, logger
 from flask import Flask
 from gcp_queue import GcpQueue, SimpleCloudEvent, to_queue_message
-from legal_api import init_db
 from legal_api.core import Filing as FilingCore
 from legal_api.models import Business, Filing, db
-from legal_api.models.db import VersioningProxy
+from legal_api.models.db import VersioningProxy, init_db
 from legal_api.services import Flags
 from legal_api.utils.datetime import datetime, timezone
 from sentry_sdk import capture_message


### PR DESCRIPTION
*Issue #:* /bcgov/entity#26262

*Description of changes:*
Try to solve the issue of not seeing db-versioning loggings suppose to be printed out when a service starts
- change importing level from `legal_api` to `legal_api.models.db` for importing `init_db` in BE components


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
