### PR TITLE
26262 - change logging approach

### DIFF
--- a/legal-api/src/legal_api/models/db.py
+++ b/legal-api/src/legal_api/models/db.py
@@ -64,10 +64,10 @@ def print_versioning_info():
             db_versioning = flag_service.value('db-versioning')
             use_new_versioning = (bool(db_versioning) and bool(db_versioning.get(current_service)))
             current_versioning = 'new' if use_new_versioning else 'old'
-            print(f'\033[31mService: {current_service}, db versioning={current_versioning}\033[0m')
+            current_app.logger.info(f'\033[31mService: {current_service}, db versioning={current_versioning}\033[0m')
     except Exception as err:
         # Don't crash if something goes wrong
-        print(f'\033[31mUnable to determine versioning type: {err}\033[0m')
+        current_app.logger.info(f'\033[31mUnable to determine versioning type: {err}\033[0m')
 
 
 def init_db(app):
@@ -182,7 +182,7 @@ class VersioningProxy:
         cls._versioning_control[previous]['disable']()
         cls._versioning_control[current]['enable']()
         # Print when versioning changes
-        print(f'\033[31mVersioning changed: {previous} -> {current}\033[0m')
+        current_app.logger.info(f'\033[31mVersioning changed: {previous} -> {current}\033[0m')
 
     @classmethod
     def lock_versioning(cls, session, transaction):

--- a/legal-api/src/legal_api/models/db.py
+++ b/legal-api/src/legal_api/models/db.py
@@ -67,7 +67,7 @@ def print_versioning_info():
             current_app.logger.info(f'\033[31mService: {current_service}, db versioning={current_versioning}\033[0m')
     except Exception as err:
         # Don't crash if something goes wrong
-        current_app.logger.info(f'\033[31mUnable to determine versioning type: {err}\033[0m')
+        current_app.logger.error('Unable to read flags: %s' % repr(err), exc_info=True)
 
 
 def init_db(app):


### PR DESCRIPTION
*Issue #:* /bcgov/entity#26262

*Description of changes:*
change logging approach to use `logger.info` to see if we'll be able to see loggings, and `logger.error` when not able to determine versioning type.
Known issue: won't be able to see it in Emailer, since the LOG_Level has been set to ERROR

![image](https://github.com/user-attachments/assets/5b065ce3-acba-4a2c-a5da-f7fca11da8e2)


When switching db versioning:
![image](https://github.com/user-attachments/assets/0e79cb27-8543-43be-bbca-0d12cff547e6)
![image](https://github.com/user-attachments/assets/409e3285-7992-4209-aa99-546c07384924)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
