### PR TITLE
26298 - Display Historical Date instead of Effective Date

### DIFF
--- a/legal-api/report-templates/template-parts/business-summary/stateTransition.html
+++ b/legal-api/report-templates/template-parts/business-summary/stateTransition.html
@@ -40,7 +40,7 @@
                 <span>{{ filing.effectiveDateTime }}</span>
               {% elif filing.filingType == 'putBackOff' %}  
                 <span>Effective Date:</span>
-                <span>{{ filing.expiryDate }}</span>
+                <span>{{ filing.historicalDate }}</span>
               {% else %}
                 <span>Filing Date:</span>
                 <span>{{filing.filingDateTime}}</span>

--- a/legal-api/src/legal_api/reports/business_document.py
+++ b/legal-api/src/legal_api/reports/business_document.py
@@ -492,6 +492,7 @@ class BusinessDocument:
             filing_info['reason'] = reason
             expiry_date = LegislationDatetime.as_legislation_timezone_from_date_str(expiry_date_str)
             filing_info['expiryDate'] = expiry_date.strftime(OUTPUT_DATE_FORMAT)
+            filing_info['historicalDate'] = LegislationDatetime.format_as_next_legislation_day(expiry_date_str)
         else:
             filing_info['filingName'] = BusinessDocument.\
                 _get_summary_display_name(filing_type, None, None, None)

--- a/legal-api/src/legal_api/utils/legislation_datetime.py
+++ b/legal-api/src/legal_api/utils/legislation_datetime.py
@@ -80,14 +80,13 @@ class LegislationDatetime():
         """Return a datetime adjusted to the GMT timezone (aka UTC) from a date (1900-12-31) string."""
         _date_time = LegislationDatetime.as_legislation_timezone_from_date_str(date_string)
         return LegislationDatetime.as_utc_timezone(_date_time)
-    
+
     @staticmethod
     def format_as_next_legislation_day(date_string: str) -> str:
         """Return the next day in this format (eg: `August 5, 2021`)."""
-        
         input_date = datetime.fromisoformat(date_string)
         next_day = input_date + timedelta(days=1)
-        
+
         return next_day.strftime('%B %d, %Y')
 
     @staticmethod

--- a/legal-api/src/legal_api/utils/legislation_datetime.py
+++ b/legal-api/src/legal_api/utils/legislation_datetime.py
@@ -80,6 +80,15 @@ class LegislationDatetime():
         """Return a datetime adjusted to the GMT timezone (aka UTC) from a date (1900-12-31) string."""
         _date_time = LegislationDatetime.as_legislation_timezone_from_date_str(date_string)
         return LegislationDatetime.as_utc_timezone(_date_time)
+    
+    @staticmethod
+    def format_as_next_legislation_day(date_string: str) -> str:
+        """Return the next day in this format (eg: `August 5, 2021`)."""
+        
+        input_date = datetime.fromisoformat(date_string)
+        next_day = input_date + timedelta(days=1)
+        
+        return next_day.strftime('%B %d, %Y')
 
     @staticmethod
     def format_as_report_string(date_time: datetime) -> str:


### PR DESCRIPTION
*Issue #:* /bcgov/entity#26298 

*Description of changes:*
- As requested, display the effective date as the day after the expiry date (i.e. if expiry date is February 20, 2025, then the effective date should be February 21, 2025)

![image](https://github.com/user-attachments/assets/3d978751-8769-4f63-9d30-51e26a873aef)
![image](https://github.com/user-attachments/assets/84a5ebe3-1047-4aa4-92bd-e03a6b01f571)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
