### PR TITLE
26321 Hide business summary for tombstone corps

### DIFF
--- a/legal-api/flags.json
+++ b/legal-api/flags.json
@@ -5,6 +5,7 @@
         "integer-flag": 10,
         "enable-legal-name-fix": true,
         "disable-nr-check": false,
+        "enable-business-summary-for-migrated-corps": true,
         "enable-involuntary-dissolution-filter": false,
         "enable-new-ben-statements": false,
         "involuntary-dissolution-filter": {

--- a/legal-api/src/legal_api/resources/v2/business/business_documents.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_documents.py
@@ -61,7 +61,7 @@ def get_business_documents(identifier: str, document_name: str = None):
         not flags.is_on('enable-business-summary-for-migrated-corps') and
         business.is_tombstone and
         business.legal_type in Business.CORPS and
-        document_name == "summary"
+        document_name == 'summary'
     ):
         return {}, HTTPStatus.NOT_FOUND
 

--- a/legal-api/src/legal_api/resources/v2/business/business_documents.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_documents.py
@@ -88,7 +88,7 @@ def _get_document_list(business):
         business.legal_type in Business.CORPS
     ):
         return jsonify(documents), HTTPStatus.OK
-    
+
     business_documents = ['summary']
     for doc in business_documents:
         documents['documents'][doc] = f'{base_url}{doc_url}/{doc}'


### PR DESCRIPTION
*Issue #:* /bcgov/entity#26321

*Description of changes:*
- Added `enable-business-summary-for-migrated-corps` FF
- Added logic to hide/show business summary for tombstone corps based on FF

_Local Testing_
Flag ON (show summary)
<img width="1035" alt="Screenshot 2025-03-07 at 8 44 14 AM" src="https://github.com/user-attachments/assets/765c954f-dd9b-4393-ad99-4dca4b5b2254" />
<img width="1035" alt="Screenshot 2025-03-07 at 8 44 27 AM" src="https://github.com/user-attachments/assets/a744f94c-06b1-4492-8329-3ed9b517150c" />

Flag OFF (hide summary)
<img width="1031" alt="Screenshot 2025-03-07 at 8 44 49 AM" src="https://github.com/user-attachments/assets/02c97f81-2d2b-472d-b9d8-584bbfcaa27e" />
<img width="1033" alt="Screenshot 2025-03-07 at 8 44 58 AM" src="https://github.com/user-attachments/assets/6a5ecca5-604b-43d0-924e-3a814ec49784" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
