### PR TITLE
26143 & 26323 Tombstone - allow skipped event_file types & partial processed_status

### DIFF
--- a/data-tool/flows/common/corp_processing_queue_service.py
+++ b/data-tool/flows/common/corp_processing_queue_service.py
@@ -8,6 +8,7 @@ class ProcessingStatuses(str, Enum):
     PROCESSING = 'PROCESSING'
     COMPLETED = 'COMPLETED'
     FAILED = 'FAILED'
+    PARTIAL = 'PARTIAL'
 
 class CorpProcessingQueueService:
     def __init__(self, environment: str, db_engine, flow_name: str):

--- a/data-tool/flows/tombstone/tombstone_base_data.py
+++ b/data-tool/flows/tombstone/tombstone_base_data.py
@@ -216,6 +216,7 @@ FILING_COMBINED = {
         # business info to update
     },
     'state_filing_index': -1,
+    'unsupported_types': None,
 }
 
 AMALGAMATION = {
@@ -303,5 +304,6 @@ TOMBSTONE = {
     'updates': {
         'businesses': BUSINESS,
         'state_filing_index': -1
-    }
+    },
+    'unsupported_types': None,
 }

--- a/data-tool/flows/tombstone/tombstone_mappings.py
+++ b/data-tool/flows/tombstone/tombstone_mappings.py
@@ -447,9 +447,18 @@ SKIPPED_EVENT_FILE_TYPES = [
     'SYST_TILAT',
     'SYST_TILHO',
     'SYST_NULL',
+    'TRESP_NULL',
+    'TRESP_COUTI',
     # Others
     'FILE_COGS1',
-    # TODO: may need to add more
+    # TODO: decide on the final list
+]
+
+
+NO_FILING_EVENT_FILE_TYPES = [
+    'SYSD1_NULL',
+    'SYSD2_NULL',
+    # TODO: decide on the final list
 ]
 
 

--- a/data-tool/flows/tombstone/tombstone_mappings.py
+++ b/data-tool/flows/tombstone/tombstone_mappings.py
@@ -428,6 +428,31 @@ EVENT_FILING_DISPLAY_NAME_MAPPING = {
 }
 
 
+SKIPPED_EVENT_FILE_TYPES = [
+    # XPRO
+    'FILE_CHGJU',
+    'FILE_NWPTA',
+    'FILE_PARES',
+    'FILE_TILAT',
+    'FILE_TILHO',
+    'FILE_TILMA',
+    'SYST_CANPS',
+    'SYST_CHGJU',
+    'SYST_CHGPN',
+    'SYST_CO_PN',
+    'SYST_LNKPS',
+    'SYST_NWPTA',
+    'SYST_PARES',
+    'SYST_RIPFL',
+    'SYST_TILAT',
+    'SYST_TILHO',
+    'SYST_NULL',
+    # Others
+    'FILE_COGS1',
+    # TODO: may need to add more
+]
+
+
 LEAR_FILING_BUSINESS_UPDATE_MAPPING = {
     'incorporationApplication': ['last_coa_date', 'last_cod_date'],
     'changeOfAddress': ['last_coa_date'],

--- a/data-tool/flows/tombstone/tombstone_mappings.py
+++ b/data-tool/flows/tombstone/tombstone_mappings.py
@@ -358,8 +358,8 @@ EVENT_FILING_DISPLAY_NAME_MAPPING = {
     # TODO: Delay of Dissolution - unsupported (need confirmation)
     # no ledger item in colin
 
-    EventFilings.DISD1_DISDE: "Registrar''s Notation - Dissolution or Cancellation Delay",  # has prefix "Registrar's Notation - "
-    EventFilings.DISD2_DISDE: "Registrar''s Notation - Dissolution or Cancellation Delay",
+    EventFilings.DISD1_DISDE: "Registrar's Notation - Dissolution or Cancellation Delay",  # has prefix "Registrar's Notation - "
+    EventFilings.DISD2_DISDE: "Registrar's Notation - Dissolution or Cancellation Delay",
 
     EventFilings.FILE_ADVD2: 'Application for Dissolution (Voluntary Dissolution)',
     EventFilings.FILE_ADVDS: 'Application for Dissolution (Voluntary Dissolution)',
@@ -381,8 +381,8 @@ EVENT_FILING_DISPLAY_NAME_MAPPING = {
     EventFilings.FILE_AM_TR: 'Amendment - Transition',
 
     # TODO: Liquidation - unsupported (need to check if anything missing)
-    # NOLDS: "Notice of Location of Dissolved Company''s Records"
-    # NOCDS: "Notice of Change Respecting Dissolved Company''s Records"
+    # NOLDS: "Notice of Location of Dissolved Company's Records"
+    # NOCDS: "Notice of Change Respecting Dissolved Company's Records"
     # NOTRA: 'Notice of Transfer of Records'
     # NOAPL: 'Notice of Appointment of Liquidator'
     # NOCAL: 'Notice of Change of Address of Liquidator And/Or Liquidation Records Office'
@@ -411,8 +411,8 @@ EVENT_FILING_DISPLAY_NAME_MAPPING = {
     EventFilings.FILE_AM_PO: 'Amendment - Put Back On',
     EventFilings.FILE_CO_PO: 'Correction - Put Back On',
 
-    EventFilings.FILE_REGSN: "Registrar''s Notation",
-    EventFilings.FILE_REGSO: "Registrar''s Order",
+    EventFilings.FILE_REGSN: "Registrar's Notation",
+    EventFilings.FILE_REGSO: "Registrar's Order",
 
     EventFilings.FILE_RESTL: 'Restoration Application - Limited',
     EventFilings.FILE_RESTF: 'Restoration Application - Full',

--- a/data-tool/flows/tombstone/tombstone_queries.py
+++ b/data-tool/flows/tombstone/tombstone_queries.py
@@ -40,7 +40,7 @@ def get_unprocessed_corps_subquery(flow_name, environment):
                             on cia2.ting_corp_num = cp.corp_num
                             and cp.flow_name = '{flow_name}'
                             and cp.environment = '{environment}'
-                            and cp.processed_status = 'COMPLETED'
+                            and cp.processed_status in ('COMPLETED', 'PARTIAL')
                         where cia2.ted_corp_num = cia1.ted_corp_num
                         and (cia2.ting_corp_num like 'BC%' or cia2.ting_corp_num like 'Q%' or cia2.ting_corp_num like 'C%')
                         and cp.corp_num is null
@@ -156,7 +156,7 @@ def get_total_unprocessed_count_query(flow_name, environment):
         and cp.environment = '{environment}'
     where 1 = 1
     and cs.end_event_id is null
-    and ((cp.processed_status is null or cp.processed_status != 'COMPLETED'))
+    and ((cp.processed_status is null or cp.processed_status not in ('COMPLETED', 'PARTIAL')))
     """
     return query
 

--- a/data-tool/flows/tombstone/tombstone_utils.py
+++ b/data-tool/flows/tombstone/tombstone_utils.py
@@ -9,14 +9,15 @@ import pytz
 from sqlalchemy import Connection, text
 from tombstone.tombstone_base_data import (ALIAS, AMALGAMATION, FILING,
                                            FILING_JSON, IN_DISSOLUTION,
-                                           JURISDICTION, OFFICE, PARTY,
-                                           PARTY_ROLE, RESOLUTION,
-                                           SHARE_CLASSES, USER, OFFICES_HELD)
+                                           JURISDICTION, OFFICE, OFFICES_HELD,
+                                           PARTY, PARTY_ROLE, RESOLUTION,
+                                           SHARE_CLASSES, USER)
 from tombstone.tombstone_mappings import (EVENT_FILING_DISPLAY_NAME_MAPPING,
                                           EVENT_FILING_LEAR_TARGET_MAPPING,
                                           LEAR_FILING_BUSINESS_UPDATE_MAPPING,
                                           LEAR_STATE_FILINGS,
                                           LEGAL_TYPE_CHANGE_FILINGS,
+                                          NO_FILING_EVENT_FILE_TYPES,
                                           SKIPPED_EVENT_FILE_TYPES,
                                           EventFilings)
 
@@ -344,7 +345,7 @@ def format_filings_data(data: dict) -> dict:
         # TODO: build a new complete filing event mapper (WIP)
         raw_filing_type, raw_filing_subtype = get_target_filing_type(event_file_type)
         # skip the unsupported ones (need to support in the future)
-        if not raw_filing_type:
+        if not raw_filing_type and event_file_type not in NO_FILING_EVENT_FILE_TYPES:
             print(f'❗ Unsupported event filing type: {event_file_type}')
             current_unsupported_types.add(event_file_type)
             all_unsupported_types.add(event_file_type)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#26143 /bcgov/entity#26323

*Description of changes:*
- Add `SKIPPED_EVENT_FILE_TYPES` list for types that we don't need to migrate
- Add `NO_FILING_EVENT_FILE_TYPES` list for types that we don't map to filings but we bring data over
- Add unsupported event_file_type info for each corp
- Update statistic info

_Testing_
1. Local
![image](https://github.com/user-attachments/assets/2cfc2013-0c23-41c3-be20-5cf6dd099644)

2. Dev
load the following businesses are loaded in dev and affiliated to account `3446`
```python
# 26143
BC1252541  # SYST event
BC0943825  # FILE_TILMA
BC1517634  # FILE_COGS1

# 26323
BC1267803  # FILE_NOAPL
C1089184   # FILE_LIQUR
```
![image](https://github.com/user-attachments/assets/5bffda37-7b65-4114-bfdc-21bc27c2b9f7)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
