### PR TITLE
26487 - Support save amalgamation out draft

### DIFF
--- a/legal-api/src/legal_api/core/filing.py
+++ b/legal-api/src/legal_api/core/filing.py
@@ -68,6 +68,7 @@ class Filing:  # pylint: disable=too-many-public-methods
         AGMLOCATIONCHANGE = 'agmLocationChange'
         ALTERATION = 'alteration'
         AMALGAMATIONAPPLICATION = 'amalgamationApplication'
+        AMALGAMATIONOUT = 'amalgamationOut'
         AMENDEDAGM = 'amendedAGM'
         AMENDEDANNUALREPORT = 'amendedAnnualReport'
         AMENDEDCHANGEOFDIRECTORS = 'amendedChangeOfDirectors'

--- a/legal-api/src/legal_api/core/meta/filing.py
+++ b/legal-api/src/legal_api/core/meta/filing.py
@@ -189,6 +189,21 @@ FILINGS: Final = {
             }
         }
     },
+    'amalgamationOut': {
+        'name': 'amalgamationOut',
+        'title': 'Amalgamation Out',
+        'displayName': 'Amalgamation Out',
+        'codes': {
+            'BC': 'AMALO',
+            'BEN': 'AMALO',
+            'ULC': 'AMALO',
+            'CC': 'AMALO',
+            'C': 'AMALO',
+            'CBEN': 'AMALO',
+            'CUL': 'AMALO',
+            'CCC': 'AMALO'
+        }
+    },
     'annualReport': {
         'name': 'annualReport',
         'title': 'Annual Report Filing',

--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -156,6 +156,20 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
                 },
             }
         },
+        'amalgamationOut': {
+            'name': 'amalgamationOut',
+            'title': 'Amalgamation Out',
+            'codes': {
+                'BC': 'AMALO',
+                'BEN': 'AMALO',
+                'ULC': 'AMALO',
+                'CC': 'AMALO',
+                'C': 'AMALO',
+                'CBEN': 'AMALO',
+                'CUL': 'AMALO',
+                'CCC': 'AMALO'
+            }
+        },
         'annualReport': {
             'name': 'annualReport',
             'title': 'Annual Report Filing',

--- a/legal-api/src/legal_api/services/authz.py
+++ b/legal-api/src/legal_api/services/authz.py
@@ -201,6 +201,13 @@ def get_allowable_filings_dict():
                         }
                     }
                 },
+                'amalgamationOut': {
+                    'legalTypes': ['BC', 'BEN', 'CC', 'ULC', 'C', 'CBEN', 'CUL', 'CCC'],
+                    'blockerChecks': {
+                        'business': [BusinessBlocker.NOT_IN_GOOD_STANDING],
+                        'completedFilings': ['consentAmalgamationOut']
+                    }
+                },
                 'annualReport': {
                     'legalTypes': ['CP', 'BEN', 'BC', 'ULC', 'CC', 'C', 'CBEN', 'CUL', 'CCC'],
                     'blockerChecks': {

--- a/legal-api/tests/unit/resources/v1/test_business_filings/test_filings.py
+++ b/legal-api/tests/unit/resources/v1/test_business_filings/test_filings.py
@@ -1031,6 +1031,9 @@ DISSOLUTION_VOLUNTARY_FILING['filing']['dissolution']['dissolutionType'] = 'volu
 SPECIAL_RESOLUTION_NO_CON_FILING = copy.deepcopy(CP_SPECIAL_RESOLUTION_TEMPLATE)
 del SPECIAL_RESOLUTION_NO_CON_FILING['filing']['changeOfName']
 
+AMALGAMATION_OUT_FILING = copy.deepcopy(FILING_HEADER)
+AMALGAMATION_OUT_FILING['filing']['amalgamationOut'] = {}
+
 CONTINUATION_OUT_FILING = copy.deepcopy(FILING_HEADER)
 CONTINUATION_OUT_FILING['filing']['continuationOut'] = {}
 
@@ -1098,6 +1101,10 @@ def _fee_code_asserts(business, filing_json: dict, multiple_fee_codes, expected_
          False, []),
         ('CP1234567', CP_SPECIAL_RESOLUTION_TEMPLATE, 'specialResolution', Business.LegalTypes.COOP.value,
          False, ['SPRLN', 'OTCON']),
+        ('BC1234567', AMALGAMATION_OUT_FILING, 'amalgamationOut', Business.LegalTypes.COMP.value, False, []),
+        ('BC1234567', AMALGAMATION_OUT_FILING, 'amalgamationOut', Business.LegalTypes.BCOMP.value, False, []),
+        ('BC1234567', AMALGAMATION_OUT_FILING, 'amalgamationOut', Business.LegalTypes.BC_ULC_COMPANY.value, False, []),
+        ('BC1234567', AMALGAMATION_OUT_FILING, 'amalgamationOut', Business.LegalTypes.BC_CCC.value, False, []),
         ('BC1234567', CONTINUATION_OUT_FILING, 'continuationOut', Business.LegalTypes.COMP.value, False, []),
         ('BC1234567', CONTINUATION_OUT_FILING, 'continuationOut', Business.LegalTypes.BCOMP.value, False, []),
         ('BC1234567', CONTINUATION_OUT_FILING, 'continuationOut', Business.LegalTypes.BC_ULC_COMPANY.value, False, []),

--- a/legal-api/tests/unit/resources/v2/test_business.py
+++ b/legal-api/tests/unit/resources/v2/test_business.py
@@ -601,6 +601,10 @@ def test_get_could_file(session, client, jwt):
             "name": "changeOfAddress"
         },
         {
+            "displayName": "Amalgamation Out",
+            "name": "amalgamationOut"
+        },
+        {
             "displayName": "Director Change",
             "name": "changeOfDirectors"
         },

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filings.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filings.py
@@ -1242,6 +1242,9 @@ RESTORATION_LIMITED_EXT_FILING['filing']['restoration']['type'] = 'limitedRestor
 RESTORATION_LIMITED_TO_FULL_FILING = copy.deepcopy(RESTORATION_FILING)
 RESTORATION_LIMITED_TO_FULL_FILING['filing']['restoration']['type'] = 'limitedRestorationToFull'
 
+AMALGAMATION_OUT_FILING = copy.deepcopy(FILING_HEADER)
+AMALGAMATION_OUT_FILING['filing']['amalgamationOut'] = {}
+
 CONTINUATION_OUT_FILING = copy.deepcopy(FILING_HEADER)
 CONTINUATION_OUT_FILING['filing']['continuationOut'] = {}
 
@@ -1320,6 +1323,10 @@ def _get_expected_fee_code(free, filing_name, filing_json: dict, legal_type):
         ('BC1234567', RESTORATION_LIMITED_TO_FULL_FILING, 'restoration', Business.LegalTypes.COMP.value, False, [], False),
         ('BC1234567', RESTORATION_LIMITED_TO_FULL_FILING, 'restoration', Business.LegalTypes.BC_ULC_COMPANY.value, False, [], False),
         ('BC1234567', RESTORATION_LIMITED_TO_FULL_FILING, 'restoration', Business.LegalTypes.BC_CCC.value, False, [], False),
+        ('BC1234567', AMALGAMATION_OUT_FILING, 'amalgamationOut', Business.LegalTypes.BCOMP.value, False, [], False),
+        ('BC1234567', AMALGAMATION_OUT_FILING, 'amalgamationOut', Business.LegalTypes.BC_ULC_COMPANY.value, False, [], False),
+        ('BC1234567', AMALGAMATION_OUT_FILING, 'amalgamationOut', Business.LegalTypes.COMP.value, False, [], False),
+        ('BC1234567', AMALGAMATION_OUT_FILING, 'amalgamationOut', Business.LegalTypes.BC_CCC.value, False, [], False),
         ('BC1234567', CONTINUATION_OUT_FILING, 'continuationOut', Business.LegalTypes.BCOMP.value, False, [], False),
         ('BC1234567', CONTINUATION_OUT_FILING, 'continuationOut', Business.LegalTypes.BC_ULC_COMPANY.value, False, [], False),
         ('BC1234567', CONTINUATION_OUT_FILING, 'continuationOut', Business.LegalTypes.COMP.value, False, [], False),

--- a/legal-api/tests/unit/services/test_authorization.py
+++ b/legal-api/tests/unit/services/test_authorization.py
@@ -31,6 +31,7 @@ from registry_schemas.example_data import (
     AGM_EXTENSION,
     AGM_LOCATION_CHANGE,
     ALTERATION_FILING_TEMPLATE,
+    AMALGAMATION_OUT,
     ANNUAL_REPORT,
     CHANGE_OF_REGISTRATION_TEMPLATE,
     CONSENT_AMALGAMATION_OUT,
@@ -139,6 +140,7 @@ class FilingKey(str, Enum):
     ADM_DISS = 'ADM_DISS'
     VOL_DISS_FIRMS = 'VOL_DISS_FIRMS'
     ADM_DISS_FIRMS = 'ADM_DISS_FIRMS'
+    AMALGAMATION_OUT = 'AMALGAMATION_OUT'
     REGISTRARS_NOTATION = 'REGISTRARS_NOTATION'
     REGISTRARS_ORDER = 'REGISTRARS_ORDER'
     SPECIAL_RESOLUTION = 'SPECIAL_RESOLUTION'
@@ -190,6 +192,7 @@ EXPECTED_DATA = {
                                'name': 'dissolution', 'type': 'voluntary'},
     FilingKey.ADM_DISS_FIRMS: {'displayName': 'Statement of Dissolution', 'feeCode': 'DIS_ADM',
                                'name': 'dissolution', 'type': 'administrative'},
+    FilingKey.AMALGAMATION_OUT: {'displayName': 'Amalgamation Out', 'feeCode': 'AMALO', 'name': 'amalgamationOut'},
     FilingKey.REGISTRARS_NOTATION: {'displayName': "Registrar's Notation", 'feeCode': 'NOFEE',
                                     'name': 'registrarsNotation'},
     FilingKey.REGISTRARS_ORDER: {'displayName': "Registrar's Order", 'feeCode': 'NOFEE', 'name': 'registrarsOrder'},
@@ -280,6 +283,7 @@ EXPECTED_DATA_CONT_IN = {
     FilingKey.AGM_EXTENSION: {'displayName': 'Request for AGM Extension', 'feeCode': 'AGMDT', 'name': 'agmExtension'},
     FilingKey.AGM_LOCATION_CHANGE: {'displayName': 'AGM Location Change', 'feeCode': 'AGMLC', 'name': 'agmLocationChange'},
     FilingKey.ALTERATION: {'displayName': 'Alteration', 'feeCode': 'ALTER', 'name': 'alteration'},
+    FilingKey.AMALGAMATION_OUT: {'displayName': 'Amalgamation Out', 'feeCode': 'AMALO', 'name': 'amalgamationOut'},
     FilingKey.CONSENT_AMALGAMATION_OUT: {'displayName': '6-Month Consent to Amalgamate Out', 'feeCode': 'IAMGO',
                                          'name': 'consentAmalgamationOut'},
     FilingKey.CONSENT_CONTINUATION_OUT: {'displayName': '6-Month Consent to Continue Out', 'feeCode': 'CONTO',
@@ -353,6 +357,9 @@ AGM_EXTENSION_FILING_TEMPLATE['filing']['agmExtension'] = AGM_EXTENSION
 AGM_LOCATION_CHANGE_FILING_TEMPLATE = copy.deepcopy(FILING_TEMPLATE)
 AGM_LOCATION_CHANGE_FILING_TEMPLATE['filing']['agmLocationChange'] = AGM_LOCATION_CHANGE
 
+AMALGAMATION_OUT_TEMPLATE = copy.deepcopy(FILING_TEMPLATE)
+AMALGAMATION_OUT_TEMPLATE['filing']['amalgamationOut'] = AMALGAMATION_OUT
+
 RESTORATION_FILING_TEMPLATE = copy.deepcopy(FILING_TEMPLATE)
 RESTORATION_FILING_TEMPLATE['filing']['restoration'] = RESTORATION
 
@@ -382,6 +389,7 @@ FILING_DATA = {
     'agmExtension': AGM_EXTENSION_FILING_TEMPLATE,
     'agmLocationChange': AGM_LOCATION_CHANGE_FILING_TEMPLATE,
     'alteration': ALTERATION_FILING_TEMPLATE,
+    'amalgamationOut': AMALGAMATION_OUT_TEMPLATE,
     'correction': CORRECTION_AR,
     'changeOfRegistration': CHANGE_OF_REGISTRATION_TEMPLATE,
     'restoration.limitedRestoration': RESTORATION_FILING_TEMPLATE,
@@ -572,14 +580,14 @@ def test_authorized_invalid_roles(monkeypatch, app, jwt):
           'registrarsNotation', 'registrarsOrder', 'specialResolution']),
         ('staff_active_corps', Business.State.ACTIVE, ['BC', 'BEN', 'CC', 'ULC'], 'staff', [STAFF_ROLE],
          ['adminFreeze', 'agmExtension', 'agmLocationChange', 'alteration',
-          {'amalgamationApplication': ['regular', 'vertical', 'horizontal']}, 'annualReport', 'appointReceiver',
+          {'amalgamationApplication': ['regular', 'vertical', 'horizontal']}, 'amalgamationOut','annualReport', 'appointReceiver',
           'ceaseReceiver', 'changeOfAddress', 'changeOfDirectors', 'consentAmalgamationOut', 'consentContinuationOut', 'continuationOut',
           'correction', 'courtOrder', {'dissolution': ['voluntary', 'administrative']},
           'incorporationApplication', 'putBackOff', 'registrarsNotation', 'registrarsOrder', 'transition',
           {'restoration': ['limitedRestorationExtension', 'limitedRestorationToFull']}, 'noticeOfWithdrawal']),
         ('staff_active_continue_in_corps', Business.State.ACTIVE, ['C', 'CBEN', 'CUL', 'CCC'], 'staff', [STAFF_ROLE],
          ['adminFreeze', 'agmExtension', 'agmLocationChange', 'alteration',
-          {'amalgamationApplication': ['regular', 'vertical', 'horizontal']}, 'annualReport', 'appointReceiver',
+          {'amalgamationApplication': ['regular', 'vertical', 'horizontal']},'amalgamationOut', 'annualReport', 'appointReceiver',
           'ceaseReceiver', 'changeOfAddress', 'changeOfDirectors', 'continuationIn', 'consentAmalgamationOut', 'consentContinuationOut',
           'continuationOut', 'correction', 'courtOrder', {'dissolution': ['voluntary', 'administrative']},
           'putBackOff', 'registrarsNotation', 'registrarsOrder', 'transition',
@@ -659,6 +667,11 @@ def test_get_allowed(monkeypatch, app, jwt, test_name, state, legal_types, usern
          ['BC', 'BEN', 'ULC', 'CC'], 'staff', [STAFF_ROLE], True),
         ('staff_active_allowed', Business.State.ACTIVE, 'amalgamationApplication', None,
          ['C', 'CBEN', 'CUL', 'CCC'], 'staff', [STAFF_ROLE], False),
+
+        ('staff_active_allowed', Business.State.ACTIVE, 'amalgamationOut', None,
+         ['BC', 'BEN', 'ULC', 'CC', 'C', 'CBEN', 'CUL', 'CCC'], 'staff', [STAFF_ROLE], False),
+        ('staff_active', Business.State.ACTIVE, 'amalgamationOut', None,
+         ['CP', 'LLC'], 'staff', [STAFF_ROLE], False),
 
         ('staff_active_allowed', Business.State.ACTIVE, 'annualReport', None,
          ['CP', 'BEN', 'BC', 'CC', 'ULC', 'C', 'CBEN', 'CUL', 'CCC'], 'staff', [STAFF_ROLE], True),
@@ -2701,8 +2714,50 @@ def test_is_allowed_to_resubmit(monkeypatch, app, session, jwt, filing_status, e
                           FilingKey.REGISTRARS_NOTATION,
                           FilingKey.REGISTRARS_ORDER,
                           FilingKey.TRANSITION])),
+        ('staff_active_corps_completed_filing_success', Business.State.ACTIVE, ['BC', 'BEN', 'CC', 'ULC'], 'staff',
+         [STAFF_ROLE], ['consentAmalgamationOut', 'consentAmalgamationOut'], [None, None], [True, True],
+         expected_lookup([FilingKey.ADMN_FRZE,
+                          FilingKey.AGM_EXTENSION,
+                          FilingKey.AGM_LOCATION_CHANGE,
+                          FilingKey.ALTERATION,
+                          FilingKey.AMALGAMATION_REGULAR,
+                          FilingKey.AMALGAMATION_VERTICAL,
+                          FilingKey.AMALGAMATION_HORIZONTAL,
+                          FilingKey.AMALGAMATION_OUT,
+                          FilingKey.AR_CORPS,
+                          FilingKey.APPOINT_RECEIVER,
+                          FilingKey.CEASE_RECEIVER,
+                          FilingKey.COA_CORPS,
+                          FilingKey.COD_CORPS,
+                          FilingKey.CONSENT_AMALGAMATION_OUT,
+                          FilingKey.CONSENT_CONTINUATION_OUT,
+                          FilingKey.CORRCTN,
+                          FilingKey.COURT_ORDER,
+                          FilingKey.VOL_DISS,
+                          FilingKey.ADM_DISS,
+                          FilingKey.PUT_BACK_OFF,
+                          FilingKey.REGISTRARS_NOTATION,
+                          FilingKey.REGISTRARS_ORDER,
+                          FilingKey.TRANSITION])),
+        ('staff_active_corps_completed_filing_success', Business.State.ACTIVE, ['BC', 'BEN', 'CC', 'ULC'], 'staff',
+         [STAFF_ROLE], ['consentAmalgamationOut', 'consentAmalgamationOut'], [None, None], [True, False],
+         expected_lookup([FilingKey.ADMN_FRZE,
+                          FilingKey.AMALGAMATION_OUT,
+                          FilingKey.COURT_ORDER,
+                          FilingKey.PUT_BACK_OFF,
+                          FilingKey.REGISTRARS_NOTATION,
+                          FilingKey.REGISTRARS_ORDER,
+                          FilingKey.TRANSITION])),
         ('staff_active_corps_completed_filing_fail', Business.State.ACTIVE, ['BC', 'BEN', 'CC', 'ULC'], 'staff',
          [STAFF_ROLE], ['consentContinuationOut', 'consentContinuationOut'], [None, None], [False, False],
+         expected_lookup([FilingKey.ADMN_FRZE,
+                          FilingKey.COURT_ORDER,
+                          FilingKey.PUT_BACK_OFF,
+                          FilingKey.REGISTRARS_NOTATION,
+                          FilingKey.REGISTRARS_ORDER,
+                          FilingKey.TRANSITION])),
+        ('staff_active_corps_completed_filing_fail', Business.State.ACTIVE, ['BC', 'BEN', 'CC', 'ULC'], 'staff',
+         [STAFF_ROLE], ['consentAmalgamationOut', 'consentAmalgamationOut'], [None, None], [False, False],
          expected_lookup([FilingKey.ADMN_FRZE,
                           FilingKey.COURT_ORDER,
                           FilingKey.PUT_BACK_OFF,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#26487

*Description of changes:*
- Add Record of Amalgamate Out Filing Type, support Save and update draft
- Add Allowable action item for Amalgamate Out, restricted to staff only
- Add checks to prevent filing when:
   Business is "Not in Good Standing"
   Business has a pending or draft filing
- Update unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
