### PR TITLE
fix: Handle February 29 leap year edge case

### DIFF
--- a/colin-api/src/colin_api/models/filing.py
+++ b/colin-api/src/colin_api/models/filing.py
@@ -1442,7 +1442,7 @@ class Filing:  # pylint: disable=too-many-instance-attributes;
         # Handle February 29 leap year edge case
         month = pacific_founding_date.month
         day = pacific_founding_date.day
-        
+
         # If it's February 29 and the filing year is not a leap year, use February 28 instead
         if month == 2 and day == 29:
             is_leap_year = (int(filing_year) % 4 == 0 and int(filing_year) % 100 != 0) or (int(filing_year) % 400 == 0)

--- a/colin-api/src/colin_api/models/filing.py
+++ b/colin-api/src/colin_api/models/filing.py
@@ -1445,7 +1445,7 @@ class Filing:  # pylint: disable=too-many-instance-attributes;
 
         # If it's February 29 and the filing year is not a leap year, use February 28 instead
         if month == 2 and day == 29:
-            is_leap_year = (int(filing_year) % 4 == 0 and int(filing_year) % 100 != 0) or (int(filing_year) % 400 == 0)
+            is_leap_year = int(filing_year) % 4 == 0 and (int(filing_year) % 100 != 0 or (int(filing_year) % 400 == 0))
             if not is_leap_year:
                 day = 28
 

--- a/colin-api/src/colin_api/models/filing.py
+++ b/colin-api/src/colin_api/models/filing.py
@@ -1439,7 +1439,17 @@ class Filing:  # pylint: disable=too-many-instance-attributes;
             convert_to_pacific_time(founding_date_str)
         ).date()
 
-        last_ar_filed_dt = f'{filing_year}-{pacific_founding_date.month:02}-{pacific_founding_date.day:02}'
+        # Handle February 29 leap year edge case
+        month = pacific_founding_date.month
+        day = pacific_founding_date.day
+        
+        # If it's February 29 and the filing year is not a leap year, use February 28 instead
+        if month == 2 and day == 29:
+            is_leap_year = (int(filing_year) % 4 == 0 and int(filing_year) % 100 != 0) or (int(filing_year) % 400 == 0)
+            if not is_leap_year:
+                day = 28
+
+        last_ar_filed_dt = f'{filing_year}-{month:02}-{day:02}'
         return last_ar_filed_dt
 
     @classmethod


### PR DESCRIPTION
*Issue #:* bcgov/business-ar/issues/544

*Description of changes:*
1. Fixed an issue in the _get_last_ar_filed_date method to properly handle February 29th dates when the filing year is not a leap year. The changes include:
2. Added logic to detect when a founding date is February 29th (leap day)
Implemented standard leap year calculation to determine if the filing year is a leap year:

- A year is a leap year if divisible by 4

- Except if divisible by 100, unless also divisible by 400

3. When the founding date is February 29th but the filing year is not a leap year, the code now returns February 28th instead
This prevents generating invalid dates like "2025-02-29" which would cause errors

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
