### PR TITLE
22143 - Add auth check for legal-api business endpoint v2

### DIFF
--- a/legal-api/flags.json
+++ b/legal-api/flags.json
@@ -8,6 +8,7 @@
         "enable-business-summary-for-migrated-corps": true,
         "enable-involuntary-dissolution-filter": false,
         "enable-new-ben-statements": false,
+        "enable-auth-v2-business": true,
         "involuntary-dissolution-filter": {
             "include-accounts": [],
             "exclude-accounts": []

--- a/legal-api/src/legal_api/config.py
+++ b/legal-api/src/legal_api/config.py
@@ -185,9 +185,6 @@ class _Config():  # pylint: disable=too-few-public-methods
     # Transparency Register
     TR_START_DATE = os.getenv('TR_START_DATE', '').strip()  # i.e. '2025-02-01'
 
-    # Flag to control if the business endpoint v2 is open to the public (no auth check)
-    BUSINESS_V2_PUBLIC = False
-
     TESTING = False
     DEBUG = False
 

--- a/legal-api/src/legal_api/config.py
+++ b/legal-api/src/legal_api/config.py
@@ -185,6 +185,9 @@ class _Config():  # pylint: disable=too-few-public-methods
     # Transparency Register
     TR_START_DATE = os.getenv('TR_START_DATE', '').strip()  # i.e. '2025-02-01'
 
+    # Flag to control if the business endpoint v2 is open to the public (no auth check)
+    BUSINESS_V2_PUBLIC = False
+
     TESTING = False
     DEBUG = False
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22143

*Description of changes:*
Add auth check for business endpoint v2. Public account with new 'view' role should not access full business information. (the slim version data is still available for public)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
