### PR TITLE
26798 Fix - Remove incorporator from tombstone

### DIFF
--- a/data-tool/flows/tombstone/tombstone_queries.py
+++ b/data-tool/flows/tombstone/tombstone_queries.py
@@ -459,7 +459,7 @@ def get_parties_and_addresses_query(corp_num):
     --    and e.corp_num = 'BC0883637' -- INC, DIR
         and e.corp_num = '{corp_num}'
         and cp.end_event_id is null
-        and cp.party_typ_cd in ('INC', 'DIR', 'OFF')
+        and cp.party_typ_cd in ('DIR', 'OFF')
     --order by e.event_id
     order by cp_full_name, e.event_id
     ;

--- a/data-tool/flows/tombstone/tombstone_utils.py
+++ b/data-tool/flows/tombstone/tombstone_utils.py
@@ -116,7 +116,6 @@ def format_parties_data(data: dict) -> list[dict]:
 
     # Map role codes to role names
     role_mapping = {
-        'INC': 'incorporator',
         'DIR': 'director',
         'OFF': 'officer'
         # Additional roles can be added here in the future


### PR DESCRIPTION
*Issue #:* /bcgov/entity#26798

*Description of changes:*
- Remove incorporator from tombstone (will bring it over in the backfill pipeline as it attaches to filing)

_Testing_
The following businesses are loaded in **dev** and affiliated to account `3446`
```
BC1054561
BC1245585
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
