### PR TITLE
26893 Update tombstone pipeline to bring officers over separately + party role model updates for officers

### DIFF
--- a/data-tool/flows/tombstone/tombstone_utils.py
+++ b/data-tool/flows/tombstone/tombstone_utils.py
@@ -123,7 +123,12 @@ def format_parties_data(data: dict) -> list[dict]:
     }
 
     df = pd.DataFrame(parties_data)
-    grouped_parties = df.groupby('cp_full_name')
+    # Modify grouping to consider both name and whether party is an officer.
+    # If officer, we want a separate party_role entry in LEAR
+    df['group_key'] = df.apply(lambda x: f"{x['cp_full_name']}_{x['cp_party_typ_cd']}"
+                                         if x['cp_party_typ_cd'] == 'OFF' else x['cp_full_name'], axis=1)
+    grouped_parties = df.groupby('group_key')
+
     for _, group in grouped_parties:
         party = copy.deepcopy(PARTY)
         party_info = group.iloc[0].to_dict()
@@ -278,7 +283,7 @@ def format_share_name(name: str):
 
     if name.endswith(' shares'):
         name = name.removesuffix(' shares')
-    
+
     return f'{name}{expected_suffix}'
 
 

--- a/legal-api/src/legal_api/models/party_role.py
+++ b/legal-api/src/legal_api/models/party_role.py
@@ -127,8 +127,11 @@ class PartyRole(db.Model, Versioned):
     @staticmethod
     def get_party_roles(business_id: int, end_date: datetime = None, role: str = None) -> list:
         """Return the parties that match the filter conditions."""
+        # TODO: remove hardcoded officer exclude filter when we know how to deal with imported officer data.
+        #       If we don't do this, it results in deletion of officer data via things like correction filing
         party_roles = db.session.query(PartyRole). \
-            filter(PartyRole.business_id == business_id)
+            filter(PartyRole.business_id == business_id). \
+            filter(PartyRole.role != 'officer')
 
         if end_date is not None:
             party_roles = party_roles.filter(cast(PartyRole.appointment_date, Date) <= end_date). \


### PR DESCRIPTION
*Issue #:* /bcgov/entity#26893

*Description of changes:*
* Update tombstone pipeline to migrate directors & officers as separate parties.  This was done incorrectly previously.  They will be managed separately
* Updated logic around party_role + party_role versioning retrieval logic such that requests to retrieve all party role or parties logic exclude officers for the time being.  This is intended to avoid scenarios where the filer will delete officer entries for things like correction filings or officers being displayed unexpectedly for things like outputs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
