### PR TITLE
26950 Update tombstone pipeline to included ceased party data

### DIFF
--- a/data-tool/flows/tombstone/tombstone_queries.py
+++ b/data-tool/flows/tombstone/tombstone_queries.py
@@ -458,7 +458,7 @@ def get_parties_and_addresses_query(corp_num):
     --    and e.corp_num = 'BC0006247' -- OFF, DIR, RCC
     --    and e.corp_num = 'BC0883637' -- INC, DIR
         and e.corp_num = '{corp_num}'
-        and cp.end_event_id is null
+        and ((cp.end_event_id is null) or (cp.end_event_id is not null and cp.cessation_dt is not null))
         and cp.party_typ_cd in ('DIR', 'OFF')
     --order by e.event_id
     order by cp_full_name, e.event_id


### PR DESCRIPTION
*Issue #:* /bcgov/entity#26950

*Description of changes:*
* Update parties query in tombstone pipeline to include ceased parties data

**Test notes:**

Have loaded some early adopters corps into dev with this update so we can compare the same corps in test:
'BC1507445','BC1507435','BC1292656','BC1249698','BC1196188'

In particular, I did some testing with BC1196188 as it tested the scenario where an AR was referencing a ceased director.  You can observe that the filing json for the AR is different in dev & test.  The corp in dev correctly files the AR with the ceased director.

![image](https://github.com/user-attachments/assets/da4fdff4-1b3b-4fb4-af89-5350eea4bd2f)

<img width="2278" alt="image" src="https://github.com/user-attachments/assets/c5f47ce8-2e6b-4629-8f9b-1154739272e4" />

filing json for AR
![image](https://github.com/user-attachments/assets/1c72ba07-28e1-43ae-b0b6-9bac204bd16a)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
