### PR TITLE
27011 Fix director address mismatch issue

### DIFF
--- a/data-tool/flows/tombstone/tombstone_utils.py
+++ b/data-tool/flows/tombstone/tombstone_utils.py
@@ -123,7 +123,9 @@ def format_parties_data(data: dict) -> list[dict]:
     }
 
     df = pd.DataFrame(parties_data)
-    df['group_by_key'] = df['cp_full_name'] + '_' + df['cp_party_typ_cd'] 
+    df['group_by_key'] = (df['cp_full_name'] + '_' + df['cp_party_typ_cd'] + '_' +
+                          df['cp_cessation_dt_str'].fillna('active'))
+
     grouped_parties = df.groupby('group_by_key')
     for _, group in grouped_parties:
         party = copy.deepcopy(PARTY)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#27011

*Description of changes:*
* Update to pipeline to include grouping by cessation date.  Without this, if there is an active and ceased party(officer or director) that both matches against the current group by criteria(full name + role), the pipeline maps to the same party in LEAR.  This causes an issues as the address may not be the same

Loaded problem corp into test and compared with prod - BC1249698.  Note that I mostly checked all the early adopter corps to see if parties were still loading correctly.  seemed like the parties were still loaded correctly
<img width="1414" alt="image" src="https://github.com/user-attachments/assets/8a73156b-b610-4939-9734-50513e2061c2" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
