### PR TITLE
27043 Tombstone pipeline - Update offices_held query to include data for ceased officers

### DIFF
--- a/data-tool/flows/tombstone/tombstone_queries.py
+++ b/data-tool/flows/tombstone/tombstone_queries.py
@@ -759,7 +759,7 @@ def get_offices_held_query(corp_num):
              join offices_held oh on oh.corp_party_id = cp.corp_party_id
     WHERE 1 = 1
       and cp.corp_num = '{corp_num}'
-      and cp.end_event_id is null
+      and ((cp.end_event_id is null) or (cp.end_event_id is not null and cp.cessation_dt is not null))
       AND cp.party_typ_cd IN ('OFF')
     """
     return query


### PR DESCRIPTION
*Issue #:* /bcgov/entity#27043

*Description of changes:*
- Updated offices_held query to include data for ceased officers.

_Local Testing_
I used BC0006247 from the prod extract for testing. Running the tombstone pipeline before implementing this update resulted in 2 entries in `offices_held`

<img width="1125" alt="Screenshot 2025-04-08 at 12 15 39 PM" src="https://github.com/user-attachments/assets/83fa9295-194a-42c2-a1d1-07877ee0f232" />

Running the tombstone pipeline after implementing this update resulted in 3 entries. The new entry is the ceased officer entry.

<img width="1126" alt="Screenshot 2025-04-08 at 12 13 24 PM" src="https://github.com/user-attachments/assets/9a8491e2-f6f8-4be4-8a3b-8a8c321a926c" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
