### PR TITLE
27057 Legal API - update get_share_class_revision & get_share_series_revision to support tombstone

### DIFF
--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -1252,6 +1252,16 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
         return filing_exists
 
     @staticmethod
+    def get_tombstone_filing(business_id: int):
+        """Return the tombstone filing for a given business if any."""
+        return (
+            db.session.query(Filing)
+            .filter(Filing.business_id == business_id)
+            .filter(Filing._status == Filing.Status.TOMBSTONE)
+            .one_or_none()
+        )
+
+    @staticmethod
     def is_filing_after_tombstone(filing_id: int, business_id: int) -> bool:
         """Determine if a filing with the given filing_id's transaction ID was after TOMBSTONE filing's transaction ID.
 
@@ -1264,10 +1274,7 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
                   If no TOMBSTONE filing exists, returns False.
         """
         # Get the TOMBSTONE filing
-        tombstone_filing = db.session.query(Filing).\
-            filter(Filing.business_id == business_id).\
-            filter(Filing._status == Filing.Status.TOMBSTONE).\
-            one_or_none()
+        tombstone_filing = Filing.get_tombstone_filing(business_id)
 
         if not tombstone_filing or not tombstone_filing.transaction_id:
             # No TOMBSTONE filing or it has no transaction ID
@@ -1282,6 +1289,23 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
 
         # Compare the transaction IDs
         return filing.transaction_id > tombstone_filing.transaction_id
+
+    @staticmethod
+    def get_first_filing_after_tombstone_by_type(business_id: int, filing_type: str):
+        """Return the first complete filing of a given filing_type after the tombstone filing."""
+        tombstone_filing = Filing.get_tombstone_filing(business_id)
+
+        if not tombstone_filing or not tombstone_filing.transaction_id:
+            return None
+
+        filing = db.session.query(Filing) \
+            .filter(Filing._filing_type == filing_type) \
+            .filter(Filing.business_id == business_id) \
+            .filter(Filing._status == Filing.Status.COMPLETED.value) \
+            .filter(Filing._source == Filing.Source.LEAR.value) \
+            .filter(Filing.transaction_id > tombstone_filing.transaction_id) \
+            .order_by(Filing.transaction_id).first()
+        return filing
 
     @staticmethod
     def get_filings_sub_type(filing_type: str, filing_json: dict):

--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -1296,7 +1296,7 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
         tombstone_filing = Filing.get_tombstone_filing(business_id)
 
         if not tombstone_filing or not tombstone_filing.transaction_id:
-            return None
+            return []
 
         filings = db.session.query(Filing) \
             .filter(Filing._filing_type == filing_type) \

--- a/legal-api/src/legal_api/models/filing.py
+++ b/legal-api/src/legal_api/models/filing.py
@@ -1291,21 +1291,21 @@ class Filing(db.Model):  # pylint: disable=too-many-instance-attributes,too-many
         return filing.transaction_id > tombstone_filing.transaction_id
 
     @staticmethod
-    def get_first_filing_after_tombstone_by_type(business_id: int, filing_type: str):
+    def get_complete_filings_after_tombstone_by_type(business_id: int, filing_type: str):
         """Return the first complete filing of a given filing_type after the tombstone filing."""
         tombstone_filing = Filing.get_tombstone_filing(business_id)
 
         if not tombstone_filing or not tombstone_filing.transaction_id:
             return None
 
-        filing = db.session.query(Filing) \
+        filings = db.session.query(Filing) \
             .filter(Filing._filing_type == filing_type) \
             .filter(Filing.business_id == business_id) \
             .filter(Filing._status == Filing.Status.COMPLETED.value) \
             .filter(Filing._source == Filing.Source.LEAR.value) \
             .filter(Filing.transaction_id > tombstone_filing.transaction_id) \
-            .order_by(Filing.transaction_id).first()
-        return filing
+            .order_by(Filing.transaction_id).all()
+        return filings
 
     @staticmethod
     def get_filings_sub_type(filing_type: str, filing_json: dict):

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -863,7 +863,7 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
         share_classes = []
         if self._filing.transaction_id:
             share_classes = VersionedBusinessDetailsService.get_share_class_revision(
-                self._filing.transaction_id,
+                self._filing,
                 primary_or_holding_business.id)
         else:
             for share_class in primary_or_holding_business.share_classes.all():
@@ -1201,7 +1201,7 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
         filing['newShareClasses'] = []
         if filing.get('shareClasses'):
             prev_share_class_json = VersionedBusinessDetailsService.get_share_class_revision(
-                prev_completed_filing.transaction_id,
+                prev_completed_filing,
                 prev_completed_filing.business_id)
             prev_share_class_ids = [x['id'] for x in prev_share_class_json]
 
@@ -1229,8 +1229,9 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
     def _format_share_series_data(self, share_class, filing, prev_completed_filing: Filing):  # pylint: disable=too-many-locals; # noqa: E501;
         if share_class.get('series'):
             prev_share_series_json = VersionedBusinessDetailsService.get_share_series_revision(
-                prev_completed_filing.transaction_id,
-                share_class.get('id'))
+                prev_completed_filing,
+                share_class.get('id'),
+                self._business.id)
             prev_share_series_ids = [x['id'] for x in prev_share_series_json]
             share_series_to_edit = []
             for share_series in share_class.get('series'):

--- a/legal-api/src/legal_api/services/business_details_version.py
+++ b/legal-api/src/legal_api/services/business_details_version.py
@@ -394,7 +394,12 @@ class VersionedBusinessDetailsService:  # pylint: disable=too-many-public-method
         # Check if original tombstone share class is overwritten by alteration filed in LEAR
         # values: [1]True, [2]False, [3]None for non-tombstone or alteration doesn't exist
         is_after_tombstone = Filing.is_filing_after_tombstone(filing_id=filing.id, business_id=business_id)
-        overwritten_filing = Filing.get_first_filing_after_tombstone_by_type(business_id, 'alteration')
+        alteration_filings = Filing.get_complete_filings_after_tombstone_by_type(business_id, 'alteration')
+        overwritten_filing = None
+        for f in alteration_filings:
+            if f.filing_json.get('filing', {}).get('alteration', {}).get('shareStructure', {}).get('shareClasses'):
+                overwritten_filing = f
+                break
         is_overwritten = bool(overwritten_filing.transaction_id > filing.transaction_id) if overwritten_filing else None
 
         share_classes = []
@@ -463,7 +468,12 @@ class VersionedBusinessDetailsService:  # pylint: disable=too-many-public-method
         # Check if original tombstone share series is overwritten by alteration filed in LEAR
         # values: [1]True, [2]False, [3]None for non-tombstone or alteration doesn't exist
         is_after_tombstone = Filing.is_filing_after_tombstone(filing_id=filing.id, business_id=business_id)
-        overwritten_filing = Filing.get_first_filing_after_tombstone_by_type(business_id, 'alteration')
+        alteration_filings = Filing.get_complete_filings_after_tombstone_by_type(business_id, 'alteration')
+        overwritten_filing = None
+        for f in alteration_filings:
+            if f.filing_json.get('filing', {}).get('alteration', {}).get('shareStructure', {}).get('shareClasses'):
+                overwritten_filing = f
+                break
         is_overwritten = bool(overwritten_filing.transaction_id > filing.transaction_id) if overwritten_filing else None
 
         share_series_version = VersioningProxy.version_class(db.session(), ShareSeries)

--- a/legal-api/src/legal_api/services/business_details_version.py
+++ b/legal-api/src/legal_api/services/business_details_version.py
@@ -463,7 +463,10 @@ class VersionedBusinessDetailsService:  # pylint: disable=too-many-public-method
         return share_classes
 
     @staticmethod
-    def get_share_series_revision(filing: Filing, share_class_id, business_id) -> dict:
+    def get_share_series_revision(  # pylint: disable=too-many-locals
+            filing: Filing,
+            share_class_id,
+            business_id) -> dict:
         """Consolidates all share series under the share class upto the given transaction id."""
         # Check if original tombstone share series is overwritten by alteration filed in LEAR
         # values: [1]True, [2]False, [3]None for non-tombstone or alteration doesn't exist


### PR DESCRIPTION
*Issue #:* /bcgov/entity#27057

*Description of changes:*
- The updates are to make sure NOA of filing can display correct information even after more subsequent filings are complete.
- Update `get_share_class_revision()`
- Update `get_share_series_revision()`
- Misc updates

_Notes & Observations_
- Alteration will completely remove the current share structure and populate new data if it alters share structure. Tombstone share structure will be replaced completely by the new ones after alteration.
- Alteration won't touch the current share structure and populate new data if it doesn't alter share structure. Tombstone share structure won't be replaced completely in this scenario.
- Correction will update the current share structure if necessary. Tombstone share structure will be updated partially.
- This work doesn't support the scenario that correction updates share structure info and we go back to download NOAs before this filings (e.g. CoD), as previous tombstone share structure will be lost due to missing versioned records.
- Transition & Conversion are not taken into considerations as they won't happen for corps in modernized system.

_Testing results for NOAs_

- All the testing businesses are in dev. "Before" means the NOAs downloaded from dev. "After" means the NOAs downloaded from local Legal API.
- All filings are processed with the old versioning, since the new versioning has cascade delete issue which block the validation.

1. CoD

NOA of CoD will only use non-versioned records
    
<img width="300" alt="image" src="https://github.com/user-attachments/assets/1b07c7ff-5918-4662-ab5b-45113299601b" />

2. CoD + Alteration (no updates for share structure)

NOA of CoD will use non-versioned records
 
<img width="300" alt="image" src="https://github.com/user-attachments/assets/a101cefd-755d-4348-b222-65cacbc32a15" />

NOA of Alteration will use non-versioned records

 
<img width="300" alt="image" src="https://github.com/user-attachments/assets/6895341d-9b56-48de-a17b-c7538bdd6cd3" />

3. CoD + Alteration (updates for share structure)

NOA of CoD will use deleted versioned records
<img width="300" alt="image" src="https://github.com/user-attachments/assets/585761e6-7dc0-4ec6-bf6f-85f73a8a2b4f" />

NOA of Alteration will use inserted versioned records

<img width="350" alt="image" src="https://github.com/user-attachments/assets/7f2cf387-bc6e-4c4d-bb85-ce1b7f3dd81e" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
