### PR TITLE
27091 - Remove sandbox environment override code

### DIFF
--- a/legal-api/src/legal_api/services/bootstrap.py
+++ b/legal-api/src/legal_api/services/bootstrap.py
@@ -77,7 +77,6 @@ class RegistrationBootstrapService:
                            corp_type_code: str = 'TMP',
                            corp_sub_type_code: str = None) -> Union[HTTPStatus, Dict]:
         """Return either a new bootstrap registration or an error struct."""
-
         if not bootstrap:
             return {'error': babel('An account number must be provided.')}
 

--- a/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/business_profile.py
+++ b/queue_services/entity-filer/src/entity_filer/filing_processors/filing_components/business_profile.py
@@ -98,7 +98,7 @@ def _update_business_profile(business: Business, profile_info: Dict) -> Dict:
     return error
 
 
-def update_affiliation(business: Business, filing: Filing, flags: Flags = None):
+def update_affiliation(business: Business, filing: Filing):
     """Create an affiliation for the business and remove the bootstrap."""
     try:
         current_app.logger.info('Updating affiliation for business')
@@ -124,8 +124,7 @@ def update_affiliation(business: Business, filing: Filing, flags: Flags = None):
             business_name=business.legal_name,
             corp_type_code=business.legal_type,
             pass_code=pass_code,
-            details=details,
-            flags=flags
+            details=details
         )
 
         if rv not in (HTTPStatus.OK, HTTPStatus.CREATED):

--- a/queue_services/entity-filer/src/entity_filer/worker.py
+++ b/queue_services/entity-filer/src/entity_filer/worker.py
@@ -371,7 +371,7 @@ async def process_filing(filing_msg: Dict, flask_app: Flask):  # pylint: disable
 
                 # update affiliation for new business
                 if filing_core_submission.filing_type != FilingCore.FilingTypes.CONVERSION:
-                    business_profile.update_affiliation(business, filing_submission, flags)
+                    business_profile.update_affiliation(business, filing_submission)
 
                 name_request.consume_nr(business, filing_submission, flags=flags)
                 business_profile.update_business_profile(business, filing_submission, flags=flags)

--- a/queue_services/entity-filer/tests/unit/filing_processors/test_registration.py
+++ b/queue_services/entity-filer/tests/unit/filing_processors/test_registration.py
@@ -173,8 +173,7 @@ def test_registration_affiliation(app, session, legal_type, filing, party_type, 
                                                           business_name=business.legal_name,
                                                           corp_type_code=legal_type,
                                                           pass_code=expected_pass_code,
-                                                          details=details,
-                                                          flags=None)
+                                                          details=details)
                     assert first_affiliation_call_args == expected_affiliation_call_args
 
                     first_update_entity_call_args = AccountService.update_entity.call_args_list[0]

--- a/queue_services/entity-filer/tests/unit/test_worker/test_incorporation.py
+++ b/queue_services/entity-filer/tests/unit/test_worker/test_incorporation.py
@@ -127,8 +127,7 @@ def test_update_affiliation(app, session, legal_type, corp_num):
                                                           business_name=business.legal_name,
                                                           corp_type_code=business.legal_type,
                                                           pass_code = '',
-                                                          details=details,
-                                                          flags=None)
+                                                          details=details)
                     assert first_affiliation_call_args == expected_affiliation_call_args
 
                     first_update_entity_call_args = AccountService.update_entity.call_args_list[0]


### PR DESCRIPTION
*Issue #:* /bcgov/entity#27091

*Description of changes:*

Remove sandbox environment override code as we now have a standalone sandbox auth API. 

Changes include:

1. Remove Environment-Override header in `get_account_by_affiliated_identifier` & `create_affiliation` method
2. Remove FFs import and parameter
3. Clean up unused flags-related code

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
