### PR TITLE
27078 Versioning - Cascade delete relationship orphans

### DIFF
--- a/python/common/sql-versioning-alt/tests/__init__.py
+++ b/python/common/sql-versioning-alt/tests/__init__.py
@@ -68,7 +68,15 @@ class Email(Base, Versioned):
     name = Column(String)
 
     user_id = Column(Integer, ForeignKey('users.id'))
+    settings = orm.relationship('Setting', backref='email', cascade='all, delete, delete-orphan')
 
+class Setting(Base, Versioned):
+    __tablename__ = 'settings'
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+
+    email_id = Column(Integer, ForeignKey('emails.id'))
 
 class Item(Base):
     __tablename__ = 'items'

--- a/python/common/sql-versioning-alt/tests/test_versioning.py
+++ b/python/common/sql-versioning-alt/tests/test_versioning.py
@@ -18,7 +18,7 @@ Test-Suite to ensure that the versioning extension is working as expected.
 import pytest
 
 from sql_versioning import (version_class)
-from tests import (Base, Model, User, Address, Location, Email, Item, Transaction)
+from tests import (Base, Model, User, Address, Location, Email, Setting, Item, Transaction)
 
 
 @pytest.mark.parametrize('test_name', ['CLASS','INSTANCE'])
@@ -209,6 +209,41 @@ def test_versioning_relationships_remove(session):
             assert email_versions[i].operation_type == 0
         else:
             assert email_versions[i].operation_type == 2
+
+
+@pytest.mark.parametrize(
+        'parent_to_delete',
+        ['email', 'user']
+)
+def test_versioning_relationships_cascade_delete(session, parent_to_delete):
+    """Test cascade delete from relationship via remove."""
+    # Setup
+    user = User(name='test')
+    email = Email(name='email')
+    setting = Setting(name='setting')
+    email.settings.append(setting)
+    user.emails.append(email)
+    session.add(user)
+    session.commit()
+
+    if (parent_to_delete == 'email'):
+        user = session.query(User).one_or_none()
+        existing_email = user.emails[0]
+        user.emails.remove(existing_email)
+        session.add(user)
+        session.commit()
+    else:
+        user = session.query(User).one_or_none()
+        session.delete(user)
+        session.commit()
+
+    # Check 
+    setting_versions = session.query(version_class(Setting))\
+        .order_by(version_class(Setting).transaction_id)\
+        .all()
+    assert len(setting_versions) == 2
+    assert setting_versions[0].operation_type == 0
+    assert setting_versions[1].operation_type == 2
 
 
 def test_versioning_delete(session):

--- a/python/common/sql-versioning/sql_versioning/versioning.py
+++ b/python/common/sql-versioning/sql_versioning/versioning.py
@@ -19,6 +19,7 @@ from sqlalchemy import (BigInteger, Column, DateTime, Integer, SmallInteger,
                         update)
 from sqlalchemy.ext.declarative import declarative_base, declared_attr
 from sqlalchemy.orm import Session, mapper, relationships
+from sqlalchemy.orm.dynamic import AppenderQuery
 
 from .relationship_builder import RelationshipBuilder
 
@@ -48,6 +49,9 @@ def _is_obj_modified(obj):
 
 def _should_relationship_delete_orphan(session, obj):
     """
+    Whether this object is orphaned from a relationship. This is primarily used  when the 
+    relationship structure is something like parent->child and parent.remove(child) is used.
+
     Checks if:
         1. This relationship is a many-to-one relationship
         2. If the opposite direction one-to-many relationship parent object has changes
@@ -65,6 +69,41 @@ def _should_relationship_delete_orphan(session, obj):
             if parent_obj in session.dirty:
                 should_delete = should_delete or "delete-orphan" in inspect(reverse_rel)._cascade
     return should_delete
+
+
+def _cascade_delete_relationship_orphans(session):
+    """
+    Marks for deletion relationship orphans that have cascade=delete-orphan. This is primarily
+    used for persisting deletions down to a grandchild object (and beyond) when the relationship 
+    structure is something like parent->child->grandchild->(...) and parent.remove(child) is used.
+    
+    Iterates through changed versioned objects and checks if:
+        1. The operation type is D (delete)
+        2. This object (considered the child) is an orphan that should be deleted.
+        3. The relationship from child to grandchild is one-to-many
+        4. The relationship from child to grandchild has cascade="delete, delete-orphan"
+
+    If all conditions are met, mark the grandchild object for deletion.
+
+    :param session: The database session instance.
+    """
+    for obj in versioned_objects(session):
+        should_delete_orphan = _should_relationship_delete_orphan(session, obj)
+        operation_type = _get_operation_type(session, obj, should_delete_orphan)
+        for r in inspect(obj.__class__).relationships:
+            if (
+                operation_type == 'D' and
+                should_delete_orphan and
+                r.direction.name == 'ONETOMANY' and
+                'delete' in r._cascade and
+                'delete-orphan' in r._cascade
+            ):
+                with session.no_autoflush:
+                    relationship_objects = getattr(obj, r.key)
+                    if isinstance(relationship_objects, AppenderQuery):
+                        relationship_objects = relationship_objects.all()
+                    for r_obj in relationship_objects:
+                        session.delete(r_obj)
 
 
 def _is_session_modified(session):
@@ -262,6 +301,8 @@ def _before_flush(session, flush_context, instances):
         if 'current_transaction_id' not in session.info:
             transaction_manager = TransactionManager(session)
             transaction_manager.create_transaction()
+
+        _cascade_delete_relationship_orphans(session)
 
     except Exception as e:
         raise e

--- a/python/common/sql-versioning/tests/__init__.py
+++ b/python/common/sql-versioning/tests/__init__.py
@@ -68,7 +68,15 @@ class Email(Base, Versioned):
     name = Column(String)
 
     user_id = Column(Integer, ForeignKey('users.id'))
+    settings = orm.relationship('Setting', backref='email', cascade='all, delete, delete-orphan')
 
+class Setting(Base, Versioned):
+    __tablename__ = 'settings'
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+
+    email_id = Column(Integer, ForeignKey('emails.id'))
 
 class Item(Base):
     __tablename__ = 'items'


### PR DESCRIPTION
*Issue #:* /bcgov/entity#27078

*Description of changes:*
- Fix relationships orphans not getting deleted when cascade="delete, delete-orphan" is set

*Analysis:*
- Cascade delete on an orphaned record removes the non versioned records without issue. It properly creates the version record for the orphaned record. It does not however create the version record for cascade deleted records. 
```
# relationships: parent -> child -> grandchild
parent.remove(child)

# result:
# - child deleted
# - grandchild deleted
# - child_version delete record IS created
# - grandchild_version delete record NOT created
```

- This could be because SQLAlchemy emits a DELETE command for the child to grandchild relationship, but the grandchild object does not actually get added to session.delete or session.dirty. In order to resolve this we need to manually add the grandchild object to session.deleted before it is flushed.

_Testing:_

- Verified that all tables created correctly for
```
# relationships: parent -> child -> grandchild
parent.remove(child)
# result: all tables created correctly

# relationships: parent -> child -> grandchild -> great-grandchild
parent.remove(child)
# result: all tables created correctly

```

- Verified `business.share_classes.remove(share_class)` also creates to correct `share_series_version` records
<img width="1273" alt="Screenshot 2025-04-10 at 6 40 26 PM" src="https://github.com/user-attachments/assets/de9611e6-783a-4f93-80b3-be95cf62b738" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
