### PR TITLE
27144 - Update Output Title for CCO and CAO Consent Letter

### DIFF
--- a/legal-api/report-templates/letterOfConsent.html
+++ b/legal-api/report-templates/letterOfConsent.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Letter Under Seal</title>
+    <title>Consent Letter</title>
     <meta charset="UTF-8">
     <meta name="author" content="BC Registries and Online Services">
     [[common/style.html]]

--- a/legal-api/report-templates/letterOfConsentAmalgamationOut.html
+++ b/legal-api/report-templates/letterOfConsentAmalgamationOut.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Letter Under Seal</title>
+    <title>Consent Letter</title>
     <meta charset="UTF-8">
     <meta name="author" content="BC Registries and Online Services">
     [[common/style.html]]


### PR DESCRIPTION
*Issue #:* /bcgov/entity#27144

*Description of changes:*
- Update the output tittle to say "Consent Letter" when open the pdf in the tab (for both CCO and CAO)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
