### PR TITLE
Include NOA for BEN correction statements

### DIFF
--- a/colin-api/src/colin_api/models/filing.py
+++ b/colin-api/src/colin_api/models/filing.py
@@ -2025,7 +2025,8 @@ class Filing:  # pylint: disable=too-many-instance-attributes;
                                       'filing_type': filing.filing_type,
                                       'filing_sub_type': None})
 
-            if bool(filing.body.get('commentOnly', False)):  # only comment added
+            # only comment added or running BEN correction statement job
+            if bool(filing.body.get('commentOnly', False)) or bool(filing.header.get('correctionBenStatement', False)):
                 filing_type_code = Filing.FILING_TYPES[filing.filing_type][f'{sub_type}_COMMENT_ONLY']
                 event_id = cls._process_comment_correction(cursor, filing, corp_num, filing_type_code)
 

--- a/jobs/correction-ben-statement/add_corrections.ipynb
+++ b/jobs/correction-ben-statement/add_corrections.ipynb
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -117,8 +117,7 @@
     "                \"details\": \"BEN Correction statement\",\n",
     "                \"correctedFilingId\": filind_id,\n",
     "                \"correctedFilingType\": \"incorporationApplication\",\n",
-    "                \"comment\": f\"\"\"Correction for Incorporation Application filed on {formatted_current_date} \\n{correction_statement}\"\"\",\n",
-    "                \"commentOnly\": True\n",
+    "                \"comment\": f\"\"\"Correction for Incorporation Application filed on {formatted_current_date} \\n{correction_statement}\"\"\"\n",
     "            }\n",
     "        }\n",
     "    }\n",


### PR DESCRIPTION
*Issue #:* /bcgov/entity#27376

*Description of changes:*

Based on recent discussions with business it was requested to have NOA for BEN correction statements. (NOA is still suppressed for Correction on the ledger/empty correction)

To enable it, removed `"commentOnly": True` from BEN correction statement job payload and added a check for `correctionBenStatement` to sync this back to COLIN

Test in DEV: https://dev.business-dashboard.bcregistry.gov.bc.ca/BC0887853?accountid=3040

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
