### PR TITLE
27375 - Remove comment for Dissolution sync

### DIFF
--- a/colin-api/src/colin_api/models/filing.py
+++ b/colin-api/src/colin_api/models/filing.py
@@ -1713,8 +1713,7 @@ class Filing:  # pylint: disable=too-many-instance-attributes;
                 corp_num=corp_num,
                 office_type=office_type
             )
-            office_desc = (office_type.replace('O', ' O')).title()
-            return f'Change to the {office_desc}.'
+            return ''
 
         for office_type in filing.body.get('offices', []):
             Office.create_new_office(


### PR DESCRIPTION
*Issue #:* /bcgov/entity#27375

*Description of changes:*

Removed comment for Dissolution sync

I looked in the code and looks like this is an issue only for Voluntary Dissolution. Involuntary and Administrative dissolutions update corp state and make it historical.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
