### PR TITLE
27271 Tombstone - implement cease liquidator, ceased liquidator updates & misc

### DIFF
--- a/data-tool/flows/tombstone/tombstone_mappings.py
+++ b/data-tool/flows/tombstone/tombstone_mappings.py
@@ -128,6 +128,7 @@ class EventFilings(str, Enum):
     FILE_NOAPL = 'FILE_NOAPL'
     FILE_NOARM = 'FILE_NOARM'
     FILE_NOCDS = 'FILE_NOCDS'
+    FILE_NOCEL = 'FILE_NOCEL'
     FILE_NOCER = 'FILE_NOCER'
 
     # TODO: Notice of Withdrawal - unsupported
@@ -276,6 +277,7 @@ EVENT_FILING_LEAR_TARGET_MAPPING = {
     EventFilings.FILE_NOAPL: 'appointLiquidator',
     EventFilings.FILE_NOARM: 'appointReceiver',
     EventFilings.FILE_NOCDS: 'changeRespectingDCR',
+    EventFilings.FILE_NOCEL: 'ceaseLiquidator',
     EventFilings.FILE_NOCER: 'ceaseReceiver',
 
     EventFilings.FILE_NWITH: 'noticeOfWithdrawal',
@@ -391,12 +393,12 @@ EVENT_FILING_DISPLAY_NAME_MAPPING = {
     # NOLDS: "Notice of Location of Dissolved Company's Records"
     # NOTRA: 'Notice of Transfer of Records'
     # NOCAL: 'Notice of Change of Address of Liquidator And/Or Liquidation Records Office'
-    # NOCEL: 'Notice of Ceasing to Act as Liquidator'
     # LIQUR: 'Liquidation Report'
     # LQWOS: 'Notice of Withdrawal Statement of Intent to Liquidate'
     EventFilings.FILE_NOAPL: 'Notice of Appointment of Liquidator',
     EventFilings.FILE_NOARM: 'Notice of Appointment of Receiver or Receiver Manager',
     EventFilings.FILE_NOCDS: 'Notice of Change Respecting Dissolved Company\'s Records',
+    EventFilings.FILE_NOCEL: 'Notice of Ceasing to Act as Liquidator',
     EventFilings.FILE_NOCER: 'Notice of Ceasing to Act as Receiver or Receiver Manager',
     # LQSIN: 'Statement of Intent to Liquidate'
     # LQSCO: 'Stay of Liquidation - Court Ordered'

--- a/data-tool/flows/tombstone/tombstone_utils.py
+++ b/data-tool/flows/tombstone/tombstone_utils.py
@@ -134,7 +134,7 @@ def format_parties_data(data: dict) -> list[dict]:
     }
 
     df = pd.DataFrame(parties_data)
-    df['group_by_key'] = (df['cp_full_name'] + '_' + df['cp_party_typ_cd'] + '_' +
+    df['group_by_key'] = (df['partial_group_key'] + '_' + df['cp_party_typ_cd'] + '_' +
                           df['cp_cessation_dt_str'].fillna('active'))
 
     grouped_parties = df.groupby('group_by_key')
@@ -185,7 +185,10 @@ def format_parties_data(data: dict) -> list[dict]:
             party_role['appointment_date'] = appointment_date
 
             cessation_date = None
-            if cessation_date := r['cp_cessation_dt_str']:
+            if role_code == 'LIQ':
+                if end_event_date := r['cp_end_event_dt_str']:
+                    cessation_date = end_event_date
+            elif cessation_date := r['cp_cessation_dt_str']:
                 cessation_date = cessation_date + ' 00:00:00+00:00'
             party_role['cessation_date'] = cessation_date
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#27271

*Description of changes:*
- Implement cease liquidator in pipeline
- Bring over ceased liquidator
    - It's a hacky solution for liquidator only.
    - There's only a small number of liquidator with `end_event_id` in COLIN.
    - This solution may not cover all the edge cases.
    - We need to sort every party type out in another work. e.g. https://github.com/bcgov/entity/issues/26973
- Fix for party group-by key

**⭐ Let me know if anyone has any questions, thanks!**

_Testing_

The following businesses are loaded in dev and affiliated to account `3446`
- Tesing data
```python
# cease liquidator filing
BC0246322
BC0442887

# liquidators got updated by filings, having both active and ceased liquidator
BC0318959
```
- DB
![image](https://github.com/user-attachments/assets/cb6ed11a-36c5-4142-8ea5-a1d7a1c7eed3)
![image](https://github.com/user-attachments/assets/8e283814-884a-42bd-b835-cc8b8095a186)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
