### PR TITLE
27492 - Add Custom Auth Handler with Missing Header

### DIFF
--- a/legal-api/src/legal_api/__init__.py
+++ b/legal-api/src/legal_api/__init__.py
@@ -19,8 +19,7 @@ import os
 
 import sentry_sdk  # noqa: I001; pylint: disable=ungrouped-imports; conflicts with Flake8
 from sentry_sdk.integrations.flask import FlaskIntegration  # noqa: I001
-from flask import Flask, make_response, jsonify  # noqa: I001
-from flask_jwt_oidc.exceptions import AuthError
+from flask import Flask, jsonify  # noqa: I001
 from registry_schemas import __version__ as registry_schemas_version  # noqa: I005
 from registry_schemas.flask import SchemaServices  # noqa: I001
 

--- a/legal-api/src/legal_api/__init__.py
+++ b/legal-api/src/legal_api/__init__.py
@@ -81,13 +81,14 @@ def setup_jwt_manager(app, jwt_manager):
         return a_dict['realm_access']['roles']  # pragma: no cover
     app.config['JWT_ROLE_CALLBACK'] = get_roles
 
-    jwt_manager.init_app(app)
-
-    @app.errorhandler(AuthError)
-    def custom_auth_error_handler(error):
-        response = make_response(jsonify(error.error), error.status_code)
+    def custom_auth_error_handler(ex):
+        response = jsonify(ex.error)
+        response.status_code = ex.status_code
         response.headers['Access-Control-Allow-Origin'] = '*'
         return response
+    app.config['JWT_OIDC_AUTH_ERROR_HANDLER'] = custom_auth_error_handler
+
+    jwt_manager.init_app(app)
 
 
 def register_shellcontext(app):

--- a/legal-api/src/legal_api/__init__.py
+++ b/legal-api/src/legal_api/__init__.py
@@ -19,7 +19,8 @@ import os
 
 import sentry_sdk  # noqa: I001; pylint: disable=ungrouped-imports; conflicts with Flake8
 from sentry_sdk.integrations.flask import FlaskIntegration  # noqa: I001
-from flask import redirect, Flask  # noqa: I001
+from flask import Flask, make_response, jsonify  # noqa: I001
+from flask_jwt_oidc.exceptions import AuthError
 from registry_schemas import __version__ as registry_schemas_version  # noqa: I005
 from registry_schemas.flask import SchemaServices  # noqa: I001
 
@@ -81,6 +82,12 @@ def setup_jwt_manager(app, jwt_manager):
     app.config['JWT_ROLE_CALLBACK'] = get_roles
 
     jwt_manager.init_app(app)
+
+    @app.errorhandler(AuthError)
+    def custom_auth_error_handler(error):
+        response = make_response(jsonify(error.error), error.status_code)
+        response.headers['Access-Control-Allow-Origin'] = '*'
+        return response
 
 
 def register_shellcontext(app):


### PR DESCRIPTION
*Issue #:* /bcgov/entity#27492

*Description of changes:*
- add missing `Access-Control-Allow-Origin` header to Auth Error Handler 
- remove unused redirect import from `flask`

![image](https://github.com/user-attachments/assets/b4283df5-905e-4b33-8b91-fbce5d6b2166)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
