### PR TITLE
27199 - Use current registrar info for corrections

### DIFF
--- a/legal-api/report-templates/template-parts/common/correctedOnCertificate.html
+++ b/legal-api/report-templates/template-parts/common/correctedOnCertificate.html
@@ -5,12 +5,12 @@
       {% set date, time = effective_date_time.split(' at ') %}
       Corrected on {{date}}<br/>at {{time}}
       {% endautoescape %}
-      {% if currentRegistrarInfo %}
+      {% if registrarInfo %}
          <div class="current-registrar-signature">
-            <img alt="signature" src={{currentRegistrarInfo.signature}}>
+            <img alt="signature" src={{registrarInfo.signature}}>
          </div>
-         <div class="current-registrar-name">{{ currentRegistrarInfo.name }}</div>
-         <div class="current-registrar-title">{{ currentRegistrarInfo.title }}</div>
+         <div class="current-registrar-name">{{ registrarInfo.name }}</div>
+         <div class="current-registrar-title">{{ registrarInfo.title }}</div>
          <div class="current-registrar-province-country-info">
             <div>PROVINCE OF BRITISH COLUMBIA</div>
             <div>CANADA</div>

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -341,8 +341,8 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
         if filing.get('correction'):
             original_filing = Filing.find_by_id(filing.get('correction').get('correctedFilingId'))
             original_registrar = {**RegistrarInfo.get_registrar_info(original_filing.effective_date)}
-            filing['registrarInfo'] = original_registrar
             current_registrar = {**RegistrarInfo.get_registrar_info(self._filing.effective_date)}
+            filing['registrarInfo'] = current_registrar
             if original_registrar['name'] != current_registrar['name']:
                 filing['currentRegistrarInfo'] = current_registrar
         elif filing.get('annualReport'):

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -339,12 +339,9 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
 
     def _set_registrar_info(self, filing):
         if filing.get('correction'):
-            original_filing = Filing.find_by_id(filing.get('correction').get('correctedFilingId'))
-            original_registrar = {**RegistrarInfo.get_registrar_info(original_filing.effective_date)}
             current_registrar = {**RegistrarInfo.get_registrar_info(self._filing.effective_date)}
             filing['registrarInfo'] = current_registrar
-            if original_registrar['name'] != current_registrar['name']:
-                filing['currentRegistrarInfo'] = current_registrar
+            filing['currentRegistrarInfo'] = current_registrar
         elif filing.get('annualReport'):
             # effective_date in annualReport will be ar_date or agm_date, which could be in past.
             filing['registrarInfo'] = {**RegistrarInfo.get_registrar_info(self._filing.filing_date)}

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -338,11 +338,7 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
                 self._format_address(filing['completingParty']['mailingAddress'])
 
     def _set_registrar_info(self, filing):
-        if filing.get('correction'):
-            current_registrar = {**RegistrarInfo.get_registrar_info(self._filing.effective_date)}
-            filing['registrarInfo'] = current_registrar
-            filing['currentRegistrarInfo'] = current_registrar
-        elif filing.get('annualReport'):
+        if filing.get('annualReport'):
             # effective_date in annualReport will be ar_date or agm_date, which could be in past.
             filing['registrarInfo'] = {**RegistrarInfo.get_registrar_info(self._filing.filing_date)}
         else:


### PR DESCRIPTION
*Issue #:* /bcgov/entity#27199

*Description of changes:*
- Use the current registrar's info instead of the original registrar's info for corrections

Before changes:
![image](https://github.com/user-attachments/assets/c00dc652-ff56-419c-913b-eadb58205aef)


After:
![image](https://github.com/user-attachments/assets/126cbb8e-d8a6-4548-b09c-01e79a176e55)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
