### PR TITLE
fix: dockerfile change default env to "production"

### DIFF
--- a/queue_services/business-filer/Dockerfile
+++ b/queue_services/business-filer/Dockerfile
@@ -15,7 +15,7 @@ LABEL org.label-schema.vcs-ref=${VCS_REF} \
 LABEL maintainer="thorwolpert"
 LABEL vendor="BCROS"
 
-ARG APP_ENV \
+ARG APP_ENV="production" \
   # Needed for fixing permissions of files created by Docker:
   UID=1000 \
   GID=1000

--- a/queue_services/business-filer/Makefile
+++ b/queue_services/business-filer/Makefile
@@ -61,7 +61,7 @@ build: ## Build the docker container
 	docker build . -t $(DOCKER_NAME) \
 		--platform linux/amd64 \
 		--build-arg VCS_REF=$(shell git rev-parse --short HEAD) \
-		--build-arg BUILD_DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ") \
+		--build-arg BUILD_DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 build-nc: ## Build the docker container without caching
 	docker build --no-cache -t $(DOCKER_NAME) .


### PR DESCRIPTION
*Issue #:* /bcgov/entity#26307

*Description of changes:*
- removed dangling \ in Makefile
- updated Dockerfile for ENV default to "production"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
