### PR TITLE
26973 Tombstone - add ceased parties

### DIFF
--- a/data-tool/flows/batch_delete_flow.py
+++ b/data-tool/flows/batch_delete_flow.py
@@ -13,14 +13,14 @@ from sqlalchemy.engine import Engine
 businesses_cnt_query = """
 SELECT COUNT(*) FROM businesses
 WHERE 1 = 1
-AND legal_type IN ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+AND legal_type IN ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE', 'BEN')
 AND legal_name LIKE '%' || :corp_name_suffix
 """
 
 identifiers_query = """
 SELECT id, identifier FROM businesses
 WHERE 1 = 1 
-AND legal_type IN ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+AND legal_type IN ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE', 'BEN')
 AND legal_name LIKE '%' || :corp_name_suffix
 LIMIT :batch_size
 """


### PR DESCRIPTION
*Issue #:* /bcgov/entity#26973

*Description of changes:*
**Note that the logic updates are excluding officer for now until further notice**
- Update logic to bring over ceased parties for
    - director
    - liquidator
    - receiver
    - custodian
- Update logic to get appointment date
 - Misc updates

_Testing_

The following businesses are loaded in dev and affiliated to account `3446` (most businesses are affiliated except BC1249698 and BC0878472)

```python
# director
BC0000621
BC1249698  # person with the same was appointed at different period of time
BC0018656  # person with the same was appointed as both director and officer

# liquidator
BC0752755
BC0318959  # liquidator updated by filings, ceased liquidator

# receiver
BC0835125 # 2 receivers with the same name and colin keeps both of them
BC0231750
BC0043660 # ceased receiver

# custodian
BC0529476 # ceased custodian and active custodian for different period of time
BC0599178 # ceased custodian
BC0878472
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
