### PR TITLE
added a is_competent_authority function to authz, removed receipt fro…

### DIFF
--- a/legal-api/src/legal_api/config.py
+++ b/legal-api/src/legal_api/config.py
@@ -317,6 +317,18 @@ NrQw+2OdQACBJiEHsdZzAkBcsTk7frTH4yGx0VfHxXDPjfTj4wmD6gZIlcIr9lZg
     # determines which version of NAICS data will be used to drive NAICS search
     NAICS_VERSION = 1
 
+    LEGAL_API_BASE_URL="https://LEGAL_API_BASE_URL/api/v2/businesses"
+    PAYMENT_SVC_URL="https://PAY_SVC_URL/api/v1/payment-requests"
+
+    BUSINESS_SCHEMA_ID = os.getenv("BUSINESS_SCHEMA_ID", "TEST_BUSINESS_SCHEMA_ID")
+    BUSINESS_CRED_DEF_ID = os.getenv("BUSINESS_CRED_DEF_ID", "TEST_BUSINESS_SCHEMA_ID")
+
+    TRACTION_API_URL = os.getenv("TRACTION_API_URL", "https://TRACTION_API_URL")
+    TRACTION_TENANT_ID = os.getenv("TRACTION_TENANT_ID", "TRACTION_TENANT_ID")
+    TRACTION_API_KEY = os.getenv("TRACTION_API_KEY", "TRACTION_API_KEY")
+    TRACTION_PUBLIC_SCHEMA_DID = os.getenv("TRACTION_PUBLIC_SCHEMA_DID", "TRACTION_PUBLIC_SCHEMA_DID")
+    TRACTION_PUBLIC_ISSUER_DID = os.getenv("TRACTION_PUBLIC_ISSUER_DID", "TRACTION_PUBLIC_ISSUER_DID")
+
 
 class ProdConfig(_Config):  # pylint: disable=too-few-public-methods
     """Production environment configuration."""

--- a/legal-api/src/legal_api/core/filing.py
+++ b/legal-api/src/legal_api/core/filing.py
@@ -30,7 +30,7 @@ from legal_api.models import Business, Document, DocumentType
 from legal_api.models import Filing as FilingStorage  # noqa: I001
 from legal_api.models import UserRoles
 from legal_api.services import VersionedBusinessDetailsService  # noqa: I005
-from legal_api.services.authz import has_roles  # noqa: I005
+from legal_api.services.authz import has_roles, is_competent_authority  # noqa: I005
 from legal_api.utils.datetime import date, datetime  # noqa: I005
 
 from .constants import REDACTED_STAFF_SUBMITTER
@@ -522,13 +522,17 @@ class Filing:  # pylint: disable=too-many-public-methods
         if filing.storage and filing.storage.filing_type in no_output_filings:
             return documents
 
-        # return a receipt for filings completed in our system
-        if filing.storage and filing.storage.payment_completion_date:
-            if filing.filing_type == 'courtOrder' and \
-                    (filing.storage.documents.filter(
-                        Document.type == DocumentType.COURT_ORDER.value).one_or_none()):
-                documents['documents']['uploadedCourtOrder'] = f'{base_url}{doc_url}/uploadedCourtOrder'
-            documents['documents']['receipt'] = f'{base_url}{doc_url}/receipt'
+        user_is_ca = is_competent_authority(jwt.get_token_auth_header())
+
+        # return a receipt for filings completed in our system (but not for ca users
+        # see https://github.com/bcgov/entity/issues/21881
+        if not(user_is_ca):
+            if filing.storage and filing.storage.payment_completion_date:
+                if filing.filing_type == 'courtOrder' and \
+                        (filing.storage.documents.filter(
+                            Document.type == DocumentType.COURT_ORDER.value).one_or_none()):
+                    documents['documents']['uploadedCourtOrder'] = f'{base_url}{doc_url}/uploadedCourtOrder'
+                documents['documents']['receipt'] = f'{base_url}{doc_url}/receipt'
 
         no_legal_filings_in_paid_withdrawn_status = [
             Filing.FilingTypes.AMALGAMATIONOUT.value,

--- a/legal-api/src/legal_api/core/filing.py
+++ b/legal-api/src/legal_api/core/filing.py
@@ -526,7 +526,7 @@ class Filing:  # pylint: disable=too-many-public-methods
 
         # return a receipt for filings completed in our system (but not for ca users
         # see https://github.com/bcgov/entity/issues/21881
-        if not user_is_ca and filing.storage and filing.storage.payment_completion_date:
+        if filing.storage and filing.storage.payment_completion_date:
             if filing.filing_type == 'courtOrder' and \
                     (filing.storage.documents.filter(
                         Document.type == DocumentType.COURT_ORDER.value).one_or_none()):
@@ -555,6 +555,8 @@ class Filing:  # pylint: disable=too-many-public-methods
                  ):
             documents['documents']['legalFilings'] = \
                 [{filing.filing_type: f'{base_url}{doc_url}/{filing.filing_type}'}, ]
+            if user_is_ca:
+                del documents['documents']['receipt']
             return documents
 
         if filing.status in (
@@ -606,4 +608,6 @@ class Filing:  # pylint: disable=too-many-public-methods
                     if static_docs := FilingMeta.get_static_documents(filing.storage, f'{base_url}{doc_url}/static'):
                         documents['documents']['staticDocuments'] = static_docs
 
+        if user_is_ca:
+            del documents['documents']['receipt']
         return documents

--- a/legal-api/src/legal_api/core/filing.py
+++ b/legal-api/src/legal_api/core/filing.py
@@ -522,7 +522,7 @@ class Filing:  # pylint: disable=too-many-public-methods
         if filing.storage and filing.storage.filing_type in no_output_filings:
             return documents
 
-        user_is_ca = is_competent_authority()
+        user_is_ca = is_competent_authority(jwt)
 
         # return a receipt for filings completed in our system (but not for ca users
         # see https://github.com/bcgov/entity/issues/21881

--- a/legal-api/src/legal_api/core/filing.py
+++ b/legal-api/src/legal_api/core/filing.py
@@ -522,17 +522,16 @@ class Filing:  # pylint: disable=too-many-public-methods
         if filing.storage and filing.storage.filing_type in no_output_filings:
             return documents
 
-        user_is_ca = is_competent_authority(jwt.get_token_auth_header())
+        user_is_ca = is_competent_authority()
 
         # return a receipt for filings completed in our system (but not for ca users
         # see https://github.com/bcgov/entity/issues/21881
-        if not(user_is_ca):
-            if filing.storage and filing.storage.payment_completion_date:
-                if filing.filing_type == 'courtOrder' and \
-                        (filing.storage.documents.filter(
-                            Document.type == DocumentType.COURT_ORDER.value).one_or_none()):
-                    documents['documents']['uploadedCourtOrder'] = f'{base_url}{doc_url}/uploadedCourtOrder'
-                documents['documents']['receipt'] = f'{base_url}{doc_url}/receipt'
+        if not user_is_ca and filing.storage and filing.storage.payment_completion_date:
+            if filing.filing_type == 'courtOrder' and \
+                    (filing.storage.documents.filter(
+                        Document.type == DocumentType.COURT_ORDER.value).one_or_none()):
+                documents['documents']['uploadedCourtOrder'] = f'{base_url}{doc_url}/uploadedCourtOrder'
+            documents['documents']['receipt'] = f'{base_url}{doc_url}/receipt'
 
         no_legal_filings_in_paid_withdrawn_status = [
             Filing.FilingTypes.AMALGAMATIONOUT.value,

--- a/legal-api/src/legal_api/services/authz.py
+++ b/legal-api/src/legal_api/services/authz.py
@@ -1008,4 +1008,5 @@ def has_product(code: str, token: str) -> bool:
     return any(p['code'] == code and p['subscriptionStatus'] == 'ACTIVE' for p in user_products)
 
 def is_competent_authority() -> bool:
+    """Return if the user has the active ca_search subscription."""
     return has_product('CA_SEARCH', jwt.get_token_auth_header())

--- a/legal-api/src/legal_api/services/authz.py
+++ b/legal-api/src/legal_api/services/authz.py
@@ -582,8 +582,7 @@ def is_allowed(business: Business,
 
 def get_could_files(jwt: JwtManager, business_type: str, business_state: str):
     """Get allowable actions."""
-    is_competent_authority = has_product('CA_SEARCH', jwt.get_token_auth_header())
-    if is_competent_authority:
+    if is_competent_authority(jwt.get_token_auth_header()):
         allowed_filings = []
     else:
         allowed_filings = get_could_file(business_type, business_state, jwt)
@@ -598,8 +597,7 @@ def get_could_files(jwt: JwtManager, business_type: str, business_state: str):
 
 def get_allowable_actions(jwt: JwtManager, business: Business):
     """Get allowable actions."""
-    is_competent_authority = has_product('CA_SEARCH', jwt.get_token_auth_header())
-    if is_competent_authority:
+    if is_competent_authority(jwt.get_token_auth_header()):
         allowed_filings = []
     else:
         allowed_filings = get_allowed_filings(business, business.state, business.legal_type, jwt)
@@ -614,7 +612,7 @@ def get_allowable_actions(jwt: JwtManager, business: Business):
         },
         'digitalBusinessCard': are_digital_credentials_allowed(business, jwt),
         'digitalBusinessCardPreconditions': get_digital_credentials_preconditions(business, jwt),
-        'viewAll': is_competent_authority
+        'viewAll': is_competent_authority(jwt.get_token_auth_header())
     }
     return result
 
@@ -1008,3 +1006,6 @@ def has_product(code: str, token: str) -> bool:
         return False
 
     return any(p['code'] == code and p['subscriptionStatus'] == 'ACTIVE' for p in user_products)
+
+def is_competent_authority(token: str) -> bool:
+    return has_product('CA_SEARCH', token)

--- a/legal-api/src/legal_api/services/authz.py
+++ b/legal-api/src/legal_api/services/authz.py
@@ -582,7 +582,7 @@ def is_allowed(business: Business,
 
 def get_could_files(jwt: JwtManager, business_type: str, business_state: str):
     """Get allowable actions."""
-    if is_competent_authority(jwt.get_token_auth_header()):
+    if is_competent_authority():
         allowed_filings = []
     else:
         allowed_filings = get_could_file(business_type, business_state, jwt)
@@ -597,7 +597,7 @@ def get_could_files(jwt: JwtManager, business_type: str, business_state: str):
 
 def get_allowable_actions(jwt: JwtManager, business: Business):
     """Get allowable actions."""
-    if is_competent_authority(jwt.get_token_auth_header()):
+    if is_competent_authority():
         allowed_filings = []
     else:
         allowed_filings = get_allowed_filings(business, business.state, business.legal_type, jwt)
@@ -612,7 +612,7 @@ def get_allowable_actions(jwt: JwtManager, business: Business):
         },
         'digitalBusinessCard': are_digital_credentials_allowed(business, jwt),
         'digitalBusinessCardPreconditions': get_digital_credentials_preconditions(business, jwt),
-        'viewAll': is_competent_authority(jwt.get_token_auth_header())
+        'viewAll': is_competent_authority()
     }
     return result
 
@@ -1007,5 +1007,5 @@ def has_product(code: str, token: str) -> bool:
 
     return any(p['code'] == code and p['subscriptionStatus'] == 'ACTIVE' for p in user_products)
 
-def is_competent_authority(token: str) -> bool:
-    return has_product('CA_SEARCH', token)
+def is_competent_authority() -> bool:
+    return has_product('CA_SEARCH', jwt.get_token_auth_header())

--- a/legal-api/src/legal_api/services/authz.py
+++ b/legal-api/src/legal_api/services/authz.py
@@ -582,7 +582,7 @@ def is_allowed(business: Business,
 
 def get_could_files(jwt: JwtManager, business_type: str, business_state: str):
     """Get allowable actions."""
-    if is_competent_authority():
+    if is_competent_authority(jwt):
         allowed_filings = []
     else:
         allowed_filings = get_could_file(business_type, business_state, jwt)
@@ -597,7 +597,7 @@ def get_could_files(jwt: JwtManager, business_type: str, business_state: str):
 
 def get_allowable_actions(jwt: JwtManager, business: Business):
     """Get allowable actions."""
-    if is_competent_authority():
+    if is_competent_authority(jwt):
         allowed_filings = []
     else:
         allowed_filings = get_allowed_filings(business, business.state, business.legal_type, jwt)
@@ -612,7 +612,7 @@ def get_allowable_actions(jwt: JwtManager, business: Business):
         },
         'digitalBusinessCard': are_digital_credentials_allowed(business, jwt),
         'digitalBusinessCardPreconditions': get_digital_credentials_preconditions(business, jwt),
-        'viewAll': is_competent_authority()
+        'viewAll': is_competent_authority(jwt)
     }
     return result
 
@@ -1007,6 +1007,6 @@ def has_product(code: str, token: str) -> bool:
 
     return any(p['code'] == code and p['subscriptionStatus'] == 'ACTIVE' for p in user_products)
 
-def is_competent_authority() -> bool:
+def is_competent_authority(jwt: JwtManager) -> bool:
     """Return if the user has the active ca_search subscription."""
     return has_product('CA_SEARCH', jwt.get_token_auth_header())

--- a/legal-api/tests/unit/resources/v2/test_business_documents.py
+++ b/legal-api/tests/unit/resources/v2/test_business_documents.py
@@ -75,6 +75,7 @@ def test_get_business_documents(session, client, jwt):
     docs_json = rv.json
     assert docs_json['documents']
     assert docs_json['documents']['summary']
+    assert docs_json['documents']['receipt']
 
 def test_get_business_documents_ca(requests_mock, session, client, jwt):
     """Assert that business summary is not returned."""
@@ -94,7 +95,7 @@ def test_get_business_documents_ca(requests_mock, session, client, jwt):
     docs_json = rv.json
     assert docs_json['documents']
     assert docs_json['documents']['summary']
-    assert not docs_json['documents']['receipt']
+    assert not docs_json['documents'].get('receipt', False)
 
 
 def test_get_document_invalid_authorization(session, client, jwt):

--- a/legal-api/tests/unit/resources/v2/test_business_documents.py
+++ b/legal-api/tests/unit/resources/v2/test_business_documents.py
@@ -75,7 +75,6 @@ def test_get_business_documents(session, client, jwt):
     docs_json = rv.json
     assert docs_json['documents']
     assert docs_json['documents']['summary']
-    assert docs_json['documents']['receipt']
 
 def test_get_business_documents_ca(requests_mock, session, client, jwt):
     """Assert that business summary is not returned."""

--- a/legal-api/tests/unit/resources/v2/test_business_documents.py
+++ b/legal-api/tests/unit/resources/v2/test_business_documents.py
@@ -76,6 +76,26 @@ def test_get_business_documents(session, client, jwt):
     assert docs_json['documents']
     assert docs_json['documents']['summary']
 
+def test_get_business_documents_ca(requests_mock, session, client, jwt):
+    """Assert that business summary is not returned."""
+    # setup
+    identifier = 'CP7654321'
+    factory_business(identifier)
+    requests_mock.get(
+        f"{current_app.config.get('AUTH_SVC_URL')}/orgs/123456/products?include_hidden=true",
+        json=[{"code": "CA_SEARCH", "subscriptionStatus": "ACTIVE"}],
+    )
+    # test
+    rv = client.get(f'/api/v2/businesses/{identifier}/documents',
+                    headers=create_header(jwt, [STAFF_ROLE], identifier, **{'Account-Id': '123456'})
+                    )
+    # check
+    assert rv.status_code == HTTPStatus.OK
+    docs_json = rv.json
+    assert docs_json['documents']
+    assert docs_json['documents']['summary']
+    assert not docs_json['documents']['receipt']
+
 
 def test_get_document_invalid_authorization(session, client, jwt):
     """Assert that business summary is not returned."""

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
@@ -1684,7 +1684,7 @@ def test_get_receipt_no_receipt_ca(session, client, jwt, requests_mock):
 
     rv = client.get(f'/api/v2/businesses/{identifier}/filings/{filing.id}/documents',
                     headers=create_header(jwt,
-                                          [STAFF_ROLE],
+                                          [],
                                           identifier,
                                           **{'accept': 'application/pdf', 'Account-Id': '123456'})
                     )

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
@@ -1650,6 +1650,49 @@ def test_get_receipt_request_mock(session, client, jwt, requests_mock):
     assert requests_mock.called_once
 
 
+def test_get_receipt_no_receipt_ca(session, client, jwt, requests_mock):
+    """Assert that a receipt is generated."""
+    from legal_api.resources.v2.business.business_filings.business_documents import _get_receipt
+
+    # Setup
+    identifier = 'CP7654321'
+    business = factory_business(identifier)
+    filing_name = 'incorporationApplication'
+    payment_id = '12345'
+
+    filing_json = copy.deepcopy(FILING_HEADER)
+    filing_json['filing']['header']['name'] = filing_name
+    filing_json['filing'][filing_name] = INCORPORATION
+    filing_json['filing'].pop('business')
+
+    filing_date = datetime.utcnow()
+    filing = factory_filing(business, filing_json, filing_date=filing_date)
+    filing.skip_status_listener = True
+    filing._status = 'PAID'
+    filing._payment_token = payment_id
+    filing._payment_completion_date = filing_date
+    filing.save()
+
+    requests_mock.post(f"{current_app.config.get('PAYMENT_SVC_URL')}/{payment_id}/receipts",
+                       json={'foo': 'bar'},
+                       status_code=HTTPStatus.CREATED)
+
+    requests_mock.get(
+        f"{current_app.config.get('AUTH_SVC_URL')}/orgs/123456/products?include_hidden=true",
+        json=[{"code": "CA_SEARCH", "subscriptionStatus": "ACTIVE"}],
+    )
+
+    rv = client.get(f'/api/v2/businesses/{identifier}/filings/{filing.id}/documents',
+                    headers=create_header(jwt,
+                                          [STAFF_ROLE],
+                                          identifier,
+                                          **{'accept': 'application/pdf', 'Account-Id': '123456'})
+                    )
+
+    assert rv.status_code == HTTPStatus.OK
+    assert not rv.json.get('documents').get('receipt', False)
+
+
 @pytest.mark.parametrize('test_name, temp_identifier, entity_type, expected_msg, expected_http_code', [
     ('now_ia_paid', 'Tb31yQIuBw', Business.LegalTypes.BCOMP.value,
      {'documents': {'receipt': f'{base_url}/api/v2/businesses/Tb31yQIuBw/filings/1/documents/receipt',


### PR DESCRIPTION
…m CA users response (ca can't file a receipt and should never see one)

*Issue #:* /bcgov/entity#21881

*Description of changes:*
Added a funciton in authz to check for CA and simplified existing checks to use that function
Check if user is a CA before adding receipt to the document responses as CA shouldn't be able to see the receipts ever

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
