### PR TITLE
28413 Legal API - Hide unsupported party roles based on FF

### DIFF
--- a/legal-api/flags.json
+++ b/legal-api/flags.json
@@ -22,6 +22,7 @@
             "dissolutions-job": true,
             "furnishings-job": true,
             "emailer-reminder-job": true
-        }
+        },
+        "unsupported-party-roles": ["officer", "receiver", "liquidator"]
     }
 }

--- a/legal-api/flags.json
+++ b/legal-api/flags.json
@@ -22,7 +22,6 @@
             "dissolutions-job": true,
             "furnishings-job": true,
             "emailer-reminder-job": true
-        },
-        "unsupported-party-roles": ["officer", "receiver", "liquidator"]
+        }
     }
 }

--- a/legal-api/src/legal_api/models/party_role.py
+++ b/legal-api/src/legal_api/models/party_role.py
@@ -138,10 +138,10 @@ class PartyRole(db.Model, Versioned):
             filter(PartyRole.business_id == business_id)
 
         # TODO: rework the unsupported party roles section; change-on-change to still bring back these roles
-        if not role or role.lower() not in unsupported_roles:
-            party_roles = party_roles.filter(PartyRole.role.notin_(unsupported_roles))
-        if role is not None:
+        if role:
             party_roles = party_roles.filter(PartyRole.role == role.lower())
+        else:
+            party_roles = party_roles.filter(PartyRole.role.notin_(unsupported_roles))
 
         if end_date is not None:
             party_roles = party_roles.filter(cast(PartyRole.appointment_date, Date) <= end_date). \

--- a/legal-api/src/legal_api/models/party_role.py
+++ b/legal-api/src/legal_api/models/party_role.py
@@ -128,13 +128,16 @@ class PartyRole(db.Model, Versioned):
     @staticmethod
     def get_party_roles(business_id: int, end_date: datetime = None, role: str = None) -> list:
         """Return the parties that match the filter conditions."""
-        from legal_api.services import flags  # pylint: disable=import-outside-toplevel
+        unsupported_roles = [
+            PartyRole.RoleTypes.OFFICER.value,
+            PartyRole.RoleTypes.LIQUIDATOR.value,
+            PartyRole.RoleTypes.RECEIVER.value,
+        ]
 
         party_roles = db.session.query(PartyRole). \
             filter(PartyRole.business_id == business_id)
 
         # TODO: rework the unsupported party roles section; change-on-change to still bring back these roles
-        unsupported_roles = flags.value('unsupported-party-roles') or []
         if not role or role.lower() not in unsupported_roles:
             party_roles = party_roles.filter(PartyRole.role.notin_(unsupported_roles))
         if role is not None:

--- a/legal-api/src/legal_api/services/business_details_version.py
+++ b/legal-api/src/legal_api/services/business_details_version.py
@@ -298,14 +298,12 @@ class VersionedBusinessDetailsService:  # pylint: disable=too-many-public-method
             is_ia_or_after (bool): Flag for incorporation application or after
             role (str): Optional role filter
         """
-        from legal_api.services import flags  # pylint: disable=import-outside-toplevel
         # TODO: remove all workaround logic to get tombstone specific data displaying after corp migration is complete
         party_role_version = VersioningProxy.version_class(db.session(), PartyRole)
         parties = []
 
         # TODO: remove filter that excludes unsupported parties when we have plans to deal with it
         # Get versioned party roles
-        unsupported_roles = flags.value('unsupported-party-roles') or []
         versioned_party_roles = db.session.query(party_role_version)\
             .filter(party_role_version.transaction_id <= filing.transaction_id) \
             .filter(party_role_version.operation_type != 2) \
@@ -314,7 +312,11 @@ class VersionedBusinessDetailsService:  # pylint: disable=too-many-public-method
                         party_role_version.role == role)) \
             .filter(or_(party_role_version.end_transaction_id == None,   # pylint: disable=singleton-comparison # noqa: E711,E501;
                         party_role_version.end_transaction_id > filing.transaction_id)) \
-            .filter(party_role_version.role.notin_(unsupported_roles)) \
+            .filter(party_role_version.role.notin_([
+                PartyRole.RoleTypes.OFFICER.value,
+                PartyRole.RoleTypes.LIQUIDATOR.value,
+                PartyRole.RoleTypes.RECEIVER.value,
+            ])) \
             .order_by(party_role_version.transaction_id).all()
 
         # Process versioned party roles

--- a/legal-api/tests/unit/models/test_party_role.py
+++ b/legal-api/tests/unit/models/test_party_role.py
@@ -302,16 +302,7 @@ def test_get_party_roles_by_filing(session):
     assert len(party_roles) == 1
 
 
-@pytest.mark.parametrize(
-    'test_name, unsupported_list', [
-        ('unsupported_empty', []),
-        ('unsupported_officer', ['officer']),
-        ('unsupported_receiver', ['receiver']),
-        ('unsupported_liquidator', ['liquidator']),
-        ('unsupported_multiple', ['officer', 'receiver', 'liquidator'])
-    ]
-)
-def test_get_party_roles_unsupported_list(session, test_name, unsupported_list):
+def test_get_party_roles_unsupported_list(session):
     """Assert that the get_party_roles works as expected."""
     identifier = 'CP1234567'
     business = factory_business(identifier)
@@ -357,13 +348,15 @@ def test_get_party_roles_unsupported_list(session, test_name, unsupported_list):
     )
     party_role_4.save()
     # Find by all party roles
-    with patch.object(flags, 'value', return_value=unsupported_list):
-        party_roles = PartyRole.get_party_roles(business.id, datetime.datetime.now())
-        assert len(party_roles) == 4 - len(unsupported_list)
-        for role in party_roles:
-            assert role.role not in unsupported_list
+    unsupported_list = ['officer', 'receiver', 'liquidator']
 
-        # Find by party role
-        for role in unsupported_list:
-            party_roles = PartyRole.get_party_roles(business.id, datetime.datetime.now(), role)
-            assert len(party_roles) == 1
+    party_roles = PartyRole.get_party_roles(business.id, datetime.datetime.now())
+    assert len(party_roles) == 4 - len(unsupported_list)
+
+    for role in party_roles:
+        assert role.role not in unsupported_list
+
+    # Find by party role
+    for role in unsupported_list:
+        party_roles = PartyRole.get_party_roles(business.id, datetime.datetime.now(), role)
+        assert len(party_roles) == 1

--- a/legal-api/tests/unit/models/test_party_role.py
+++ b/legal-api/tests/unit/models/test_party_role.py
@@ -18,8 +18,12 @@ Test-Suite to ensure that the PartyRole Model is working as expected.
 """
 import datetime
 import json
+from unittest.mock import patch
+
+import pytest
 
 from legal_api.models import Filing, Party, PartyRole
+from legal_api.services import flags
 from tests.unit.models import factory_business
 
 
@@ -298,7 +302,16 @@ def test_get_party_roles_by_filing(session):
     assert len(party_roles) == 1
 
 
-def test_get_party_roles_officers(session):
+@pytest.mark.parametrize(
+    'test_name, unsupported_list', [
+        ('unsupported_empty', []),
+        ('unsupported_officer', ['officer']),
+        ('unsupported_receiver', ['receiver']),
+        ('unsupported_liquidator', ['liquidator']),
+        ('unsupported_multiple', ['officer', 'receiver', 'liquidator'])
+    ]
+)
+def test_get_party_roles_unsupported_list(session, test_name, unsupported_list):
     """Assert that the get_party_roles works as expected."""
     identifier = 'CP1234567'
     business = factory_business(identifier)
@@ -327,10 +340,30 @@ def test_get_party_roles_officers(session):
         business_id=business.id
     )
     party_role_2.save()
+    party_role_3 = PartyRole(
+        role=PartyRole.RoleTypes.RECEIVER.value,
+        appointment_date=datetime.datetime(2017, 5, 17),
+        cessation_date=None,
+        party_id=member.id,
+        business_id=business.id
+    )
+    party_role_3.save()
+    party_role_4 = PartyRole(
+        role=PartyRole.RoleTypes.LIQUIDATOR.value,
+        appointment_date=datetime.datetime(2017, 5, 17),
+        cessation_date=None,
+        party_id=member.id,
+        business_id=business.id
+    )
+    party_role_4.save()
     # Find by all party roles
-    party_roles = PartyRole.get_party_roles(business.id, datetime.datetime.now())
-    assert len(party_roles) == 1
+    with patch.object(flags, 'value', return_value=unsupported_list):
+        party_roles = PartyRole.get_party_roles(business.id, datetime.datetime.now())
+        assert len(party_roles) == 4 - len(unsupported_list)
+        for role in party_roles:
+            assert role.role not in unsupported_list
 
-    # Find by party role
-    party_roles = PartyRole.get_party_roles(business.id, datetime.datetime.now(), PartyRole.RoleTypes.OFFICER.value)
-    assert len(party_roles) == 1
+        # Find by party role
+        for role in unsupported_list:
+            party_roles = PartyRole.get_party_roles(business.id, datetime.datetime.now(), role)
+            assert len(party_roles) == 1

--- a/python/common/business-registry-model/src/business_model/models/party_role.py
+++ b/python/common/business-registry-model/src/business_model/models/party_role.py
@@ -144,10 +144,10 @@ class PartyRole(db.Model, Versioned):
                 filter(or_(PartyRole.cessation_date.is_(None), cast(PartyRole.cessation_date, Date) > end_date))
 
         # TODO: rework the unsupported party roles section; change-on-change to still bring back these roles
-        if not role or role.lower() not in unsupported_roles:
-            party_roles = party_roles.filter(PartyRole.role.notin_(unsupported_roles))
-        if role is not None:
+        if role:
             party_roles = party_roles.filter(PartyRole.role == role.lower())
+        else:
+            party_roles = party_roles.filter(PartyRole.role.notin_(unsupported_roles))
 
         party_roles = party_roles.all()
         return party_roles

--- a/python/common/business-registry-model/tests/models/test_party_role.py
+++ b/python/common/business-registry-model/tests/models/test_party_role.py
@@ -296,3 +296,63 @@ def test_get_party_roles_by_filing(session):
 
     party_roles = PartyRole.get_party_roles_by_filing(filing.id, datetime.datetime.utcnow())
     assert len(party_roles) == 1
+
+
+def test_get_party_roles_unsupported_list(session):
+    """Assert that the get_party_roles works as expected."""
+    identifier = 'CP1234567'
+    business = factory_business(identifier)
+    member = Party(
+        first_name='Connor',
+        last_name='Horton',
+        middle_initial='',
+        title='VP',
+    )
+    member.save()
+    # sanity check
+    assert member.id
+    party_role_1 = PartyRole(
+        role=PartyRole.RoleTypes.DIRECTOR.value,
+        appointment_date=datetime.datetime(2017, 5, 17),
+        cessation_date=None,
+        party_id=member.id,
+        business_id=business.id
+    )
+    party_role_1.save()
+    party_role_2 = PartyRole(
+        role=PartyRole.RoleTypes.OFFICER.value,
+        appointment_date=datetime.datetime(2017, 5, 17),
+        cessation_date=None,
+        party_id=member.id,
+        business_id=business.id
+    )
+    party_role_2.save()
+    party_role_3 = PartyRole(
+        role=PartyRole.RoleTypes.RECEIVER.value,
+        appointment_date=datetime.datetime(2017, 5, 17),
+        cessation_date=None,
+        party_id=member.id,
+        business_id=business.id
+    )
+    party_role_3.save()
+    party_role_4 = PartyRole(
+        role=PartyRole.RoleTypes.LIQUIDATOR.value,
+        appointment_date=datetime.datetime(2017, 5, 17),
+        cessation_date=None,
+        party_id=member.id,
+        business_id=business.id
+    )
+    party_role_4.save()
+    # Find by all party roles
+    unsupported_list = ['officer', 'receiver', 'liquidator']
+
+    party_roles = PartyRole.get_party_roles(business.id, datetime.datetime.now())
+    assert len(party_roles) == 4 - len(unsupported_list)
+
+    for role in party_roles:
+        assert role.role not in unsupported_list
+
+    # Find by party role
+    for role in unsupported_list:
+        party_roles = PartyRole.get_party_roles(business.id, datetime.datetime.now(), role)
+        assert len(party_roles) == 1


### PR DESCRIPTION
*Issue #:* /bcgov/entity#28413

*Description of changes:*
- Update both legal-api and business-registry-model
- Hide unsupported roles ~~based on FF~~
- Update unit tests

~~**I've turned the flag on for dev/test/prod.**~~

_Testing_

#### Group 1
- default view 1
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/ae91aa99-0525-4c4f-870a-2acf5c01b33d" />

- query officer
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/716909ac-aaa7-4bc1-aaac-7b2b28a1c8b1" />

- query receiver
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/ed566a32-6558-4df7-9a64-5fe58e7a7634" />

#### Group 2
- default view 2
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/6eb622c4-dedc-441a-99bd-524f79687091" />

- query liquidator
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/04e14945-9528-4431-a519-ebc9aa0fe0d6" />

- query liquidator with end date
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/b78c31f6-c025-4c49-88e8-9d8120aae75f" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
