### PR TITLE
27641 - Improve 500 error response

### DIFF
--- a/legal-api/src/legal_api/errorhandlers.py
+++ b/legal-api/src/legal_api/errorhandlers.py
@@ -59,6 +59,15 @@ def handle_uncaught_error(error: Exception):  # pylint: disable=unused-argument
     ensure it's logged and recorded in Sentry.
     """
     logger.error('Uncaught exception', exc_info=sys.exc_info())
+    if isinstance(error, KeyError):
+        return jsonify({'message': f'A required field {error.args[0]} was missing or invalid.'}), 400
+    if isinstance(error, AttributeError):
+        return jsonify({
+            'message': 'Invalid request format, one or more fields have an unexpected value or structure.'
+        }), 400
+    if isinstance(error, TypeError):
+        return jsonify({'message': f'Encountered an error processing the request, {str(error)}'}), 400
+
     response = jsonify({'message': 'Internal server error'})
     response.status_code = 500
     return response


### PR DESCRIPTION
*Issue #:* /bcgov/entity#27641

*Description of changes:*
- Improved error handling for 500 errors, focusing on scenarios most frequently encountered by API users (as discussed on Discourse) and in our internal tests.
- Most uncaught errors we found that return a 500 error are:
`KeyError`: when required keys are missing/invalid in the filing json.
`AttributeError`: when fields have unexpected types or structures.
`TypeError`: due to invalid value types in the database or submitted payload.

So, for each error type we found, we improved the return message and status code to help give API users more useful information.

**Local Testing Results**:
`KeyError` issue:
- when required fields are invalid: (given an invalid field in the URL: `{{url}}/api/v2/businesses/:identifier/filings/:filing_id/documents/noticeOfArticle`)
![image](https://github.com/user-attachments/assets/7d94a750-06dc-448b-a01a-cc754ea5e114)

can retrieve the PDF, when the request URL is correct `{{url}}/api/v2/businesses/:identifier/filings/:filing_id/documents/noticeOfArticles` 
<img width="1393" alt="image" src="https://github.com/user-attachments/assets/3a6fb8c9-0efc-48ac-9a15-a9d5668d76c3" />

- when required fields are missing:
![image](https://github.com/user-attachments/assets/385bb2fb-27ce-4c2e-888c-15e639a42de4)

`AttributeError` issue:
- when getting keys in dicts with invalid types or structures in the payload
![image](https://github.com/user-attachments/assets/a1469858-843a-416c-bc61-01c55764fbb6)

`TypeError` issue:
![image](https://github.com/user-attachments/assets/deb7448a-9506-489a-927f-afa708de46ff)
<img width="1657" alt="image" src="https://github.com/user-attachments/assets/13af80ea-0ac4-47b8-9b87-7b99b077b1ff" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
