### PR TITLE
fix(business-filer): set payment_completion_date to the datetime of the payment CloudEvent

### DIFF
--- a/queue_services/business-pay/src/business_pay/resources/pay_filer.py
+++ b/queue_services/business-pay/src/business_pay/resources/pay_filer.py
@@ -126,7 +126,7 @@ async def worker():
     if not (
         filing := Filing.get_filing_by_payment_token(pay_token=str(payment_token.id))
     ):
-        if payment_token.filing_identifier == None and \
+        if payment_token.filing_identifier is None and \
            payment_token.corp_type_code == "BC":
             logger.debug(
                 f"Take Off Queue - BOGUS Filing Not Found: {payment_token} for : {str(ce)}")
@@ -145,7 +145,8 @@ async def worker():
     logger.info(f"processing payment: {payment_token.id}")
 
     # setting the payment_completion_date, marks the filing as paid
-    filing.payment_completion_date = datetime.now(timezone.utc)
+    # in the unlikely event that the CE time is null, use now()
+    filing.payment_completion_date = ce.time or datetime.now(timezone.utc)
     filing.payment_status_code = "COMPLETED"
     filing.status = Filing.Status.PAID
     filing.save()


### PR DESCRIPTION
*Issue #:* /bcgov/entity#28618

*Description of changes:*
Set the filing.payment_completion_date to the datetime of the payment CloudEvent, if missing use now()

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
