### PR TITLE
Add cd_runner_version to business API CD workflow

### DIFF
--- a/.github/workflows/business-api-cd.yml
+++ b/.github/workflows/business-api-cd.yml
@@ -32,6 +32,7 @@ jobs:
     uses: bcgov/bcregistry-sre/.github/workflows/backend-cd.yaml@main
     with:
       target: ${{ inputs.target }}
+      cd_runner_version: "1.0.0"
       app_name: "business-api"
       working_directory: "./legal-api"
       redeploy: ${{ inputs.redeploy }}


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*
The Legal API hasn’t used Poetry as its package manager for now. However, an issue has occurred due to the Docker buildx environment, which is in use by other applications that rely on Poetry. To prevent this issue, we can specify a different version of the CD runner image in the CI/CD pipeline.

![image](https://github.com/user-attachments/assets/f032bc08-f445-4b4c-bb9f-4053755ca261)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
