### PR TITLE
DC Unit tests in business-registry-model

### DIFF
--- a/python/common/business-registry-model/src/business_model/models/dc_definition.py
+++ b/python/common/business-registry-model/src/business_model/models/dc_definition.py
@@ -62,6 +62,10 @@ class DCDefinition(db.Model):  # pylint: disable=too-many-instance-attributes
         db.session.add(self)
         db.session.commit()
 
+    def save_to_session(self):
+        """Save to the session, do not commit immediately."""
+        db.session.add(self)
+
     @classmethod
     def find_by_id(cls, dc_definition_id: str) -> DCDefinition:
         """Return the digital credential definition matching the id."""
@@ -99,5 +103,5 @@ class DCDefinition(db.Model):  # pylint: disable=too-many-instance-attributes
 
     @classmethod
     def deactivate(cls, credential_type: CredentialType):
-        """Deactivate all definition for the specific credential type."""
-        db.session.execute(text(f"UPDATE dc_definitions SET is_deleted=true WHERE credential_type='{credential_type.name}'"))
+        """Deactivate all definitions for the specific credential type using ORM."""
+        cls.query.filter_by(credential_type=credential_type).update({"is_deleted": True})

--- a/python/common/business-registry-model/tests/models/test_dc_definition.py
+++ b/python/common/business-registry-model/tests/models/test_dc_definition.py
@@ -18,20 +18,18 @@ Test-Suite to ensure that the DCDefinition Model is working as expected.
 """
 import uuid
 
-import pytest
-
 from business_model.models import DCDefinition
 
 
 def test_valid_dc_definition_save(session):
     """Assert that a valid dc_definition can be saved."""
-    definition = create_dc_definition()
+    definition = create_dc_definition(session)
     assert definition.id
 
 
 def test_find_by_id(session):
     """Assert that the method returns correct value."""
-    definition = create_dc_definition()
+    definition = create_dc_definition(session)
 
     res = DCDefinition.find_by_id(definition.id)
 
@@ -40,13 +38,9 @@ def test_find_by_id(session):
     assert not res.is_deleted
 
 
-@pytest.mark.skip('Not working in full run')
 def test_find_by_credential_type(session):
-    """Assert that the method returns correct value.
-    
-    TODO: fix test to run in the full series.
-    """
-    definition = create_dc_definition()
+    """Assert that the method returns correct value."""
+    definition = create_dc_definition(session)
 
     res = DCDefinition.find_by_credential_type(DCDefinition.CredentialType.business)
 
@@ -56,7 +50,7 @@ def test_find_by_credential_type(session):
 
 def test_deactivate(session):
     """Assert that the deactivate set is_deleted value."""
-    definition = create_dc_definition()
+    definition = create_dc_definition(session)
 
     DCDefinition.deactivate(DCDefinition.CredentialType.business)
 
@@ -69,7 +63,7 @@ def test_deactivate(session):
 
 def test_find_by(session):
     """Assert that the method returns correct value."""
-    definition = create_dc_definition()
+    definition = create_dc_definition(session)
 
     res = DCDefinition.find_by(credential_type=DCDefinition.CredentialType.business,
                                schema_id=definition.schema_id,
@@ -79,7 +73,7 @@ def test_find_by(session):
     assert res.id == definition.id
 
 
-def create_dc_definition():
+def create_dc_definition(session):
     """Create new dc_definition object."""
     definition = DCDefinition(
         credential_type=DCDefinition.CredentialType.business,
@@ -88,5 +82,7 @@ def create_dc_definition():
         schema_id='test_schema_id',
         credential_definition_id=str(uuid.uuid4())
     )
-    definition.save()
+    definition.save_to_session()
+    
+    session.flush()
     return definition

--- a/python/common/business-registry-model/tests/models/test_dc_issued_credential.py
+++ b/python/common/business-registry-model/tests/models/test_dc_issued_credential.py
@@ -19,8 +19,6 @@ Test-Suite to ensure that the DCIssuedCredential Model is working as expected.
 import random
 import uuid
 
-import pytest
-
 from business_model.models import DCIssuedCredential
 from tests.models import factory_business
 from tests.models.test_dc_connection import create_dc_connection
@@ -29,23 +27,20 @@ from tests.models.test_dc_definition import create_dc_definition
 
 def test_valid_dc_issued_credential_save(session):
     """Assert that a valid dc_issued_credential can be saved."""
-    issued_credential = create_dc_issued_credential()
+    issued_credential = create_dc_issued_credential(session)
     assert issued_credential.id
 
 
 def test_find_by_id(session):
     """Assert that the method returns correct value."""
-    issued_credential = create_dc_issued_credential()
+    issued_credential = create_dc_issued_credential(session)
     res = DCIssuedCredential.find_by_id(issued_credential.id)
     assert res
 
 
-@pytest.mark.skip('Not working yet')
 def test_find_by_credential_exchange_id(session):
-    """Assert that the method returns correct value.
-    
-    TODO: fix this """
-    issued_credential = create_dc_issued_credential()
+    """Assert that the method returns correct value."""
+    issued_credential = create_dc_issued_credential(session)
     res = DCIssuedCredential.find_by_credential_exchange_id(issued_credential.credential_exchange_id)
 
     assert res
@@ -54,7 +49,7 @@ def test_find_by_credential_exchange_id(session):
 
 def test_find_by(session):
     """Assert that the method returns correct value."""
-    issued_credential = create_dc_issued_credential()
+    issued_credential = create_dc_issued_credential(session)
     res = DCIssuedCredential.find_by(dc_connection_id=issued_credential.dc_connection_id,
                                      dc_definition_id=issued_credential.dc_definition_id)
 
@@ -62,12 +57,12 @@ def test_find_by(session):
     assert res[0].id == issued_credential.id
 
 
-def create_dc_issued_credential(business=None):
+def create_dc_issued_credential(session, business=None):
     """Create new dc_issued_credential object."""
     if not business:
         identifier = f'FM{random.randint(1000000, 9999999)}'
         business = factory_business(identifier)
-    definition = create_dc_definition()
+    definition = create_dc_definition(session)
     connection = create_dc_connection(business, is_active=True)
     issued_credential = DCIssuedCredential(
         dc_definition_id=definition.id,


### PR DESCRIPTION
*Issue #:* N/A

Couple tests failing in the digital credentials model stuff after (or before even? I've only run legal-api tests so far) changes in https://github.com/bcgov/lear/pull/3531
They were accumulating records as DB commits were happening so use a non-commit save function and flush so that the base rollback works as expected per-function from the session fixture in conftest.py.

This can be merged any time (without affecting existing DBC functionality).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
