### PR TITLE
wrap mras email in a flag so we can turn off in dev

### DIFF
--- a/queue_services/business-filer/flags.json
+++ b/queue_services/business-filer/flags.json
@@ -2,6 +2,7 @@
     "flagValues": {
         "enable-involuntary-dissolution": true,
         "namex-nro-decommissioned": true,
-        "enable-sandbox": false
+        "enable-sandbox": false,
+        "disable-mras-email": false
     }
 }

--- a/queue_services/business-filer/src/business_filer/services/filer.py
+++ b/queue_services/business-filer/src/business_filer/services/filer.py
@@ -291,7 +291,8 @@ def process_filing(filing_message: FilingMessage): # noqa: PLR0915, PLR0912
 
             name_request.consume_nr(business, filing_submission, flags=flags)
             business_profile.update_business_profile(business, filing_submission, flags=flags)
-            if flags.is_on("enable-mras-email"):
+            # this is a double negative so that we don't have to break test / prod
+            if not flags.is_on("disable-mras-email"):
                 PublishEvent.publish_mras_email(current_app, business, filing_submission)
         elif not flags.is_on("enable-sandbox"):
             for filing_type in filing_meta.legal_filings:


### PR DESCRIPTION
*Issue #:* /bcgov/entity#28864

*Description of changes:*
Wrapped MRAS emails in filer in an disable-mras-email flag so that we can turn off in dev. This blocks the event going back on the queue for pay to complete, 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
