### PR TITLE
28953 - Fix affiliation auth call for migrated businesses

### DIFF
--- a/data-tool/flows/common/auth_service.py
+++ b/data-tool/flows/common/auth_service.py
@@ -85,8 +85,9 @@ class AuthService:
         # Create an account:business affiliation
         affiliate_data = {
             'businessIdentifier': business_registration,
-            'passCode': pass_code
         }
+        if pass_code:
+            affiliate_data['passCode'] = pass_code
         if details:
             affiliate_data['entityDetails'] = details
         affiliate = requests.post(


### PR DESCRIPTION
*Issue #:* /bcgov/entity#28953

*Description of changes:*
-  Fix affiliation auth call for businesses don't have passcode

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
