### PR TITLE
28460 - Add Backend validations for FE/BE mismatch in sandbox

### DIFF
--- a/legal-api/requirements.txt
+++ b/legal-api/requirements.txt
@@ -59,5 +59,5 @@ PyPDF2==1.26.0
 reportlab==3.6.12
 html-sanitizer==2.4.1
 lxml==5.2.2
-git+https://github.com/bcgov/business-schemas.git@2.18.31#egg=registry_schemas
+git+https://github.com/bcgov/business-schemas.git@2.18.46#egg=registry_schemas
 git+https://github.com/bcgov/lear.git#egg=sql-versioning&subdirectory=python/common/sql-versioning

--- a/legal-api/requirements/bcregistry-libraries.txt
+++ b/legal-api/requirements/bcregistry-libraries.txt
@@ -1,2 +1,2 @@
-git+https://github.com/bcgov/business-schemas.git@2.18.31#egg=registry_schemas
+git+https://github.com/bcgov/business-schemas.git@2.18.46#egg=registry_schemas
 git+https://github.com/bcgov/lear.git#egg=sql-versioning&subdirectory=python/common/sql-versioning

--- a/legal-api/src/legal_api/services/filings/validations/alteration.py
+++ b/legal-api/src/legal_api/services/filings/validations/alteration.py
@@ -39,7 +39,7 @@ def validate(business: Business, filing: Dict) -> Error:  # pylint: disable=too-
 
     msg.extend(type_change_validation(filing, business))
     msg.extend(company_name_validation(filing, business))
-    msg.extend(share_structure_validation(filing))
+    msg.extend(share_structure_validation(filing, business))
     msg.extend(court_order_validation(filing))
     msg.extend(rules_change_validation(filing))
     msg.extend(memorandum_change_validation(filing))
@@ -63,11 +63,15 @@ def court_order_validation(filing):
     return []
 
 
-def share_structure_validation(filing):
+def share_structure_validation(filing, business: Business):
     """Validate share structure."""
     share_structure_path: Final = '/filing/alteration/shareStructure'
+    new_legal_type = get_str(filing, '/filing/alteration/business/legalType')
+
     if get_str(filing, share_structure_path):
-        err = validate_share_structure(filing, Filing.FilingTypes.ALTERATION.value)
+        err = validate_share_structure(filing,
+                                       Filing.FilingTypes.ALTERATION.value,
+                                       new_legal_type or business.legal_type)
         if err:
             return err
     return []

--- a/legal-api/src/legal_api/services/filings/validations/amalgamation_application.py
+++ b/legal-api/src/legal_api/services/filings/validations/amalgamation_application.py
@@ -27,7 +27,10 @@ from legal_api.services.filings.validations.common_validations import (
     validate_parties_names,
     validate_share_structure,
 )
-from legal_api.services.filings.validations.incorporation_application import validate_offices
+from legal_api.services.filings.validations.incorporation_application import (
+    validate_offices,
+    validate_parties_delivery_address,
+)
 from legal_api.services.utils import get_str
 from legal_api.utils.auth import jwt
 # noqa: I003
@@ -58,6 +61,9 @@ def validate(amalgamation_json: Dict, account_id) -> Optional[Error]:
     if amalgamation_type == Amalgamation.AmalgamationTypes.regular.name:
         msg.extend(validate_offices(amalgamation_json, filing_type))
         err = validate_share_structure(amalgamation_json, filing_type)
+        if err:
+            msg.extend(err)
+        err = validate_parties_delivery_address(amalgamation_json, legal_type, filing_type)
         if err:
             msg.extend(err)
 

--- a/legal-api/src/legal_api/services/filings/validations/amalgamation_application.py
+++ b/legal-api/src/legal_api/services/filings/validations/amalgamation_application.py
@@ -60,7 +60,7 @@ def validate(amalgamation_json: Dict, account_id) -> Optional[Error]:
 
     if amalgamation_type == Amalgamation.AmalgamationTypes.regular.name:
         msg.extend(validate_offices(amalgamation_json, filing_type))
-        err = validate_share_structure(amalgamation_json, filing_type)
+        err = validate_share_structure(amalgamation_json, filing_type, legal_type)
         if err:
             msg.extend(err)
         err = validate_parties_delivery_address(amalgamation_json, legal_type, filing_type)

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -60,14 +60,13 @@ def has_rights_or_restrictions_true_in_share_series(share_class) -> bool:
     return any(x.get('hasRightsOrRestrictions', False) for x in series)
 
 
-def validate_share_structure(incorporation_json, filing_type) -> Error:  # pylint: disable=too-many-branches
+def validate_share_structure(incorporation_json, filing_type, legal_type) -> Error:  # pylint: disable=too-many-branches
     """Validate the share structure data of the incorporation filing."""
     share_classes = incorporation_json['filing'][filing_type] \
         .get('shareStructure', {}).get('shareClasses', [])
     msg = []
     memoize_names = []
 
-    legal_type = incorporation_json['filing'][filing_type].get('nameRequest', {}).get('legalType')
     for index, item in enumerate(share_classes):
         shares_msg = validate_shares(item, memoize_names, filing_type, index, legal_type)
         if shares_msg:

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -128,6 +128,13 @@ def validate_shares(item, memoize_names, filing_type, index) -> Error:
             err_path = '/filing/{0}/shareClasses/{1}/currency/'.format(filing_type, index)
             msg.append({'error': 'Share class %s must specify currency' % item['name'], 'path': err_path})
 
+    # Add validation for series when hasRightsOrRestrictions is false
+    if not item.get('hasRightsOrRestrictions', False) and 'series' in item:
+        err_path = '/filing/{0}/shareClasses/{1}/series/'.format(filing_type, index)
+        msg.append({'error': 'Share class %s cannot have series when hasRightsOrRestrictions is false' % item['name'],
+                    'path': err_path})
+        return msg
+
     series_msg = validate_series(item, memoize_names, filing_type, index)
     if series_msg:
         msg.extend(series_msg)

--- a/legal-api/src/legal_api/services/filings/validations/continuation_in.py
+++ b/legal-api/src/legal_api/services/filings/validations/continuation_in.py
@@ -31,6 +31,7 @@ from legal_api.services.filings.validations.common_validations import (
 from legal_api.services.filings.validations.incorporation_application import (
     validate_incorporation_effective_date,
     validate_offices,
+    validate_parties_delivery_address,
     validate_parties_mailing_address,
 )
 from legal_api.services.utils import get_bool, get_str
@@ -61,6 +62,9 @@ def validate(filing_json: dict) -> Optional[Error]:  # pylint: disable=too-many-
         msg.extend(validate_parties_names(filing_json, filing_type))
 
         if err := validate_parties_mailing_address(filing_json, legal_type, filing_type):
+            msg.extend(err)
+
+        if err := validate_parties_delivery_address(filing_json, legal_type, filing_type):
             msg.extend(err)
 
         if err := validate_share_structure(filing_json, filing_type):

--- a/legal-api/src/legal_api/services/filings/validations/continuation_in.py
+++ b/legal-api/src/legal_api/services/filings/validations/continuation_in.py
@@ -67,7 +67,7 @@ def validate(filing_json: dict) -> Optional[Error]:  # pylint: disable=too-many-
         if err := validate_parties_delivery_address(filing_json, legal_type, filing_type):
             msg.extend(err)
 
-        if err := validate_share_structure(filing_json, filing_type):
+        if err := validate_share_structure(filing_json, filing_type, legal_type):
             msg.extend(err)
 
         if err := validate_incorporation_effective_date(filing_json):

--- a/legal-api/src/legal_api/services/filings/validations/correction.py
+++ b/legal-api/src/legal_api/services/filings/validations/correction.py
@@ -109,7 +109,7 @@ def _validate_corps_correction(filing_dict, legal_type, msg):
         if err:
             msg.extend(err)
     if filing_dict.get('filing', {}).get('correction', {}).get('shareStructure', None):
-        err = validate_share_structure(filing_dict, filing_type)
+        err = validate_share_structure(filing_dict, filing_type, legal_type)
         if err:
             msg.extend(err)
 

--- a/legal-api/src/legal_api/services/filings/validations/dissolution.py
+++ b/legal-api/src/legal_api/services/filings/validations/dissolution.py
@@ -173,6 +173,8 @@ def validate_parties_address(filing_json, legal_type, dissolution_type) -> Optio
     party_path = '/filing/dissolution/parties'
 
     if len(parties) > 0:
+        msg.extend(_validate_officer_email(parties, dissolution_type, legal_type))
+
         err, address_in_bc, address_in_ca = _validate_address_location(parties)
         if err:
             msg.extend(err)
@@ -256,3 +258,15 @@ def _validate_court_order(filing):
         if err:
             return err
     return []
+
+
+def _validate_officer_email(parties, dissolution_type, legal_type) -> list:
+    """Validate officer email for voluntary dissolution."""
+    msg = []
+    for idx, party in enumerate(parties):
+        if dissolution_type == DissolutionTypes.VOLUNTARY and legal_type in Business.CORPS:
+            email = get_str(party, '/officer/email')
+            if not email:
+                msg.append({'error': 'Officer email is required for voluntary dissolution.',
+                            'path': f'/filing/dissolution/parties/{idx}/officer/email'})
+    return msg

--- a/legal-api/src/legal_api/services/filings/validations/dissolution.py
+++ b/legal-api/src/legal_api/services/filings/validations/dissolution.py
@@ -180,7 +180,7 @@ def validate_parties_address(filing_json, legal_type, dissolution_type) -> Optio
     party_path = '/filing/dissolution/parties'
 
     if len(parties) > 0:
-        msg.extend(_validate_officer_email(parties, dissolution_type, legal_type))
+        msg.extend(_validate_custodian_email(parties, dissolution_type, legal_type))
 
         err, address_in_bc, address_in_ca = _validate_address_location(parties)
         if err:
@@ -267,14 +267,14 @@ def _validate_court_order(filing):
     return []
 
 
-def _validate_officer_email(parties, dissolution_type, legal_type) -> list:
-    """Validate officer email for voluntary dissolution."""
+def _validate_custodian_email(parties, dissolution_type, legal_type) -> list:
+    """Validate custodian email for voluntary dissolution."""
     msg = []
     for idx, party in enumerate(parties):
         if dissolution_type == DissolutionTypes.VOLUNTARY and legal_type in Business.CORPS:
             email = get_str(party, '/officer/email')
             if not email:
-                msg.append({'error': 'Officer email is required for voluntary dissolution.',
+                msg.append({'error': 'Custodian email is required for voluntary dissolution.',
                             'path': f'/filing/dissolution/parties/{idx}/officer/email'})
     return msg
 

--- a/legal-api/src/legal_api/services/filings/validations/dissolution.py
+++ b/legal-api/src/legal_api/services/filings/validations/dissolution.py
@@ -83,6 +83,10 @@ def validate(business: Business, dissolution: Dict) -> Optional[Error]:
     if err:
         msg.extend(err)
 
+    err = validate_custodial_office(dissolution, business.legal_type, dissolution_type)
+    if err:
+        msg.extend(err)
+
     msg.extend(_validate_court_order(dissolution))
 
     if msg:
@@ -273,3 +277,18 @@ def _validate_officer_email(parties, dissolution_type, legal_type) -> list:
                 msg.append({'error': 'Officer email is required for voluntary dissolution.',
                             'path': f'/filing/dissolution/parties/{idx}/officer/email'})
     return msg
+
+
+def validate_custodial_office(filing_json, legal_type, dissolution_type) -> Optional[list]:
+    """Validate custodial office of the dissolution filing."""
+    # Only validate for CORP voluntary dissolution
+    if not (legal_type in Business.CORPS and dissolution_type == DissolutionTypes.VOLUNTARY.value):
+        return None
+
+    dissolution = filing_json.get('filing', {}).get('dissolution', {})
+
+    if 'custodialOffice' not in dissolution:
+        return [{'error': 'Custodial office is required for voluntary dissolution.',
+                'path': '/filing/dissolution/custodialOffice'}]
+
+    return None

--- a/legal-api/src/legal_api/services/filings/validations/dissolution.py
+++ b/legal-api/src/legal_api/services/filings/validations/dissolution.py
@@ -165,6 +165,9 @@ def validate_parties_address(filing_json, legal_type, dissolution_type) -> Optio
     if legal_type in [Business.LegalTypes.SOLE_PROP.value, Business.LegalTypes.PARTNERSHIP.value]:
         return None
 
+    if 'parties' not in filing_json['filing']['dissolution']:
+        return [{'error': 'Parties are required.', 'path': '/filing/dissolution/parties'}]
+
     parties_json = filing_json['filing']['dissolution']['parties']
     parties = list(filter(lambda x: _is_dissolution_party_role(x.get('roles', [])), parties_json))
     msg = []

--- a/legal-api/src/legal_api/services/filings/validations/incorporation_application.py
+++ b/legal-api/src/legal_api/services/filings/validations/incorporation_application.py
@@ -67,7 +67,9 @@ def validate(incorporation_json: dict):  # pylint: disable=too-many-branches;
 
     if legal_type in [Business.LegalTypes.BCOMP.value, Business.LegalTypes.BC_ULC_COMPANY.value,
                       Business.LegalTypes.COMP.value, Business.LegalTypes.BC_CCC.value]:
-        err = validate_share_structure(incorporation_json, coreFiling.FilingTypes.INCORPORATIONAPPLICATION.value)
+        err = validate_share_structure(incorporation_json,
+                                       coreFiling.FilingTypes.INCORPORATIONAPPLICATION.value,
+                                       legal_type)
         if err:
             msg.extend(err)
 

--- a/legal-api/tests/unit/services/filings/validations/test_continuation_in.py
+++ b/legal-api/tests/unit/services/filings/validations/test_continuation_in.py
@@ -856,3 +856,102 @@ def test_validate_before_and_after_approval(mocker, app, session, test_status, i
         assert err.code == HTTPStatus.UNPROCESSABLE_ENTITY
     else:
         assert not err
+
+
+@pytest.mark.parametrize(
+    'legal_type, has_rights_or_restrictions, has_series, should_pass',
+    [
+        (Business.LegalTypes.CONTINUE_IN.value, False, True, False),
+        (Business.LegalTypes.CONTINUE_IN.value, False, False, True),
+        (Business.LegalTypes.CONTINUE_IN.value, True, True, True),
+        (Business.LegalTypes.CONTINUE_IN.value, True, False, True),
+
+        (Business.LegalTypes.BCOMP_CONTINUE_IN.value, False, True, False),
+        (Business.LegalTypes.BCOMP_CONTINUE_IN.value, False, False, True),
+        (Business.LegalTypes.BCOMP_CONTINUE_IN.value, True, True, True),
+        (Business.LegalTypes.BCOMP_CONTINUE_IN.value, True, False, True),
+
+        (Business.LegalTypes.CCC_CONTINUE_IN.value, False, True, False),
+        (Business.LegalTypes.CCC_CONTINUE_IN.value, False, False, True),
+        (Business.LegalTypes.CCC_CONTINUE_IN.value, True, True, True),
+        (Business.LegalTypes.CCC_CONTINUE_IN.value, True, False, True),
+
+        (Business.LegalTypes.ULC_CONTINUE_IN.value, False, True, False),
+        (Business.LegalTypes.ULC_CONTINUE_IN.value, False, False, True),
+        (Business.LegalTypes.ULC_CONTINUE_IN.value, True, True, True),
+        (Business.LegalTypes.ULC_CONTINUE_IN.value, True, False, True),
+    ]
+)
+def test_continuation_in_share_class_series_validation(mocker, app, session, legal_type,
+                                                       has_rights_or_restrictions, has_series, should_pass):
+    """Test share class/series validation in continuation in application."""
+    filing = {'filing': {}}
+    filing['filing']['header'] = {'name': 'continuationIn', 'date': '2019-04-08',
+                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+    filing['filing']['continuationIn'] = copy.deepcopy(CONTINUATION_IN)
+    filing['filing']['continuationIn']['isApproved'] = True
+
+    filing['filing']['continuationIn']['nameRequest'] = {}
+    filing['filing']['continuationIn']['nameRequest']['nrNumber'] = 'NR 1234567'
+    filing['filing']['continuationIn']['nameRequest']['legalType'] = legal_type
+
+    if 'shareStructure' in filing['filing']['continuationIn']:
+        for share_class in filing['filing']['continuationIn']['shareStructure']['shareClasses']:
+            share_class['hasRightsOrRestrictions'] = has_rights_or_restrictions
+            if not has_rights_or_restrictions:
+                if not has_series:
+                    share_class.pop('series', None)
+
+    mocker.patch('legal_api.services.filings.validations.continuation_in.validate_roles', return_value=[])
+    mocker.patch('legal_api.services.filings.validations.continuation_in.validate_pdf', return_value=None)
+    mocker.patch('legal_api.services.filings.validations.continuation_in.validate_name_request',
+                 return_value=[])
+    mocker.patch('legal_api.services.filings.validations.continuation_in.validate_business_in_colin',
+                 return_value=[])
+
+    err = validate(None, filing)
+
+    if should_pass:
+        assert err is None
+    else:
+        assert err
+        assert any('cannot have series when hasRightsOrRestrictions is false' in msg['error'] for msg in err.msg)
+
+
+@pytest.mark.parametrize(
+    'test_name, has_delivery_address, expected_code, expected_msg',
+    [
+        ('MISSING_DELIVERY_ADDRESS', False, HTTPStatus.BAD_REQUEST, 'deliveryAddress is required.'),
+        ('SUCCESS', True, None, None),
+    ]
+)
+def test_continuation_in_parties_delivery_address_validation(mocker, app, session, test_name, has_delivery_address,
+                                                             expected_code, expected_msg):
+    """Test parties delivery address validation in continuation in application."""
+    filing = {'filing': {}}
+    filing['filing']['header'] = {'name': 'continuationIn', 'date': '2019-04-08',
+                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+    filing['filing']['continuationIn'] = copy.deepcopy(CONTINUATION_IN)
+    filing['filing']['continuationIn']['isApproved'] = True
+
+    filing['filing']['continuationIn']['nameRequest'] = {}
+    filing['filing']['continuationIn']['nameRequest']['nrNumber'] = 'NR 1234567'
+    filing['filing']['continuationIn']['nameRequest']['legalType'] = 'BC'
+
+
+    if not has_delivery_address:
+        if 'deliveryAddress' in filing['filing']['continuationIn']['parties'][0]:
+            del filing['filing']['continuationIn']['parties'][0]['deliveryAddress']
+
+    mocker.patch('legal_api.services.filings.validations.continuation_in.validate_roles', return_value=[])
+    mocker.patch('legal_api.services.filings.validations.continuation_in.validate_pdf', return_value=None)
+    mocker.patch('legal_api.services.filings.validations.continuation_in.validate_name_request', return_value=[])
+    mocker.patch('legal_api.services.filings.validations.continuation_in.validate_business_in_colin', return_value=[])
+
+    err = validate(None, filing)
+
+    if expected_code:
+        assert err.code == expected_code
+        assert any(expected_msg in msg['error'] for msg in err.msg)
+    else:
+        assert err is None

--- a/legal-api/tests/unit/services/filings/validations/test_dissolution.py
+++ b/legal-api/tests/unit/services/filings/validations/test_dissolution.py
@@ -319,13 +319,13 @@ def test_dissolution_court_orders(session, test_status, file_number, effect_of_o
     'test_status, legal_type, dissolution_type, has_email, expected_code, expected_msg',
     [
         ('FAIL', 'BC', 'voluntary', False, HTTPStatus.BAD_REQUEST,
-         'Officer email is required for voluntary dissolution.'),
+         'Custodian email is required for voluntary dissolution.'),
         ('FAIL', 'BEN', 'voluntary', False, HTTPStatus.BAD_REQUEST,
-         'Officer email is required for voluntary dissolution.'),
+         'Custodian email is required for voluntary dissolution.'),
         ('FAIL', 'CC', 'voluntary', False, HTTPStatus.BAD_REQUEST,
-         'Officer email is required for voluntary dissolution.'),
+         'Custodian email is required for voluntary dissolution.'),
         ('FAIL', 'ULC', 'voluntary', False, HTTPStatus.BAD_REQUEST,
-         'Officer email is required for voluntary dissolution.'),
+         'Custodian email is required for voluntary dissolution.'),
         ('SUCCESS', 'CP', 'voluntary', False, None, None),
         ('SUCCESS', 'BC', 'voluntary', True, None, None),
         ('SUCCESS', 'BEN', 'voluntary', True, None, None),
@@ -334,8 +334,8 @@ def test_dissolution_court_orders(session, test_status, file_number, effect_of_o
         ('SUCCESS', 'BC', 'administrative', False, None, None),
     ]
 )
-def test_dissolution_officer_email(session, test_status, legal_type, dissolution_type, has_email, expected_code, expected_msg):
-    """Test officer email validation in voluntary dissolution."""
+def test_dissolution_custodian_email(session, test_status, legal_type, dissolution_type, has_email, expected_code, expected_msg):
+    """Test custodian email validation in voluntary dissolution."""
     business = Business(identifier='BC1234567', legal_type=legal_type)
     filing = copy.deepcopy(FILING_HEADER)
     filing['filing']['header']['name'] = 'dissolution'

--- a/legal-api/tests/unit/services/filings/validations/test_dissolution.py
+++ b/legal-api/tests/unit/services/filings/validations/test_dissolution.py
@@ -313,3 +313,98 @@ def test_dissolution_court_orders(session, test_status, file_number, effect_of_o
         assert expected_msg == err.msg[0]['error']
     else:
         assert not err
+
+
+@pytest.mark.parametrize(
+    'test_status, legal_type, dissolution_type, has_email, expected_code, expected_msg',
+    [
+        ('FAIL', 'BC', 'voluntary', False, HTTPStatus.BAD_REQUEST,
+         'Officer email is required for voluntary dissolution.'),
+        ('FAIL', 'BEN', 'voluntary', False, HTTPStatus.BAD_REQUEST,
+         'Officer email is required for voluntary dissolution.'),
+        ('FAIL', 'CC', 'voluntary', False, HTTPStatus.BAD_REQUEST,
+         'Officer email is required for voluntary dissolution.'),
+        ('FAIL', 'ULC', 'voluntary', False, HTTPStatus.BAD_REQUEST,
+         'Officer email is required for voluntary dissolution.'),
+        ('SUCCESS', 'CP', 'voluntary', False, None, None),
+        ('SUCCESS', 'BC', 'voluntary', True, None, None),
+        ('SUCCESS', 'BEN', 'voluntary', True, None, None),
+        ('SUCCESS', 'CC', 'voluntary', True, None, None),
+        ('SUCCESS', 'ULC', 'voluntary', True, None, None),
+        ('SUCCESS', 'BC', 'administrative', False, None, None),
+    ]
+)
+def test_dissolution_officer_email(session, test_status, legal_type, dissolution_type, has_email, expected_code, expected_msg):
+    """Test officer email validation in voluntary dissolution."""
+    business = Business(identifier='BC1234567', legal_type=legal_type)
+    filing = copy.deepcopy(FILING_HEADER)
+    filing['filing']['header']['name'] = 'dissolution'
+    filing['filing']['business']['legalType'] = legal_type
+    filing['filing']['dissolution'] = copy.deepcopy(DISSOLUTION)
+    filing['filing']['dissolution']['dissolutionType'] = dissolution_type
+    filing['filing']['dissolution']['parties'][1]['deliveryAddress'] = \
+        filing['filing']['dissolution']['parties'][1]['mailingAddress']
+
+    if not has_email:
+        del filing['filing']['dissolution']['parties'][1]['officer']['email']
+
+    if dissolution_type == 'administrative':
+        filing['filing']['dissolution']['details'] = "Some Details"
+        del filing['filing']['dissolution']['affidavitFileKey']
+
+    with patch.object(dissolution, 'validate_affidavit', return_value=None):
+        err = validate(business, filing)
+
+    if test_status == 'FAIL':
+        assert err.code == expected_code
+        assert any(expected_msg in msg['error'] for msg in err.msg)
+    else:
+        assert err is None
+
+
+@pytest.mark.parametrize(
+    'test_status, legal_type, dissolution_type, has_custodial_office, expected_code, expected_msg',
+    [
+        ('FAIL', 'BC', 'voluntary', False, HTTPStatus.BAD_REQUEST,
+        'Custodial office is required for voluntary dissolution.'),
+        ('FAIL', 'BEN', 'voluntary', False, HTTPStatus.BAD_REQUEST,
+        'Custodial office is required for voluntary dissolution.'),
+        ('FAIL', 'CC', 'voluntary', False, HTTPStatus.BAD_REQUEST,
+        'Custodial office is required for voluntary dissolution.'),
+        ('FAIL', 'ULC', 'voluntary', False, HTTPStatus.BAD_REQUEST,
+        'Custodial office is required for voluntary dissolution.'),
+        ('SUCCESS', 'CP', 'voluntary', False, None, None),
+        ('SUCCESS', 'BC', 'voluntary', True, None, None),
+        ('SUCCESS', 'BEN', 'voluntary', True, None, None),
+        ('SUCCESS', 'CC', 'voluntary', True, None, None),
+        ('SUCCESS', 'ULC', 'voluntary', True, None, None),
+        ('SUCCESS', 'BC', 'administrative', False, None, None),
+    ]
+)
+def test_dissolution_custodial_office(session, test_status, legal_type, dissolution_type, has_custodial_office,
+                                      expected_code, expected_msg):
+    """Test custodial office validation in voluntary dissolution."""
+    business = Business(identifier='BC1234567', legal_type=legal_type)
+    filing = copy.deepcopy(FILING_HEADER)
+    filing['filing']['header']['name'] = 'dissolution'
+    filing['filing']['business']['legalType'] = legal_type
+    filing['filing']['dissolution'] = copy.deepcopy(DISSOLUTION)
+    filing['filing']['dissolution']['dissolutionType'] = dissolution_type
+    filing['filing']['dissolution']['parties'][1]['deliveryAddress'] = \
+        filing['filing']['dissolution']['parties'][1]['mailingAddress']
+
+    if not has_custodial_office:
+        del filing['filing']['dissolution']['custodialOffice']
+
+    if dissolution_type == 'administrative':
+        filing['filing']['dissolution']['details'] = "Some Details"
+        del filing['filing']['dissolution']['affidavitFileKey']
+
+    with patch.object(dissolution, 'validate_affidavit', return_value=None):
+        err = validate(business, filing)
+
+    if test_status == 'FAIL':
+        assert err.code == expected_code
+        assert any(expected_msg in msg['error'] for msg in err.msg)
+    else:
+        assert err is None

--- a/legal-api/tests/unit/services/filings/validations/test_incorporation_application.py
+++ b/legal-api/tests/unit/services/filings/validations/test_incorporation_application.py
@@ -1421,3 +1421,83 @@ def test_ia_court_order(session, mocker, test_name):
         err = validate(None, filing_json)
 
     assert err is None
+
+
+@pytest.mark.parametrize(
+    'legal_type, has_rights_or_restrictions, has_series, should_pass',
+    [
+        (Business.LegalTypes.BCOMP.value, False, True, False),
+        (Business.LegalTypes.BCOMP.value, False, False, True),
+        (Business.LegalTypes.BCOMP.value, True, True, True),
+        (Business.LegalTypes.BCOMP.value, True, False, True),
+
+        (Business.LegalTypes.BC_ULC_COMPANY.value, False, True, False),
+        (Business.LegalTypes.BC_ULC_COMPANY.value, False, False, True),
+        (Business.LegalTypes.BC_ULC_COMPANY.value, True, True, True),
+        (Business.LegalTypes.BC_ULC_COMPANY.value, True, False, True),
+
+        (Business.LegalTypes.BC_CCC.value, False, True, False),
+        (Business.LegalTypes.BC_CCC.value, False, False, True),
+        (Business.LegalTypes.BC_CCC.value, True, True, True),
+        (Business.LegalTypes.BC_CCC.value, True, False, True),
+
+        (Business.LegalTypes.COMP.value, False, True, False),
+        (Business.LegalTypes.COMP.value, False, False, True),
+        (Business.LegalTypes.COMP.value, True, True, True),
+        (Business.LegalTypes.COMP.value, True, False, True),
+    ]
+)
+def test_incorporation_application_share_class_series_validation(mocker, app, session, legal_type,
+                                                       has_rights_or_restrictions, has_series, should_pass):
+    """Test share class/series validation in incorporation application."""
+    filing_json = copy.deepcopy(FILING_HEADER)
+    filing_json['filing'].pop('business')
+    filing_json['filing']['header'] = {'name': incorporation_application_name, 'date': '2019-04-08',
+                                       'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+
+    filing_json['filing'][incorporation_application_name] = copy.deepcopy(INCORPORATION)
+
+    if 'shareStructure' in filing_json['filing'][incorporation_application_name]:
+        for share_class in filing_json['filing'][incorporation_application_name]['shareStructure']['shareClasses']:
+            share_class['hasRightsOrRestrictions'] = has_rights_or_restrictions
+            if not has_rights_or_restrictions:
+                if not has_series:
+                    share_class.pop('series', None)
+
+    err = validate(None, filing_json)
+
+    if should_pass:
+        assert err is None
+    else:
+        assert err
+        assert any('cannot have series when hasRightsOrRestrictions is false' in msg['error'] for msg in err.msg)
+
+
+@pytest.mark.parametrize(
+    'test_name, has_delivery_address, expected_code, expected_msg',
+    [
+        ('MISSING_DELIVERY_ADDRESS', False, HTTPStatus.BAD_REQUEST, 'deliveryAddress is required.'),
+        ('SUCCESS', True, None, None),
+    ]
+)
+def test_validate_incorporation_application_parties_delivery_address(mocker, app, session, test_name,
+                                                                     has_delivery_address, expected_code, expected_msg):
+    """Test parties delivery address validation in incorporation application."""
+    filing_json = copy.deepcopy(FILING_HEADER)
+    filing_json['filing'].pop('business')
+    filing_json['filing']['header'] = {'name': incorporation_application_name, 'date': '2019-04-08',
+                                       'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+
+    filing_json['filing'][incorporation_application_name] = copy.deepcopy(INCORPORATION)
+
+    if not has_delivery_address:
+        if 'deliveryAddress' in filing_json['filing'][incorporation_application_name]['parties'][0]:
+            del filing_json['filing'][incorporation_application_name]['parties'][0]['deliveryAddress']
+
+    err = validate(None, filing_json)
+
+    if expected_code:
+        assert err.code == expected_code
+        assert any(expected_msg in msg['error'] for msg in err.msg)
+    else:
+        assert err is None

--- a/legal-api/tests/unit/services/filings/validations/test_registration.py
+++ b/legal-api/tests/unit/services/filings/validations/test_registration.py
@@ -267,8 +267,8 @@ def test_invalid_business_address(mocker, app, session, jwt, test_name, filing):
     """Assert that delivery business address is invalid."""
     mocker.patch('legal_api.utils.auth.jwt.validate_roles', return_value=False)  # Client
 
-    filing['filing']['registration']['offices']['businessOffice']['deliveryAddress']['addressRegion'] = 'invalid'
-    filing['filing']['registration']['offices']['businessOffice']['deliveryAddress']['addressCountry'] = 'invalid'
+    filing['filing']['registration']['offices']['businessOffice']['deliveryAddress']['addressRegion'] = 'AB'
+    filing['filing']['registration']['offices']['businessOffice']['deliveryAddress']['addressCountry'] = 'US'
 
     legal_type = filing['filing']['registration']['nameRequest']['legalType']
     with patch.object(NameXService, 'query_nr_number', return_value=_mock_nr_response(legal_type)):


### PR DESCRIPTION
*Issue #:* /bcgov/entity#28460

*Description of changes:*
For this PR, we primarily added and updated BE validations for the corps type business to ensure validation consistency with FE in the sandbox.

### Scope of the change:

#### Share class and series validation:
* Added backend validation to ensure corps-type companies cannot have share series when hasRightsOrRestrictions is false.
* Aligned with FE logic. The UI prevents users from adding series if the share class does not have rights or restrictions.

#### Party and office address validation:
  * Added validations for parties' delivery addresses in multiple filing types to match FE behavior, including:
 1. IA Corps
 2. Amalgamation Application(Regular type) Corps 
 3. Continuation In Corps 

#### Voluntary dissolution validations:
* Added backend validations for parties, custodial office, and email fields in voluntary dissolution filings.
* These fields are required on the FE but were not validated on the BE.

#### Fixed failed unit tests:
* Updated test cases for invalid business addresses 

#### Other changes:
* Updated business schema version number to pull in the latest updates.

#### Local test results:
##### The validation for the Share class and series :
![image](https://github.com/user-attachments/assets/5c909df7-43ca-46aa-b9a3-febbaa9df5b4)

#### The validation for the missing delivery address:
![image](https://github.com/user-attachments/assets/ac6310ba-2262-40de-ad5a-4f55a2cd89bb)
![image](https://github.com/user-attachments/assets/8e2277a6-2801-41bb-85b6-ecd11ee045f6)
![image](https://github.com/user-attachments/assets/9b0507c4-349a-47ad-9af7-1f06511b2aa7)


#### The validation for Voluntary dissolution:
![image](https://github.com/user-attachments/assets/dd8aea17-b339-40e5-a8c1-8a0d8ce51083)
![image](https://github.com/user-attachments/assets/8a6e9a3b-23ff-4c26-a4d4-fc9a38042552)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
