### PR TITLE
add transition application tasks

### DIFF
--- a/legal-api/src/legal_api/models/business.py
+++ b/legal-api/src/legal_api/models/business.py
@@ -488,7 +488,7 @@ class Business(db.Model, Versioned):  # pylint: disable=too-many-instance-attrib
             return True
         # When involuntary dissolution feature flag is on, check transition filing
         if flags.is_on('enable_involuntary_dissolution'):
-            if self._has_no_transition_filed_after_restoration():
+            if self._transition_needed_but_not_filed():
                 return False
         # Date of last AR or founding date if they haven't yet filed one
         last_ar_date = self.last_ar_date or self.founding_date
@@ -502,10 +502,10 @@ class Business(db.Model, Versioned):  # pylint: disable=too-many-instance-attrib
                 return date_cutoff.replace(tzinfo=pytz.UTC) > datetime.utcnow()
         return True
 
-    def _has_no_transition_filed_after_restoration(self) -> bool:
+    def _transition_needed_but_not_filed(self) -> bool:
         """Return True for no transition filed after restoration check. Otherwise, return False.
 
-        Check whether the business needs to file Transition but does not file it within 12 months after restoration.
+        Check whether the business needs to file Transition but has not done so
         """
         from legal_api.core.filing import Filing as CoreFiling  # pylint: disable=import-outside-toplevel
 
@@ -513,7 +513,6 @@ class Business(db.Model, Versioned):  # pylint: disable=too-many-instance-attrib
         restoration_filing = aliased(Filing)
         transition_filing = aliased(Filing)
 
-        restoration_filing_effective_cutoff = restoration_filing.effective_date + text("""INTERVAL '1 YEAR'""")
         condition = exists().where(
             and_(
                 self.legal_type != Business.LegalTypes.EXTRA_PRO_A.value,
@@ -524,7 +523,6 @@ class Business(db.Model, Versioned):  # pylint: disable=too-many-instance-attrib
                     CoreFiling.FilingTypes.RESTORATIONAPPLICATION.value
                 ]),
                 restoration_filing._status == Filing.Status.COMPLETED.value,  # pylint: disable=protected-access
-                restoration_filing_effective_cutoff <= func.timezone('UTC', func.now()),
                 not_(
                     exists().where(
                         and_(
@@ -533,10 +531,7 @@ class Business(db.Model, Versioned):  # pylint: disable=too-many-instance-attrib
                              CoreFiling.FilingTypes.TRANSITION.value),
                             (transition_filing._status ==  # pylint: disable=protected-access
                              Filing.Status.COMPLETED.value),
-                            transition_filing.effective_date.between(
-                                restoration_filing.effective_date,
-                                restoration_filing_effective_cutoff
-                            )
+                            transition_filing.effective_date >= restoration_filing.effective_date
                         )
                     )
                 )

--- a/legal-api/src/legal_api/services/involuntary_dissolution.py
+++ b/legal-api/src/legal_api/services/involuntary_dissolution.py
@@ -194,7 +194,7 @@ def _has_specific_filing_overdue():
 def _has_no_transition_filed_after_restoration():
     """Return SQLAlchemy clause for no transition filed after restoration check.
 
-    Check if the business needs to file Transition but does not file it within 12 months after restoration.
+    Check if the business needs to file Transition but does not file it
     """
     from legal_api.core.filing import Filing as CoreFiling  # pylint: disable=import-outside-toplevel
 
@@ -203,9 +203,7 @@ def _has_no_transition_filed_after_restoration():
     restoration_filing = aliased(Filing)
     transition_filing = aliased(Filing)
 
-    restoration_filing_effective_cutoff = restoration_filing.effective_date + text("""INTERVAL '1 YEAR'""")
-
-    return select([func.max(func.coalesce(restoration_filing_effective_cutoff, None))]).where(
+    return select([func.max(func.coalesce(restoration_filing.effective_date, None))]).where(
             and_(
                 Business.legal_type != Business.LegalTypes.EXTRA_PRO_A.value,
                 Business.founding_date < new_act_date,
@@ -223,10 +221,7 @@ def _has_no_transition_filed_after_restoration():
                             == CoreFiling.FilingTypes.TRANSITION.value,  # pylint: disable=protected-access
                             transition_filing._status == \
                             Filing.Status.COMPLETED.value,  # pylint: disable=protected-access
-                            transition_filing.effective_date.between(
-                                restoration_filing.effective_date,
-                                restoration_filing_effective_cutoff
-                            )
+                            transition_filing.effective_date >= restoration_filing.effective_date
                         )
                     )
                 )

--- a/legal-api/tests/unit/models/test_business.py
+++ b/legal-api/tests/unit/models/test_business.py
@@ -273,29 +273,30 @@ RESTORATION_FILING = copy.deepcopy(FILING_HEADER)
 RESTORATION_FILING['filing']['restoration'] = RESTORATION
 
 
-@pytest.mark.parametrize('test_name, has_no_transition_filed, good_standing', [
-    ('NO_NEED_TRANSITION_NEW_ACT', False, True),
-    ('NO_NEED_TRANSITION_BUT_IN_LIMITED_RESTORATION', False, False),
-    ('TRANSITION_COMPLETED', False, True),
-    ('TRANSITION_NOT_FILED', True, False)
+@pytest.mark.parametrize('test_name, transition_needed_but_not_filed, good_standing', [
+    ('BUSINES_FOUNDED_AFTER_NEW_ACT', False, True),
+    ('TRANSITION_NEEDED_BUT_NOT_FILED_RESTORATION_WITHIN_12_MONTH', True, False),
+    ('TRANSITION_NEEDED_BUT_NOT_FILED', True, False),
+    ('TRANSITION_NEEDED_AND_COMPLETED', False, True),
 ])
-def test_good_standing_check_transition_filing(session, test_name, has_no_transition_filed, good_standing):
+def test_good_standing_check_transition_filing(session, test_name, transition_needed_but_not_filed, good_standing):
     "Assert that the business is in good standing with additional check for transition filing"
     business = factory_business_from_tests(identifier='BC1234567', entity_type=Business.LegalTypes.COMP.value, last_ar_date=datetime.utcnow())
     restoration_filing = factory_completed_filing(business, RESTORATION_FILING, filing_type='restoration')
-    if test_name == 'NO_NEED_TRANSITION_NEW_ACT':
+    if test_name == 'BUSINES_FOUNDED_AFTER_NEW_ACT':
         business.founding_date = datetime.utcnow()
         business.save()
-    elif test_name == 'NO_NEED_TRANSITION_BUT_IN_LIMITED_RESTORATION':
+    elif test_name == 'TRANSITION_NEEDED_BUT_NOT_FILED_RESTORATION_WITHIN_12_MONTH':
         business.restoration_expiry_date = datetime.utcnow() + datedelta.datedelta(years=1)
         business.save()
         restoration_filing.effective_date = datetime.utcnow()
         restoration_filing.save()
-    elif test_name == 'TRANSITION_COMPLETED':
+    elif test_name == 'TRANSITION_NEEDED_AND_COMPLETED':
         factory_completed_filing(business, TRANSITION_FILING_TEMPLATE, filing_type='transition')
 
-    check_result = business._has_no_transition_filed_after_restoration()
-    assert check_result == has_no_transition_filed
+    check_result = business._transition_needed_but_not_filed()
+
+    assert check_result == transition_needed_but_not_filed
     with patch.object(flags, 'is_on', return_value=True):
         assert business.good_standing == good_standing
 


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/28926

*Description of changes:*
- update logic for determining good standing status. For business founded before 2024.03.29, when it gets restored, a transition application filing is required. The business will have 'not in good standing' status until a transition filing has been made. No need to wait for 12 months. 
- Add transition application todo item to the v2 task endpoint. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
