### PR TITLE
fix: for the namex URL slash issue

### DIFF
--- a/queue_services/business-filer/src/business_filer/filing_processors/filing_components/name_request.py
+++ b/queue_services/business-filer/src/business_filer/filing_processors/filing_components/name_request.py
@@ -69,7 +69,7 @@ def consume_nr(business: Business,
                 data = json.dumps({"consume": {"corpNum": business.identifier}})
 
             rv = requests.patch(
-                url="".join([namex_svc_url, nr_num]),
+                url="/".join([namex_svc_url.rstrip("/"), nr_num]),
                 headers={**AccountService.CONTENT_TYPE_JSON,
                          "Authorization": AccountService.BEARER + token},
                 data=data,


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*
In filer cleanup namex url end slashes and append new one when joining name request identifier for the url patch

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
