### PR TITLE
29204 Add scripts for backing up and restoring specific COLIN extract tables

### DIFF
--- a/data-tool/backup_extract_tables.sh
+++ b/data-tool/backup_extract_tables.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# restore_extract.sh
+#
+# Backs up a list of Postgres tables that we want to restore whenever a new COLIN extract is created
+
+set -euo pipefail
+
+##############################################################################
+# USER‑TUNABLE PARAMETERS                                               #
+##############################################################################
+
+# -- Connection ----------------------------------------------------------------
+PGHOST="${PGHOST:-localhost}"        # or ‑‑host
+PGPORT="${PGPORT:-5432}"             # or ‑‑port
+PGUSER="${PGUSER:-postgres}"        # or ‑‑user
+PGDATABASE="${PGDATABASE:-colin-mig-corps-test}"     # or ‑‑dbname
+# Supply the password *either* via a .pgpass file *or* one‑shot:
+#   PGPASSWORD=secret ./backup_extract_tables.sh
+##############################################################################
+
+# -- Tables to keep ------------------------------------------------------------
+KEEP=(corp_processing colin_tracking mig_group mig_batch mig_corp_batch corps_with_third_party)
+
+# -- Runtime options -----------------------------------------------------------
+BACKUP_DIR="${BACKUP_DIR:-/backups}"
+DUMP="$BACKUP_DIR/keep_$(date +%F).dump"
+
+##############################################################################
+# INTERNAL HELPERS
+##############################################################################
+
+die() { printf >&2 "error: %s\n" "$*"; exit 1; }
+
+# Build a single “‑h … ‑p … ‑U …” string so every call is consistent
+pg_conn_opts() {
+  printf -- "-h %s -p %s -d %s -U %s" "$PGHOST" "$PGPORT" "$PGDATABASE" "$PGUSER"
+}
+
+# Pass arrays (e.g., KEEP) as repeated --table switches
+as_table_opts() { local t; for t in "$@"; do printf -- '--table=%s ' "$t"; done; }
+
+##############################################################################
+# BACK UP THE TABLES                                                     #
+##############################################################################
+
+printf "📦  Dumping preserved tables …\n"
+mkdir -p "$BACKUP_DIR"
+
+pg_dump $(pg_conn_opts) -Fc \
+        $(as_table_opts "${KEEP[@]}") \
+        --no-owner --no-acl \
+        -f "$DUMP"
+

--- a/data-tool/restore_extract.sh
+++ b/data-tool/restore_extract.sh
@@ -16,9 +16,11 @@ PGPORT="${PGPORT:-5432}"             # or ‑‑port
 PGUSER="${PGUSER:-postgres}"        # or ‑‑user
 PGDATABASE="${PGDATABASE:-colin-mig-corps-test}"     # or ‑‑dbname
 # Supply the password *either* via a .pgpass file *or* one‑shot:
-#   PGPASSWORD=secret ./backup_extract_tables.sh
+#   PGPASSWORD=secret ./restore_extract.sh
 ##############################################################################
 
+# -- Tables to restore ------------------------------------------------------------
+RESTORE=(corp_processing colin_tracking mig_group mig_batch mig_corp_batch corps_with_third_party)
 
 # -- Runtime options -----------------------------------------------------------
 DUMP="${DUMP}"
@@ -52,7 +54,7 @@ printf "🔄  Re‑importing Postgres from Oracle …\n"
 printf "🚚  Copying preserved rows (constraints temporarily disabled) …\n"
 pg_restore $(pg_conn_opts) --section=data --data-only \
           --disable-triggers \
-          $(as_table_opts "${KEEP[@]}") "$DUMP"
+          $(as_table_opts "${RESTORE[@]}") "$DUMP"
 
 ##############################################################################
 # ── FIX ANY SEQUENCES                                                     #

--- a/data-tool/restore_extract.sh
+++ b/data-tool/restore_extract.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# restore_extract.sh
+#
+# 1. Drops / regenerates the database from Oracle
+# 2. Restores the preserved tables and repairs sequences
+
+set -euo pipefail
+
+##############################################################################
+# USER‑TUNABLE PARAMETERS                                               #
+##############################################################################
+
+# -- Connection ----------------------------------------------------------------
+PGHOST="${PGHOST:-localhost}"        # or ‑‑host
+PGPORT="${PGPORT:-5432}"             # or ‑‑port
+PGUSER="${PGUSER:-postgres}"        # or ‑‑user
+PGDATABASE="${PGDATABASE:-colin-mig-corps-test}"     # or ‑‑dbname
+# Supply the password *either* via a .pgpass file *or* one‑shot:
+#   PGPASSWORD=secret ./backup_extract_tables.sh
+##############################################################################
+
+
+# -- Runtime options -----------------------------------------------------------
+DUMP="${DUMP}"
+
+##############################################################################
+# INTERNAL HELPERS
+##############################################################################
+
+die() { printf >&2 "error: %s\n" "$*"; exit 1; }
+
+# Build a single “‑h … ‑p … ‑U …” string so every call is consistent
+pg_conn_opts() {
+  printf -- "-h %s -p %s -d %s -U %s" "$PGHOST" "$PGPORT" "$PGDATABASE" "$PGUSER"
+}
+
+# Pass arrays (e.g., KEEP) as repeated --table switches
+as_table_opts() { local t; for t in "$@"; do printf -- '--table=%s ' "$t"; done; }
+
+
+##############################################################################
+# ── RECREATE THE DATABASE FROM ORACLE                                      #
+##############################################################################
+
+# TODO: test adding extract script reference here.  i.e. /data-tool/scripts/transfer_cprd_corps.sql
+printf "🔄  Re‑importing Postgres from Oracle …\n"
+
+##############################################################################
+# ── RESTORE DATA FOR THE PRESERVED TABLES                                           #
+##############################################################################
+
+printf "🚚  Copying preserved rows (constraints temporarily disabled) …\n"
+pg_restore $(pg_conn_opts) --section=data --data-only \
+          --disable-triggers \
+          $(as_table_opts "${KEEP[@]}") "$DUMP"
+
+##############################################################################
+# ── FIX ANY SEQUENCES                                                     #
+##############################################################################
+
+printf "🛠   Advancing sequences …\n"
+psql $(pg_conn_opts) <<'SQL'
+DO $$
+DECLARE r record;
+BEGIN
+  FOR r IN
+    SELECT seq.relname AS seq,
+           tbl.relname AS tbl,
+           col.attname AS col
+    FROM   pg_class seq
+    JOIN   pg_depend d   ON d.objid = seq.oid AND d.deptype = 'a'
+    JOIN   pg_class tbl  ON tbl.oid = d.refobjid
+    JOIN   pg_attribute col
+           ON col.attrelid = tbl.oid AND col.attnum = d.refobjsubid
+    WHERE  seq.relkind = 'S'
+  LOOP
+    EXECUTE format(
+      'SELECT setval(%L, COALESCE((SELECT MAX(%I) FROM %I), 0));',
+      r.seq, r.col, r.tbl
+    );
+  END LOOP;
+END;
+$$;
+SQL
+
+printf "✅  Done. Preserved tables restored; sequences synchronised.\n"

--- a/data-tool/scripts/colin_corps_extract_postgres_ddl
+++ b/data-tool/scripts/colin_corps_extract_postgres_ddl
@@ -622,6 +622,56 @@ comment on column corp_party_relationship.relationship_typ_cd is 'Court ordered 
 alter table corp_party_relationship
     owner to postgres;
 
+create table if not exists mig_group
+(
+    id          integer default nextval('mig_group_id_seq'::regclass) not null
+        constraint pk_mig_group primary key,
+    name        varchar(100)                                       not null,
+    display_name       varchar(100) not null,
+    source_db          varchar(25),
+    target_environment varchar(25),
+    create_date timestamp with time zone default CURRENT_TIMESTAMP not null,
+    notes       varchar(600)
+);
+
+alter table mig_group
+    owner to postgres;
+
+
+create table if not exists mig_batch
+(
+    id                 integer default nextval('mig_batch_id_seq'::regclass) not null
+        constraint pk_mig_batch primary key,
+    name               varchar(100) not null,
+    display_name       varchar(100) not null,
+    created_date       timestamp with time zone default CURRENT_TIMESTAMP,
+    requested_date     date,
+    migrated_date      date,
+    notes              varchar(600),
+    mig_group_id           integer
+        constraint fk_mig_batch_mig_group
+            references mig_group,
+    source_db          varchar(25),
+    target_environment varchar(25)
+);
+
+alter table mig_batch
+    owner to postgres;
+
+
+create table if not exists mig_corp_batch
+(
+    id           integer default nextval('mig_corp_batch_id_seq'::regclass) not null
+        constraint pk_mig_corp_batch primary key,
+    mig_batch_id integer     not null
+        constraint fk_mig_corp_batch_mig_batch
+            references mig_batch,
+    corp_num     varchar(10) not null
+);
+
+alter table mig_corp_batch
+    owner to postgres;
+
 create table if not exists corp_processing
 (
     id                      integer default nextval('corp_processing_id_seq'::regclass) not null
@@ -829,56 +879,6 @@ create table if not exists colin_tracking
 );
 
 alter table colin_tracking
-    owner to postgres;
-
-
-create table if not exists mig_group
-(
-    id          integer default nextval('mig_group_id_seq'::regclass) not null
-        constraint pk_mig_group primary key,
-    name        varchar(100)                                       not null,
-    display_name       varchar(100) not null,
-    source_db          varchar(25),
-    target_environment varchar(25)
-    create_date timestamp with time zone default CURRENT_TIMESTAMP not null,
-    notes       varchar(600)
-);
-
-alter table mig_group
-    owner to postgres;
-
-
-create table if not exists mig_batch
-(
-    id                 integer default nextval('mig_batch_id_seq'::regclass) not null
-        constraint pk_mig_batch primary key,
-    name               varchar(100) not null,
-    display_name       varchar(100) not null,
-    created_date       timestamp with time zone default CURRENT_TIMESTAMP,
-    migrated_date      date,
-    notes              varchar(600),
-    mig_group_id           integer
-        constraint fk_mig_batch_mig_group
-            references mig_group,
-    source_db          varchar(25),
-    target_environment varchar(25)
-);
-
-alter table mig_batch
-    owner to postgres;
-
-
-create table if not exists mig_corp_batch
-(
-    id           integer default nextval('mig_corp_batch_id_seq'::regclass) not null
-        constraint pk_mig_corp_batch primary key,
-    mig_batch_id integer     not null
-        constraint fk_mig_corp_batch_mig_batch
-            references mig_batch,
-    corp_num     varchar(10) not null
-);
-
-alter table mig_corp_batch
     owner to postgres;
 
 CREATE INDEX if not exists ix_conv_event_event_id ON conv_event (event_id);


### PR DESCRIPTION
*Issue #:* /bcgov/entity#29204

*Description of changes:*
* Misc updates to COLIN extract ddl as migration tables ordering was incorrect and ddl failed to create initial skeleton tables
* Add shell script(`backup_extract_tables.sh`) to back up data for specific extract tables
  * corp_processing
  * colin_tracking
  * mig_group
  * mig_batch
  * mig_corp_batch
  * corps_with_third_party
* Add shell script(`restore_extract.sh`) to restore data for specific extract tables.  Note: there are some TODOs in this script as there is some future work to maybe integrate the extract transfer script into this this script.

**Example run details:**
<img width="612" alt="image" src="https://github.com/user-attachments/assets/b790e5f0-ed2f-4b34-a132-9568293b7a0a" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
