### PR TITLE
Hotfix for Search

### DIFF
--- a/legal-api/src/legal_api/services/search_service.py
+++ b/legal-api/src/legal_api/services/search_service.py
@@ -196,7 +196,7 @@ class BusinessSearchService:  # pylint: disable=too-many-public-methods
                                             search_filters: AffiliationSearchDetails = None):
         """Return contact point from business json."""
         if not identifiers:
-            return [], False        
+            return [], False
         name = search_filters.name
         types = search_filters.type
         statuses = search_filters.status

--- a/legal-api/src/legal_api/services/search_service.py
+++ b/legal-api/src/legal_api/services/search_service.py
@@ -243,7 +243,6 @@ class BusinessSearchService:  # pylint: disable=too-many-public-methods
         limit = search_filters.limit
         offset = (search_filters.page - 1) * limit
         draft_query = db.session.query(Filing).filter(*filters).limit(limit+1).offset(offset).all()
-        
         draft_results = []
         # base filings query (for draft incorporation/registration filings -- treated as 'draft' business in auth-web)
         if identifiers:

--- a/legal-api/src/legal_api/services/search_service.py
+++ b/legal-api/src/legal_api/services/search_service.py
@@ -195,7 +195,7 @@ class BusinessSearchService:  # pylint: disable=too-many-public-methods
                                             identifiers=None,
                                             search_filters: AffiliationSearchDetails = None):
         """Return contact point from business json."""
-        if not search_filters or not identifiers:
+        if not search_filters and not identifiers:
             return [], False        
         name = search_filters.name
         types = search_filters.type

--- a/legal-api/src/legal_api/services/search_service.py
+++ b/legal-api/src/legal_api/services/search_service.py
@@ -195,7 +195,7 @@ class BusinessSearchService:  # pylint: disable=too-many-public-methods
                                             identifiers=None,
                                             search_filters: AffiliationSearchDetails = None):
         """Return contact point from business json."""
-        if not search_filters and not identifiers:
+        if not identifiers:
             return [], False        
         name = search_filters.name
         types = search_filters.type

--- a/legal-api/src/legal_api/services/search_service.py
+++ b/legal-api/src/legal_api/services/search_service.py
@@ -196,8 +196,7 @@ class BusinessSearchService:  # pylint: disable=too-many-public-methods
                                             search_filters: AffiliationSearchDetails = None):
         """Return contact point from business json."""
         if not search_filters or not identifiers:
-            return [], False
-        
+            return [], False        
         name = search_filters.name
         types = search_filters.type
         statuses = search_filters.status

--- a/legal-api/src/legal_api/services/search_service.py
+++ b/legal-api/src/legal_api/services/search_service.py
@@ -242,8 +242,7 @@ class BusinessSearchService:  # pylint: disable=too-many-public-methods
 
         limit = search_filters.limit
         offset = (search_filters.page - 1) * limit
-        results = db.session.query(Filing).filter(*filters).limit(limit+1).offset(offset)
-        draft_query = results.all()
+        draft_query = db.session.query(Filing).filter(*filters).limit(limit+1).offset(offset).all()
         
         draft_results = []
         # base filings query (for draft incorporation/registration filings -- treated as 'draft' business in auth-web)

--- a/legal-api/src/legal_api/services/search_service.py
+++ b/legal-api/src/legal_api/services/search_service.py
@@ -195,6 +195,9 @@ class BusinessSearchService:  # pylint: disable=too-many-public-methods
                                             identifiers=None,
                                             search_filters: AffiliationSearchDetails = None):
         """Return contact point from business json."""
+        if not search_filters or not identifiers:
+            return [], False
+        
         name = search_filters.name
         types = search_filters.type
         statuses = search_filters.status
@@ -239,7 +242,9 @@ class BusinessSearchService:  # pylint: disable=too-many-public-methods
 
         limit = search_filters.limit
         offset = (search_filters.page - 1) * limit
-        draft_query = db.session.query(Filing).filter(*filters).limit(limit+1).offset(offset).all()
+        results = db.session.query(Filing).filter(*filters).limit(limit+1).offset(offset)
+        draft_query = results.all()
+        
         draft_results = []
         # base filings query (for draft incorporation/registration filings -- treated as 'draft' business in auth-web)
         if identifiers:


### PR DESCRIPTION
*Issue #:* /bcgov/entity#

*Description of changes:*
Hotfix for search endpoint
- updated early return if no filings being searched.
limit is always being set by default so would be always search filters, no identifiers then return early

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
