### PR TITLE
29204 Tweaks to restore extract script

### DIFF
--- a/data-tool/restore_extract.sh
+++ b/data-tool/restore_extract.sh
@@ -41,14 +41,24 @@ as_table_opts() { local t; for t in "$@"; do printf -- '--table=%s ' "$t"; done;
 
 
 ##############################################################################
-# ── RECREATE THE DATABASE FROM ORACLE                                      #
+# ── RECREATE THE DATABASE FROM ORACLE                                       #
 ##############################################################################
 
 # TODO: test adding extract script reference here.  i.e. /data-tool/scripts/transfer_cprd_corps.sql
 printf "🔄  Re‑importing Postgres from Oracle …\n"
 
 ##############################################################################
-# ── RESTORE DATA FOR THE PRESERVED TABLES                                           #
+# -- EMPTY the tables but keep their structure                               #
+##############################################################################
+printf "🧹  Truncating existing rows …\n"
+psql $(pg_conn_opts) -v ON_ERROR_STOP=1 -q <<SQL
+  TRUNCATE TABLE $(IFS=,; echo "${RESTORE[*]}") RESTART IDENTITY;
+SQL
+#  - RESTART IDENTITY zeros the sequences; we'll set them correctly later.
+#  - No CASCADE → we don’t wipe child tables that reference these rows.
+
+##############################################################################
+# ── RESTORE DATA FOR THE PRESERVED TABLES                                   #
 ##############################################################################
 
 printf "🚚  Copying preserved rows (constraints temporarily disabled) …\n"
@@ -57,29 +67,48 @@ pg_restore $(pg_conn_opts) --section=data --data-only \
           $(as_table_opts "${RESTORE[@]}") "$DUMP"
 
 ##############################################################################
-# ── FIX ANY SEQUENCES                                                     #
+# ── FIX ANY SEQUENCES                                                       #
 ##############################################################################
 
-printf "🛠   Advancing sequences …\n"
+printf "🛠  Advancing sequences …\n"
 psql $(pg_conn_opts) <<'SQL'
 DO $$
-DECLARE r record;
+DECLARE
+  r record;
+  max_val bigint;
 BEGIN
   FOR r IN
+    -- For SERIAL/IDENTITY columns (auto-dependency from sequence to column)
     SELECT seq.relname AS seq,
            tbl.relname AS tbl,
            col.attname AS col
-    FROM   pg_class seq
-    JOIN   pg_depend d   ON d.objid = seq.oid AND d.deptype = 'a'
-    JOIN   pg_class tbl  ON tbl.oid = d.refobjid
-    JOIN   pg_attribute col
+    FROM pg_class seq
+    JOIN pg_depend d ON d.objid = seq.oid AND d.deptype = 'a'
+    JOIN pg_class tbl  ON tbl.oid = d.refobjid
+    JOIN pg_attribute col
            ON col.attrelid = tbl.oid AND col.attnum = d.refobjsubid
     WHERE  seq.relkind = 'S'
+    UNION ALL
+    -- For columns with DEFAULT nextval('sequence') (normal dependency from column default to sequence)
+    SELECT
+      seq.relname as seq,
+      tbl.relname as tbl,
+      col.attname as col
+    FROM pg_depend d
+    JOIN pg_class seq ON seq.oid = d.refobjid AND seq.relkind = 'S'
+    JOIN pg_attrdef ad ON ad.oid = d.objid AND d.classid = 'pg_attrdef'::regclass
+    JOIN pg_attribute col ON col.attrelid = ad.adrelid AND col.attnum = ad.adnum
+    JOIN pg_class tbl ON tbl.oid = ad.adrelid
+    WHERE d.deptype = 'n'
   LOOP
-    EXECUTE format(
-      'SELECT setval(%L, COALESCE((SELECT MAX(%I) FROM %I), 0));',
-      r.seq, r.col, r.tbl
-    );
+    EXECUTE format('SELECT MAX(%I) FROM %I', r.col, r.tbl) INTO max_val;
+    IF max_val IS NULL THEN
+      -- Table is empty, reset sequence to start at 1. The next call to nextval() will return 1.
+      EXECUTE format('SELECT setval(%L, 1, false);', r.seq);
+    ELSE
+      -- Table has data, set sequence so nextval() returns max_val + 1.
+      EXECUTE format('SELECT setval(%L, %s);', r.seq, max_val);
+    END IF;
   END LOOP;
 END;
 $$;


### PR DESCRIPTION
*Issue #:* /bcgov/entity#29204

*Description of changes:*
- Add logic to empty data in tables that will be restored with data dump(e.g. `keep_2025-07-11.dump`) generated from `backup_extract.sh`
- Update sequence logic so it properly updates sequences that use nextval pattern as opposed to serial/identity method in postgres

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
