### PR TITLE
29516 - add effective date to AR filing payload

### DIFF
--- a/docs/business.yaml
+++ b/docs/business.yaml
@@ -5550,7 +5550,7 @@ components:
           type: string
           format: date-time
           title: The date and time a filing should become valid and applied.
-          description: Date and time the filing is taking effect. Required for Annual Report and Change of Directors filing.
+          description: Date and time the filing is taking effect. Required for Annual Report and Change of Directors filing. For Annual report, this is a required field and should be the Annual report date.
         paymentToken:
           type: string
           title: A valid payment token for this filing against this business.

--- a/docs/business.yaml
+++ b/docs/business.yaml
@@ -5550,7 +5550,7 @@ components:
           type: string
           format: date-time
           title: The date and time a filing should become valid and applied.
-          description: Date and time the filing is taking effect. Required for Change of Directors filing.
+          description: Date and time the filing is taking effect. Required for Annual Report and Change of Directors filing.
         paymentToken:
           type: string
           title: A valid payment token for this filing against this business.

--- a/docs/business.yaml
+++ b/docs/business.yaml
@@ -1007,6 +1007,7 @@ paths:
                       certifiedBy: First Last
                       date: '2025-03-21'
                       accountId: 1234
+                      effectiveDate: '2025-03-21T07:00:00+00:00'
                     business:
                       foundingDate: '2024-02-21T18:05:47.466120+00:00'
                       identifier: BC1234567


### PR DESCRIPTION
*Issue #:* /bcgov/entity#29516

*Description of changes:*

Add `effectiveDate` to AR payload, update specs and postman collection
Ref: Discourse link of original API user question https://discourse.onebc.ca/t/annual-report-date/545/3


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
