### PR TITLE
27028 - Update Logic to Retrieve COOP Docs and Info from Correction

### DIFF
--- a/legal-api/src/legal_api/services/business/validations/validator.py
+++ b/legal-api/src/legal_api/services/business/validations/validator.py
@@ -49,8 +49,7 @@ def validate_document_request(document_type, business: Business):
         if (status := document_rules.get('status', None)) and business.state != status:
             errors.append({'error': babel('Specified document type is not valid for the current entity status.')})
 
-        good_standing = document_rules.get('goodStanding', None)
-        if good_standing and not business.good_standing:
+        if document_rules.get('goodStanding', None) and not business.good_standing:
             errors.append({'error': babel('Specified document type is not valid for the current entity status.')})
 
     if errors:

--- a/legal-api/src/legal_api/services/business/validations/validator.py
+++ b/legal-api/src/legal_api/services/business/validations/validator.py
@@ -35,6 +35,7 @@ document_rule_set = {
     }
 }
 
+
 def validate_document_request(document_type, business: Business):
     """Validate the business document request."""
     errors = []

--- a/legal-api/src/legal_api/services/business/validations/validator.py
+++ b/legal-api/src/legal_api/services/business/validations/validator.py
@@ -48,7 +48,8 @@ def validate_document_request(document_type, business: Business):
         if (status := document_rules.get('status', None)) and business.state != status:
             errors.append({'error': babel('Specified document type is not valid for the current entity status.')})
 
-        if (good_standing := document_rules.get('goodStanding', None)) and not business.good_standing:
+        good_standing = document_rules.get('goodStanding', None)
+        if good_standing and not business.good_standing:
             errors.append({'error': babel('Specified document type is not valid for the current entity status.')})
 
     if errors:


### PR DESCRIPTION
*Issue #:* /bcgov/entity#27028 

*Description of changes:*
- Also check correction filings for any resolutions when retrieving COOP Docs and Info
- Refactored logic into helpers due to `too-many-locals` lint warning 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
