### PR TITLE
30249 use message_id from argument (if exist) (#3711)

### DIFF
--- a/legal-api/src/legal_api/services/event_publisher.py
+++ b/legal-api/src/legal_api/services/event_publisher.py
@@ -64,7 +64,7 @@ def _publish_to_nats(payload, subject):
     )
 
 
-def _publish_to_gcp(data, subject, identifier, event_type):
+def _publish_to_gcp(data, subject, identifier, event_type, message_id):
     """Publish the event message onto the GCP topic."""
     source, time = _get_source_and_time(identifier)
     nats_to_gcp_topic = {
@@ -81,7 +81,7 @@ def _publish_to_gcp(data, subject, identifier, event_type):
         payload = data
 
     ce = SimpleCloudEvent(
-        id=str(uuid.uuid4()),
+        id=message_id or str(uuid.uuid4()),
         source=source,
         subject=topic,
         time=time,
@@ -133,7 +133,13 @@ def publish_to_queue(  # pylint: disable=too-many-arguments
     """
     try:
         if current_app.config['DEPLOYMENT_PLATFORM'] == 'GCP':
-            _publish_to_gcp(data=data, subject=subject, identifier=identifier, event_type=event_type)
+            _publish_to_gcp(
+                data=data,
+                subject=subject,
+                identifier=identifier,
+                event_type=event_type,
+                message_id=message_id
+            )
         elif is_wrapped:
             _publish_to_nats_with_wrapper(
                 data=data,

--- a/legal-api/tests/unit/services/test_event_publisher.py
+++ b/legal-api/tests/unit/services/test_event_publisher.py
@@ -94,7 +94,8 @@ def test_publish_to_gcp(app):
             data=test_data,
             subject=test_subject,
             identifier='123',
-            event_type=test_event_type
+            event_type=test_event_type,
+            message_id=None
         )
 
         mock_gcp_publish.assert_called_once()
@@ -156,7 +157,8 @@ def test_gcp_topic_mapping(app, nats_subject, gcp_subject):
             data={'test': 'data'},
             subject=app.config.get(nats_subject),
             identifier='123',
-            event_type='test.event'
+            event_type='test.event',
+            message_id=None
         )
 
         mock_gcp_publish.assert_called_once()


### PR DESCRIPTION
(cherry picked from commit 43a592087ff0566666d2312faae3e69815ac48c6)

*Issue #:* /bcgov/entity#30249

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
