### PR TITLE
29457 Update tombstone flow to have more comprehensive support for account affiliation

### DIFF
--- a/data-tool/backup_extract_tables.sh
+++ b/data-tool/backup_extract_tables.sh
@@ -19,7 +19,7 @@ PGDATABASE="${PGDATABASE:-colin-mig-corps-test}"     # or ‑‑dbname
 ##############################################################################
 
 # -- Tables to keep ------------------------------------------------------------
-KEEP=(corp_processing colin_tracking mig_group mig_batch mig_corp_batch corps_with_third_party)
+KEEP=(corp_processing colin_tracking mig_group mig_batch mig_corp_batch mig_corp_account corps_with_third_party)
 
 # -- Runtime options -----------------------------------------------------------
 BACKUP_DIR="${BACKUP_DIR:-/backups}"

--- a/data-tool/flows/common/extract_tracking_service.py
+++ b/data-tool/flows/common/extract_tracking_service.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import List
+from typing import List, Optional
 from sqlalchemy import Engine, text
 import logging
 
@@ -33,20 +33,66 @@ class ExtractTrackingService:
         self.table_name = table_name
         self.logger = logging.getLogger(__name__)
 
-    def reserve_for_flow(self, base_query: str, flow_run_id: str) -> int:
+    def reserve_for_flow(self, base_query: str, flow_run_id: str,
+                    extra_insert_cols: Optional[List[str]] = None,
+                    *,
+                    fallback_account_ids: Optional[str] = None) -> int:
         """Reserve corporations for processing in a specific flow run.
 
         Args:
             base_query: SQL query that selects corps to be processed
             flow_run_id: Unique identifier for this flow run
+            fallback_account_ids: Optional CSV string of account IDs to use when candidate_corps does not
+                                  provide account_ids.
 
         Returns:
             Number of corporations successfully reserved for this flow
         """
+        # Columns from candidate_corps we also want to persist (e.g., 'account_ids')
+        extra_cols: List[str] = extra_insert_cols or []
+        # We may need to ensure 'account_ids' is present even when the base query doesn't return it
+        include_account_ids = ('account_ids' in extra_cols) or (fallback_account_ids is not None)
+
+        # Any pass-through extra columns EXCEPT 'account_ids' (handled specially)
+        passthrough_cols = [c for c in extra_cols if c != 'account_ids']
+
+        # Build the SELECT extras for available_corps
+        select_extras_parts: List[str] = []
+        if passthrough_cols:
+            select_extras_parts.append(', ' + ', '.join(f"candidate_corps.{c}" for c in passthrough_cols))
+
+        # Track whether the SQL will reference the :fallback_account_ids bind
+        uses_fallback_bind = False
+        if include_account_ids:
+            if 'account_ids' in extra_cols:
+                if fallback_account_ids is not None:
+                    # base query yields account_ids; prefer it, but allow fallback when NULL
+                    select_extras_parts.append(
+                        ", COALESCE(candidate_corps.account_ids, CAST(:fallback_account_ids AS varchar(100))) AS account_ids"
+                    )
+                    uses_fallback_bind = True
+                else:
+                    # base query yields account_ids; no fallback
+                    select_extras_parts.append(", candidate_corps.account_ids AS account_ids")
+            else:
+                # base query does NOT yield account_ids; inject constant fallback
+                select_extras_parts.append(", CAST(:fallback_account_ids AS varchar(100)) AS account_ids")
+                uses_fallback_bind = True
+
+        available_select_extras = ''.join(select_extras_parts)
+
+        # Build the INSERT column list for extra values (passthrough and optionally account_ids)
+        insert_extra_cols = list(passthrough_cols)
+        if include_account_ids and 'account_ids' not in insert_extra_cols:
+            insert_extra_cols.append('account_ids')
+
+        # This must include a leading comma when used in the SELECT list
+        insert_extra_cols_csv = (', ' + ', '.join(insert_extra_cols)) if insert_extra_cols else ''
+
         init_query = f"""
         WITH candidate_corps AS ({base_query}),
         available_corps AS (
-            SELECT corp_num, corp_type_cd, mig_batch_id
+            SELECT corp_num, corp_type_cd, mig_batch_id{available_select_extras}
             FROM candidate_corps
             FOR UPDATE SKIP LOCKED
         )
@@ -54,6 +100,7 @@ class ExtractTrackingService:
             corp_num,
             corp_type_cd,
             mig_batch_id,
+            {', '.join(insert_extra_cols) + ',' if insert_extra_cols else ''}
             flow_name,
             processed_status,
             environment,
@@ -65,7 +112,7 @@ class ExtractTrackingService:
         SELECT 
             corp_num,
             corp_type_cd,
-            mig_batch_id,
+            mig_batch_id{insert_extra_cols_csv},
             :flow_name,
             :status,
             :environment,
@@ -81,20 +128,23 @@ class ExtractTrackingService:
 
         with self.db_engine.connect() as conn:
             with conn.begin():
-                result = conn.execute(
-                    text(init_query),
-                    {
-                        'flow_name': self.flow_name,
-                        'status': ProcessingStatuses.PENDING,
-                        'environment': self.data_load_env,
-                        'flow_run_id': flow_run_id
-                    }
-                )
+                params = {
+                    'flow_name': self.flow_name,
+                    'status': ProcessingStatuses.PENDING,
+                    'environment': self.data_load_env,
+                    'flow_run_id': flow_run_id
+                }
+                # Only add the fallback bind if the SQL references it
+                if uses_fallback_bind:
+                        params['fallback_account_ids'] = fallback_account_ids
+
+                result = conn.execute(text(init_query), params)
                 count = len(result.fetchall())
                 self.logger.info(f"Initialized {count} corps for flow run {flow_run_id}")
                 return count
 
-    def claim_batch(self, flow_run_id: str, batch_size: int) -> List[str]:
+    def claim_batch(self, flow_run_id: str, batch_size: int,
+                    extra_return_cols: Optional[List[str]] = None, as_dict: bool = False) -> List[str] | List[dict]:
         """Claim a batch of corporations for immediate processing within a flow run.
 
         Args:
@@ -104,6 +154,10 @@ class ExtractTrackingService:
         Returns:
             List of corporation numbers that were successfully claimed for processing
         """
+        extra_cols = extra_return_cols or []
+        ret_cols = ['tbl.corp_num', 'tbl.claimed_at'] + [f'tbl.{c}' for c in extra_cols]
+        returning_sql = ', '.join(ret_cols)
+
         query = f"""
         WITH claimable AS (
             SELECT corp_num, id
@@ -123,7 +177,7 @@ class ExtractTrackingService:
         FROM claimable
         WHERE tbl.corp_num = claimable.corp_num
         AND  tbl.id = claimable.id
-        RETURNING tbl.corp_num, tbl.claimed_at
+        RETURNING {returning_sql}
         """
 
         with self.db_engine.connect() as conn:
@@ -139,14 +193,24 @@ class ExtractTrackingService:
                         'batch_size': batch_size
                     }
                 )
-                claimed = result.fetchall()
-                claimed_corps = [row[0] for row in claimed]
-                if claimed_corps:
-                    self.logger.info(f"Claimed {len(claimed_corps)} corps for flow {flow_run_id}")
-                    self.logger.info(f"Corps: {', '.join(claimed_corps[:5])}...")
-                    for corp, claimed_at in claimed:
-                        self.logger.debug(f"  {corp} claimed at {claimed_at}")
-                return claimed_corps
+                rows = result.fetchall()
+                if extra_cols or as_dict:
+                    keys = ['corp_num', 'claimed_at']  + extra_cols
+                    claimed = [dict(zip(keys, row)) for row in rows]
+                    if claimed:
+                        self.logger.info(f"Claimed {len(claimed)} corps for flow {flow_run_id}")
+                        self.logger.info(f"Corps: {', '.join([c['corp_num'] for c in claimed[:5]])}...")
+                        for c in claimed:
+                                self.logger.debug(f"  {c['corp_num']} claimed at {c['claimed_at']}")
+                    return claimed
+                else:
+                    claimed_corps = [row[0] for row in rows]
+                    if claimed_corps:
+                        self.logger.info(f"Claimed {len(claimed_corps)} corps for flow {flow_run_id}")
+                        self.logger.info(f"Corps: {', '.join(claimed_corps[:5])}...")
+                        for corp, claimed_at in rows:
+                            self.logger.debug(f"  {corp} claimed at {claimed_at}")
+                    return claimed_corps
 
     def update_corp_status(
         self,
@@ -176,7 +240,12 @@ class ExtractTrackingService:
             set_clauses.append('in_early_adopter = :in_early_adopter')
             params['frozen'] = extra_params['frozen']
             params['in_early_adopter'] = extra_params['in_early_adopter']
- 
+
+        for k, v in extra_params.items():
+            if k not in ('frozen', 'in_early_adopter'):
+                set_clauses.append(f'{k} = :{k}')
+                params[k] = v
+
         query = f"""
         UPDATE {self.table_name}
         SET {', '.join(set_clauses)}

--- a/data-tool/flows/config.py
+++ b/data-tool/flows/config.py
@@ -55,11 +55,17 @@ class _Config():  # pylint: disable=too-few-public-methods
     CORP_NAME_SUFFIX = os.getenv('CORP_NAME_SUFFIX', '')
     UPDATE_ENTITY = os.getenv('UPDATE_ENTITY', 'False') == 'True'
     AFFILIATE_ENTITY = os.getenv('AFFILIATE_ENTITY', 'False') == 'True'
-    AFFILIATE_ENTITY_ACCOUNT_ID = os.getenv('AFFILIATE_ENTITY_ACCOUNT_ID')
-    if AFFILIATE_ENTITY_ACCOUNT_ID.isnumeric():
-        AFFILIATE_ENTITY_ACCOUNT_ID = int(AFFILIATE_ENTITY_ACCOUNT_ID)
-    else:
-        AFFILIATE_ENTITY_ACCOUNT_ID = None
+    AFFILIATE_ENTITY_ACCOUNT_ID = os.getenv('AFFILIATE_ENTITY_ACCOUNT_ID', '')
+    # Normalized parsed list of ints (preferred for program logic)
+    AFFILIATE_ENTITY_ACCOUNT_IDS = [
+        int(x.strip()) for x in AFFILIATE_ENTITY_ACCOUNT_ID.split(',')
+        if x and x.strip().isdigit()
+    ]
+    # Normalized CSV string (useful when passing into SQL as a single value)
+    AFFILIATE_ENTITY_ACCOUNT_IDS_CSV = (
+        ','.join(str(x) for x in AFFILIATE_ENTITY_ACCOUNT_IDS)
+        if AFFILIATE_ENTITY_ACCOUNT_IDS else None
+    )
 
     USE_CUSTOM_CONTACT_EMAIL = os.getenv('USE_CUSTOM_CONTACT_EMAIL', 'False') == 'True'
     CUSTOM_CONTACT_EMAIL = os.getenv('CUSTOM_CONTACT_EMAIL', '')

--- a/data-tool/restore_extract.sh
+++ b/data-tool/restore_extract.sh
@@ -20,7 +20,7 @@ PGDATABASE="${PGDATABASE:-colin-mig-corps-test}"     # or ‑‑dbname
 ##############################################################################
 
 # -- Tables to restore ------------------------------------------------------------
-RESTORE=(corp_processing colin_tracking mig_group mig_batch mig_corp_batch corps_with_third_party)
+RESTORE=(corp_processing colin_tracking mig_group mig_batch mig_corp_batch mig_corp_account corps_with_third_party)
 
 # -- Runtime options -----------------------------------------------------------
 DUMP="${DUMP}"

--- a/data-tool/scripts/colin_corps_extract_postgres_ddl
+++ b/data-tool/scripts/colin_corps_extract_postgres_ddl
@@ -22,6 +22,10 @@ create sequence mig_corp_batch_id_seq;
 
 alter sequence mig_corp_batch_id_seq owner to postgres;
 
+create sequence if not exists mig_corp_account_id_seq;
+
+alter sequence mig_corp_account_id_seq owner to postgres;
+
 create table if not exists address
 (
     addr_id                numeric(10)
@@ -725,6 +729,22 @@ create table if not exists mig_corp_batch
 alter table mig_corp_batch
     owner to postgres;
 
+
+create table if not exists mig_corp_account
+(
+    id                 integer default nextval('mig_corp_account_id_seq'::regclass) not null
+        constraint pk_mig_corp_account primary key,
+    corp_num           varchar(10)  not null,
+    target_environment varchar(25)  not null,
+    account_id         integer      not null,
+    mig_batch_id       integer      not null
+        constraint fk_mig_corp_account_mig_batch
+            references mig_batch
+);
+
+alter table mig_corp_account
+    owner to postgres;
+
 create table if not exists corp_processing
 (
     id                      integer default nextval('corp_processing_id_seq'::regclass) not null
@@ -754,6 +774,7 @@ create table if not exists corp_processing
     mig_batch_id            integer
         constraint fk_corp_processing_batch
             references mig_batch,
+    account_ids             varchar(100),
     constraint unq_corp_processing
         unique (corp_num, flow_name, environment)
 );
@@ -1057,3 +1078,7 @@ CREATE INDEX if not exists idx_corp_processing_claim_batch ON corp_processing (e
 CREATE INDEX if not exists idx_corp_state_active ON corp_state (end_event_id, corp_num);
 
 CREATE INDEX if not exists idx_corp_state_corp_num_end_event_id ON corp_state (corp_num, end_event_id);
+
+CREATE INDEX if not exists ix_mig_corp_account_corp_env ON mig_corp_account (corp_num, target_environment);
+
+CREATE INDEX if not exists ix_mig_corp_account_mig_batch ON mig_corp_account (mig_batch_id);


### PR DESCRIPTION
*Issue #:* /bcgov/entity#29457

*Description of changes:*
* CoLIN Extract Db updates
  * Add `mig_corp_account` table to allow defining which account ids to affiliate with a given corp num.  Supports mutiple target environments as well as more than one account affiliation per corp num.
  * Add `accounts_ids` column to `corp_processing` table to provide audit trail
* Update tombstone flow to support account affiliation based off of `mig_corp_account` entries when `USE_MIGRATION_FIlTER` = True.  Note that when `USE_MIGRATION_FIlTER` = True and `AFFILIATE_ENTITY=True` and there is no corresponding `mig_corp_account` entry, the account id populated(if any) in `AFFILIATE_ENTITY_ACCOUNT_ID` will be used as a fallback affiliation account id
* Update delete flow to delete appropriate migration table entries when `USE_MIGRATION_FIlTER` = True.  Also takes into account affiliation entries based off of `mig_corp_account` entries
* Update tracking table backup and restore scripts to include `mig_corp_account` table
* Uploaded latest COLIN extract to GCP storage

**CoLIN Extract Db Additions**
<img width="1158" height="840" alt="image" src="https://github.com/user-attachments/assets/0754c1b6-c818-499b-b177-c641e4c86209" />

<img width="1960" height="996" alt="image" src="https://github.com/user-attachments/assets/f6ddb91e-a382-429a-82dc-9983ff9dbb93" />




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
