### PR TITLE
30276 - Set submitter_roles to staff if filing was done by staff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ celerybeat-schedule
 .venv
 env/
 venv/
+venv-*/
 ENV/
 env.bak/
 venv.bak/

--- a/data-tool/flows/tombstone/tombstone_utils.py
+++ b/data-tool/flows/tombstone/tombstone_utils.py
@@ -499,6 +499,7 @@ def format_filings_data(data: dict) -> dict:
             'hide_in_ledger': hide_in_ledger,
             'status': status,
             'submitter_id': user_id,  # will be updated to real user_id when loading data into db
+            'submitter_roles': 'staff' if x.get('u_role_typ_cd') and x['u_role_typ_cd'].lower() == 'staff' else None,
             'court_order_file_number' : x['court_order_num'],
             'court_order_effect_of_order' : 'planOfArrangement' if x['arrangement_ind'] == True else None,
         }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#30276

*Description of changes:*
Before:
<img width="1487" height="217" alt="before migration submitter roles" src="https://github.com/user-attachments/assets/3e883de9-2efd-4bd6-83b3-46ff518747b5" />

After:
<img width="1496" height="277" alt="after migration submitter roles" src="https://github.com/user-attachments/assets/28e69a0d-32cf-481f-9349-dbb4bb5749cd" />

The submitter_roles is now set to staff if the filing was done as staff in COLIN

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
