### PR TITLE
29457 fix tombstone pipeline affiliation bug

### DIFF
--- a/data-tool/flows/tombstone/tombstone_queries.py
+++ b/data-tool/flows/tombstone/tombstone_queries.py
@@ -120,8 +120,9 @@ def get_unprocessed_corps_query(flow_name, config, batch_size):
         if mig_group_ids:
                mig_extra_where += f" AND g.id IN ({mig_group_ids})"
 
+        account_map_prefix = "WITH" if not cte_clause.strip() else ","
         account_map_cte = f"""
-        , account_map AS (
+        {account_map_prefix} account_map AS (
             SELECT mca.corp_num,
                    array_to_string(array_agg(DISTINCT mca.account_id ORDER BY mca.account_id), ',') AS account_ids
             FROM mig_corp_account mca


### PR DESCRIPTION
*Issue #:* /bcgov/entity#29457

*Description of changes:*
- Fix affiliation bug where certain `MIG_GROUP_IDS` + `MIG_BATCH_IDS` would fail due to `mig_corp_account` entries when `USE_MIGRATION_FILTER` = True

**Before fix**
<img width="252" height="110" alt="image" src="https://github.com/user-attachments/assets/b434c278-5d8b-471d-9fd6-b0e0fbd0fd65" />

<img width="1182" height="1016" alt="image" src="https://github.com/user-attachments/assets/e2276ee7-e33c-4f21-87f9-679464dc72da" />


**After fix**
<img width="943" height="159" alt="image" src="https://github.com/user-attachments/assets/2e3de4a0-b6cb-4a54-9980-3684f05eb5e5" />

<img width="2462" height="880" alt="image" src="https://github.com/user-attachments/assets/e9b0bea9-6b37-46b4-af16-e462f8ef1413" />

<img width="705" height="146" alt="image" src="https://github.com/user-attachments/assets/fbd913ff-e0f4-4b68-a03c-ddcd08901e09" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
