### PR TITLE
30318 - Update to populate backfill cutoff filing id

### DIFF
--- a/data-tool/flows/tombstone/tombstone_utils.py
+++ b/data-tool/flows/tombstone/tombstone_utils.py
@@ -53,7 +53,8 @@ def format_business_data(data: dict) -> dict:
         'last_ar_reminder_year': last_ar_reminder_year,
         'fiscal_year_end_date': business_data['founding_date'],
         'last_ledger_timestamp': business_data['founding_date'],
-        'last_modified': datetime.now(tz=timezone.utc).isoformat()
+        'last_modified': datetime.now(tz=timezone.utc).isoformat(),
+        'backfill_cutoff_filing_id': None  # Will be set dynamically during filing processing
     }
 
     return formatted_business


### PR DESCRIPTION
*Issue #:* /bcgov/entity#30318

*Description of changes:*
Updated to populate the backfill_cutoff_filing_id field:

After running corp migration with a batch size of 6:
Businesses Table:
<img width="875" height="282" alt="after migration businesses" src="https://github.com/user-attachments/assets/8320f112-78b9-4f4c-96c6-d63e8927240e" />

For first business:
<img width="493" height="167" alt="image" src="https://github.com/user-attachments/assets/ddc5d7ce-fc42-46a0-bd7c-912e15ee0828" />

For second business:
<img width="506" height="148" alt="image" src="https://github.com/user-attachments/assets/9d38d164-e343-406c-83a1-46d94aafc30f" />

For third business:
<img width="482" height="220" alt="image" src="https://github.com/user-attachments/assets/ff227e82-66c8-4932-a438-998b95b3d1ac" />

For fourth business:
<img width="502" height="240" alt="image" src="https://github.com/user-attachments/assets/bd242dba-e9f9-4273-81da-6641b5e42245" />

For fifth business:
<img width="508" height="338" alt="image" src="https://github.com/user-attachments/assets/44dce82d-e3bd-48da-9964-5346f98a6515" />

For sixth business:
<img width="492" height="487" alt="image" src="https://github.com/user-attachments/assets/09dfe08e-2a9b-40d5-9e50-3db6d92cc50b" />

The IDs check out (last COLIN Filing)! 👍  


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
