### PR TITLE
29946 - do not sync COA text/comment for restoration

### DIFF
--- a/colin-api/src/colin_api/models/filing.py
+++ b/colin-api/src/colin_api/models/filing.py
@@ -1853,7 +1853,7 @@ class Filing:  # pylint: disable=too-many-instance-attributes;
             )
             # create new ledger text for address change
             if filing.filing_type not in ['amalgamationApplication', 'continuationIn', 'incorporationApplication',
-                                          'transition']:
+                                          'restoration', 'transition']:
                 office_desc = (office_type.replace('O', ' O')).title()
                 if text:
                     text = f'{text} Change to the {office_desc}.'


### PR DESCRIPTION
*Issue #:* /bcgov/entity#29946

*Description of changes:*

Update the process for restoration to NOT sync comment (ledger text)

<img width="1717" height="667" alt="image" src="https://github.com/user-attachments/assets/f76eb83c-d53c-4576-9dfe-e49941339f8e" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
