### PR TITLE
30343 use alternate name for sole props chg of reg

### DIFF
--- a/queue_services/business-emailer/src/business_emailer/email_processors/__init__.py
+++ b/queue_services/business-emailer/src/business_emailer/email_processors/__init__.py
@@ -32,11 +32,13 @@ from business_model.utils.legislation_datetime import LegislationDatetime
 def get_filing_info(filing_id: str) -> tuple[Filing, dict, dict, str, str]:
     """Get filing info for the email."""
     filing = Filing.find_by_id(filing_id)
+    alternate_names = []
     if filing.business_id:
         business = Business.find_by_internal_id(filing.business_id)
+        alternate_names = Business.get_alternate_names(business)
         business_json = business.json()
     else:
-        business_json = (filing.json)["filing"].get("business")
+        business_json = (filing.json)["filing"].get("business") 
 
     filing_date = datetime.fromisoformat(filing.filing_date.isoformat())
     leg_tmz_filing_date = LegislationDatetime.as_legislation_timezone(filing_date)
@@ -50,7 +52,7 @@ def get_filing_info(filing_id: str) -> tuple[Filing, dict, dict, str, str]:
     am_pm = leg_tmz_effective_date.strftime("%p").lower()
     leg_tmz_effective_date = leg_tmz_effective_date.strftime(f"%B %d, %Y at {hour}:%M {am_pm} Pacific time")
 
-    return filing, business_json, leg_tmz_filing_date, leg_tmz_effective_date
+    return filing, alternate_names, business_json, leg_tmz_filing_date, leg_tmz_effective_date
 
 
 def get_recipients(option: str, filing_json: dict, token: str | None = None, filing_type: str | None = None) -> str:

--- a/queue_services/business-emailer/src/business_emailer/email_processors/change_of_registration_notification.py
+++ b/queue_services/business-emailer/src/business_emailer/email_processors/change_of_registration_notification.py
@@ -120,11 +120,21 @@ def process(email_info: dict, token: str) -> dict:  # pylint: disable=too-many-l
         f'{current_app.config.get("TEMPLATE_PATH")}/CHGREG-{status}.html'
     ).read_text()
     filled_template = substitute_template_parts(template)
+        # Firms can have proprietors or partners, so we may need to pass in a different value for name.
+    business_name = None
+    if business.get('legalType') in ["SP", "GP"]:
+        alt_names = business.get('alternateNames')
+        if alt_names is not None:
+            for alt_name in alt_names:
+                if alt_name.get('identifier') == business.get('identifier') and alt_name.get('name'):
+                    business_name = alt_name.get('name')
+                    break
     # render template with vars
     jnja_template = Template(filled_template, autoescape=True)
     filing_data = (filing.json)["filing"][f"{filing_type}"]
     html_out = jnja_template.render(
         business=business,
+        business_name=business_name,
         filing=filing_data,
         header=(filing.json)["filing"]["header"],
         filing_date_time=leg_tmz_filing_date,

--- a/queue_services/business-emailer/src/business_emailer/email_templates/common/reg-business-info.html
+++ b/queue_services/business-emailer/src/business_emailer/email_templates/common/reg-business-info.html
@@ -5,7 +5,9 @@
   <div>
     <div class="name bold">Business name:</div>
     {% if  filing_type == 'registration' %}
-      {% if filing.nameRequest.legalName %}
+      {% if business_name %}
+      <div clases="value">{{ business_name }}</div>
+      {% elif filing.nameRequest.legalName %}
       <!-- try to get legal name from Name Request object -->
       <div class="value">{{ filing.nameRequest.legalName }}</div>
       {% else %}

--- a/queue_services/business-emailer/src/business_emailer/email_templates/common/reg-business-info.html
+++ b/queue_services/business-emailer/src/business_emailer/email_templates/common/reg-business-info.html
@@ -15,7 +15,11 @@
       <div class="value">Unknown</div>
       {% endif %}
     {% else %}
+      {% if business_name %}
+      <div clases="value">{{ business_name }}</div>
+      {% else %}
       <div class="value">{{ business.legalName }}</div>
+      {%endif %}
     {% endif %}
   </div>
 


### PR DESCRIPTION
*Issue #:* /bcgov/30343

Update to business emailer so that emails properly show SP, GP names if they have a proprietor company.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
