### PR TITLE
DBC: adjust credential offer founding date to handle timezone

### DIFF
--- a/legal-api/src/legal_api/services/digital_credentials_helpers.py
+++ b/legal-api/src/legal_api/services/digital_credentials_helpers.py
@@ -18,6 +18,7 @@ from typing import List, Union
 
 from legal_api.models import Business, CorpType, DCBusinessUser, DCDefinition, User
 from legal_api.services.digital_credentials_rules import DigitalCredentialsRulesService
+from legal_api.utils.legislation_datetime import LegislationDatetime
 
 
 def get_digital_credential_data(business_user: DCBusinessUser,
@@ -108,7 +109,11 @@ def get_company_status(business: Business) -> str:
 
 def get_registered_on_dateint(business: Business) -> str:
     """Get registered on date in YYYYMMDD format."""
-    return business.founding_date.strftime('%Y%m%d') if business.founding_date else ''
+    return (
+        LegislationDatetime.as_legislation_timezone(business.founding_date).strftime('%Y%m%d')
+        if business.founding_date
+        else ''
+    )
 
 
 def get_family_name(user: User) -> str:


### PR DESCRIPTION
*Issue #:* /bcgov/entity#30628

*Description of changes:*
Use the timezone helper so the correct date ends up in the string sent in the credential offer if the biz is registered after the time cutoff. Add unit test for the function that determines date.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
