### PR TITLE
30319 - Fix to updating backfill_cutoff_filing_id in version table

### DIFF
--- a/data-tool/scripts/data-fixes/backfill_cutoff_filing_id.sql
+++ b/data-tool/scripts/data-fixes/backfill_cutoff_filing_id.sql
@@ -57,7 +57,6 @@ SET backfill_cutoff_filing_id = lhf.last_historical_filing_id,
     last_modified = NOW()
 FROM last_historical_filings lhf
 WHERE businesses_version.id = lhf.business_id
-    AND businesses_version.end_transaction_id IS NULL
     AND lhf.last_historical_filing_id IS NOT NULL;
 
 -- The following queries are for verification purposes only


### PR DESCRIPTION
*Issue #:* /bcgov/entity#30319

*Description of changes:*
All versioning records for matching businesses should have the end_transaction_id populated. Removed the IS NULL check.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
