### PR TITLE
30658 Add gunicorn post fork hook to re-initialize LD client

### DIFF
--- a/legal-api/gunicorn_config.py
+++ b/legal-api/gunicorn_config.py
@@ -21,7 +21,7 @@ import gunicorn_server
 # https://docs.gunicorn.org/en/stable/settings.html#workers
 workers = int(os.environ.get("GUNICORN_PROCESSES", "1"))  # gunicorn default - 1
 worker_class = os.environ.get("GUNICORN_WORKER_CLASS", "sync")  # gunicorn default - sync
-worker_connections = int(os.environ.get("GUNICORN_WORKER_CONNECIONS", "1000"))  # gunicorn default - 1000
+worker_connections = int(os.environ.get("GUNICORN_WORKER_CONNECTIONS", "1000"))  # gunicorn default - 1000
 threads = int(os.environ.get("GUNICORN_THREADS", "3"))  # gunicorn default - 1
 timeout = int(os.environ.get("GUNICORN_TIMEOUT", "100"))  # gunicorn default - 30
 keepalive = int(os.environ.get("GUNICORN_KEEPALIVE", "2"))  # gunicorn default - 2
@@ -33,3 +33,5 @@ secure_scheme_headers = {"X-Forwarded-Proto": "https"}  # pylint: disable=invali
 
 # Server Hooks
 pre_fork = gunicorn_server.pre_fork
+post_fork = gunicorn_server.post_fork
+worker_exit = gunicorn_server.worker_exit

--- a/legal-api/gunicorn_server.py
+++ b/legal-api/gunicorn_server.py
@@ -1,4 +1,3 @@
-
 import time
 
 
@@ -8,3 +7,23 @@ def pre_fork(server, worker):
     # when successive token retrieval calls are made with less than 2-3 seconds between the calls.
     time.sleep(5)
 
+def post_fork(server, worker):
+    """Reinitialize LaunchDarkly client in the forked worker (required when using --preload)."""
+    try:
+        # Import inside the hook so it runs in the child process
+        import ldclient
+        client = ldclient.get()
+        # Start LD background threads in the child process
+        client.postfork()
+        server.log.info("LaunchDarkly postfork() completed for worker pid=%s", worker.pid)
+    except Exception as e:  # noqa: BLE001
+        server.log.error("LaunchDarkly postfork() failed in worker pid=%s: %s", worker.pid, e)
+
+def worker_exit(server, worker):
+    """Flush and close LaunchDarkly client on worker shutdown."""
+    try:
+        import ldclient
+        ldclient.get().close()
+        server.log.info("LaunchDarkly client closed for worker pid=%s", worker.pid)
+    except Exception:  # safe to ignore if client wasn't created
+        pass


### PR DESCRIPTION
*Issue #:* /bcgov/entity#30658

*Description of changes:*
- Add gunicorn post fork hook to re-init LD client so FF value updates and flag evaluations are updated between LD client & server in real-time.  Note this is how LD official documentation recommends dealing with this issue if you use gunicorn with the `--preload` flag.
- Add gunicron exit work hook to flush any buffered LD events
- Fix typo for worker connections

**Local testing results**
<img width="1993" height="1805" alt="image" src="https://github.com/user-attachments/assets/2ce58e09-fc93-4eda-92d5-520180f0e3a1" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
