### PR TITLE
30385 - Add Whitespace Validation

### DIFF
--- a/legal-api/src/legal_api/services/filings/validations/agm_location_change.py
+++ b/legal-api/src/legal_api/services/filings/validations/agm_location_change.py
@@ -20,7 +20,7 @@ from flask_babel import _ as babel  # noqa: N813, I004, I001; importing camelcas
 from legal_api.errors import Error
 from legal_api.models import Business
 from legal_api.services import flags
-from legal_api.services.utils import get_int
+from legal_api.services.utils import get_int, get_str
 from legal_api.utils.legislation_datetime import LegislationDatetime
 # noqa: I003
 
@@ -46,6 +46,14 @@ def validate(business: Business, filing: Dict) -> Optional[Error]:
             msg.append({'error': 'AGM year must be between -2 or +1 year from current year.', 'path': agm_year_path})
     else:
         msg.append({'error': 'Invalid AGM year.', 'path': agm_year_path})
+
+    if msg:
+        return Error(HTTPStatus.BAD_REQUEST, msg)
+    
+    agm_reason_path: Final = '/filing/agmLocationChange/reason'
+    reason = get_str(filing, agm_reason_path)
+    if reason is not None and not reason.strip():
+        msg.append({'error': 'Reason cannot be only whitespace.', 'path': agm_reason_path})
 
     if msg:
         return Error(HTTPStatus.BAD_REQUEST, msg)

--- a/legal-api/src/legal_api/services/filings/validations/agm_location_change.py
+++ b/legal-api/src/legal_api/services/filings/validations/agm_location_change.py
@@ -47,12 +47,9 @@ def validate(business: Business, filing: Dict) -> Optional[Error]:
     else:
         msg.append({'error': 'Invalid AGM year.', 'path': agm_year_path})
 
-    if msg:
-        return Error(HTTPStatus.BAD_REQUEST, msg)
-    
     agm_reason_path: Final = '/filing/agmLocationChange/reason'
     reason = get_str(filing, agm_reason_path)
-    if reason is not None and not reason.strip():
+    if not reason.strip():
         msg.append({'error': 'Reason is required.', 'path': agm_reason_path})
 
     if msg:

--- a/legal-api/src/legal_api/services/filings/validations/agm_location_change.py
+++ b/legal-api/src/legal_api/services/filings/validations/agm_location_change.py
@@ -53,7 +53,7 @@ def validate(business: Business, filing: Dict) -> Optional[Error]:
     agm_reason_path: Final = '/filing/agmLocationChange/reason'
     reason = get_str(filing, agm_reason_path)
     if reason is not None and not reason.strip():
-        msg.append({'error': 'Reason cannot be empty or only whitespace.', 'path': agm_reason_path})
+        msg.append({'error': 'Reason is required.', 'path': agm_reason_path})
 
     if msg:
         return Error(HTTPStatus.BAD_REQUEST, msg)

--- a/legal-api/src/legal_api/services/filings/validations/agm_location_change.py
+++ b/legal-api/src/legal_api/services/filings/validations/agm_location_change.py
@@ -53,7 +53,7 @@ def validate(business: Business, filing: Dict) -> Optional[Error]:
     agm_reason_path: Final = '/filing/agmLocationChange/reason'
     reason = get_str(filing, agm_reason_path)
     if reason is not None and not reason.strip():
-        msg.append({'error': 'Reason cannot be only whitespace.', 'path': agm_reason_path})
+        msg.append({'error': 'Reason cannot be empty or only whitespace.', 'path': agm_reason_path})
 
     if msg:
         return Error(HTTPStatus.BAD_REQUEST, msg)

--- a/legal-api/src/legal_api/services/filings/validations/alteration.py
+++ b/legal-api/src/legal_api/services/filings/validations/alteration.py
@@ -26,6 +26,7 @@ from legal_api.services.utils import get_bool, get_str
 from .common_validations import (
     validate_court_order,
     validate_effective_date,
+    validate_name_translation,
     validate_name_request,
     validate_pdf,
     validate_phone_number,
@@ -62,6 +63,7 @@ def validate(business: Business, filing: Dict) -> Error:  # pylint: disable=too-
         msg.extend(err)
 
     msg.extend(validate_effective_date(filing))    
+    msg.extend(validate_name_translation(filing, 'alteration'))
 
     if msg:
         return Error(HTTPStatus.BAD_REQUEST, msg)

--- a/legal-api/src/legal_api/services/filings/validations/amalgamation_application.py
+++ b/legal-api/src/legal_api/services/filings/validations/amalgamation_application.py
@@ -24,6 +24,7 @@ from legal_api.services.filings.validations.common_validations import (
     validate_court_order,
     validate_effective_date,
     validate_foreign_jurisdiction,
+    validate_name_translation,
     validate_name_request,
     validate_offices_addresses,
     validate_parties_addresses,
@@ -86,6 +87,8 @@ def validate(amalgamation_json: Dict, account_id) -> Optional[Error]:
         msg.extend(err)
 
     msg.extend(validate_effective_date(amalgamation_json))
+
+    msg.extend(validate_name_translation(amalgamation_json, filing_type))
 
     if msg:
         return Error(HTTPStatus.BAD_REQUEST, msg)

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -658,8 +658,9 @@ def validate_certify_name(filing_json) -> bool:
         current_app.logger.error(err)
         return True
     return True
-def validate_certified_by(filing_json: dict, filing_type: str) -> list:
-    """Validate and normalize certifiedBy field."""
+
+def validate_and_sanitize_certified_by(filing_json: dict) -> list:
+    """Validate certifiedBy field and strip whitespaces to match the FE."""
     msg = []
 
     certified_by = filing_json.get('filing', {}).get('header', {}).get('certifiedBy')

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -106,7 +106,7 @@ def validate_series(item, memoize_names, filing_type, index) -> Error:
             })
 
         if trimmed_series_name in memoize_names:
-            msg.append({'error': 'Share series %s name already used in a share class or series.' % cleaned_series_name,
+            msg.append({'error': 'Share series %s name already used in a share class or series.' % trimmed_series_name,
                         'path': err_path})
         else:
             memoize_names.append(trimmed_series_name)
@@ -145,7 +145,7 @@ def validate_shares(item, memoize_names, filing_type, index, legal_type) -> Erro
 
     if trimmed_share_name in memoize_names:
         err_path = '/filing/{0}/shareClasses/{1}/name/'.format(filing_type, index)
-        msg.append({'error': 'Share class %s name already used in a share class or series.' % cleaned_name,
+        msg.append({'error': 'Share class %s name already used in a share class or series.' % trimmed_share_name,
                     'path': err_path})
     else:
         memoize_names.append(trimmed_share_name)
@@ -719,7 +719,7 @@ def validate_certify_name(filing_json) -> bool:
 def validate_certified_by(filing_json: dict) -> list:
     """Validate certifiedBy field."""
     msg = []
-    certified_by = filing_json.get('filing', {}).get('header', {}).get('certifiedBy')
+    certified_by = filing_json['filing']['header'].get('certifiedBy')
 
     if certified_by not in (None, ""):
         trimmed = get_clean_str(certified_by)

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -658,3 +658,22 @@ def validate_certify_name(filing_json) -> bool:
         current_app.logger.error(err)
         return True
     return True
+def validate_certified_by(filing_json: dict, filing_type: str) -> list:
+    """Validate and normalize certifiedBy field."""
+    msg = []
+
+    certified_by = filing_json.get('filing', {}).get('header', {}).get('certifiedBy')
+
+    # empty string is passed for some staff filings that have no ceritifiedBy component
+    if certified_by not in (None, ""):
+
+        normalized = re.sub(r'\s+', ' ', certified_by).strip()
+        filing_json['filing']['header']['certifiedBy'] = normalized
+
+        if not normalized:
+            msg.append({
+                'error': 'Certified By field cannot be only whitespace.',
+                'path': '/filing/header/certifiedBy'
+            })
+
+    return msg

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -95,21 +95,21 @@ def validate_series(item, memoize_names, filing_type, index) -> Error:
     for series_index, series in enumerate(item.get('series', [])):
         err_path = '/filing/{0}/shareClasses/{1}/series/{2}'.format(filing_type, index, series_index)
 
-        raw_series_name = series.get('name', '')
-        cleaned_series_name = raw_series_name.strip()
-        series['name'] = cleaned_series_name
+        series_name = series.get('name', '')
+        trimmed_series_name = get_clean_str(series_name)
+        series['name'] = trimmed_series_name
 
-        if not cleaned_series_name:
+        if not trimmed_series_name:
             msg.append({
                 'error': 'Share series name cannot be empty or only whitespace',
                 'path': f'{err_path}/name/'
             })
 
-        if cleaned_series_name in memoize_names:
+        if trimmed_series_name in memoize_names:
             msg.append({'error': 'Share series %s name already used in a share class or series.' % cleaned_series_name,
                         'path': err_path})
         else:
-            memoize_names.append(cleaned_series_name)
+            memoize_names.append(trimmed_series_name)
 
         if series['hasMaximumShares']:
             if not series.get('maxNumberOfShares', None):
@@ -132,23 +132,23 @@ def validate_shares(item, memoize_names, filing_type, index, legal_type) -> Erro
     """Validate a wellformed share structure."""
     msg = []
 
-    raw_name = item.get('name', '')
-    cleaned_name = raw_name.strip()
-    item['name'] = cleaned_name
+    share_name = item.get('name', '')
+    trimmed_share_name = get_clean_str(share_name)
+    item['name'] = trimmed_share_name
 
-    if not cleaned_name:
+    if not trimmed_share_name:
         err_path = '/filing/{0}/shareClasses/{1}/name/'.format(filing_type, index)
         msg.append({
             'error': 'Share class name cannot be empty or only whitespace',
             'path': err_path
         })
 
-    if cleaned_name in memoize_names:
+    if trimmed_share_name in memoize_names:
         err_path = '/filing/{0}/shareClasses/{1}/name/'.format(filing_type, index)
         msg.append({'error': 'Share class %s name already used in a share class or series.' % cleaned_name,
                     'path': err_path})
     else:
-        memoize_names.append(cleaned_name)
+        memoize_names.append(trimmed_share_name)
 
     if item['hasMaximumShares'] and not item.get('maxNumberOfShares', None):
         err_path = '/filing/{0}/shareClasses/{1}/maxNumberOfShares/'.format(filing_type, index)
@@ -291,7 +291,7 @@ def validate_party_name(party: dict, party_path: str, legal_type: str) -> list:
             err_msg = f'{party_roles_str} first name cannot be longer than {custom_allowed_max_length} characters'
             msg.append({'error': err_msg, 'path': party_path})
 
-        middle_initial = officer.get('middleInitial')
+        middle_initial = officer.get('middleInitial', None)
         if middle_initial:
             trimmed_initial = get_clean_str(middle_initial)
             officer['middleInitial'] = trimmed_initial
@@ -302,7 +302,7 @@ def validate_party_name(party: dict, party_path: str, legal_type: str) -> list:
                 err_msg = f'{party_roles_str} middle initial cannot be longer than {custom_allowed_max_length} characters'
                 msg.append({'error': err_msg, 'path': party_path})    
 
-        middle_name = officer.get('middleName')
+        middle_name = officer.get('middleName', None)
         if middle_name:
             trimmed_middle = get_clean_str(middle_name)
             officer['middleName'] = trimmed_middle

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -732,3 +732,22 @@ def validate_certified_by(filing_json: dict) -> list:
             })
 
     return msg
+
+def validate_name_translation(filing_json: dict, filing_type: str) -> list:
+    """Validate name translations fields."""
+    msg = []
+    translations = filing_json['filing'][filing_type].get('nameTranslations', [])
+
+    for idx, translation in enumerate(translations):
+
+        cleaned_name = get_clean_str(translation.get('name'))
+        translation['name'] = cleaned_name
+        print('here is the cleaned name: ', cleaned_name)
+
+        if not cleaned_name:
+            msg.append({
+                'error': 'Name translation cannot be empty or only whitespace.',
+                'path': f'/filing/{filing_type}/nameTranslations/{idx}/name/'
+            })
+
+    return msg

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -747,7 +747,7 @@ def validate_name_translation(filing_json: dict, filing_type: str) -> list:
 
         if not stripped_name:
             msg.append({
-                'error': 'Name translation is required.',
+                'error': 'Name translation cannot be an empty string.',
                 'path': f'/filing/{filing_type}/nameTranslations/{idx}/name/'
             })
         elif name != stripped_name:

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -742,7 +742,6 @@ def validate_name_translation(filing_json: dict, filing_type: str) -> list:
 
         cleaned_name = get_clean_str(translation.get('name'))
         translation['name'] = cleaned_name
-        print('here is the cleaned name: ', cleaned_name)
 
         if not cleaned_name:
             msg.append({

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -448,7 +448,7 @@ def validate_phone_number(filing_json: Dict, legal_type: str, filing_type: str) 
     return msg
 
 def validate_effective_date(filing_json: dict) -> list:
-    """Validate effective date like incorporation filing, with debug prints."""
+    """Validate effective date"""
     msg = []
 
     now = dt.utcnow() 

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -101,7 +101,7 @@ def validate_series(item, memoize_names, filing_type, index) -> Error:
 
         if not trimmed_series_name:
             msg.append({
-                'error': 'Share series name cannot be empty or only whitespace',
+                'error': 'Share series name is required.',
                 'path': f'{err_path}/name/'
             })
 
@@ -139,7 +139,7 @@ def validate_shares(item, memoize_names, filing_type, index, legal_type) -> Erro
     if not trimmed_share_name:
         err_path = '/filing/{0}/shareClasses/{1}/name/'.format(filing_type, index)
         msg.append({
-            'error': 'Share class name cannot be empty or only whitespace',
+            'error': 'Share class name is required.',
             'path': err_path
         })
 
@@ -745,7 +745,7 @@ def validate_name_translation(filing_json: dict, filing_type: str) -> list:
 
         if not cleaned_name:
             msg.append({
-                'error': 'Name translation cannot be empty or only whitespace.',
+                'error': 'Name translation is required.',
                 'path': f'/filing/{filing_type}/nameTranslations/{idx}/name/'
             })
 

--- a/legal-api/src/legal_api/services/filings/validations/continuation_in.py
+++ b/legal-api/src/legal_api/services/filings/validations/continuation_in.py
@@ -24,6 +24,7 @@ from legal_api.services.filings.validations.common_validations import (
     validate_court_order,
     validate_effective_date,
     validate_foreign_jurisdiction,
+    validate_name_translation,
     validate_name_request,
     validate_offices_addresses,
     validate_parties_addresses,
@@ -62,6 +63,7 @@ def validate(filing_json: dict) -> Optional[Error]:  # pylint: disable=too-many-
     msg.extend(validate_continuation_in_authorization(filing_json, filing_type, legal_type))
     msg.extend(_validate_foreign_jurisdiction(filing_json, filing_type, legal_type))
     msg.extend(validate_name_request(filing_json, legal_type, filing_type))
+    msg.extend(validate_name_translation(filing_json, filing_type))
 
     if get_bool(filing_json, '/filing/continuationIn/isApproved'):
         msg.extend(validate_offices(filing_json, legal_type, filing_type))

--- a/legal-api/src/legal_api/services/filings/validations/dissolution.py
+++ b/legal-api/src/legal_api/services/filings/validations/dissolution.py
@@ -318,7 +318,7 @@ def validate_custodian_org_name(parties, dissolution_type, legal_type) -> list:
 
             if not org_name:
                 msg.append({
-                    'error': 'Corporation or firm name is required',
+                    'error': 'Corporation or firm name is required for organization',
                     'path': f'/filing/dissolution/parties/{idx}/officer/organizationName'
                 })
 

--- a/legal-api/src/legal_api/services/filings/validations/dissolution.py
+++ b/legal-api/src/legal_api/services/filings/validations/dissolution.py
@@ -316,12 +316,12 @@ def validate_custodian_org_name(parties, dissolution_type, legal_type) -> list:
 
             if not stripped_org_name:
                 msg.append({
-                    'error': 'Corporation or firm name is required for an organization.',
+                    'error': 'Organization name is required.',
                     'path': f'/filing/dissolution/parties/{idx}/officer/organizationName'
                 })
             elif org_name != stripped_org_name:
                 msg.append({
-                    'error': 'Corporation or firm name cannot have leading or trailing spaces.',
+                    'error': 'Organization name cannot have leading or trailing spaces.',
                     'path': f'/filing/dissolution/parties/{idx}/officer/organizationName'
                 })    
 

--- a/legal-api/src/legal_api/services/filings/validations/dissolution.py
+++ b/legal-api/src/legal_api/services/filings/validations/dissolution.py
@@ -27,7 +27,7 @@ from legal_api.services.filings.validations.common_validations import (
     validate_parties_addresses,
     validate_pdf,
 )
-from legal_api.services.utils import get_str, get_clean_str # noqa: I003; needed as the linter gets confused from the babel override.
+from legal_api.services.utils import get_str # noqa: I003; needed as the linter gets confused from the babel override.
 
 
 class DissolutionTypes(str, Enum):
@@ -311,16 +311,19 @@ def validate_custodian_org_name(parties, dissolution_type, legal_type) -> list:
         # Only validate if partyType is organization
         if party_type == 'organization':
 
-            raw_name = get_str(party, '/officer/organizationName')
-            org_name = get_clean_str(raw_name)
+            org_name = get_str(party, '/officer/organizationName')
+            stripped_org_name = org_name.strip()
 
-            party['officer']['organizationName'] = org_name or ''
-
-            if not org_name:
+            if not stripped_org_name:
                 msg.append({
                     'error': 'Corporation or firm name is required for an organization.',
                     'path': f'/filing/dissolution/parties/{idx}/officer/organizationName'
                 })
+            elif org_name != stripped_org_name:
+                msg.append({
+                    'error': 'Corporation or firm name cannot have leading or trailing spaces.',
+                    'path': f'/filing/dissolution/parties/{idx}/officer/organizationName'
+                })    
 
     return msg
 

--- a/legal-api/src/legal_api/services/filings/validations/dissolution.py
+++ b/legal-api/src/legal_api/services/filings/validations/dissolution.py
@@ -318,7 +318,7 @@ def validate_custodian_org_name(parties, dissolution_type, legal_type) -> list:
 
             if not org_name:
                 msg.append({
-                    'error': 'Corporation or firm name is required for organization',
+                    'error': 'Corporation or firm name is required for an organization.',
                     'path': f'/filing/dissolution/parties/{idx}/officer/organizationName'
                 })
 

--- a/legal-api/src/legal_api/services/filings/validations/dissolution.py
+++ b/legal-api/src/legal_api/services/filings/validations/dissolution.py
@@ -291,6 +291,11 @@ def _validate_custodian_email(parties, dissolution_type, legal_type) -> list:
         if not email:
             msg.append({'error': 'Custodian email is required for voluntary dissolution.',
                         'path': f'/filing/dissolution/parties/{idx}/officer/email'})
+        elif any(char.isspace() for char in email):
+            msg.append({
+                'error': 'Custodian email cannot contain any whitespaces.',
+                'path': f'/filing/dissolution/parties/{idx}/officer/email'
+            })    
     return msg
 
 

--- a/legal-api/src/legal_api/services/filings/validations/incorporation_application.py
+++ b/legal-api/src/legal_api/services/filings/validations/incorporation_application.py
@@ -23,6 +23,7 @@ from legal_api.models import Business, PartyRole
 from legal_api.services.filings.validations.common_validations import (  # noqa: I001
     validate_court_order,
     validate_effective_date,
+    validate_name_translation,
     validate_name_request,
     validate_offices_addresses,
     validate_parties_addresses,
@@ -81,6 +82,8 @@ def validate(incorporation_json: dict):  # pylint: disable=too-many-branches;
     err = validate_phone_number(incorporation_json, legal_type, 'incorporationApplication')
     if err:
         msg.extend(err)
+
+    msg.extend(validate_name_translation(incorporation_json, filing_type))    
 
     if msg:
         return Error(HTTPStatus.BAD_REQUEST, msg)

--- a/legal-api/src/legal_api/services/filings/validations/restoration.py
+++ b/legal-api/src/legal_api/services/filings/validations/restoration.py
@@ -23,6 +23,7 @@ from legal_api.models import Business, Filing, PartyRole
 from legal_api.services.filings.validations.common_validations import (
     validate_court_order,
     validate_name_request,
+    validate_name_translation,
     validate_offices_addresses,
     validate_parties_addresses,
 )
@@ -73,6 +74,7 @@ def validate(business: Business, restoration: Dict) -> Optional[Error]:
     msg.extend(validate_approval_type(restoration, restoration_type, limited_restoration))
     msg.extend(validate_restoration_court_order(restoration, restoration_type, limited_restoration))
     msg.extend(validate_restoration_registrar(restoration, restoration_type))
+    msg.extend(validate_name_translation(restoration, filing_type))
 
     if msg:
         return Error(HTTPStatus.BAD_REQUEST, msg)

--- a/legal-api/src/legal_api/services/filings/validations/validation.py
+++ b/legal-api/src/legal_api/services/filings/validations/validation.py
@@ -38,7 +38,7 @@ from .change_of_directors import validate as cod_validate
 from .change_of_name import validate as con_validate
 from .change_of_officers import validate as coo_validate
 from .change_of_registration import validate as change_of_registration_validate
-from .common_validations import validate_and_sanitize_certified_by
+from .common_validations import validate_certified_by
 from .consent_amalgamation_out import validate as consent_amalgamation_out_validate
 from .consent_continuation_out import validate as consent_continuation_out_validate
 from .continuation_in import validate as continuation_in_validate
@@ -70,7 +70,7 @@ def validate(business: Business,  # pylint: disable=too-many-branches,too-many-s
     if err:
         return err
 
-    cert_errs = validate_and_sanitize_certified_by(filing_json)
+    cert_errs = validate_certified_by(filing_json)
     if cert_errs:
         return Error(HTTPStatus.BAD_REQUEST, cert_errs)
 

--- a/legal-api/src/legal_api/services/filings/validations/validation.py
+++ b/legal-api/src/legal_api/services/filings/validations/validation.py
@@ -38,6 +38,7 @@ from .change_of_directors import validate as cod_validate
 from .change_of_name import validate as con_validate
 from .change_of_officers import validate as coo_validate
 from .change_of_registration import validate as change_of_registration_validate
+from .common_validations import validate_and_sanitize_certified_by
 from .consent_amalgamation_out import validate as consent_amalgamation_out_validate
 from .consent_continuation_out import validate as consent_continuation_out_validate
 from .continuation_in import validate as continuation_in_validate
@@ -69,7 +70,9 @@ def validate(business: Business,  # pylint: disable=too-many-branches,too-many-s
     if err:
         return err
 
-    err = None
+    cert_errs = validate_and_sanitize_certified_by(filing_json)
+    if cert_errs:
+        return Error(HTTPStatus.BAD_REQUEST, cert_errs)
 
     if validate_staff_payment(filing_json) and flags.is_on('enabled-deeper-permission-action'):
         required_permission = ListActionsPermissionsAllowed.STAFF_PAYMENT.value

--- a/legal-api/src/legal_api/services/utils.py
+++ b/legal-api/src/legal_api/services/utils.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Common utilities used by the services."""
-
 from datetime import date
 from typing import Dict
 

--- a/legal-api/src/legal_api/services/utils.py
+++ b/legal-api/src/legal_api/services/utils.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Common utilities used by the services."""
+import re
 from datetime import date
-from typing import Dict
+from typing import Dict, Optional
 
 import dpath.util
 
@@ -86,3 +87,9 @@ def get_int(filing: Dict, path: str) -> str:
         return int(raw)
     except (IndexError, KeyError, TypeError, ValueError):
         return None
+
+def get_clean_str(value: Optional[str]) -> Optional[str]:
+    """Return the string with whitespace collapsed and trimmed."""
+    if value is None:
+        return None
+    return re.sub(r'\s+', ' ', value).strip()

--- a/legal-api/src/legal_api/services/utils.py
+++ b/legal-api/src/legal_api/services/utils.py
@@ -87,9 +87,3 @@ def get_int(filing: Dict, path: str) -> str:
         return int(raw)
     except (IndexError, KeyError, TypeError, ValueError):
         return None
-
-def get_clean_str(value: Optional[str]) -> Optional[str]:
-    """Return the string with whitespace collapsed and trimmed."""
-    if value is None:
-        return None
-    return re.sub(r'\s+', ' ', value).strip()

--- a/legal-api/src/legal_api/services/utils.py
+++ b/legal-api/src/legal_api/services/utils.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Common utilities used by the services."""
-import re
+
 from datetime import date
-from typing import Dict, Optional
+from typing import Dict
 
 import dpath.util
 

--- a/legal-api/tests/unit/services/filings/validations/test_agm_location_change.py
+++ b/legal-api/tests/unit/services/filings/validations/test_agm_location_change.py
@@ -72,8 +72,8 @@ def test_validate_agm_year(session, mocker, test_name, expected_code, message, m
 @pytest.mark.parametrize(
     'test_name, reason, expected_code, message',
     [
-        ('EMPTY', '', HTTPStatus.BAD_REQUEST, 'Reason cannot be empty or only whitespace.'),        
-        ('ONLY_WHITESPACE', '     ', HTTPStatus.BAD_REQUEST, 'Reason cannot be empty or only whitespace.'),
+        ('EMPTY', '', HTTPStatus.BAD_REQUEST, 'Reason is required.'),        
+        ('ONLY_WHITESPACE', '     ', HTTPStatus.BAD_REQUEST, 'Reason is required.'),
         ('VALID_REASON', 'Test Reason', None, None),
         ('VALID_REASON_WITH_SPACES', '   Valid Reason   ', None, None),
     ]

--- a/legal-api/tests/unit/services/filings/validations/test_agm_location_change.py
+++ b/legal-api/tests/unit/services/filings/validations/test_agm_location_change.py
@@ -72,7 +72,8 @@ def test_validate_agm_year(session, mocker, test_name, expected_code, message, m
 @pytest.mark.parametrize(
     'test_name, reason, expected_code, message',
     [
-        ('ONLY_WHITESPACE', '     ', HTTPStatus.BAD_REQUEST, 'Reason cannot be only whitespace.'),
+        ('EMPTY', '', HTTPStatus.BAD_REQUEST, 'Reason cannot be empty or only whitespace.'),        
+        ('ONLY_WHITESPACE', '     ', HTTPStatus.BAD_REQUEST, 'Reason cannot be empty or only whitespace.'),
         ('VALID_REASON', 'Test Reason', None, None),
         ('VALID_REASON_WITH_SPACES', '   Valid Reason   ', None, None),
     ]

--- a/legal-api/tests/unit/services/filings/validations/test_alteration.py
+++ b/legal-api/tests/unit/services/filings/validations/test_alteration.py
@@ -714,7 +714,7 @@ def test_alteration_good_standing(session, good_standing, has_permission, should
             assert HTTPStatus.BAD_REQUEST == err.code
 
 @pytest.mark.parametrize('test_name, name_translation, expected_code, expected_msg', [
-    ('SUCCESS_EMPTY_ARRAY', [], None, None),
+    ('SUCCESS_NAME_TRANSLATION_EMPTY_ARRAY', [], None, None),
     ('SUCCESS_NAME_TRANSLATION', [{"name": "TEST"}], None, None),
     ('FAIL_EMPTY_NAME_TRANSLATION', [{"name": ""}],  HTTPStatus.BAD_REQUEST, [{
         'error': 'Name translation is required.',
@@ -724,10 +724,19 @@ def test_alteration_good_standing(session, good_standing, has_permission, should
         'error': 'Name translation is required.',
         'path': '/filing/alteration/nameTranslations/0/name/'
     }]),
-    ('FAIL_SECOND_NAME_TRANSLATION', [{"name": "TEST"}, {"name": "   "}], HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation is required.',
-        'path': '/filing/alteration/nameTranslations/1/name/'
+    ('FAIL_LEADING_AND_TRAILING_WHITESPACE_NAME_TRANSLATION', [{"name": " TEST "}], HTTPStatus.BAD_REQUEST, [{
+        'error': 'Name translation cannot start or end with whitespace.',
+        'path': '/filing/alteration/nameTranslations/0/name/'
     }]),
+    ('FAIL_MULTIPLE_NAME_TRANSLATION', [{"name": "   "}, {"name": " TEST  "}], HTTPStatus.BAD_REQUEST, [{
+        'error': 'Name translation is required.',
+        'path': '/filing/alteration/nameTranslations/0/name/'
+    },
+    {
+        'error': 'Name translation cannot start or end with whitespace.',
+        'path': '/filing/alteration/nameTranslations/1/name/'
+    }
+    ]),
 ])
 def test_validate_name_translation(session, test_name, name_translation, expected_code, expected_msg):
     """Test validate name translation if provided."""

--- a/legal-api/tests/unit/services/filings/validations/test_alteration.py
+++ b/legal-api/tests/unit/services/filings/validations/test_alteration.py
@@ -717,15 +717,15 @@ def test_alteration_good_standing(session, good_standing, has_permission, should
     ('SUCCESS_EMPTY_ARRAY', [], None, None),
     ('SUCCESS_NAME_TRANSLATION', [{"name": "TEST"}], None, None),
     ('FAIL_EMPTY_NAME_TRANSLATION', [{"name": ""}],  HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation cannot be empty or only whitespace.',
+        'error': 'Name translation is required.',
         'path': '/filing/alteration/nameTranslations/0/name/'
     }]),
     ('FAIL_WHITESPACE_ONLY_NAME_TRANSLATION', [{"name": "   "}], HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation cannot be empty or only whitespace.',
+        'error': 'Name translation is required.',
         'path': '/filing/alteration/nameTranslations/0/name/'
     }]),
     ('FAIL_SECOND_NAME_TRANSLATION', [{"name": "TEST"}, {"name": "   "}], HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation cannot be empty or only whitespace.',
+        'error': 'Name translation is required.',
         'path': '/filing/alteration/nameTranslations/1/name/'
     }]),
 ])

--- a/legal-api/tests/unit/services/filings/validations/test_alteration.py
+++ b/legal-api/tests/unit/services/filings/validations/test_alteration.py
@@ -717,11 +717,11 @@ def test_alteration_good_standing(session, good_standing, has_permission, should
     ('SUCCESS_NAME_TRANSLATION_EMPTY_ARRAY', [], None, None),
     ('SUCCESS_NAME_TRANSLATION', [{"name": "TEST"}], None, None),
     ('FAIL_EMPTY_NAME_TRANSLATION', [{"name": ""}],  HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation is required.',
+        'error': 'Name translation cannot be an empty string.',
         'path': '/filing/alteration/nameTranslations/0/name/'
     }]),
     ('FAIL_WHITESPACE_ONLY_NAME_TRANSLATION', [{"name": "   "}], HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation is required.',
+        'error': 'Name translation cannot be an empty string.',
         'path': '/filing/alteration/nameTranslations/0/name/'
     }]),
     ('FAIL_LEADING_AND_TRAILING_WHITESPACE_NAME_TRANSLATION', [{"name": " TEST "}], HTTPStatus.BAD_REQUEST, [{
@@ -729,7 +729,7 @@ def test_alteration_good_standing(session, good_standing, has_permission, should
         'path': '/filing/alteration/nameTranslations/0/name/'
     }]),
     ('FAIL_MULTIPLE_NAME_TRANSLATION', [{"name": "   "}, {"name": " TEST  "}], HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation is required.',
+        'error': 'Name translation cannot be an empty string.',
         'path': '/filing/alteration/nameTranslations/0/name/'
     },
     {

--- a/legal-api/tests/unit/services/filings/validations/test_alteration.py
+++ b/legal-api/tests/unit/services/filings/validations/test_alteration.py
@@ -713,3 +713,45 @@ def test_alteration_good_standing(session, good_standing, has_permission, should
         else:
             assert HTTPStatus.BAD_REQUEST == err.code
 
+@pytest.mark.parametrize('test_name, name_translation, expected_code, expected_msg', [
+    ('SUCCESS_EMPTY_ARRAY', [], None, None),
+    ('SUCCESS_NAME_TRANSLATION', [{"name": "TEST"}], None, None),
+    ('FAIL_EMPTY_NAME_TRANSLATION', [{"name": ""}],  HTTPStatus.BAD_REQUEST, [{
+        'error': 'Name translation cannot be empty or only whitespace.',
+        'path': '/filing/alteration/nameTranslations/0/name/'
+    }]),
+    ('FAIL_WHITESPACE_ONLY_NAME_TRANSLATION', [{"name": "   "}], HTTPStatus.BAD_REQUEST, [{
+        'error': 'Name translation cannot be empty or only whitespace.',
+        'path': '/filing/alteration/nameTranslations/0/name/'
+    }]),
+    ('FAIL_SECOND_NAME_TRANSLATION', [{"name": "TEST"}, {"name": "   "}], HTTPStatus.BAD_REQUEST, [{
+        'error': 'Name translation cannot be empty or only whitespace.',
+        'path': '/filing/alteration/nameTranslations/1/name/'
+    }]),
+])
+def test_validate_name_translation(session, test_name, name_translation, expected_code, expected_msg):
+    """Test validate name translation if provided."""
+    identifier = 'BC1234567'
+    business = factory_business(identifier, entity_type='BC')
+    filing = copy.deepcopy(ALTERATION_FILING_TEMPLATE)
+    filing['filing']['header']['identifier'] = identifier
+    filing['filing']['business']['legalType'] = 'BC'
+    filing['filing']['alteration']['business']['legalType'] = 'BEN'
+    del filing['filing']['alteration']['nameRequest']
+    if 'courtOrder' in filing['filing']['alteration']:
+        del filing['filing']['alteration']['courtOrder']
+    
+    filing['filing']['alteration']['nameTranslations'] = name_translation
+
+    # perform test
+    with freeze_time(now):
+        err = validate(business, filing)
+
+    # validate outcomes
+    if expected_code:
+        assert err.code == expected_code
+        assert lists_are_equal(err.msg, expected_msg)
+    else:
+        if err:
+            print(err, err.code, err.msg)
+        assert err is None

--- a/legal-api/tests/unit/services/filings/validations/test_amalgamation_application.py
+++ b/legal-api/tests/unit/services/filings/validations/test_amalgamation_application.py
@@ -1620,3 +1620,68 @@ def test_validate_amalgamation_effective_date(
         assert lists_are_equal(err.msg, expected_msg)
     else:
         assert err is None
+
+@pytest.mark.parametrize(
+    'amalgamation_type',
+    [
+        Amalgamation.AmalgamationTypes.regular.name,
+        Amalgamation.AmalgamationTypes.horizontal.name,
+        Amalgamation.AmalgamationTypes.vertical.name,
+    ]
+)
+@pytest.mark.parametrize('test_name, name_translation, expected_code, expected_msg', [
+    ('SUCCESS_EMPTY_ARRAY', [], None, None),
+    ('SUCCESS_NAME_TRANSLATION', [{"name": "TEST"}], None, None),
+    ('FAIL_EMPTY_NAME_TRANSLATION', [{"name": ""}],  HTTPStatus.BAD_REQUEST, [{
+        'error': 'Name translation cannot be empty or only whitespace.',
+        'path': '/filing/amalgamationApplication/nameTranslations/0/name/'
+    }]),
+    ('FAIL_WHITESPACE_ONLY_NAME_TRANSLATION', [{"name": "   "}], HTTPStatus.BAD_REQUEST, [{
+        'error': 'Name translation cannot be empty or only whitespace.',
+        'path': '/filing/amalgamationApplication/nameTranslations/0/name/'
+    }]),
+    ('FAIL_SECOND_NAME_TRANSLATION', [{"name": "TEST"}, {"name": "   "}], HTTPStatus.BAD_REQUEST, [{
+        'error': 'Name translation cannot be empty or only whitespace.',
+        'path': '/filing/amalgamationApplication/nameTranslations/1/name/'
+    }]),
+])
+def test_validate_amalgamation_name_translation(mocker, session, test_name, amalgamation_type, name_translation, expected_code, expected_msg):
+    """Test validate name translation if provided."""
+    filing = {'filing': {}}
+    filing['filing']['header'] = {
+        'name': 'amalgamationApplication',
+        'date': '2019-04-08',
+        'certifiedBy': 'full name',
+        'email': 'no_one@never.get',
+        'filingId': 1
+    }
+    filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
+    filing['filing']['amalgamationApplication']['nameRequest']['legalType'] = Business.LegalTypes.BCOMP.value
+    filing['filing']['amalgamationApplication']['type'] = amalgamation_type
+
+    if 'courtOrder' in filing['filing']['amalgamationApplication']:
+        del filing['filing']['amalgamationApplication']['courtOrder']    
+
+    filing['filing']['amalgamationApplication']['nameTranslations'] = name_translation    
+
+    mocker.patch(
+        'legal_api.services.filings.validations.amalgamation_application.validate_name_request',
+        return_value=[]
+    )
+    mocker.patch(
+        'legal_api.services.filings.validations.amalgamation_application.validate_amalgamating_businesses',
+        return_value=[]
+    )
+
+    # perform test
+    with freeze_time(now):
+        err = validate(None, filing)
+
+    # validate outcomes
+    if expected_code:
+        assert err.code == expected_code
+        assert lists_are_equal(err.msg, expected_msg)
+    else:
+        if err:
+            print(err, err.code, err.msg)
+        assert err is None

--- a/legal-api/tests/unit/services/filings/validations/test_amalgamation_application.py
+++ b/legal-api/tests/unit/services/filings/validations/test_amalgamation_application.py
@@ -1630,7 +1630,7 @@ def test_validate_amalgamation_effective_date(
     ]
 )
 @pytest.mark.parametrize('test_name, name_translation, expected_code, expected_msg', [
-    ('SUCCESS_EMPTY_ARRAY', [], None, None),
+    ('SUCCESS_NAME_TRANSLATION_EMPTY_ARRAY', [], None, None),
     ('SUCCESS_NAME_TRANSLATION', [{"name": "TEST"}], None, None),
     ('FAIL_EMPTY_NAME_TRANSLATION', [{"name": ""}],  HTTPStatus.BAD_REQUEST, [{
         'error': 'Name translation is required.',
@@ -1640,10 +1640,19 @@ def test_validate_amalgamation_effective_date(
         'error': 'Name translation is required.',
         'path': '/filing/amalgamationApplication/nameTranslations/0/name/'
     }]),
-    ('FAIL_SECOND_NAME_TRANSLATION', [{"name": "TEST"}, {"name": "   "}], HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation is required.',
-        'path': '/filing/amalgamationApplication/nameTranslations/1/name/'
+    ('FAIL_LEADING_AND_TRAILING_WHITESPACE_NAME_TRANSLATION', [{"name": " TEST "}], HTTPStatus.BAD_REQUEST, [{
+        'error': 'Name translation cannot start or end with whitespace.',
+        'path': '/filing/amalgamationApplication/nameTranslations/0/name/'
     }]),
+    ('FAIL_MULTIPLE_NAME_TRANSLATION', [{"name": "   "}, {"name": " TEST  "}], HTTPStatus.BAD_REQUEST, [{
+        'error': 'Name translation is required.',
+        'path': '/filing/amalgamationApplication/nameTranslations/0/name/'
+    },
+    {
+        'error': 'Name translation cannot start or end with whitespace.',
+        'path': '/filing/amalgamationApplication/nameTranslations/1/name/'
+    }
+    ]),
 ])
 def test_validate_amalgamation_name_translation(mocker, session, test_name, amalgamation_type, name_translation, expected_code, expected_msg):
     """Test validate name translation if provided."""

--- a/legal-api/tests/unit/services/filings/validations/test_amalgamation_application.py
+++ b/legal-api/tests/unit/services/filings/validations/test_amalgamation_application.py
@@ -1634,12 +1634,10 @@ def test_validate_amalgamation_effective_date(
     ('SUCCESS_NAME_TRANSLATION', [{"name": "TEST"}], None, None),
     ('FAIL_EMPTY_NAME_TRANSLATION', [{"name": ""}],  HTTPStatus.BAD_REQUEST, [{
         'error': 'Name translation cannot be an empty string.',
-
         'path': '/filing/amalgamationApplication/nameTranslations/0/name/'
     }]),
     ('FAIL_WHITESPACE_ONLY_NAME_TRANSLATION', [{"name": "   "}], HTTPStatus.BAD_REQUEST, [{
         'error': 'Name translation cannot be an empty string.',
-
         'path': '/filing/amalgamationApplication/nameTranslations/0/name/'
     }]),
     ('FAIL_LEADING_AND_TRAILING_WHITESPACE_NAME_TRANSLATION', [{"name": " TEST "}], HTTPStatus.BAD_REQUEST, [{
@@ -1648,7 +1646,6 @@ def test_validate_amalgamation_effective_date(
     }]),
     ('FAIL_MULTIPLE_NAME_TRANSLATION', [{"name": "   "}, {"name": " TEST  "}], HTTPStatus.BAD_REQUEST, [{
         'error': 'Name translation cannot be an empty string.',
-
         'path': '/filing/amalgamationApplication/nameTranslations/0/name/'
     },
     {

--- a/legal-api/tests/unit/services/filings/validations/test_amalgamation_application.py
+++ b/legal-api/tests/unit/services/filings/validations/test_amalgamation_application.py
@@ -1633,15 +1633,15 @@ def test_validate_amalgamation_effective_date(
     ('SUCCESS_EMPTY_ARRAY', [], None, None),
     ('SUCCESS_NAME_TRANSLATION', [{"name": "TEST"}], None, None),
     ('FAIL_EMPTY_NAME_TRANSLATION', [{"name": ""}],  HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation cannot be empty or only whitespace.',
+        'error': 'Name translation is required.',
         'path': '/filing/amalgamationApplication/nameTranslations/0/name/'
     }]),
     ('FAIL_WHITESPACE_ONLY_NAME_TRANSLATION', [{"name": "   "}], HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation cannot be empty or only whitespace.',
+        'error': 'Name translation is required.',
         'path': '/filing/amalgamationApplication/nameTranslations/0/name/'
     }]),
     ('FAIL_SECOND_NAME_TRANSLATION', [{"name": "TEST"}, {"name": "   "}], HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation cannot be empty or only whitespace.',
+        'error': 'Name translation is required.',
         'path': '/filing/amalgamationApplication/nameTranslations/1/name/'
     }]),
 ])

--- a/legal-api/tests/unit/services/filings/validations/test_amalgamation_application.py
+++ b/legal-api/tests/unit/services/filings/validations/test_amalgamation_application.py
@@ -1633,11 +1633,13 @@ def test_validate_amalgamation_effective_date(
     ('SUCCESS_NAME_TRANSLATION_EMPTY_ARRAY', [], None, None),
     ('SUCCESS_NAME_TRANSLATION', [{"name": "TEST"}], None, None),
     ('FAIL_EMPTY_NAME_TRANSLATION', [{"name": ""}],  HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation is required.',
+        'error': 'Name translation cannot be an empty string.',
+
         'path': '/filing/amalgamationApplication/nameTranslations/0/name/'
     }]),
     ('FAIL_WHITESPACE_ONLY_NAME_TRANSLATION', [{"name": "   "}], HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation is required.',
+        'error': 'Name translation cannot be an empty string.',
+
         'path': '/filing/amalgamationApplication/nameTranslations/0/name/'
     }]),
     ('FAIL_LEADING_AND_TRAILING_WHITESPACE_NAME_TRANSLATION', [{"name": " TEST "}], HTTPStatus.BAD_REQUEST, [{
@@ -1645,7 +1647,8 @@ def test_validate_amalgamation_effective_date(
         'path': '/filing/amalgamationApplication/nameTranslations/0/name/'
     }]),
     ('FAIL_MULTIPLE_NAME_TRANSLATION', [{"name": "   "}, {"name": " TEST  "}], HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation is required.',
+        'error': 'Name translation cannot be an empty string.',
+
         'path': '/filing/amalgamationApplication/nameTranslations/0/name/'
     },
     {

--- a/legal-api/tests/unit/services/filings/validations/test_common_validations.py
+++ b/legal-api/tests/unit/services/filings/validations/test_common_validations.py
@@ -304,6 +304,7 @@ def test_find_updated_keys_for_firms(mock_address, mock_party, mock_party_role):
     assert edited_result['address_changed'] == False
     assert edited_result['delivery_address_changed'] == True
 @pytest.mark.parametrize('input_value, expected_value, expect_error', [
+@pytest.mark.parametrize('input_value, expected_value, expected_error', [
     ('John   Doe', 'John Doe', False),
     ('   \t   ', '', True),
     ('', '', False),

--- a/legal-api/tests/unit/services/filings/validations/test_common_validations.py
+++ b/legal-api/tests/unit/services/filings/validations/test_common_validations.py
@@ -309,7 +309,7 @@ def test_find_updated_keys_for_firms(mock_address, mock_party, mock_party_role):
     ('', '', False),
     (None, None, False),
 ])
-def test_validate_and_normalize_certified_by(input_value, expected_value, expect_error):
+def test_validate_certified_by(input_value, expected_value, expect_error):
     """Test that certified by field can be validated."""
     filing = copy.deepcopy(FILING_HEADER)
     filing['filing']['header']['certifiedBy'] = input_value

--- a/legal-api/tests/unit/services/filings/validations/test_common_validations.py
+++ b/legal-api/tests/unit/services/filings/validations/test_common_validations.py
@@ -309,8 +309,14 @@ def test_find_updated_keys_for_firms(mock_address, mock_party, mock_party_role):
     ('   \t   ', '', True),
     ('', '', False),
     (None, None, False),
+@pytest.mark.parametrize('input_value, expected_error', [
+    ('John   Doe', False),
+    ('   \t   ', False),
+    ('', False),
+    ('  John Doe', True),
+    ('John Doe   ', True),    
 ])
-def test_validate_certified_by(input_value, expected_value, expected_error):
+def test_validate_certified_by(input_value, expected_error):
     """Test that certified by field can be validated."""
     filing = copy.deepcopy(FILING_HEADER)
     filing['filing']['header']['certifiedBy'] = input_value
@@ -319,9 +325,7 @@ def test_validate_certified_by(input_value, expected_value, expected_error):
 
     if expected_error:
         assert errors
-        assert errors[0]['error'] == 'Certified By field cannot be only whitespace.'
+        assert errors[0]['error'] == 'Certified by field cannot start or end with whitespace.'
         assert errors[0]['path'] == '/filing/header/certifiedBy'
     else:
         assert errors == []
-
-    assert filing['filing']['header']['certifiedBy'] == expected_value

--- a/legal-api/tests/unit/services/filings/validations/test_common_validations.py
+++ b/legal-api/tests/unit/services/filings/validations/test_common_validations.py
@@ -303,12 +303,7 @@ def test_find_updated_keys_for_firms(mock_address, mock_party, mock_party_role):
     assert edited_result['name_changed'] == False
     assert edited_result['address_changed'] == False
     assert edited_result['delivery_address_changed'] == True
-@pytest.mark.parametrize('input_value, expected_value, expect_error', [
-@pytest.mark.parametrize('input_value, expected_value, expected_error', [
-    ('John   Doe', 'John Doe', False),
-    ('   \t   ', '', True),
-    ('', '', False),
-    (None, None, False),
+
 @pytest.mark.parametrize('input_value, expected_error', [
     ('John   Doe', False),
     ('   \t   ', False),

--- a/legal-api/tests/unit/services/filings/validations/test_common_validations.py
+++ b/legal-api/tests/unit/services/filings/validations/test_common_validations.py
@@ -309,14 +309,14 @@ def test_find_updated_keys_for_firms(mock_address, mock_party, mock_party_role):
     ('', '', False),
     (None, None, False),
 ])
-def test_validate_certified_by(input_value, expected_value, expect_error):
+def test_validate_certified_by(input_value, expected_value, expected_error):
     """Test that certified by field can be validated."""
     filing = copy.deepcopy(FILING_HEADER)
     filing['filing']['header']['certifiedBy'] = input_value
 
     errors = validate_certified_by(filing)
 
-    if expect_error:
+    if expected_error:
         assert errors
         assert errors[0]['error'] == 'Certified By field cannot be only whitespace.'
         assert errors[0]['path'] == '/filing/header/certifiedBy'

--- a/legal-api/tests/unit/services/filings/validations/test_common_validations.py
+++ b/legal-api/tests/unit/services/filings/validations/test_common_validations.py
@@ -37,6 +37,7 @@ from registry_schemas.example_data import (
 from legal_api.services.filings.validations.common_validations import (
     find_updated_keys_for_firms,
     validate_certify_name,
+    validate_and_sanitize_certified_by,
     validate_offices_addresses,
     validate_parties_addresses,
     validate_staff_payment,
@@ -302,3 +303,24 @@ def test_find_updated_keys_for_firms(mock_address, mock_party, mock_party_role):
     assert edited_result['name_changed'] == False
     assert edited_result['address_changed'] == False
     assert edited_result['delivery_address_changed'] == True
+@pytest.mark.parametrize('input_value, expected_value, expect_error', [
+    ('John   Doe', 'John Doe', False),
+    ('   \t   ', '', True),
+    ('', '', False),
+    (None, None, False),
+])
+def test_validate_and_normalize_certified_by(input_value, expected_value, expect_error):
+    """Test certifiedBy normalization and validation rules."""
+    filing = copy.deepcopy(FILING_HEADER)
+    filing['filing']['header']['certifiedBy'] = input_value
+
+    errors = validate_and_sanitize_certified_by(filing)
+
+    if expect_error:
+        assert errors
+        assert errors[0]['error'] == 'Certified By field cannot be only whitespace.'
+        assert errors[0]['path'] == '/filing/header/certifiedBy'
+    else:
+        assert errors == []
+
+    assert filing['filing']['header']['certifiedBy'] == expected_value

--- a/legal-api/tests/unit/services/filings/validations/test_common_validations.py
+++ b/legal-api/tests/unit/services/filings/validations/test_common_validations.py
@@ -37,7 +37,7 @@ from registry_schemas.example_data import (
 from legal_api.services.filings.validations.common_validations import (
     find_updated_keys_for_firms,
     validate_certify_name,
-    validate_and_sanitize_certified_by,
+    validate_certified_by,
     validate_offices_addresses,
     validate_parties_addresses,
     validate_staff_payment,
@@ -310,11 +310,11 @@ def test_find_updated_keys_for_firms(mock_address, mock_party, mock_party_role):
     (None, None, False),
 ])
 def test_validate_and_normalize_certified_by(input_value, expected_value, expect_error):
-    """Test certifiedBy normalization and validation rules."""
+    """Test that certified by field can be validated."""
     filing = copy.deepcopy(FILING_HEADER)
     filing['filing']['header']['certifiedBy'] = input_value
 
-    errors = validate_and_sanitize_certified_by(filing)
+    errors = validate_certified_by(filing)
 
     if expect_error:
         assert errors

--- a/legal-api/tests/unit/services/filings/validations/test_continuation_in.py
+++ b/legal-api/tests/unit/services/filings/validations/test_continuation_in.py
@@ -1068,12 +1068,10 @@ def test_validate_continuation_in_effective_date(mocker, app, session, test_name
     ('SUCCESS_NAME_TRANSLATION', [{"name": "TEST"}], None, None),
     ('FAIL_EMPTY_NAME_TRANSLATION', [{"name": ""}],  HTTPStatus.BAD_REQUEST, [{
         'error': 'Name translation cannot be an empty string.',
-
         'path': '/filing/continuationIn/nameTranslations/0/name/'
     }]),
     ('FAIL_WHITESPACE_ONLY_NAME_TRANSLATION', [{"name": "   "}], HTTPStatus.BAD_REQUEST, [{
         'error': 'Name translation cannot be an empty string.',
-
         'path': '/filing/continuationIn/nameTranslations/0/name/'
     }]),
     ('FAIL_LEADING_AND_TRAILING_WHITESPACE_NAME_TRANSLATION', [{"name": " TEST "}], HTTPStatus.BAD_REQUEST, [{
@@ -1082,7 +1080,6 @@ def test_validate_continuation_in_effective_date(mocker, app, session, test_name
     }]),
     ('FAIL_MULTIPLE_NAME_TRANSLATION', [{"name": "   "}, {"name": " TEST  "}], HTTPStatus.BAD_REQUEST, [{
         'error': 'Name translation cannot be an empty string.',
-
         'path': '/filing/continuationIn/nameTranslations/0/name/'
     },
     {

--- a/legal-api/tests/unit/services/filings/validations/test_continuation_in.py
+++ b/legal-api/tests/unit/services/filings/validations/test_continuation_in.py
@@ -1067,15 +1067,15 @@ def test_validate_continuation_in_effective_date(mocker, app, session, test_name
     ('SUCCESS_EMPTY_ARRAY', [], None, None),
     ('SUCCESS_NAME_TRANSLATION', [{"name": "TEST"}], None, None),
     ('FAIL_EMPTY_NAME_TRANSLATION', [{"name": ""}],  HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation cannot be empty or only whitespace.',
+        'error': 'Name translation is required.',
         'path': '/filing/continuationIn/nameTranslations/0/name/'
     }]),
     ('FAIL_WHITESPACE_ONLY_NAME_TRANSLATION', [{"name": "   "}], HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation cannot be empty or only whitespace.',
+        'error': 'Name translation is required.',
         'path': '/filing/continuationIn/nameTranslations/0/name/'
     }]),
     ('FAIL_SECOND_NAME_TRANSLATION', [{"name": "TEST"}, {"name": "   "}], HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation cannot be empty or only whitespace.',
+        'error': 'Name translation is required.',
         'path': '/filing/continuationIn/nameTranslations/1/name/'
     }]),
 ])

--- a/legal-api/tests/unit/services/filings/validations/test_continuation_in.py
+++ b/legal-api/tests/unit/services/filings/validations/test_continuation_in.py
@@ -1067,11 +1067,13 @@ def test_validate_continuation_in_effective_date(mocker, app, session, test_name
     ('SUCCESS_NAME_TRANSLATION_EMPTY_ARRAY', [], None, None),
     ('SUCCESS_NAME_TRANSLATION', [{"name": "TEST"}], None, None),
     ('FAIL_EMPTY_NAME_TRANSLATION', [{"name": ""}],  HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation is required.',
+        'error': 'Name translation cannot be an empty string.',
+
         'path': '/filing/continuationIn/nameTranslations/0/name/'
     }]),
     ('FAIL_WHITESPACE_ONLY_NAME_TRANSLATION', [{"name": "   "}], HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation is required.',
+        'error': 'Name translation cannot be an empty string.',
+
         'path': '/filing/continuationIn/nameTranslations/0/name/'
     }]),
     ('FAIL_LEADING_AND_TRAILING_WHITESPACE_NAME_TRANSLATION', [{"name": " TEST "}], HTTPStatus.BAD_REQUEST, [{
@@ -1079,7 +1081,8 @@ def test_validate_continuation_in_effective_date(mocker, app, session, test_name
         'path': '/filing/continuationIn/nameTranslations/0/name/'
     }]),
     ('FAIL_MULTIPLE_NAME_TRANSLATION', [{"name": "   "}, {"name": " TEST  "}], HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation is required.',
+        'error': 'Name translation cannot be an empty string.',
+
         'path': '/filing/continuationIn/nameTranslations/0/name/'
     },
     {

--- a/legal-api/tests/unit/services/filings/validations/test_continuation_in.py
+++ b/legal-api/tests/unit/services/filings/validations/test_continuation_in.py
@@ -1062,3 +1062,57 @@ def test_validate_continuation_in_effective_date(mocker, app, session, test_name
         assert lists_are_equal(err.msg, expected_msg)
     else:
         assert err is None
+
+@pytest.mark.parametrize('test_name, name_translation, expected_code, expected_msg', [
+    ('SUCCESS_EMPTY_ARRAY', [], None, None),
+    ('SUCCESS_NAME_TRANSLATION', [{"name": "TEST"}], None, None),
+    ('FAIL_EMPTY_NAME_TRANSLATION', [{"name": ""}],  HTTPStatus.BAD_REQUEST, [{
+        'error': 'Name translation cannot be empty or only whitespace.',
+        'path': '/filing/continuationIn/nameTranslations/0/name/'
+    }]),
+    ('FAIL_WHITESPACE_ONLY_NAME_TRANSLATION', [{"name": "   "}], HTTPStatus.BAD_REQUEST, [{
+        'error': 'Name translation cannot be empty or only whitespace.',
+        'path': '/filing/continuationIn/nameTranslations/0/name/'
+    }]),
+    ('FAIL_SECOND_NAME_TRANSLATION', [{"name": "TEST"}, {"name": "   "}], HTTPStatus.BAD_REQUEST, [{
+        'error': 'Name translation cannot be empty or only whitespace.',
+        'path': '/filing/continuationIn/nameTranslations/1/name/'
+    }]),
+])
+def test_validate_continuation_in_name_translation(mocker, session, test_name, name_translation, expected_code, expected_msg, monkeypatch):
+    """Test validate name translation if provided."""
+    monkeypatch.setattr(
+            'legal_api.services.flags.value',
+            lambda flag: "C CBEN CCC CUL"  if flag == 'supported-continuation-in-entities' else {}
+        ) 
+    filing = {'filing': {}}
+    filing['filing']['header'] = {'name': 'continuationIn', 'date': '2019-04-08',
+                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+
+    filing['filing']['continuationIn'] = copy.deepcopy(CONTINUATION_IN)
+    filing['filing']['continuationIn']['isApproved'] = True
+
+    filing['filing']['continuationIn']['nameRequest'] = {}
+    filing['filing']['continuationIn']['nameRequest']['nrNumber'] = 'NR 1234567'
+    filing['filing']['continuationIn']['nameRequest']['legalType'] = 'CBEN'
+
+    filing['filing']['continuationIn']['nameTranslations'] = name_translation
+
+    mocker.patch('legal_api.services.filings.validations.continuation_in.validate_roles', return_value=[])
+    mocker.patch('legal_api.services.filings.validations.continuation_in.validate_pdf', return_value=None)
+    mocker.patch('legal_api.services.filings.validations.continuation_in.validate_name_request', return_value=[])
+    mocker.patch('legal_api.services.filings.validations.continuation_in.validate_business_in_colin', return_value=[])
+
+    # perform test
+    with freeze_time(now):
+        err = validate(None, filing)
+
+    # validate outcomes
+    if expected_code:
+        assert err.code == expected_code
+        assert lists_are_equal(err.msg, expected_msg)
+    else:
+        if err:
+            print(err, err.code, err.msg)
+        assert err is None
+

--- a/legal-api/tests/unit/services/filings/validations/test_continuation_in.py
+++ b/legal-api/tests/unit/services/filings/validations/test_continuation_in.py
@@ -1064,7 +1064,7 @@ def test_validate_continuation_in_effective_date(mocker, app, session, test_name
         assert err is None
 
 @pytest.mark.parametrize('test_name, name_translation, expected_code, expected_msg', [
-    ('SUCCESS_EMPTY_ARRAY', [], None, None),
+    ('SUCCESS_NAME_TRANSLATION_EMPTY_ARRAY', [], None, None),
     ('SUCCESS_NAME_TRANSLATION', [{"name": "TEST"}], None, None),
     ('FAIL_EMPTY_NAME_TRANSLATION', [{"name": ""}],  HTTPStatus.BAD_REQUEST, [{
         'error': 'Name translation is required.',
@@ -1074,10 +1074,19 @@ def test_validate_continuation_in_effective_date(mocker, app, session, test_name
         'error': 'Name translation is required.',
         'path': '/filing/continuationIn/nameTranslations/0/name/'
     }]),
-    ('FAIL_SECOND_NAME_TRANSLATION', [{"name": "TEST"}, {"name": "   "}], HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation is required.',
-        'path': '/filing/continuationIn/nameTranslations/1/name/'
+    ('FAIL_LEADING_AND_TRAILING_WHITESPACE_NAME_TRANSLATION', [{"name": " TEST "}], HTTPStatus.BAD_REQUEST, [{
+        'error': 'Name translation cannot start or end with whitespace.',
+        'path': '/filing/continuationIn/nameTranslations/0/name/'
     }]),
+    ('FAIL_MULTIPLE_NAME_TRANSLATION', [{"name": "   "}, {"name": " TEST  "}], HTTPStatus.BAD_REQUEST, [{
+        'error': 'Name translation is required.',
+        'path': '/filing/continuationIn/nameTranslations/0/name/'
+    },
+    {
+        'error': 'Name translation cannot start or end with whitespace.',
+        'path': '/filing/continuationIn/nameTranslations/1/name/'
+    }
+    ]),
 ])
 def test_validate_continuation_in_name_translation(mocker, session, test_name, name_translation, expected_code, expected_msg, monkeypatch):
     """Test validate name translation if provided."""

--- a/legal-api/tests/unit/services/filings/validations/test_dissolution.py
+++ b/legal-api/tests/unit/services/filings/validations/test_dissolution.py
@@ -394,17 +394,17 @@ def test_dissolution_custodian_email(session, test_status, legal_type, dissoluti
     [
         # Required organization name cases
         ('FAIL', 'BC', 'voluntary', 'organization', '', HTTPStatus.BAD_REQUEST,
-         'Corporation or firm name is required for an organization.'),
+         'Organization name is required.'),
         ('FAIL', 'BC', 'voluntary', 'organization', '   ', HTTPStatus.BAD_REQUEST,
-         'Corporation or firm name is required for an organization.'),
+         'Organization name is required.'),
 
         # Leading/trailing whitespace
         ('FAIL', 'BC', 'voluntary', 'organization', '  LeadingSpace', HTTPStatus.BAD_REQUEST,
-         'Corporation or firm name cannot have leading or trailing spaces.'),
+         'Organization name cannot have leading or trailing spaces.'),
         ('FAIL', 'BC', 'voluntary', 'organization', 'TrailingSpace  ', HTTPStatus.BAD_REQUEST,
-         'Corporation or firm name cannot have leading or trailing spaces.'),
+         'Organization name cannot have leading or trailing spaces.'),
         ('FAIL', 'BC', 'voluntary', 'organization', '  BothSides  ', HTTPStatus.BAD_REQUEST,
-         'Corporation or firm name cannot have leading or trailing spaces.'),
+         'Organization name cannot have leading or trailing spaces.'),
 
         # Valid name
         ('SUCCESS', 'BC', 'voluntary', 'organization', 'Test Org', None, None),

--- a/legal-api/tests/unit/services/filings/validations/test_dissolution.py
+++ b/legal-api/tests/unit/services/filings/validations/test_dissolution.py
@@ -394,11 +394,11 @@ def test_dissolution_custodian_email(session, test_status, legal_type, dissoluti
     [
         # Required organization name cases (missing or None)
         ('FAIL', 'BC', 'voluntary', 'organization', None, HTTPStatus.BAD_REQUEST,
-         'Corporation or firm name is required'),
+         'Corporation or firm name is required for organization'),
         ('FAIL', 'BC', 'voluntary', 'organization', '', HTTPStatus.BAD_REQUEST,
-         'Corporation or firm name is required'),
+         'Corporation or firm name is required for organization'),
         ('FAIL', 'BC', 'voluntary', 'organization', '   ', HTTPStatus.BAD_REQUEST,
-         'Corporation or firm name is required'),
+         'Corporation or firm name is required for organization'),
 
         # Leading/trailing whitespace
         ('SUCCESS', 'BC', 'voluntary', 'organization', '  LeadingSpace', None, None),

--- a/legal-api/tests/unit/services/filings/validations/test_dissolution.py
+++ b/legal-api/tests/unit/services/filings/validations/test_dissolution.py
@@ -392,18 +392,19 @@ def test_dissolution_custodian_email(session, test_status, legal_type, dissoluti
 @pytest.mark.parametrize(
     'test_status, legal_type, dissolution_type, party_type, org_name, expected_code, expected_msg',
     [
-        # Required organization name cases (missing or None)
-        ('FAIL', 'BC', 'voluntary', 'organization', None, HTTPStatus.BAD_REQUEST,
-         'Corporation or firm name is required for an organization.'),
+        # Required organization name cases
         ('FAIL', 'BC', 'voluntary', 'organization', '', HTTPStatus.BAD_REQUEST,
          'Corporation or firm name is required for an organization.'),
         ('FAIL', 'BC', 'voluntary', 'organization', '   ', HTTPStatus.BAD_REQUEST,
          'Corporation or firm name is required for an organization.'),
 
         # Leading/trailing whitespace
-        ('SUCCESS', 'BC', 'voluntary', 'organization', '  LeadingSpace', None, None),
-        ('SUCCESS', 'BC', 'voluntary', 'organization', 'TrailingSpace  ', None, None),
-        ('SUCCESS', 'BC', 'voluntary', 'organization', '  BothSides  ', None, None),
+        ('FAIL', 'BC', 'voluntary', 'organization', '  LeadingSpace', HTTPStatus.BAD_REQUEST,
+         'Corporation or firm name cannot have leading or trailing spaces.'),
+        ('FAIL', 'BC', 'voluntary', 'organization', 'TrailingSpace  ', HTTPStatus.BAD_REQUEST,
+         'Corporation or firm name cannot have leading or trailing spaces.'),
+        ('FAIL', 'BC', 'voluntary', 'organization', '  BothSides  ', HTTPStatus.BAD_REQUEST,
+         'Corporation or firm name cannot have leading or trailing spaces.'),
 
         # Valid name
         ('SUCCESS', 'BC', 'voluntary', 'organization', 'Test Org', None, None),
@@ -448,11 +449,6 @@ def test_dissolution_custodian_org_name(session, test_status, legal_type, dissol
         assert any(expected_msg in msg['error'] for msg in err.msg)
     else:
         assert err is None
-
-    # Check that the organizationName is trimmed for successful payloads
-    if org_name and party_type == 'organization' and test_status == 'SUCCESS' and legal_type in Business.CORPS:
-        trimmed = filing['filing']['dissolution']['parties'][1]['officer'].get('organizationName')
-        assert trimmed == org_name.strip()
 
 
 

--- a/legal-api/tests/unit/services/filings/validations/test_dissolution.py
+++ b/legal-api/tests/unit/services/filings/validations/test_dissolution.py
@@ -319,25 +319,47 @@ def test_dissolution_court_orders(session, test_status, file_number, effect_of_o
 
 
 @pytest.mark.parametrize(
-    'test_status, legal_type, dissolution_type, has_email, expected_code, expected_msg',
+    'test_status, legal_type, dissolution_type, email, expected_code, expected_msg',
     [
-        ('FAIL', 'BC', 'voluntary', False, HTTPStatus.BAD_REQUEST,
+        # Required email cases (missing or None)
+        ('FAIL', 'BC', 'voluntary', None, HTTPStatus.BAD_REQUEST,
          'Custodian email is required for voluntary dissolution.'),
-        ('FAIL', 'BEN', 'voluntary', False, HTTPStatus.BAD_REQUEST,
+        ('FAIL', 'BEN', 'voluntary', None, HTTPStatus.BAD_REQUEST,
          'Custodian email is required for voluntary dissolution.'),
-        ('FAIL', 'CC', 'voluntary', False, HTTPStatus.BAD_REQUEST,
+        ('FAIL', 'CC', 'voluntary', None, HTTPStatus.BAD_REQUEST,
          'Custodian email is required for voluntary dissolution.'),
-        ('FAIL', 'ULC', 'voluntary', False, HTTPStatus.BAD_REQUEST,
+        ('FAIL', 'ULC', 'voluntary', None, HTTPStatus.BAD_REQUEST,
          'Custodian email is required for voluntary dissolution.'),
-        ('SUCCESS', 'CP', 'voluntary', False, None, None),
-        ('SUCCESS', 'BC', 'voluntary', True, None, None),
-        ('SUCCESS', 'BEN', 'voluntary', True, None, None),
-        ('SUCCESS', 'CC', 'voluntary', True, None, None),
-        ('SUCCESS', 'ULC', 'voluntary', True, None, None),
-        ('SUCCESS', 'BC', 'administrative', False, None, None),
+
+        # Whitespace-only emails
+        ('FAIL', 'BC', 'voluntary', ' ', HTTPStatus.BAD_REQUEST,
+         'Custodian email cannot contain any whitespaces'),
+        ('FAIL', 'BC', 'voluntary', '   ', HTTPStatus.BAD_REQUEST,
+         'Custodian email cannot contain any whitespaces'),
+        ('FAIL', 'BC', 'voluntary', '\t', HTTPStatus.BAD_REQUEST,
+         'Custodian email cannot contain any whitespaces'),
+        ('FAIL', 'BC', 'voluntary', '\n', HTTPStatus.BAD_REQUEST,
+         'Custodian email cannot contain any whitespaces'),
+
+        # Leading/trailing/middle whitespace
+        ('FAIL', 'BC', 'voluntary', ' test@example.com', HTTPStatus.BAD_REQUEST,
+         'Custodian email cannot contain any whitespaces'),
+        ('FAIL', 'BC', 'voluntary', 'test@example.com ', HTTPStatus.BAD_REQUEST,
+         'Custodian email cannot contain any whitespaces'),
+        ('FAIL', 'BC', 'voluntary', 'te st@example.com', HTTPStatus.BAD_REQUEST,
+         'Custodian email cannot contain any whitespaces'),
+
+        # Valid emails (no whitespace)
+        ('SUCCESS', 'CP', 'voluntary', None, None, None),
+        ('SUCCESS', 'BC', 'voluntary', 'test@example.com', None, None),
+        ('SUCCESS', 'BEN', 'voluntary', 'test@example.com', None, None),
+        ('SUCCESS', 'CC', 'voluntary', 'test@example.com', None, None),
+        ('SUCCESS', 'ULC', 'voluntary', 'test@example.com', None, None),
+        ('SUCCESS', 'BC', 'administrative', None, None, None),
     ]
 )
-def test_dissolution_custodian_email(session, test_status, legal_type, dissolution_type, has_email, expected_code, expected_msg):
+def test_dissolution_custodian_email(session, test_status, legal_type, dissolution_type,
+                                     email, expected_code, expected_msg):
     """Test custodian email validation in voluntary dissolution."""
     business = Business(identifier='BC1234567', legal_type=legal_type)
     filing = copy.deepcopy(FILING_HEADER)
@@ -348,8 +370,11 @@ def test_dissolution_custodian_email(session, test_status, legal_type, dissoluti
     filing['filing']['dissolution']['parties'][1]['deliveryAddress'] = \
         filing['filing']['dissolution']['parties'][1]['mailingAddress']
 
-    if not has_email:
-        del filing['filing']['dissolution']['parties'][1]['officer']['email']
+    officer = filing['filing']['dissolution']['parties'][1]['officer']
+    if email is None:
+        officer.pop('email', None)
+    else:
+        officer['email'] = email
 
     if dissolution_type == 'administrative':
         filing['filing']['dissolution']['details'] = "Some Details"
@@ -363,6 +388,7 @@ def test_dissolution_custodian_email(session, test_status, legal_type, dissoluti
         assert any(expected_msg in msg['error'] for msg in err.msg)
     else:
         assert err is None
+
 
 
 @pytest.mark.parametrize(

--- a/legal-api/tests/unit/services/filings/validations/test_dissolution.py
+++ b/legal-api/tests/unit/services/filings/validations/test_dissolution.py
@@ -333,21 +333,21 @@ def test_dissolution_court_orders(session, test_status, file_number, effect_of_o
 
         # Whitespace-only emails
         ('FAIL', 'BC', 'voluntary', ' ', HTTPStatus.BAD_REQUEST,
-         'Custodian email cannot contain any whitespaces'),
+         'Custodian email cannot contain any whitespaces.'),
         ('FAIL', 'BC', 'voluntary', '   ', HTTPStatus.BAD_REQUEST,
-         'Custodian email cannot contain any whitespaces'),
+         'Custodian email cannot contain any whitespaces.'),
         ('FAIL', 'BC', 'voluntary', '\t', HTTPStatus.BAD_REQUEST,
-         'Custodian email cannot contain any whitespaces'),
+         'Custodian email cannot contain any whitespaces.'),
         ('FAIL', 'BC', 'voluntary', '\n', HTTPStatus.BAD_REQUEST,
-         'Custodian email cannot contain any whitespaces'),
+         'Custodian email cannot contain any whitespaces.'),
 
         # Leading/trailing/middle whitespace
         ('FAIL', 'BC', 'voluntary', ' test@example.com', HTTPStatus.BAD_REQUEST,
-         'Custodian email cannot contain any whitespaces'),
+         'Custodian email cannot contain any whitespaces.'),
         ('FAIL', 'BC', 'voluntary', 'test@example.com ', HTTPStatus.BAD_REQUEST,
-         'Custodian email cannot contain any whitespaces'),
+         'Custodian email cannot contain any whitespaces.'),
         ('FAIL', 'BC', 'voluntary', 'te st@example.com', HTTPStatus.BAD_REQUEST,
-         'Custodian email cannot contain any whitespaces'),
+         'Custodian email cannot contain any whitespaces.'),
 
         # Valid emails (no whitespace)
         ('SUCCESS', 'CP', 'voluntary', None, None, None),
@@ -394,11 +394,11 @@ def test_dissolution_custodian_email(session, test_status, legal_type, dissoluti
     [
         # Required organization name cases (missing or None)
         ('FAIL', 'BC', 'voluntary', 'organization', None, HTTPStatus.BAD_REQUEST,
-         'Corporation or firm name is required for organization'),
+         'Corporation or firm name is required for an organization.'),
         ('FAIL', 'BC', 'voluntary', 'organization', '', HTTPStatus.BAD_REQUEST,
-         'Corporation or firm name is required for organization'),
+         'Corporation or firm name is required for an organization.'),
         ('FAIL', 'BC', 'voluntary', 'organization', '   ', HTTPStatus.BAD_REQUEST,
-         'Corporation or firm name is required for organization'),
+         'Corporation or firm name is required for an organization.'),
 
         # Leading/trailing whitespace
         ('SUCCESS', 'BC', 'voluntary', 'organization', '  LeadingSpace', None, None),

--- a/legal-api/tests/unit/services/filings/validations/test_incorporation_application.py
+++ b/legal-api/tests/unit/services/filings/validations/test_incorporation_application.py
@@ -709,6 +709,79 @@ def test_validate_incorporation_parties_mailing_address(session, mocker, test_na
             None
         ),
         (
+            'FAIL_FIRST_NAME_WHITESPACE_ONLY', 'BEN',
+            [
+                {
+                    'partyName': 'officer1',
+                    'roles': ['Completing Party', 'Incorporator'],
+                    'officer': {'firstName': '  ', 'middleName': None, 'lastName': 'Doe'}
+                },
+                {
+                    'partyName': 'officer2',
+                    'roles': ['Incorporator', 'Director'],
+                    'officer': {'firstName': '  ', 'middleName': 'jkalsdf', 'lastName': 'Doe'}
+                }
+            ],
+            [{'error': 'Completing Party, Incorporator first name cannot be only whitespace',
+              'path': '/filing/incorporationApplication/parties'},
+             {'error': 'Incorporator, Director first name cannot be only whitespace',
+              'path': '/filing/incorporationApplication/parties'}]
+        ),
+        (
+            'FAIL_MIDDLE_NAME_WHITESPACE_ONLY', 'BEN',
+            [
+                {
+                    'partyName': 'officer1',
+                    'roles': ['Completing Party', 'Incorporator'],
+                    'officer': {'firstName': 'Johnajksdfjljdkslfja', 'middleName': '  ', 'lastName': 'Doe'}
+                },
+                {
+                    'partyName': 'officer2',
+                    'roles': ['Incorporator', 'Director'],
+                    'officer': {'firstName': 'Janeajksdfjljdkslfja', 'middleName': '  ', 'lastName': 'Doe'}
+                }
+            ],
+            [{'error': 'Completing Party, Incorporator middle name cannot be only whitespace',
+              'path': '/filing/incorporationApplication/parties'},
+             {'error': 'Incorporator, Director middle name cannot be only whitespace',
+              'path': '/filing/incorporationApplication/parties'}]
+        ),
+        (
+            'FAIL_LAST_NAME_WHITESPACE_ONLY', 'BEN',
+            [
+                {
+                    'partyName': 'officer1',
+                    'roles': ['Completing Party', 'Incorporator'],
+                    'officer': {'firstName': 'Johnajksdfjljdkslfja', 'middleName': None, 'lastName': '  '}
+                },
+                {
+                    'partyName': 'officer2',
+                    'roles': ['Incorporator', 'Director'],
+                    'officer': {'firstName': 'Janeajksdfjljdkslfja', 'middleName': 'jkalsdf', 'lastName': '  '}
+                }
+            ],
+            [{'error': 'Completing Party, Incorporator last name cannot be only whitespace',
+              'path': '/filing/incorporationApplication/parties'},
+             {'error': 'Incorporator, Director last name cannot be only whitespace',
+              'path': '/filing/incorporationApplication/parties'}]
+        ),
+        (
+            'FAIL_PARTY_FIRST_AND_MIDDLE_NAME_AND_LAST_NAME_WHITESPACE_ONLY', 'BEN',
+            [
+                {
+                    'partyName': 'officer1',
+                    'roles': ['Completing Party', 'Incorporator'],
+                    'officer': {'firstName': '   ', 'middleName': '   ', 'lastName': '   '}
+                },
+            ],
+            [{'error': 'Completing Party, Incorporator first name cannot be only whitespace',
+              'path': '/filing/incorporationApplication/parties'},
+             {'error': 'Completing Party, Incorporator middle name cannot be only whitespace',
+              'path': '/filing/incorporationApplication/parties'},
+             {'error': 'Completing Party, Incorporator last name cannot be only whitespace',
+              'path': '/filing/incorporationApplication/parties'}]
+        ),
+        (
             'FAIL_PARTY_FIRST_NAME_TOO_LONG', 'BEN',
             [
                 {
@@ -747,17 +820,40 @@ def test_validate_incorporation_parties_mailing_address(session, mocker, test_na
               'path': '/filing/incorporationApplication/parties'}]
         ),
         (
-            'FAIL_PARTY_FIRST_AND_MIDDLE_NAME_TOO_LONG', 'BEN',
+            'FAIL_PARTY_LAST_NAME_TOO_LONG', 'BEN',
             [
                 {
                     'partyName': 'officer1',
                     'roles': ['Completing Party', 'Incorporator'],
-                    'officer': {'firstName': 'Janeajksdfjljdkslfjab', 'middleName': 'Janeajksdfjljdkslfjab', 'lastName': 'Doe'}
+                    'officer': {'firstName': 'John', 'middleName': 'None', 'lastName': 'Doeasdfasdfasdfasdfasdfasdfasdf'}
+                },
+                {
+                    'partyName': 'officer2',
+                    'roles': ['Director'],
+                    'officer': {'firstName': 'Jane', 'middleName': 'jkalsdf', 'lastName': 'Doeasdfasdfasdfasdfasdfasdfasdf'}
+                }
+            ],
+            [{'error': 'Completing Party, Incorporator last name cannot be longer than 30 characters',
+              'path': '/filing/incorporationApplication/parties'},
+             {'error': 'Director last name cannot be longer than 30 characters',
+              'path': '/filing/incorporationApplication/parties'}]
+        ),
+        (
+            'FAIL_PARTY_FIRST_AND_MIDDLE_NAME_AND_LAST_NAME_TOO_LONG', 'BEN',
+            [
+                {
+                    'partyName': 'officer1',
+                    'roles': ['Completing Party', 'Incorporator'],
+                    'officer': {'firstName': 'Janeajksdfjljdkslfjab',
+                                'middleName': 'Janeajksdfjljdkslfjab',
+                                'lastName': 'Doeasdfasdfasdfasdfasdfasdfasdf'}
                 },
             ],
             [{'error': 'Completing Party, Incorporator first name cannot be longer than 20 characters',
               'path': '/filing/incorporationApplication/parties'},
              {'error': 'Completing Party, Incorporator middle name cannot be longer than 20 characters',
+              'path': '/filing/incorporationApplication/parties'},
+             {'error': 'Completing Party, Incorporator last name cannot be longer than 30 characters',
               'path': '/filing/incorporationApplication/parties'}]
         ),
         (

--- a/legal-api/tests/unit/services/filings/validations/test_incorporation_application.py
+++ b/legal-api/tests/unit/services/filings/validations/test_incorporation_application.py
@@ -693,7 +693,7 @@ def test_validate_incorporation_parties_mailing_address(session, mocker, test_na
     'test_name, legal_type, parties, expected_msg',
     [
         (
-            'SUCCESS_VALID_FIRST_MIDDLE_NAME_LENGTHS', 'BEN',
+            'SUCCESS_VALID_FIRST_MIDDLE_LAST_NAME_LENGTHS', 'BEN',
             [
                 {
                     'partyName': 'officer1',
@@ -704,6 +704,11 @@ def test_validate_incorporation_parties_mailing_address(session, mocker, test_na
                     'partyName': 'officer2',
                     'roles': ['Incorporator', 'Director'],
                     'officer': {'firstName': 'Janeajksdfjljdkslfja', 'middleName': '', 'lastName': 'Doe'}
+                },
+                                {
+                    'partyName': 'officer3',
+                    'roles': ['Incorporator', 'Director'],
+                    'officer': {'firstName': 'Janeajksdfjljdkslfja', 'middleName': '  ', 'lastName': 'Doe'}
                 }
             ],
             None
@@ -747,6 +752,79 @@ def test_validate_incorporation_parties_mailing_address(session, mocker, test_na
               'path': '/filing/incorporationApplication/parties'}]
         ),
         (
+            'FAIL_FIRST_NAME_LEADING_AND_TRAILING_WHITESPACE', 'BEN',
+            [
+                {
+                    'partyName': 'officer1',
+                    'roles': ['Completing Party', 'Incorporator'],
+                    'officer': {'firstName': '  John', 'middleName': None, 'lastName': 'Doe'}
+                },
+                {
+                    'partyName': 'officer2',
+                    'roles': ['Incorporator', 'Director'],
+                    'officer': {'firstName': 'John  ', 'middleName': 'jkalsdf', 'lastName': 'Doe'}
+                }
+            ],
+            [{'error': 'Completing Party, Incorporator first name cannot start or end with whitespace',
+              'path': '/filing/incorporationApplication/parties'},
+             {'error': 'Incorporator, Director first name cannot start or end with whitespace',
+              'path': '/filing/incorporationApplication/parties'}]
+        ),
+        (
+            'FAIL_MIDDLE_NAME_LEADING_AND_TRAILING_WHITESPACE', 'BEN',
+            [
+                {
+                    'partyName': 'officer1',
+                    'roles': ['Completing Party', 'Incorporator'],
+                    'officer': {'firstName': 'John', 'middleName': '  B', 'lastName': 'Doe'}
+                },
+                {
+                    'partyName': 'officer2',
+                    'roles': ['Incorporator', 'Director'],
+                    'officer': {'firstName': 'John', 'middleName': 'B  ', 'lastName': 'Doe'}
+                }
+            ],
+            [{'error': 'Completing Party, Incorporator middle name cannot start or end with whitespace',
+              'path': '/filing/incorporationApplication/parties'},
+             {'error': 'Incorporator, Director middle name cannot start or end with whitespace',
+              'path': '/filing/incorporationApplication/parties'}]
+        ),
+        (
+            'FAIL_LAST_NAME_LEADING_AND_TRAILING_WHITESPACE', 'BEN',
+            [
+                {
+                    'partyName': 'officer1',
+                    'roles': ['Completing Party', 'Incorporator'],
+                    'officer': {'firstName': 'Johnajksdfjldkslfja', 'middleName': None, 'lastName': '  Doe'}
+                },
+                {
+                    'partyName': 'officer2',
+                    'roles': ['Incorporator', 'Director'],
+                    'officer': {'firstName': 'Janeajksdfjljdkslfja', 'middleName': 'jkalsdf', 'lastName': 'Doe  '}
+                }
+            ],
+            [{'error': 'Completing Party, Incorporator last name cannot start or end with whitespace',
+              'path': '/filing/incorporationApplication/parties'},
+             {'error': 'Incorporator, Director last name cannot start or end with whitespace',
+              'path': '/filing/incorporationApplication/parties'}]
+        ),
+        (
+            'FAIL_PARTY_FIRST_MIDDLE_LAST_NAME_WHITESPACE', 'BEN',
+            [
+                {
+                    'partyName': 'officer1',
+                    'roles': ['Completing Party', 'Incorporator'],
+                    'officer': {'firstName': ' John  ', 'middleName': ' B ', 'lastName': '  Doe  '}
+                },
+            ],
+            [{'error': 'Completing Party, Incorporator first name cannot start or end with whitespace',
+              'path': '/filing/incorporationApplication/parties'},
+             {'error': 'Completing Party, Incorporator middle name cannot start or end with whitespace',
+              'path': '/filing/incorporationApplication/parties'},
+             {'error': 'Completing Party, Incorporator last name cannot start or end with whitespace',
+              'path': '/filing/incorporationApplication/parties'}]
+        ),
+        (
             'FAIL_FIRST_NAME_WHITESPACE_ONLY', 'BEN',
             [
                 {
@@ -760,28 +838,9 @@ def test_validate_incorporation_parties_mailing_address(session, mocker, test_na
                     'officer': {'firstName': '  ', 'middleName': 'jkalsdf', 'lastName': 'Doe'}
                 }
             ],
-            [{'error': 'Completing Party, Incorporator first name cannot be only whitespace',
+            [{'error': 'Completing Party, Incorporator first name is required',
               'path': '/filing/incorporationApplication/parties'},
-             {'error': 'Incorporator, Director first name cannot be only whitespace',
-              'path': '/filing/incorporationApplication/parties'}]
-        ),
-        (
-            'FAIL_MIDDLE_NAME_WHITESPACE_ONLY', 'BEN',
-            [
-                {
-                    'partyName': 'officer1',
-                    'roles': ['Completing Party', 'Incorporator'],
-                    'officer': {'firstName': 'Johnajksdfjljdkslfja', 'middleName': '  ', 'lastName': 'Doe'}
-                },
-                {
-                    'partyName': 'officer2',
-                    'roles': ['Incorporator', 'Director'],
-                    'officer': {'firstName': 'Janeajksdfjljdkslfja', 'middleName': '  ', 'lastName': 'Doe'}
-                }
-            ],
-            [{'error': 'Completing Party, Incorporator middle name cannot be only whitespace',
-              'path': '/filing/incorporationApplication/parties'},
-             {'error': 'Incorporator, Director middle name cannot be only whitespace',
+             {'error': 'Incorporator, Director first name is required',
               'path': '/filing/incorporationApplication/parties'}]
         ),
         (
@@ -798,13 +857,13 @@ def test_validate_incorporation_parties_mailing_address(session, mocker, test_na
                     'officer': {'firstName': 'Janeajksdfjljdkslfja', 'middleName': 'jkalsdf', 'lastName': '  '}
                 }
             ],
-            [{'error': 'Completing Party, Incorporator last name cannot be only whitespace',
+            [{'error': 'Completing Party, Incorporator last name is required',
               'path': '/filing/incorporationApplication/parties'},
-             {'error': 'Incorporator, Director last name cannot be only whitespace',
+             {'error': 'Incorporator, Director last name is required',
               'path': '/filing/incorporationApplication/parties'}]
         ),
         (
-            'FAIL_PARTY_FIRST_AND_MIDDLE_NAME_AND_LAST_NAME_WHITESPACE_ONLY', 'BEN',
+            'FAIL_PARTY_FIRST_LAST_NAME_WHITESPACE_ONLY', 'BEN',
             [
                 {
                     'partyName': 'officer1',
@@ -812,11 +871,9 @@ def test_validate_incorporation_parties_mailing_address(session, mocker, test_na
                     'officer': {'firstName': '   ', 'middleName': '   ', 'lastName': '   '}
                 },
             ],
-            [{'error': 'Completing Party, Incorporator first name cannot be only whitespace',
+            [{'error': 'Completing Party, Incorporator first is required',
               'path': '/filing/incorporationApplication/parties'},
-             {'error': 'Completing Party, Incorporator middle name cannot be only whitespace',
-              'path': '/filing/incorporationApplication/parties'},
-             {'error': 'Completing Party, Incorporator last name cannot be only whitespace',
+             {'error': 'Completing Party, Incorporator last name is required',
               'path': '/filing/incorporationApplication/parties'}]
         ),
         (
@@ -1083,6 +1140,11 @@ def test_validate_incorporation_party_names(session, mocker, test_name,
              'error': 'Share class name is required.',
              'path': '/filing/incorporationApplication/shareClasses/0/name/'
          }]),
+        ('FAIL_LEADING_AND_TRAILING_WHITESPACE_CLASS_NAME', 'BEN', ' Share Series 1 ', True, 5000, True, 0.875, 'CAD', 'Share Series 1', True, 1000,
+         None, None,  HTTPStatus.BAD_REQUEST, [{
+             'error': 'Share class name cannot start or end with whitespace.',
+             'path': '/filing/incorporationApplication/shareClasses/0/name/'
+         }]),
         ('FAIL_EMPTY_SERIES_NAME', 'BEN', 'Share Class 1', True, 5000, True, 0.875, 'CAD', '', True, 1000,
          None, None,  HTTPStatus.BAD_REQUEST, [{
              'error': 'Share series name is required.',
@@ -1093,6 +1155,11 @@ def test_validate_incorporation_party_names(session, mocker, test_name,
              'error': 'Share series name is required.',
              'path': '/filing/incorporationApplication/shareClasses/0/series/0/name/'
          }]),
+        ('FAIL_LEADING_AND_TRAILING_WHITESPACE_SERIES_NAME', 'BEN', 'Share Class 1', True, 5000, True, 0.875, 'CAD', '  Share Series 1  ', True, 1000,
+         None, None,  HTTPStatus.BAD_REQUEST, [{
+             'error': 'Share series name cannot start or end with whitespace.',
+             'path': '/filing/incorporationApplication/shareClasses/0/series/0/name/'
+         }]), 
         ('FAIL_INVALID_CLASS_MAX_SHARES', 'BEN',
          'Share Class 1', True, None, True, 0.875, 'CAD', 'Share Series 1', True, 1000,
          None, None,

--- a/legal-api/tests/unit/services/filings/validations/test_incorporation_application.py
+++ b/legal-api/tests/unit/services/filings/validations/test_incorporation_application.py
@@ -1732,17 +1732,14 @@ def test_ia_phone_number_validation(session, should_pass, phone_number, extensio
     ('SUCCESS_NAME_TRANSLATION', [{"name": "TEST"}], None, None),
     ('FAIL_EMPTY_NAME_TRANSLATION', [{"name": ""}],  HTTPStatus.BAD_REQUEST, [{
         'error': 'Name translation cannot be an empty string.',
-
         'path': '/filing/incorporationApplication/nameTranslations/0/name/'
     }]),
     ('FAIL_WHITESPACE_ONLY_NAME_TRANSLATION', [{"name": "   "}], HTTPStatus.BAD_REQUEST, [{
         'error': 'Name translation cannot be an empty string.',
-
         'path': '/filing/incorporationApplication/nameTranslations/0/name/'
     }]),
     ('FAIL_SECOND_NAME_TRANSLATION', [{"name": "TEST"}, {"name": "   "}], HTTPStatus.BAD_REQUEST, [{
         'error': 'Name translation cannot be an empty string.',
-
         'path': '/filing/incorporationApplication/nameTranslations/1/name/'
     }]),
 ])

--- a/legal-api/tests/unit/services/filings/validations/test_incorporation_application.py
+++ b/legal-api/tests/unit/services/filings/validations/test_incorporation_application.py
@@ -698,7 +698,7 @@ def test_validate_incorporation_parties_mailing_address(session, mocker, test_na
                 {
                     'partyName': 'officer1',
                     'roles': ['Completing Party', 'Incorporator'],
-                    'officer': {'firstName': 'Johnajksdfjljdkslfja', 'middleName': None, 'lastName': 'Doe'}
+                    'officer': {'firstName': 'Johnajksdfjldkslfja', 'middleName': None, 'lastName': 'Doe'}
                 },
                 {
                     'partyName': 'officer2',
@@ -707,6 +707,44 @@ def test_validate_incorporation_parties_mailing_address(session, mocker, test_na
                 }
             ],
             None
+        ),
+        (
+            'FAIL_FIRST_NAME_EMPTY', 'BEN',
+            [
+                {
+                    'partyName': 'officer1',
+                    'roles': ['Completing Party', 'Incorporator'],
+                    'officer': {'firstName': '', 'middleName': None, 'lastName': 'Doe'}
+                },
+                {
+                    'partyName': 'officer2',
+                    'roles': ['Incorporator', 'Director'],
+                    'officer': {'firstName': '', 'middleName': 'jkalsdf', 'lastName': 'Doe'}
+                }
+            ],
+            [{'error': 'Completing Party, Incorporator first name is required',
+              'path': '/filing/incorporationApplication/parties'},
+             {'error': 'Incorporator, Director first name is required',
+              'path': '/filing/incorporationApplication/parties'}]
+        ),
+        (
+            'FAIL_LAST_NAME_EMPTY', 'BEN',
+            [
+                {
+                    'partyName': 'officer1',
+                    'roles': ['Completing Party', 'Incorporator'],
+                    'officer': {'firstName': 'Johnajksdfjldkslfja', 'middleName': None, 'lastName': ''}
+                },
+                {
+                    'partyName': 'officer2',
+                    'roles': ['Incorporator', 'Director'],
+                    'officer': {'firstName': 'Janeajksdfjljdkslfja', 'middleName': 'jkalsdf', 'lastName': ''}
+                }
+            ],
+            [{'error': 'Completing Party, Incorporator last name is required',
+              'path': '/filing/incorporationApplication/parties'},
+             {'error': 'Incorporator, Director last name is required',
+              'path': '/filing/incorporationApplication/parties'}]
         ),
         (
             'FAIL_FIRST_NAME_WHITESPACE_ONLY', 'BEN',
@@ -1034,6 +1072,26 @@ def test_validate_incorporation_party_names(session, mocker, test_name,
          HTTPStatus.BAD_REQUEST, [{
              'error': 'Share series Share Series 1 name already used in a share class or series.',
              'path': '/filing/incorporationApplication/shareClasses/0/series/1'
+         }]),
+        ('FAIL_EMPTY_CLASS_NAME', 'BEN', '', True, 5000, True, 0.875, 'CAD', 'Share Series 1', True, 1000,
+         None, None,  HTTPStatus.BAD_REQUEST, [{
+             'error': 'Share class name cannot be empty or only whitespace',
+             'path': '/filing/incorporationApplication/shareClasses/0/name/'
+         }]),
+        ('FAIL_WHITESPACE_ONLY_CLASS_NAME', 'BEN', '   ', True, 5000, True, 0.875, 'CAD', 'Share Series 1', True, 1000,
+         None, None,  HTTPStatus.BAD_REQUEST, [{
+             'error': 'Share class name cannot be empty or only whitespace',
+             'path': '/filing/incorporationApplication/shareClasses/0/name/'
+         }]),
+        ('FAIL_EMPTY_SERIES_NAME', 'BEN', 'Share Class 1', True, 5000, True, 0.875, 'CAD', '', True, 1000,
+         None, None,  HTTPStatus.BAD_REQUEST, [{
+             'error': 'Share series name cannot be empty or only whitespace',
+             'path': '/filing/incorporationApplication/shareClasses/0/series/0/name/'
+         }]),
+        ('FAIL_WHITESPACE_ONLY_SERIES_NAME', 'BEN', 'Share Class 1', True, 5000, True, 0.875, 'CAD', '   ', True, 1000,
+         None, None,  HTTPStatus.BAD_REQUEST, [{
+             'error': 'Share series name cannot be empty or only whitespace',
+             'path': '/filing/incorporationApplication/shareClasses/0/series/0/name/'
          }]),
         ('FAIL_INVALID_CLASS_MAX_SHARES', 'BEN',
          'Share Class 1', True, None, True, 0.875, 'CAD', 'Share Series 1', True, 1000,

--- a/legal-api/tests/unit/services/filings/validations/test_incorporation_application.py
+++ b/legal-api/tests/unit/services/filings/validations/test_incorporation_application.py
@@ -1075,22 +1075,22 @@ def test_validate_incorporation_party_names(session, mocker, test_name,
          }]),
         ('FAIL_EMPTY_CLASS_NAME', 'BEN', '', True, 5000, True, 0.875, 'CAD', 'Share Series 1', True, 1000,
          None, None,  HTTPStatus.BAD_REQUEST, [{
-             'error': 'Share class name cannot be empty or only whitespace',
+             'error': 'Share class name is required.',
              'path': '/filing/incorporationApplication/shareClasses/0/name/'
          }]),
         ('FAIL_WHITESPACE_ONLY_CLASS_NAME', 'BEN', '   ', True, 5000, True, 0.875, 'CAD', 'Share Series 1', True, 1000,
          None, None,  HTTPStatus.BAD_REQUEST, [{
-             'error': 'Share class name cannot be empty or only whitespace',
+             'error': 'Share class name is required.',
              'path': '/filing/incorporationApplication/shareClasses/0/name/'
          }]),
         ('FAIL_EMPTY_SERIES_NAME', 'BEN', 'Share Class 1', True, 5000, True, 0.875, 'CAD', '', True, 1000,
          None, None,  HTTPStatus.BAD_REQUEST, [{
-             'error': 'Share series name cannot be empty or only whitespace',
+             'error': 'Share series name is required.',
              'path': '/filing/incorporationApplication/shareClasses/0/series/0/name/'
          }]),
         ('FAIL_WHITESPACE_ONLY_SERIES_NAME', 'BEN', 'Share Class 1', True, 5000, True, 0.875, 'CAD', '   ', True, 1000,
          None, None,  HTTPStatus.BAD_REQUEST, [{
-             'error': 'Share series name cannot be empty or only whitespace',
+             'error': 'Share series name is required.',
              'path': '/filing/incorporationApplication/shareClasses/0/series/0/name/'
          }]),
         ('FAIL_INVALID_CLASS_MAX_SHARES', 'BEN',
@@ -1664,15 +1664,15 @@ def test_ia_phone_number_validation(session, should_pass, phone_number, extensio
     ('SUCCESS_EMPTY_ARRAY', [], None, None),
     ('SUCCESS_NAME_TRANSLATION', [{"name": "TEST"}], None, None),
     ('FAIL_EMPTY_NAME_TRANSLATION', [{"name": ""}],  HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation cannot be empty or only whitespace.',
+        'error': 'Name translation is required.',
         'path': '/filing/incorporationApplication/nameTranslations/0/name/'
     }]),
     ('FAIL_WHITESPACE_ONLY_NAME_TRANSLATION', [{"name": "   "}], HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation cannot be empty or only whitespace.',
+        'error': 'Name translation is required.',
         'path': '/filing/incorporationApplication/nameTranslations/0/name/'
     }]),
     ('FAIL_SECOND_NAME_TRANSLATION', [{"name": "TEST"}, {"name": "   "}], HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation cannot be empty or only whitespace.',
+        'error': 'Name translation is required.',
         'path': '/filing/incorporationApplication/nameTranslations/1/name/'
     }]),
 ])

--- a/legal-api/tests/unit/services/filings/validations/test_incorporation_application.py
+++ b/legal-api/tests/unit/services/filings/validations/test_incorporation_application.py
@@ -1731,15 +1731,18 @@ def test_ia_phone_number_validation(session, should_pass, phone_number, extensio
     ('SUCCESS_EMPTY_ARRAY', [], None, None),
     ('SUCCESS_NAME_TRANSLATION', [{"name": "TEST"}], None, None),
     ('FAIL_EMPTY_NAME_TRANSLATION', [{"name": ""}],  HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation is required.',
+        'error': 'Name translation cannot be an empty string.',
+
         'path': '/filing/incorporationApplication/nameTranslations/0/name/'
     }]),
     ('FAIL_WHITESPACE_ONLY_NAME_TRANSLATION', [{"name": "   "}], HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation is required.',
+        'error': 'Name translation cannot be an empty string.',
+
         'path': '/filing/incorporationApplication/nameTranslations/0/name/'
     }]),
     ('FAIL_SECOND_NAME_TRANSLATION', [{"name": "TEST"}, {"name": "   "}], HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation is required.',
+        'error': 'Name translation cannot be an empty string.',
+
         'path': '/filing/incorporationApplication/nameTranslations/1/name/'
     }]),
 ])

--- a/legal-api/tests/unit/services/filings/validations/test_restoration.py
+++ b/legal-api/tests/unit/services/filings/validations/test_restoration.py
@@ -491,11 +491,13 @@ def test_restoration_nr_type(session, mocker, test_status, filing_sub_type, lega
     ('SUCCESS_NAME_TRANSLATION_EMPTY_ARRAY', [], None, None),
     ('SUCCESS_NAME_TRANSLATION', [{"name": "TEST"}], None, None),
     ('FAIL_EMPTY_NAME_TRANSLATION', [{"name": ""}],  HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation is required.',
+        'error': 'Name translation cannot be an empty string.',
+
         'path': '/filing/restoration/nameTranslations/0/name/'
     }]),
     ('FAIL_WHITESPACE_ONLY_NAME_TRANSLATION', [{"name": "   "}], HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation is required.',
+        'error': 'Name translation cannot be an empty string.',
+
         'path': '/filing/restoration/nameTranslations/0/name/'
     }]),
     ('FAIL_LEADING_AND_TRAILING_WHITESPACE_NAME_TRANSLATION', [{"name": " TEST "}], HTTPStatus.BAD_REQUEST, [{
@@ -503,7 +505,8 @@ def test_restoration_nr_type(session, mocker, test_status, filing_sub_type, lega
         'path': '/filing/restoration/nameTranslations/0/name/'
     }]),
     ('FAIL_MULTIPLE_NAME_TRANSLATION', [{"name": "   "}, {"name": " TEST  "}], HTTPStatus.BAD_REQUEST, [{
-        'error': 'Name translation is required.',
+        'error': 'Name translation cannot be an empty string.',
+
         'path': '/filing/restoration/nameTranslations/0/name/'
     },
     {

--- a/legal-api/tests/unit/services/filings/validations/test_restoration.py
+++ b/legal-api/tests/unit/services/filings/validations/test_restoration.py
@@ -488,9 +488,9 @@ def test_restoration_nr_type(session, mocker, test_status, filing_sub_type, lega
 @pytest.mark.parametrize('test_name, name_translation, expected_code, expected_msg', [
     ('SUCCESS_EMPTY_ARRAY', [], None, None),
     ('SUCCESS_NAME_TRANSLATION', [{"name": "TEST"}], None, None),
-    ('FAIL_EMPTY_NAME_TRANSLATION', [{"name": ""}],  HTTPStatus.BAD_REQUEST, 'Name translation cannot be empty or only whitespace.'),
-    ('FAIL_WHITESPACE_ONLY_NAME_TRANSLATION', [{"name": "   "}], HTTPStatus.BAD_REQUEST, 'Name translation cannot be empty or only whitespace.'),
-    ('FAIL_SECOND_NAME_TRANSLATION', [{"name": "TEST"}, {"name": "   "}], HTTPStatus.BAD_REQUEST, 'Name translation cannot be empty or only whitespace.'),
+    ('FAIL_EMPTY_NAME_TRANSLATION', [{"name": ""}],  HTTPStatus.BAD_REQUEST, 'Name translation is required.'),
+    ('FAIL_WHITESPACE_ONLY_NAME_TRANSLATION', [{"name": "   "}], HTTPStatus.BAD_REQUEST, 'Name translation is required.'),
+    ('FAIL_SECOND_NAME_TRANSLATION', [{"name": "TEST"}, {"name": "   "}], HTTPStatus.BAD_REQUEST, 'Name translation is required.'),
 ])
 def test_validate_restoration_name_translation(session, test_name, name_translation, expected_code, expected_msg):
     """Assert that party is validated."""

--- a/legal-api/tests/unit/services/filings/validations/test_restoration.py
+++ b/legal-api/tests/unit/services/filings/validations/test_restoration.py
@@ -492,12 +492,10 @@ def test_restoration_nr_type(session, mocker, test_status, filing_sub_type, lega
     ('SUCCESS_NAME_TRANSLATION', [{"name": "TEST"}], None, None),
     ('FAIL_EMPTY_NAME_TRANSLATION', [{"name": ""}],  HTTPStatus.BAD_REQUEST, [{
         'error': 'Name translation cannot be an empty string.',
-
         'path': '/filing/restoration/nameTranslations/0/name/'
     }]),
     ('FAIL_WHITESPACE_ONLY_NAME_TRANSLATION', [{"name": "   "}], HTTPStatus.BAD_REQUEST, [{
         'error': 'Name translation cannot be an empty string.',
-
         'path': '/filing/restoration/nameTranslations/0/name/'
     }]),
     ('FAIL_LEADING_AND_TRAILING_WHITESPACE_NAME_TRANSLATION', [{"name": " TEST "}], HTTPStatus.BAD_REQUEST, [{
@@ -506,7 +504,6 @@ def test_restoration_nr_type(session, mocker, test_status, filing_sub_type, lega
     }]),
     ('FAIL_MULTIPLE_NAME_TRANSLATION', [{"name": "   "}, {"name": " TEST  "}], HTTPStatus.BAD_REQUEST, [{
         'error': 'Name translation cannot be an empty string.',
-
         'path': '/filing/restoration/nameTranslations/0/name/'
     },
     {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#30385 

*Description of changes:*
- Add whitespace validation for **Agm Location Change** `reason `field
- Add whitespace validation for **Voluntary Dissolution** custodian of records -> `organizationName` field and `email` field
- Add whitespace validation for `certifiedBy ` field for **all filings**
- Add whitespace validation for `nameTranslation `field for **IA, Amalgamation, Cont. In, Alteration, Correction**
- Update existing `validate_series `and `validate_shares` method to include whitespace validation for share class name and share series name
- Update existing `validate_party_name` method to include whitespace validation for parties -> officer ->` firstName`, `middleName`/`middleInitial` and `lastName` + add 30 char limit for `lastName` field
- Add/update unit tests

See detailed spreadsheet: https://docs.google.com/spreadsheets/d/1N5zs291nvPpHbGCxJS9jmxX3yoUyG_mi-906j-_TuHo/edit?gid=117926542#gid=117926542

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
