### PR TITLE
30680 update warning text date formatting to account for timezone 

### DIFF
--- a/legal-api/src/legal_api/reports/business_document.py
+++ b/legal-api/src/legal_api/reports/business_document.py
@@ -339,7 +339,7 @@ class BusinessDocument:
             filing = Filing.find_by_id(self._business.backfill_cutoff_filing_id)
 
             business['warning_text'] = 'Warning, data older than {} may not appear in the Business Summary'.format(
-                filing.filing_date.strftime(OUTPUT_DATE_FORMAT)
+                LegislationDatetime.format_as_report_string(filing.filing_date)
             )
 
     def _set_officers(self, business: dict):

--- a/legal-api/tests/unit/reports/test_business_document_officers_and_warning.py
+++ b/legal-api/tests/unit/reports/test_business_document_officers_and_warning.py
@@ -120,7 +120,8 @@ def test_set_warning_text_from_backfill_cutoff(session, app, jwt):
         filing_json = {"filing": {"header": {"name": "annualReport"}}}
         filing = factory_filing(business, filing_json)
         # Use a fixed date to create deterministic output
-        filing.filing_date = datetime(2020, 1, 15)
+        # set date to 30 min past midnight UTC on 16th, the warning should say 15th as it should be in pacific time
+        filing.filing_date = datetime(2020, 1, 16, 00, 30)
         filing.save()
 
         business.backfill_cutoff_filing_id = filing.id
@@ -130,6 +131,6 @@ def test_set_warning_text_from_backfill_cutoff(session, app, jwt):
 
         assert template_data.get('warning_text')
         assert 'Warning, data older than' in template_data['warning_text']
-        assert 'January 15, 2020' in template_data['warning_text']
+        assert 'January 15, 2020 at 4:30 pm Pacific time' in template_data['warning_text']
         assert 'may not appear in the Business Summary' in template_data['warning_text']
 


### PR DESCRIPTION
*Issue #:30680* /bcgov/entity#30680

*Description of changes:*
- fix: update warning text date formatting to account for timezone in business summary doc
- Adjusted test to verify timezone-corrected warning text.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
