### PR TITLE
31296 - Update Correction Output Logic

### DIFF
--- a/legal-api/src/legal_api/core/meta/filing.py
+++ b/legal-api/src/legal_api/core/meta/filing.py
@@ -1009,9 +1009,12 @@ class FilingMeta:  # pylint: disable=too-few-public-methods
         """Handle output file list modification for corrections."""
         if filing.filing_type == "correction":
             correction = filing.meta_data.get("correction", {})
-            if correction.get("commentOnly") and business.legal_type in Business.CORPS:
-                if not correction.get("correctionBenStatement"):  # BEN correction statement require NOA
-                    outputs.remove("noticeOfArticles")
+            if (
+                correction.get("commentOnly") and
+                business.legal_type in Business.CORPS and
+                not correction.get("correctionBenStatement")  # BEN correction statement require NOA
+            ):
+                outputs.remove("noticeOfArticles")
             if correction.get("toLegalName"):
                 corrected_filing_type = filing.meta_data.get("correction", {}).get("correctedFilingType")
                 if corrected_filing_type == "amalgamationApplication":

--- a/legal-api/src/legal_api/core/meta/filing.py
+++ b/legal-api/src/legal_api/core/meta/filing.py
@@ -1012,8 +1012,8 @@ class FilingMeta:  # pylint: disable=too-few-public-methods
             if correction.get("commentOnly") and business.legal_type in Business.CORPS:
                 if not correction.get("correctionBenStatement"):  # BEN correction statement require NOA
                     outputs.remove("noticeOfArticles")
-            else:
-                corrected_filing_type = filing.filing_json["filing"].get("correction", {}).get("correctedFilingType")
+            if correction.get("toLegalName"):
+                corrected_filing_type = filing.meta_data.get("correction", {}).get("correctedFilingType")
                 if corrected_filing_type == "amalgamationApplication":
                     outputs.add("certificateOfAmalgamation")
                 elif corrected_filing_type == "continuationIn":
@@ -1023,9 +1023,9 @@ class FilingMeta:  # pylint: disable=too-few-public-methods
                     business.legal_type != Business.LegalTypes.COOP.value
                 ):
                     outputs.add("certificateOfIncorporation")
+                elif business.legal_type == Business.LegalTypes.COOP.value:
+                    outputs.add("certificateOfNameCorrection")
 
-            if correction.get("toLegalName") and business.legal_type == Business.LegalTypes.COOP.value:
-                outputs.add("certificateOfNameCorrection")
             if correction.get("uploadNewRules"):
                 outputs.add("certifiedRules")
             if correction.get("uploadNewMemorandum"):

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
@@ -270,7 +270,6 @@ MOCK_NOTICE_OF_WITHDRAWAL['partOfPoa'] = False
      {'documents': {
         'receipt': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/receipt',
         'noticeOfArticles': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/noticeOfArticles',
-        'certificateOfIncorporation': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/certificateOfIncorporation',
         'legalFilings': [
             {'correction': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/correction'}
         ]
@@ -283,7 +282,6 @@ MOCK_NOTICE_OF_WITHDRAWAL['partOfPoa'] = False
      {'documents': {
         'receipt': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/receipt',
         'noticeOfArticles': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/noticeOfArticles',
-        'certificateOfIncorporation': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/certificateOfIncorporation',
         'legalFilings': [
             {'correction': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/correction'}
         ]
@@ -296,7 +294,6 @@ MOCK_NOTICE_OF_WITHDRAWAL['partOfPoa'] = False
      {'documents': {
         'receipt': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/receipt',
         'noticeOfArticles': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/noticeOfArticles',
-        'certificateOfIncorporation': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/certificateOfIncorporation',
         'legalFilings': [
             {'correction': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/correction'}
         ]
@@ -309,7 +306,6 @@ MOCK_NOTICE_OF_WITHDRAWAL['partOfPoa'] = False
      {'documents': {
         'receipt': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/receipt',
         'noticeOfArticles': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/noticeOfArticles',
-        'certificateOfIncorporation': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/certificateOfIncorporation',
         'legalFilings': [
             {'correction': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/correction'}
         ]
@@ -322,7 +318,6 @@ MOCK_NOTICE_OF_WITHDRAWAL['partOfPoa'] = False
      {'documents': {
         'receipt': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/receipt',
         'noticeOfArticles': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/noticeOfArticles',
-        'certificateOfIncorporation': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/certificateOfIncorporation',
         'legalFilings': [
             {'correction': f'{base_url}/api/v2/businesses/BC7654321/filings/1/documents/correction'}
         ]


### PR DESCRIPTION
*Issue #:* /bcgov/entity#31296 

*Description of changes:*
- Only generate new correction certificates when company name is corrected
- Update unit tests

Correction of IA where company name is NOT corrected (i.e. changing director address):
<img width="521" height="410" alt="image" src="https://github.com/user-attachments/assets/18cdda1a-118b-45e9-8549-0954033c0644" />

Before - generates the Incorporation Certificate:
<img width="554" height="322" alt="image" src="https://github.com/user-attachments/assets/e85c1cb7-9847-44e9-8597-e28d159ec708" />

After - does not generate the Incorporation Certificate:
<img width="1465" height="853" alt="image" src="https://github.com/user-attachments/assets/f3d2bb21-eb3e-49b3-84f5-bbd997f4e1fc" />

Correction where company name IS corrected:
<img width="705" height="467" alt="image" src="https://github.com/user-attachments/assets/41e339d6-8bd0-4f32-83b8-f0d94900962a" />
<img width="719" height="422" alt="image" src="https://github.com/user-attachments/assets/9f262158-22f9-413e-9028-b6e388495fc2" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
