### PR TITLE
32826 - Add Validation for authorizationReceived for Corps

### DIFF
--- a/legal-api/poetry.lock
+++ b/legal-api/poetry.lock
@@ -2231,8 +2231,8 @@ strict-rfc3339 = "*"
 [package.source]
 type = "git"
 url = "https://github.com/bcgov/business-schemas.git"
-reference = "2.18.65"
-resolved_reference = "56b5f387f42cb02d06fe33df5d3468216e65d099"
+reference = "2.18.67"
+resolved_reference = "bd6808dbb26807ab2e5dc8bcdf0d28276b1f8e39"
 
 [[package]]
 name = "reportlab"
@@ -3134,4 +3134,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9.22,<3.10"
-content-hash = "112d1641a00fbe06e51d3bede55de47b59917baf015f4be91198bc9bd4d1fb79"
+content-hash = "67e000ff0c7fd13ce0e7cbead37105db0a8425bf60cb2ecdbf16c2a664ff9450"

--- a/legal-api/pyproject.toml
+++ b/legal-api/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "blinker (==1.4)",
     "pyjwt (==2.8.0)",
 
-    "registry_schemas @ git+https://github.com/bcgov/business-schemas.git@2.18.65#egg=registry_schemas",
+    "registry_schemas @ git+https://github.com/bcgov/business-schemas.git@2.18.67#egg=registry_schemas",
     "sql-versioning @ git+https://github.com/bcgov/lear.git@main#subdirectory=python/common/sql-versioning",
     "gcp-queue @ git+https://github.com/bcgov/sbc-connect-common.git@main#subdirectory=python/gcp-queue",
     "structured-logging @ git+https://github.com/bcgov/sbc-connect-common.git@main#subdirectory=python/structured-logging"

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -1202,13 +1202,15 @@ def validate_certify_name(filing_json) -> bool:
         return True
     return True
 
-def validate_certified_by(filing_json: dict, legal_type: str) -> list:
+def validate_certified_by(filing_json: dict, filing_type: str, legal_type: str) -> list:
+    from legal_api.services.filings.validations.dissolution import DissolutionTypes
     """Validate certifiedBy field."""
     msg = []
     certified_by = filing_json["filing"]["header"].get("certifiedBy")
 
     if legal_type in Business.CORPS:
         return msg  # certifiedBy is not required for corporations
+
     is_cert_filing = filing_type in FILINGS_REQUIRING_CERTIFICATION
 
     is_client_correction = (

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -1202,19 +1202,10 @@ def validate_certify_name(filing_json) -> bool:
         return True
     return True
 
-def validate_certified_by(filing_json: dict, business: Business) -> list:
-    from legal_api.services.filings.validations.dissolution import DissolutionTypes
+def validate_certified_by(filing_json: dict, business: Business, legal_type: str) -> list:
     """Validate certifiedBy field."""
     msg = []
     certified_by = filing_json["filing"]["header"].get("certifiedBy")
-    filing_type = filing_json["filing"]["header"].get("name")
-
-    if isinstance(business, Business):
-        legal_type = business.legal_type
-    elif filing_type == CoreFiling.FilingTypes.NOTICEOFWITHDRAWAL:
-        legal_type = filing_json["filing"].get("business", None).get("legalType")
-    else:
-        legal_type = filing_json["filing"][filing_type]["nameRequest"].get("legalType")
 
     if legal_type in Business.CORPS:
         return msg  # certifiedBy is not required for corporations
@@ -1246,17 +1237,9 @@ def validate_certified_by(filing_json: dict, business: Business) -> list:
 
     return msg
 
-def validate_authorization_received(filing_json: dict, business: Business) -> list:
+def validate_authorization_received(filing_json: dict, business: Business, legal_type: str) -> list:
     """Validate authorizationReceived field."""
     msg = []
-    filing_type = filing_json["filing"]["header"].get("name")
-
-    if isinstance(business, Business):
-        legal_type = business.legal_type
-    elif filing_type == CoreFiling.FilingTypes.NOTICEOFWITHDRAWAL:
-        legal_type = filing_json["filing"].get("business", None).get("legalType")
-    else:
-        legal_type = filing_json["filing"][filing_type]["nameRequest"].get("legalType")
 
     if legal_type not in Business.CORPS:
         return msg  # authorizationReceived is only required for corporations

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -1246,6 +1246,21 @@ def validate_certified_by(filing_json: dict, business: Business) -> list:
 
     return msg
 
+def validate_authorization_received(filing_json: dict, business: Business) -> list:
+    """Validate authorizationReceived field."""
+    msg = []
+
+    if business.legal_type not in Business.CORPS:
+        return msg  # authorizationReceived is only required for corporations
+
+    authorization_received = filing_json["filing"]["header"].get("authorizationReceived")
+
+    if not authorization_received:
+            msg.append({"error": "Authorization received is required.",
+                        "path": "/filing/header/authorizationReceived"})
+
+    return msg
+
 def validate_name_translation(filing_json: dict, filing_type: str) -> list:
     """Validate name translations fields."""
     msg = []

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -1202,7 +1202,7 @@ def validate_certify_name(filing_json) -> bool:
         return True
     return True
 
-def validate_certified_by(filing_json: dict, business: Business, legal_type: str) -> list:
+def validate_certified_by(filing_json: dict, legal_type: str) -> list:
     """Validate certifiedBy field."""
     msg = []
     certified_by = filing_json["filing"]["header"].get("certifiedBy")
@@ -1237,7 +1237,7 @@ def validate_certified_by(filing_json: dict, business: Business, legal_type: str
 
     return msg
 
-def validate_authorization_received(filing_json: dict, business: Business, legal_type: str) -> list:
+def validate_authorization_received(filing_json: dict, legal_type: str) -> list:
     """Validate authorizationReceived field."""
     msg = []
 

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -1249,14 +1249,22 @@ def validate_certified_by(filing_json: dict, business: Business) -> list:
 def validate_authorization_received(filing_json: dict, business: Business) -> list:
     """Validate authorizationReceived field."""
     msg = []
+    filing_type = filing_json["filing"]["header"].get("name")
 
-    if business.legal_type not in Business.CORPS:
+    if isinstance(business, Business):
+        legal_type = business.legal_type
+    elif filing_type == CoreFiling.FilingTypes.NOTICEOFWITHDRAWAL:
+        legal_type = filing_json["filing"].get("business", None).get("legalType")
+    else:
+        legal_type = filing_json["filing"][filing_type]["nameRequest"].get("legalType")
+
+    if legal_type not in Business.CORPS:
         return msg  # authorizationReceived is only required for corporations
 
     authorization_received = filing_json["filing"]["header"].get("authorizationReceived")
 
     if not authorization_received:
-            msg.append({"error": "Authorization received is required.",
+            msg.append({"error": "Authorization received must be true to authorize the filing submission.",
                         "path": "/filing/header/authorizationReceived"})
 
     return msg

--- a/legal-api/src/legal_api/services/filings/validations/validation.py
+++ b/legal-api/src/legal_api/services/filings/validations/validation.py
@@ -79,7 +79,7 @@ def validate(business: Business,  # noqa: PLR0915, PLR0912, PLR0911
     else:
         legal_type = filing_json["filing"].get(filing_type, {}).get("nameRequest", {}).get("legalType")
 
-    cert_errs = validate_certified_by(filing_json, legal_type)
+    cert_errs = validate_certified_by(filing_json, filing_type, legal_type)
     if cert_errs:
         return Error(HTTPStatus.BAD_REQUEST, cert_errs)
     

--- a/legal-api/src/legal_api/services/filings/validations/validation.py
+++ b/legal-api/src/legal_api/services/filings/validations/validation.py
@@ -16,6 +16,7 @@ from http import HTTPStatus
 
 from flask_babel import _ as babel
 
+from legal_api.core.filing import Filing as CoreFiling
 from legal_api.errors import Error
 from legal_api.models import Business, Filing
 from legal_api.services import flags
@@ -68,12 +69,21 @@ def validate(business: Business,  # noqa: PLR0915, PLR0912, PLR0911
     err = validate_against_schema(filing_json)
     if err:
         return err
+    
+    filing_type = filing_json["filing"]["header"].get("name")
 
-    cert_errs = validate_certified_by(filing_json, business)
+    if isinstance(business, Business):
+        legal_type = business.legal_type
+    elif filing_type == CoreFiling.FilingTypes.NOTICEOFWITHDRAWAL:
+        legal_type = filing_json["filing"].get("business", {}).get("legalType")
+    else:
+        legal_type = filing_json["filing"].get(filing_type, {}).get("nameRequest", {}).get("legalType")
+
+    cert_errs = validate_certified_by(filing_json, business, legal_type)
     if cert_errs:
         return Error(HTTPStatus.BAD_REQUEST, cert_errs)
     
-    auth_received_errs = validate_authorization_received(filing_json, business)
+    auth_received_errs = validate_authorization_received(filing_json, business, legal_type)
     if auth_received_errs:
         return Error(HTTPStatus.BAD_REQUEST, auth_received_errs)
 

--- a/legal-api/src/legal_api/services/filings/validations/validation.py
+++ b/legal-api/src/legal_api/services/filings/validations/validation.py
@@ -79,11 +79,11 @@ def validate(business: Business,  # noqa: PLR0915, PLR0912, PLR0911
     else:
         legal_type = filing_json["filing"].get(filing_type, {}).get("nameRequest", {}).get("legalType")
 
-    cert_errs = validate_certified_by(filing_json, business, legal_type)
+    cert_errs = validate_certified_by(filing_json, legal_type)
     if cert_errs:
         return Error(HTTPStatus.BAD_REQUEST, cert_errs)
     
-    auth_received_errs = validate_authorization_received(filing_json, business, legal_type)
+    auth_received_errs = validate_authorization_received(filing_json, legal_type)
     if auth_received_errs:
         return Error(HTTPStatus.BAD_REQUEST, auth_received_errs)
 

--- a/legal-api/src/legal_api/services/filings/validations/validation.py
+++ b/legal-api/src/legal_api/services/filings/validations/validation.py
@@ -37,7 +37,7 @@ from .change_of_name import validate as con_validate
 from .change_of_officers import validate as coo_validate
 from .change_of_receivers import validate as cor_validate
 from .change_of_registration import validate as change_of_registration_validate
-from .common_validations import validate_certified_by
+from .common_validations import validate_authorization_received, validate_certified_by
 from .consent_amalgamation_out import validate as consent_amalgamation_out_validate
 from .consent_continuation_out import validate as consent_continuation_out_validate
 from .continuation_in import validate as continuation_in_validate
@@ -72,6 +72,10 @@ def validate(business: Business,  # noqa: PLR0915, PLR0912, PLR0911
     cert_errs = validate_certified_by(filing_json, business)
     if cert_errs:
         return Error(HTTPStatus.BAD_REQUEST, cert_errs)
+    
+    auth_received_errs = validate_authorization_received(filing_json, business)
+    if auth_received_errs:
+        return Error(HTTPStatus.BAD_REQUEST, auth_received_errs)
 
     if validate_staff_payment(filing_json) and flags.is_on("enabled-deeper-permission-action"):
         required_permission = ListActionsPermissionsAllowed.STAFF_PAYMENT.value

--- a/legal-api/tests/unit/services/filings/validations/test_amalgamation_application.py
+++ b/legal-api/tests/unit/services/filings/validations/test_amalgamation_application.py
@@ -60,7 +60,8 @@ def test_invalid_nr_amalgamation(mocker, app, session):
     """Assert that nr is invalid."""
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'amalgamationApplication', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True,
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
 
@@ -94,7 +95,8 @@ def test_amalgamation_parties_missing_role(mocker, app, session, amalgamation_ty
     """Assert that amalgamation party roles can be validated for missing roles."""
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'amalgamationApplication', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True,
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
 
@@ -133,6 +135,7 @@ def test_amalgamation_parties_invalid_role(mocker, app, session, parties, expect
         'name': 'amalgamationApplication',
         'date': '2019-04-08',
         'certifiedBy': 'full name',
+        'authorizationReceived': True,
         'email': 'no_one@never.get',
         'filingId': 1
     }
@@ -339,7 +342,8 @@ def test_validate_amalgamation_office(session, mocker, test_name, legal_type, de
     """Assert that amalgamation offices can be validated."""
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'amalgamationApplication', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True, 
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
 
     filing['filing']['amalgamationApplication']['nameRequest'] = {}
@@ -624,7 +628,8 @@ def test_validate_incorporation_share_classes(session, mocker, test_name, legal_
     """Assert that validator validates share class correctly."""
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'amalgamationApplication', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True, 
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
 
     filing['filing']['amalgamationApplication']['nameRequest'] = {}
@@ -679,7 +684,8 @@ def test_validate_amalgamation_office_or_share_required(session, mocker, amalgam
     """Assert that amalgamation offices/shareStructure required can be validated."""
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'amalgamationApplication', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True, 
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['type'] = amalgamation_type
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
@@ -713,7 +719,8 @@ def test_amalgamation_court_orders(mocker, app, session,
     """Assert valid court orders."""
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'amalgamationApplication', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True,
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
 
@@ -748,7 +755,8 @@ def test_is_business_historical(mocker, app, session, jwt, test_status, expected
     account_id = '123456'
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'amalgamationApplication', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True,
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
 
@@ -788,7 +796,8 @@ def test_has_pending_filing(mocker, app, session, jwt, test_status, expected_cod
     """Assert valid amalgamating businesses has draft, pending or future effective filing."""
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'amalgamationApplication', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True,
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
 
@@ -824,7 +833,8 @@ def test_in_future_effective_amalgamation_filing(mocker, app, session, jwt,
     """Assert valid amalgamating businesses is part of a future effective amalgamation filing."""
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'amalgamationApplication', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True,
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
 
@@ -862,7 +872,8 @@ def test_is_business_affliated(mocker, app, session, jwt, test_status, flag_enab
     account_id = '123456'
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'amalgamationApplication', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True,
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
     filing['filing']['amalgamationApplication']['amalgamatingBusinesses'] = [
@@ -932,7 +943,8 @@ def test_is_business_in_good_standing(mocker, app, session, jwt, test_status, fl
     account_id = '123456'
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'amalgamationApplication', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True,
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
     filing['filing']['amalgamationApplication']['amalgamatingBusinesses'] = [
@@ -1002,7 +1014,8 @@ def test_is_business_not_found(mocker, app, session, jwt, test_status, expected_
     account_id = '123456'
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'amalgamationApplication', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True,
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
     filing['filing']['amalgamationApplication']['amalgamatingBusinesses'] = [
@@ -1060,7 +1073,8 @@ def test_amalgamating_foreign_business(mocker, app, session, jwt, test_status, r
     account_id = '123456'
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'amalgamationApplication', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True,
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
 
@@ -1117,7 +1131,8 @@ def test_amalgamating_foreign_business_with_bc_company_to_ulc(mocker, app, sessi
     account_id = '123456'
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'amalgamationApplication', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True,
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
     if test_status == 'FAIL':
@@ -1165,7 +1180,8 @@ def test_amalgamating_foreign_business_with_ulc_company(mocker, app, session, jw
     account_id = '123456'
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'amalgamationApplication', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True,
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
 
@@ -1212,7 +1228,8 @@ def test_amalgamating_cc_to_cc(mocker, app, session, jwt,
     account_id = '123456'
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'amalgamationApplication', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True,
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['legalType'] = 'CC'
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
@@ -1256,7 +1273,8 @@ def test_amalgamating_expro_to_cc_or_ulc(mocker, app, session, jwt, test_status,
     account_id = '123456'
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'amalgamationApplication', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True,
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['legalType'] = legal_type
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
@@ -1315,7 +1333,8 @@ def test_regular_amalgamation_adoptable_name(mocker, app, session, jwt, test_sta
     account_id = '123456'
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'amalgamationApplication', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True,
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['legalType'] = legal_type
     adoptable_name = f'Test adoptable name {legal_type}'
@@ -1385,7 +1404,8 @@ def test_duplicate_amalgamating_businesses(mocker, app, session, jwt, test_statu
     account_id = '123456'
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'amalgamationApplication', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True, 
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
     filing['filing']['amalgamationApplication']['amalgamatingBusinesses'] = amalgamating_businesses
@@ -1471,7 +1491,8 @@ def test_amalgamating_business_roles(mocker, app, session, jwt, amalgamation_typ
     account_id = '123456'
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'amalgamationApplication', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True, 
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
     filing['filing']['amalgamationApplication']['type'] = amalgamation_type
@@ -1524,7 +1545,8 @@ def test_amalgamation_legal_type_mismatch(mocker, app, session, jwt, legal_type,
     account_id = '123456'
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'amalgamationApplication', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True, 
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
     filing['filing']['amalgamationApplication']['nameRequest']['legalType'] = legal_type
@@ -1571,7 +1593,8 @@ def test_horizontal_amalgamation(mocker, app, session, jwt, test_name, expected_
     account_id = '123456'
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'amalgamationApplication', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True, 
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['type'] = Amalgamation.AmalgamationTypes.horizontal.name
     filing['filing']['amalgamationApplication']['amalgamatingBusinesses'][0]['role'] = \
@@ -1625,7 +1648,8 @@ def test_amalgamation_share_class_series_validation(mocker, app, session, jwt, a
     """Test share class/series validation in amalgamation application with different amalgamation types."""
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'amalgamationApplication', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True, 
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['legalType'] = legal_type
     filing['filing']['amalgamationApplication']['type'] = amalgamation_type
@@ -1692,6 +1716,7 @@ def test_validate_amalgamation_effective_date(
         'name': 'amalgamationApplication',
         'date': '2019-04-08',
         'certifiedBy': 'full name',
+        'authorizationReceived': True,
         'email': 'no_one@never.get',
         'filingId': 1
     }
@@ -1765,6 +1790,7 @@ def test_validate_amalgamation_name_translation(mocker, session, test_name, amal
         'name': 'amalgamationApplication',
         'date': '2019-04-08',
         'certifiedBy': 'full name',
+        'authorizationReceived': True,
         'email': 'no_one@never.get',
         'filingId': 1
     }
@@ -1816,6 +1842,7 @@ def test_amalgamation_permission_and_completing_party_flag(mocker, app, session,
         'name': 'amalgamationApplication',
         'date': '2019-04-08',
         'certifiedBy': 'fname mname lname',
+        'authorizationReceived': True,
         'email': 'test@email.com',
         'filingId': 1
     }

--- a/legal-api/tests/unit/services/filings/validations/test_common_validations.py
+++ b/legal-api/tests/unit/services/filings/validations/test_common_validations.py
@@ -569,9 +569,8 @@ def test_validate_certified_by_corps(session, legal_type, input_value, expected_
     filing = copy.deepcopy(FILING_HEADER)
     filing['filing']['header']['certifiedBy'] = input_value
     filing['filing']['incorporationApplication'] = INCORPORATION
-    identifier = 'BC1234567'
 
-    errors = validate_certified_by(filing, legal_type)
+    errors = validate_certified_by(filing, "incorporationApplication", legal_type)
 
     if legal_type in Business.CORPS:
         assert errors == []
@@ -640,7 +639,7 @@ def test_validate_certified_by_firms(
     identifier = 'FM1234567'
     business = factory_business(identifier=identifier, entity_type=legal_type)
 
-    errors = validate_certified_by(filing, business)
+    errors = validate_certified_by(filing, filing_type, legal_type)
 
     if not expected_required:
         assert errors == []
@@ -701,7 +700,7 @@ def test_validate_certified_by_coops(
     identifier = 'CP1234567'
     business = factory_business(identifier=identifier, entity_type=Business.LegalTypes.COOP)
 
-    errors = validate_certified_by(filing, business)
+    errors = validate_certified_by(filing, filing_type, Business.LegalTypes.COOP)
 
     if not expected_required:
         assert errors == []

--- a/legal-api/tests/unit/services/filings/validations/test_common_validations.py
+++ b/legal-api/tests/unit/services/filings/validations/test_common_validations.py
@@ -573,7 +573,7 @@ def test_validate_certified_by_corps(session, legal_type, input_value, expected_
 
     business = factory_business(identifier=identifier, entity_type=legal_type)
 
-    errors = validate_certified_by(filing, business)
+    errors = validate_certified_by(filing, business, legal_type)
 
     if legal_type in Business.CORPS:
         assert errors == []
@@ -1826,7 +1826,7 @@ def test_validate_authorization_received(session, legal_type, authorization_rece
 
     business = factory_business(identifier=identifier, entity_type=legal_type)
 
-    errors = validate_authorization_received(filing, business)
+    errors = validate_authorization_received(filing, business, legal_type)
 
     if legal_type in Business.CORPS and expected_error:
         assert errors

--- a/legal-api/tests/unit/services/filings/validations/test_common_validations.py
+++ b/legal-api/tests/unit/services/filings/validations/test_common_validations.py
@@ -1824,7 +1824,7 @@ def test_validate_authorization_received(session, legal_type, authorization_rece
 
     business = factory_business(identifier=identifier, entity_type=legal_type)
 
-    errors = validate_authorization_received(filing, business, legal_type)
+    errors = validate_authorization_received(filing, legal_type)
 
     if legal_type in Business.CORPS and expected_error:
         assert errors

--- a/legal-api/tests/unit/services/filings/validations/test_common_validations.py
+++ b/legal-api/tests/unit/services/filings/validations/test_common_validations.py
@@ -1811,6 +1811,8 @@ def test_validate_authorization_received(session, legal_type, authorization_rece
     filing = copy.deepcopy(FILING_HEADER)
     if authorization_received is not None:
         filing['filing']['header']['authorizationReceived'] = authorization_received
+    else:
+        filing['filing']['header'].pop('authorizationReceived', None)
         
     filing['filing']['incorporationApplication'] = INCORPORATION
     
@@ -1828,7 +1830,7 @@ def test_validate_authorization_received(session, legal_type, authorization_rece
 
     if legal_type in Business.CORPS and expected_error:
         assert errors
-        assert errors[0]['error'] == 'Authorization received is required.'
+        assert errors[0]['error'] == 'Authorization received must be true to authorize the filing submission.'
         assert errors[0]['path'] == '/filing/header/authorizationReceived'
     else:
         assert errors == []

--- a/legal-api/tests/unit/services/filings/validations/test_common_validations.py
+++ b/legal-api/tests/unit/services/filings/validations/test_common_validations.py
@@ -571,9 +571,7 @@ def test_validate_certified_by_corps(session, legal_type, input_value, expected_
     filing['filing']['incorporationApplication'] = INCORPORATION
     identifier = 'BC1234567'
 
-    business = factory_business(identifier=identifier, entity_type=legal_type)
-
-    errors = validate_certified_by(filing, business, legal_type)
+    errors = validate_certified_by(filing, legal_type)
 
     if legal_type in Business.CORPS:
         assert errors == []

--- a/legal-api/tests/unit/services/filings/validations/test_common_validations.py
+++ b/legal-api/tests/unit/services/filings/validations/test_common_validations.py
@@ -49,6 +49,7 @@ from legal_api.services.filings.validations.common_validations import (
     EXCLUDED_WORDS_FOR_SERIES,
     find_updated_keys_for_firms,
     is_officer_proprietor_replace_valid,
+    validate_authorization_received,
     validate_certify_name,
     validate_certified_by,
     validate_court_order,
@@ -1798,3 +1799,36 @@ def test_share_series_max_number_of_shares_validation(session, max_shares, expec
     result = validate_series(share_class, memoize_names, 'incorporationApplication', 0)
     assert any(expected_error in e.get('error', '') for e in result)
 
+@pytest.mark.parametrize('legal_type', Business.CORPS + [
+    Business.LegalTypes.COOP, Business.LegalTypes.SOLE_PROP, Business.LegalTypes.PARTNERSHIP])
+@pytest.mark.parametrize('authorization_received, expected_error', [
+    (True, False),
+    (False, True),
+    (None, True),
+])
+def test_validate_authorization_received(session, legal_type, authorization_received, expected_error):
+    """Test that authorizationReceived is enforced for Corps filings only."""
+    filing = copy.deepcopy(FILING_HEADER)
+    if authorization_received is not None:
+        filing['filing']['header']['authorizationReceived'] = authorization_received
+        
+    filing['filing']['incorporationApplication'] = INCORPORATION
+    
+    if legal_type == Business.LegalTypes.COOP:
+        identifier = 'CP1234567'
+    elif legal_type in [Business.LegalTypes.SOLE_PROP, Business.LegalTypes.PARTNERSHIP]:
+        identifier = 'FM1234567'
+        filing['filing']['registration'] = REGISTRATION
+    else:
+        identifier = 'BC1234567'
+
+    business = factory_business(identifier=identifier, entity_type=legal_type)
+
+    errors = validate_authorization_received(filing, business)
+
+    if legal_type in Business.CORPS and expected_error:
+        assert errors
+        assert errors[0]['error'] == 'Authorization received is required.'
+        assert errors[0]['path'] == '/filing/header/authorizationReceived'
+    else:
+        assert errors == []

--- a/legal-api/tests/unit/services/filings/validations/test_continuation_in.py
+++ b/legal-api/tests/unit/services/filings/validations/test_continuation_in.py
@@ -63,7 +63,8 @@ def test_invalid_nr_continuation_in(mocker, app, session, monkeypatch):
         )
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'continuationIn', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True,
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['continuationIn'] = copy.deepcopy(CONTINUATION_IN)
     filing['filing']['continuationIn']['nameRequest']['nrNumber'] = 'NR 1234567'
 
@@ -110,7 +111,8 @@ def test_continuation_in_parties_missing_role(mocker, app, session, legal_type, 
     }
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'continuationIn', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True,
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['continuationIn'] = copy.deepcopy(CONTINUATION_IN)
     filing['filing']['continuationIn']['isApproved'] = True
 
@@ -152,6 +154,7 @@ def test_continuation_in_parties_invalid_role(mocker, app, session, parties, exp
         'name': 'continuationIn',
         'date': '2019-04-08',
         'certifiedBy': 'full name',
+        'authorizationReceived': True,
         'email': 'no_one@never.get',
         'filingId': 1
     }
@@ -357,7 +360,8 @@ def test_validate_continuation_in_office(session, mocker, test_name, legal_type,
 
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'continuationIn', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True,
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['continuationIn'] = copy.deepcopy(CONTINUATION_IN)
     filing['filing']['continuationIn']['isApproved'] = True
 
@@ -649,7 +653,8 @@ def test_validate_continuation_in_share_classes(session, mocker, test_name, lega
     ) 
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'continuationIn', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True, 
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['continuationIn'] = copy.deepcopy(CONTINUATION_IN)
     filing['filing']['continuationIn']['isApproved'] = True
 
@@ -722,7 +727,8 @@ def test_continuation_in_court_orders(mocker, app, session,
     ) 
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'continuationIn', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True, 
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['continuationIn'] = copy.deepcopy(CONTINUATION_IN)
     filing['filing']['continuationIn']['isApproved'] = True
 
@@ -767,7 +773,8 @@ def test_continuation_in_foreign_jurisdiction(mocker, app, session, legal_type, 
     ) 
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'continuationIn', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True,
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['continuationIn'] = copy.deepcopy(CONTINUATION_IN)
     filing['filing']['continuationIn']['nameRequest']['nrNumber'] = 'NR 1234567'
     filing['filing']['continuationIn']['nameRequest']['legalType'] = legal_type
@@ -799,7 +806,8 @@ def test_validate_business_in_colin(mocker, app, session, monkeypatch):
 
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'continuationIn', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True,
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['continuationIn'] = copy.deepcopy(CONTINUATION_IN)
     filing['filing']['continuationIn']['nameRequest']['legalType'] = 'C'
     filing['filing']['continuationIn']['nameRequest']['nrNumber'] = 'NR 1234567'
@@ -818,7 +826,8 @@ def test_validate_business_in_colin_founding_date_mismatch(mocker, app, session)
     """Assert continuation EXPRO business with founding date mismatch."""
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'continuationIn', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True,
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['continuationIn'] = copy.deepcopy(CONTINUATION_IN)
     
     # Add the EXPRO business data to simulate a mismatch in founding date
@@ -849,7 +858,8 @@ def test_validate_business_in_colin_founding_date_match(mocker, app, session):
     """Assert continuation EXPRO business with matching founding date."""
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'continuationIn', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True,
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['continuationIn'] = copy.deepcopy(CONTINUATION_IN)
     
     # Add the EXPRO business data with a matching founding date
@@ -924,7 +934,8 @@ def test_validate_before_and_after_approval(mocker, app, session, test_status, i
     )
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'continuationIn', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True,
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['continuationIn'] = copy.deepcopy(CONTINUATION_IN)
     filing['filing']['continuationIn']['isApproved'] = is_approved
     del filing['filing']['continuationIn']['offices']
@@ -978,7 +989,8 @@ def test_continuation_in_share_class_series_validation(mocker, app, session, leg
     ) 
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'continuationIn', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True, 
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['continuationIn'] = copy.deepcopy(CONTINUATION_IN)
     filing['filing']['continuationIn']['isApproved'] = True
 
@@ -1026,7 +1038,8 @@ def test_continuation_in_parties_delivery_address_validation(mocker, app, sessio
         ) 
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'continuationIn', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True, 
+                                  'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['continuationIn'] = copy.deepcopy(CONTINUATION_IN)
     filing['filing']['continuationIn']['isApproved'] = True
 
@@ -1085,7 +1098,8 @@ def test_validate_continuation_in_effective_date(mocker, app, session, test_name
         ) 
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'continuationIn', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True,
+                                  'email': 'no_one@never.get', 'filingId': 1}
 
     if effective_date is not None:
         filing['filing']['header']['effectiveDate'] = effective_date
@@ -1145,7 +1159,8 @@ def test_validate_continuation_in_name_translation(mocker, session, test_name, n
         ) 
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'continuationIn', 'date': '2019-04-08',
-                                  'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                  'certifiedBy': 'full name', 'authorizationReceived': True,
+                                  'email': 'no_one@never.get', 'filingId': 1}
 
     filing['filing']['continuationIn'] = copy.deepcopy(CONTINUATION_IN)
     filing['filing']['continuationIn']['isApproved'] = True

--- a/legal-api/tests/unit/services/filings/validations/test_incorporation_application.py
+++ b/legal-api/tests/unit/services/filings/validations/test_incorporation_application.py
@@ -231,8 +231,8 @@ def test_validate_incorporation_addresses_basic(session, mocker, test_name, lega
     """Assert that incorporation offices can be validated."""
     filing_json = copy.deepcopy(INCORPORATION_FILING_TEMPLATE)
     filing_json['filing']['header'] = {'name': incorporation_application_name, 'date': '2019-04-08',
-                                       'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1,
-                                       'effectiveDate': effective_date}
+                                       'certifiedBy': 'full name', 'authorizationReceived': True, 
+                                       'email': 'no_one@never.get', 'filingId': 1, 'effectiveDate': effective_date}
 
     filing_json['filing'][incorporation_application_name] = copy.deepcopy(INCORPORATION)
     filing_json['filing'][incorporation_application_name]['nameRequest'] = {}
@@ -398,8 +398,8 @@ def test_validate_incorporation_addresses_whitespace(session, mocker, test_name,
     """Assert that incorporation offices can be validated."""
     filing_json = copy.deepcopy(INCORPORATION_FILING_TEMPLATE)
     filing_json['filing']['header'] = {'name': incorporation_application_name, 'date': '2019-04-08',
-                                       'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1,
-                                       'effectiveDate': effective_date}
+                                       'certifiedBy': 'full name', 'authorizationReceived': True,
+                                       'email': 'no_one@never.get', 'filingId': 1, 'effectiveDate': effective_date}
 
     filing_json['filing'][incorporation_application_name] = copy.deepcopy(INCORPORATION)
     filing_json['filing'][incorporation_application_name]['nameRequest'] = {}
@@ -465,8 +465,8 @@ def test_validate_name_request(session, mocker, test_name, legal_type, expected_
     """Assert that incorporation name request can be validated."""
     filing_json = copy.deepcopy(INCORPORATION_FILING_TEMPLATE)
     filing_json['filing']['header'] = {'name': incorporation_application_name, 'date': '2019-04-08',
-                                       'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1,
-                                       'effectiveDate': effective_date}
+                                       'certifiedBy': 'full name', 'authorizationReceived': True,
+                                       'email': 'no_one@never.get', 'filingId': 1, 'effectiveDate': effective_date}
 
     filing_json['filing'][incorporation_application_name] = copy.deepcopy(INCORPORATION)
     filing_json['filing'][incorporation_application_name]['nameRequest'] = {}
@@ -669,7 +669,7 @@ def test_validate_incorporation_role(session, minio_server, mocker, test_name,
     """Assert that incorporation parties roles can be validated."""
     filing_json = copy.deepcopy(INCORPORATION_FILING_TEMPLATE)
     filing_json['filing']['header'] = {'name': incorporation_application_name, 'date': '2019-04-08', 'certifiedBy': 'full name',
-                                       'email': 'no_one@never.get', 'filingId': 1}
+                                       'authorizationReceived': True, 'email': 'no_one@never.get', 'filingId': 1}
     filing_json['filing']['business']['legalType'] = legal_type
 
     filing_json['filing'][incorporation_application_name] = copy.deepcopy(INCORPORATION)
@@ -833,7 +833,8 @@ def test_validate_incorporation_parties_mailing_address(session, mocker, test_na
     """Assert that incorporation parties mailing address is not empty."""
     filing_json = copy.deepcopy(INCORPORATION_FILING_TEMPLATE)
     filing_json['filing']['header'] = {'name': incorporation_application_name, 'date': '2019-04-08', 'certifiedBy': 'full name',
-                                       'email': 'no_one@never.get', 'filingId': 1, 'effectiveDate': effective_date}
+                                       'authorizationReceived': True, 'email': 'no_one@never.get', 'filingId': 1, 
+                                       'effectiveDate': effective_date}
 
     filing_json['filing'][incorporation_application_name] = copy.deepcopy(INCORPORATION)
     filing_json['filing']['business']['legalType'] = legal_type
@@ -1242,7 +1243,8 @@ def test_validate_incorporation_party_names(session, mocker, test_name,
     """Assert that incorporation parties roles can be validated."""
     filing_json = copy.deepcopy(INCORPORATION_FILING_TEMPLATE)
     filing_json['filing']['header'] = {'name': incorporation_application_name, 'date': '2019-04-08', 'certifiedBy': 'full name',
-                                       'email': 'no_one@never.get', 'filingId': 1, 'effectiveDate': effective_date}
+                                       'authorizationReceived': True, 'email': 'no_one@never.get', 'filingId': 1, 
+                                       'effectiveDate': effective_date}
 
     filing_json['filing'][incorporation_application_name] = copy.deepcopy(INCORPORATION)
     base_officer = filing_json['filing'][incorporation_application_name]['parties'][0]['officer']
@@ -1562,7 +1564,8 @@ def test_validate_incorporation_share_classes(session, mocker, test_name, legal_
     """Assert that validator validates share class correctly."""
     filing_json = copy.deepcopy(INCORPORATION_FILING_TEMPLATE)
     filing_json['filing']['header'] = {'name': incorporation_application_name, 'date': '2019-04-08', 'certifiedBy': 'full name',
-                                       'email': 'no_one@never.get', 'filingId': 1, 'effectiveDate': effective_date}
+                                       'authorizationReceived': True, 'email': 'no_one@never.get', 'filingId': 1, 
+                                       'effectiveDate': effective_date}
 
     filing_json['filing'][incorporation_application_name] = copy.deepcopy(INCORPORATION)
     filing_json['filing'][incorporation_application_name]['nameRequest'] = {}
@@ -1710,7 +1713,7 @@ def test_validate_cooperative_documents(session, mocker, minio_server, test_name
     """Assert that validator validates cooperative documents correctly."""
     filing_json = copy.deepcopy(INCORPORATION_FILING_TEMPLATE)
     filing_json['filing']['header'] = {'name': incorporation_application_name, 'date': '2019-04-08', 'certifiedBy': 'full name',
-                                       'email': 'no_one@never.get', 'filingId': 1}
+                                       'authorizationReceived': True, 'email': 'no_one@never.get', 'filingId': 1}
     legal_type = 'CP'
     filing_json['filing']['business']['legalType'] = legal_type
     filing_json['filing'][incorporation_application_name] = copy.deepcopy(INCORPORATION)
@@ -1768,8 +1771,8 @@ def test_ia_court_order(session, mocker, test_name):
     """Assert that incorporation court order can be validated."""
     filing_json = copy.deepcopy(INCORPORATION_FILING_TEMPLATE)
     filing_json['filing']['header'] = {'name': incorporation_application_name, 'date': '2019-04-08',
-                                       'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1,
-                                       'effectiveDate': effective_date}
+                                       'certifiedBy': 'full name', 'authorizationReceived': True, 
+                                       'email': 'no_one@never.get', 'filingId': 1, 'effectiveDate': effective_date}
 
     filing_json['filing'][incorporation_application_name] = copy.deepcopy(INCORPORATION)
     if test_name == 'with_court_order':
@@ -1816,7 +1819,8 @@ def test_incorporation_application_share_class_series_validation(mocker, app, se
     filing_json = copy.deepcopy(FILING_HEADER)
     filing_json['filing'].pop('business')
     filing_json['filing']['header'] = {'name': incorporation_application_name, 'date': '2019-04-08',
-                                       'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                       'certifiedBy': 'full name', 'authorizationReceived': True, ''
+                                       'email': 'no_one@never.get', 'filingId': 1}
 
     filing_json['filing'][incorporation_application_name] = copy.deepcopy(INCORPORATION)
 
@@ -1849,7 +1853,8 @@ def test_validate_incorporation_application_parties_delivery_address(mocker, app
     filing_json = copy.deepcopy(FILING_HEADER)
     filing_json['filing'].pop('business')
     filing_json['filing']['header'] = {'name': incorporation_application_name, 'date': '2019-04-08',
-                                       'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                       'certifiedBy': 'full name', 'authorizationReceived': True,
+                                       'email': 'no_one@never.get', 'filingId': 1}
 
     filing_json['filing'][incorporation_application_name] = copy.deepcopy(INCORPORATION)
 
@@ -1897,8 +1902,8 @@ def test_ia_phone_number_validation(session, should_pass, phone_number, extensio
     """Test validate phone number and / or extension if they are provided."""
     filing_json = copy.deepcopy(INCORPORATION_FILING_TEMPLATE)
     filing_json['filing']['header'] = {'name': incorporation_application_name, 'date': '2019-04-08',
-                                       'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1,
-                                       'effectiveDate': effective_date}
+                                       'certifiedBy': 'full name', 'authorizationReceived': True, 
+                                       'email': 'no_one@never.get', 'filingId': 1, 'effectiveDate': effective_date}
 
     if phone_number:
         filing_json['filing'][incorporation_application_name]['contactPoint']['phone'] = phone_number
@@ -1939,8 +1944,8 @@ def test_ia_email_validation(session, should_pass, email):
     """Test validate email format if provided."""
     filing_json = copy.deepcopy(INCORPORATION_FILING_TEMPLATE)
     filing_json['filing']['header'] = {'name': incorporation_application_name, 'date': '2019-04-08',
-                                       'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1,
-                                       'effectiveDate': effective_date}
+                                       'certifiedBy': 'full name', 'authorizationReceived': True, 
+                                       'email': 'no_one@never.get', 'filingId': 1, 'effectiveDate': effective_date}
 
     filing_json['filing'][incorporation_application_name]['contactPoint']['email'] = email
 
@@ -1965,8 +1970,8 @@ def test_ia_email_required_validation(session, email):
     """Test validate email is a required field."""
     filing_json = copy.deepcopy(INCORPORATION_FILING_TEMPLATE)
     filing_json['filing']['header'] = {'name': incorporation_application_name, 'date': '2019-04-08',
-                                       'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1,
-                                       'effectiveDate': effective_date}
+                                       'certifiedBy': 'full name', 'authorizationReceived': True, 
+                                       'email': 'no_one@never.get', 'filingId': 1, 'effectiveDate': effective_date}
 
     filing_json['filing'][incorporation_application_name]['contactPoint']['email'] = email
 
@@ -1996,9 +2001,9 @@ def test_validate_name_translation(session, test_name, name_translation, expecte
     """Test validate name translation if provided."""
     filing_json = copy.deepcopy(INCORPORATION_FILING_TEMPLATE)
     filing_json['filing']['header'] = {'name': incorporation_application_name, 'date': '2019-04-08',
-                                       'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1,
-                                       'effectiveDate': effective_date}
-    
+                                       'certifiedBy': 'full name', 'authorizationReceived': True, 
+                                       'email': 'no_one@never.get', 'filingId': 1, 'effectiveDate': effective_date}
+
     filing_json['filing'][incorporation_application_name]['nameTranslations'] = name_translation
 
     # perform test
@@ -2031,6 +2036,7 @@ def test_incorporation_permission_and_completing_party_flag(mocker, app, session
         'name': incorporation_application_name,
         'date': '2019-04-08',
         'certifiedBy': 'fname mname lname',
+        'authorizationReceived': True,
         'email': 'test@email.com',
         'filingId': 1
     }
@@ -2091,7 +2097,8 @@ def test_coop_incorporation_does_not_validate_shares(session, mocker):
     """Assert that COOP incorporation does not call validate_share_structure."""
     filing_json = copy.deepcopy(INCORPORATION_FILING_TEMPLATE)
     filing_json['filing']['header'] = {'name': 'incorporationApplication', 'date': '2019-04-08',
-                                       'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+                                       'certifiedBy': 'full name', 'authorizationReceived': True,
+                                       'email': 'no_one@never.get', 'filingId': 1}
     filing_json['filing']['incorporationApplication'] = copy.deepcopy(INCORPORATION)
     filing_json['filing']['incorporationApplication']['nameRequest']['legalType'] = Business.LegalTypes.COOP.value
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#32826 

*Description of changes:*
- Add validation for authorizationReceived in common_validations
- Update/Add unit tests
- Import registry schema version [2.18.67](https://github.com/bcgov/business-schemas/releases/tag/2.18.67)

**_Note: Cannot be merged until UI changes are also complete but is ready for review_**
 
Validation for Corp Example (BC):
<img width="1489" height="745" alt="image" src="https://github.com/user-attachments/assets/a6ea4ef0-36bd-400f-8b6f-d2b5332287c4" />
<img width="1498" height="688" alt="image" src="https://github.com/user-attachments/assets/7a955869-c127-4f3a-b568-ef941da0f8a6" />
<img width="1495" height="828" alt="image" src="https://github.com/user-attachments/assets/f4c4c996-cd73-4870-bc75-4d38b7c37698" />

Validation for Non-Corp Example (CP):
<img width="1509" height="819" alt="image" src="https://github.com/user-attachments/assets/13c8770c-8bd9-492e-8e00-4412b230b1f1" />
<img width="1510" height="888" alt="image" src="https://github.com/user-attachments/assets/e8cd82ea-ccca-40c2-b9a9-37cdc8740cb5" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
