### PR TITLE
32211: Currency validation

### DIFF
--- a/legal-api/src/legal_api/models/share_class.py
+++ b/legal-api/src/legal_api/models/share_class.py
@@ -67,6 +67,7 @@ class ShareClass(db.Model, Versioned):  # pylint: disable=too-many-instance-attr
             "hasParValue": self.par_value_flag,
             "parValue": self.par_value,
             "currency": self.currency,
+            "currencyAdditional": self.currency_additional,
             "hasRightsOrRestrictions": self.special_rights_flag
         }
 

--- a/legal-api/src/legal_api/services/filings/validations/alteration.py
+++ b/legal-api/src/legal_api/services/filings/validations/alteration.py
@@ -28,10 +28,10 @@ from .common_validations import (
     validate_effective_date,
     validate_name_request,
     validate_name_translation,
-    validate_share_currency,
     validate_pdf,
     validate_phone_number,
     validate_resolution_date_in_share_structure,
+    validate_share_currency,
     validate_share_structure,
 )
 

--- a/legal-api/src/legal_api/services/filings/validations/alteration.py
+++ b/legal-api/src/legal_api/services/filings/validations/alteration.py
@@ -28,6 +28,7 @@ from .common_validations import (
     validate_effective_date,
     validate_name_request,
     validate_name_translation,
+    validate_share_currency,
     validate_pdf,
     validate_phone_number,
     validate_resolution_date_in_share_structure,
@@ -88,6 +89,9 @@ def share_structure_validation(filing, business: Business):
 
     if get_str(filing, share_structure_path):
         err = validate_share_structure(filing, "alteration", new_legal_type or business.legal_type)
+        if err:
+            return err
+        err = validate_share_currency(filing, "alteration", business)
         if err:
             return err
     return []

--- a/legal-api/src/legal_api/services/filings/validations/amalgamation_application.py
+++ b/legal-api/src/legal_api/services/filings/validations/amalgamation_application.py
@@ -31,6 +31,7 @@ from legal_api.services.filings.validations.common_validations import (
     validate_parties_addresses,
     validate_parties_names,
     validate_permission_and_completing_party,
+    validate_share_currency,
     validate_phone_number,
     validate_share_structure,
 )
@@ -83,6 +84,9 @@ def validate(amalgamation_json: dict, account_id) -> Optional[Error]:
         msg.extend(validate_offices(amalgamation_json, legal_type, filing_type))
         msg.extend(validate_offices_addresses(amalgamation_json, filing_type))
         err = validate_share_structure(amalgamation_json, filing_type, legal_type)
+        if err:
+            msg.extend(err)
+        err = validate_share_currency(amalgamation_json, filing_type)
         if err:
             msg.extend(err)
 

--- a/legal-api/src/legal_api/services/filings/validations/amalgamation_application.py
+++ b/legal-api/src/legal_api/services/filings/validations/amalgamation_application.py
@@ -31,8 +31,8 @@ from legal_api.services.filings.validations.common_validations import (
     validate_parties_addresses,
     validate_parties_names,
     validate_permission_and_completing_party,
-    validate_share_currency,
     validate_phone_number,
+    validate_share_currency,
     validate_share_structure,
 )
 from legal_api.services.filings.validations.incorporation_application import (

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -341,6 +341,68 @@ def validate_shares(item, memoize_names, filing_type, index, legal_type) -> Erro
     return msg
 
 
+def _is_valid_currency(code: str) -> bool:
+    """Check if the currency code is a recognized ISO 4217 code."""
+    return pycountry.currencies.get(alpha_3=code) is not None
+
+
+def validate_share_currency(filing_json, filing_type, business=None):
+    """Validate share class currency codes are valid ISO 4217 codes.
+
+    Only validates share classes where hasParValue is true (currency is only
+    required/meaningful when par value is set).
+
+    Existing share classes with currency OTHER are allowed to pass through unchanged
+    when a business is provided and the incoming share class ID matches an existing
+    OTHER share class in the DB. New series under those classes are blocked.
+    """
+    share_classes = filing_json["filing"][filing_type] \
+        .get("shareStructure", {}).get("shareClasses", [])
+    msg = []
+
+    # Build lookup of existing OTHER share classes and their series by ID
+    existing_other_classes = {}
+    if business:
+        for sc in business.share_classes:
+            if sc.currency and sc.currency.upper() == "OTHER":
+                existing_series_ids = {s.id for s in sc.series}
+                existing_other_classes[sc.id] = existing_series_ids
+
+    for index, item in enumerate(share_classes):
+        if not item.get("hasParValue", False):
+            continue
+
+        currency = item.get("currency", None)
+        if not currency:
+            continue  # presence check handled by validate_shares()
+
+        err_path = f"/filing/{filing_type}/shareClasses/{index}"
+
+        # Allow grandfathered OTHER share classes to pass through
+        if currency.upper() == "OTHER":
+            share_class_id = item.get("id", None)
+            if share_class_id and share_class_id in existing_other_classes:
+                # Existing OTHER class allowed, but block new series
+                existing_series_ids = existing_other_classes[share_class_id]
+                for series_index, series in enumerate(item.get("series", [])):
+                    if series.get("id", None) not in existing_series_ids:
+                        msg.append({
+                            "error": "Cannot add new series under a share class with currency type OTHER.",
+                            "path": f"{err_path}/series/{series_index}"
+                        })
+                continue
+
+        # Reject invalid currency codes (includes OTHER on new/unmatched share classes)
+        if not _is_valid_currency(currency):
+            msg.append({
+                "error": f"Invalid currency for share class {item.get('name', '')}. "
+                         f"Currency must be a valid ISO 4217 code.",
+                "path": f"{err_path}/currency/"
+            })
+
+    return msg if msg else None
+
+
 def validate_court_order(court_order_path, court_order):
     """Validate the courtOrder data of the filing."""
     msg = []

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -410,7 +410,7 @@ def validate_share_currency(filing_json, filing_type, business=None):
                 "path": f"{err_path}/currency/"
             })
 
-    return msg if msg else None
+    return msg
 
 
 def validate_court_order(court_order_path, court_order):

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -346,6 +346,29 @@ def _is_valid_currency(code: str) -> bool:
     return pycountry.currencies.get(alpha_3=code) is not None
 
 
+def _get_grandfathered_other_classes(business):
+    """Get lookup of existing share classes with currency OTHER and their series IDs."""
+    existing_other_classes = {}
+    if not business:
+        return existing_other_classes
+    for sc in business.share_classes:
+        if sc.currency and sc.currency.upper() == "OTHER":
+            existing_other_classes[sc.id] = {s.id for s in sc.series}
+    return existing_other_classes
+
+
+def _validate_grandfathered_other_series(item, existing_series_ids, err_path):
+    """Block new series added under a grandfathered OTHER share class."""
+    msg = []
+    for series_index, series in enumerate(item.get("series", [])):
+        if series.get("id", None) not in existing_series_ids:
+            msg.append({
+                "error": "Cannot add new series under a share class with currency type OTHER.",
+                "path": f"{err_path}/series/{series_index}"
+            })
+    return msg
+
+
 def validate_share_currency(filing_json, filing_type, business=None):
     """Validate share class currency codes are valid ISO 4217 codes.
 
@@ -359,14 +382,7 @@ def validate_share_currency(filing_json, filing_type, business=None):
     share_classes = filing_json["filing"][filing_type] \
         .get("shareStructure", {}).get("shareClasses", [])
     msg = []
-
-    # Build lookup of existing OTHER share classes and their series by ID
-    existing_other_classes = {}
-    if business:
-        for sc in business.share_classes:
-            if sc.currency and sc.currency.upper() == "OTHER":
-                existing_series_ids = {s.id for s in sc.series}
-                existing_other_classes[sc.id] = existing_series_ids
+    existing_other_classes = _get_grandfathered_other_classes(business)
 
     for index, item in enumerate(share_classes):
         if not item.get("hasParValue", False):
@@ -382,14 +398,8 @@ def validate_share_currency(filing_json, filing_type, business=None):
         if currency.upper() == "OTHER":
             share_class_id = item.get("id", None)
             if share_class_id and share_class_id in existing_other_classes:
-                # Existing OTHER class allowed, but block new series
-                existing_series_ids = existing_other_classes[share_class_id]
-                for series_index, series in enumerate(item.get("series", [])):
-                    if series.get("id", None) not in existing_series_ids:
-                        msg.append({
-                            "error": "Cannot add new series under a share class with currency type OTHER.",
-                            "path": f"{err_path}/series/{series_index}"
-                        })
+                msg.extend(_validate_grandfathered_other_series(
+                    item, existing_other_classes[share_class_id], err_path))
                 continue
 
         # Reject invalid currency codes (includes OTHER on new/unmatched share classes)

--- a/legal-api/src/legal_api/services/filings/validations/continuation_in.py
+++ b/legal-api/src/legal_api/services/filings/validations/continuation_in.py
@@ -30,6 +30,7 @@ from legal_api.services.filings.validations.common_validations import (
     validate_parties_addresses,
     validate_parties_names,
     validate_pdf,
+    validate_share_currency,
     validate_phone_number,
     validate_share_structure,
 )
@@ -76,6 +77,8 @@ def validate(filing_json: dict) -> Optional[Error]:  # pylint: disable=too-many-
             msg.extend(err)
 
         if err := validate_share_structure(filing_json, filing_type, legal_type):
+            msg.extend(err)
+        if err := validate_share_currency(filing_json, filing_type):
             msg.extend(err)
 
         msg.extend(validate_effective_date(filing_json))

--- a/legal-api/src/legal_api/services/filings/validations/continuation_in.py
+++ b/legal-api/src/legal_api/services/filings/validations/continuation_in.py
@@ -30,8 +30,8 @@ from legal_api.services.filings.validations.common_validations import (
     validate_parties_addresses,
     validate_parties_names,
     validate_pdf,
-    validate_share_currency,
     validate_phone_number,
+    validate_share_currency,
     validate_share_structure,
 )
 from legal_api.services.filings.validations.incorporation_application import (

--- a/legal-api/src/legal_api/services/filings/validations/correction.py
+++ b/legal-api/src/legal_api/services/filings/validations/correction.py
@@ -27,12 +27,12 @@ from legal_api.services.filings.validations.common_validations import (
     validate_court_order,
     validate_name_request,
     validate_offices_addresses,
-    validate_share_currency,
     validate_parties_addresses,
     validate_parties_names,
     validate_pdf,
     validate_relationships,
     validate_resolution_date_in_share_structure,
+    validate_share_currency,
     validate_share_structure,
 )
 from legal_api.services.filings.validations.incorporation_application import (

--- a/legal-api/src/legal_api/services/filings/validations/correction.py
+++ b/legal-api/src/legal_api/services/filings/validations/correction.py
@@ -27,6 +27,7 @@ from legal_api.services.filings.validations.common_validations import (
     validate_court_order,
     validate_name_request,
     validate_offices_addresses,
+    validate_share_currency,
     validate_parties_addresses,
     validate_parties_names,
     validate_pdf,
@@ -138,6 +139,10 @@ def _validate_corps_correction(business: Business, filing_dict, legal_type, msg)
         msg.extend(validate_parties_names(filing_dict, filing_type, legal_type))
     if filing_dict.get("filing", {}).get("correction", {}).get("shareStructure", None):
         err = validate_share_structure(filing_dict, filing_type, legal_type)
+        if err:
+            msg.extend(err)
+
+        err = validate_share_currency(filing_dict, filing_type, business)
         if err:
             msg.extend(err)
 

--- a/legal-api/src/legal_api/services/filings/validations/incorporation_application.py
+++ b/legal-api/src/legal_api/services/filings/validations/incorporation_application.py
@@ -32,6 +32,7 @@ from legal_api.services.filings.validations.common_validations import (
     validate_parties_names,
     validate_pdf,
     validate_permission_and_completing_party,
+    validate_share_currency,
     validate_phone_number,
     validate_share_structure,
 )
@@ -76,6 +77,9 @@ def validate(incorporation_json: dict):  # pylint: disable=too-many-branches;
 
     if legal_type in Business.CORPS:
         err = validate_share_structure(incorporation_json, filing_type, legal_type)
+        if err:
+            msg.extend(err)
+        err = validate_share_currency(incorporation_json, filing_type)
         if err:
             msg.extend(err)
 

--- a/legal-api/src/legal_api/services/filings/validations/incorporation_application.py
+++ b/legal-api/src/legal_api/services/filings/validations/incorporation_application.py
@@ -77,7 +77,7 @@ def validate(incorporation_json: dict):  # pylint: disable=too-many-branches;
 
     if legal_type in Business.CORPS:
         msg.extend(validate_share_structure(incorporation_json, filing_type, legal_type) or [])
-        msg.extend(validate_share_currency(incorporation_json, filing_type))
+        msg.extend(validate_share_currency(incorporation_json, filing_type) or [])
 
     elif legal_type == Business.LegalTypes.COOP.value:
         msg.extend(validate_cooperative_documents(incorporation_json))

--- a/legal-api/src/legal_api/services/filings/validations/incorporation_application.py
+++ b/legal-api/src/legal_api/services/filings/validations/incorporation_application.py
@@ -32,8 +32,8 @@ from legal_api.services.filings.validations.common_validations import (
     validate_parties_names,
     validate_pdf,
     validate_permission_and_completing_party,
-    validate_share_currency,
     validate_phone_number,
+    validate_share_currency,
     validate_share_structure,
 )
 from legal_api.services.utils import get_str

--- a/legal-api/src/legal_api/services/filings/validations/incorporation_application.py
+++ b/legal-api/src/legal_api/services/filings/validations/incorporation_application.py
@@ -76,12 +76,8 @@ def validate(incorporation_json: dict):  # pylint: disable=too-many-branches;
     msg.extend(validate_name_request(incorporation_json, legal_type, filing_type))
 
     if legal_type in Business.CORPS:
-        err = validate_share_structure(incorporation_json, filing_type, legal_type)
-        if err:
-            msg.extend(err)
-        err = validate_share_currency(incorporation_json, filing_type)
-        if err:
-            msg.extend(err)
+        msg.extend(validate_share_structure(incorporation_json, filing_type, legal_type) or [])
+        msg.extend(validate_share_currency(incorporation_json, filing_type))
 
     elif legal_type == Business.LegalTypes.COOP.value:
         msg.extend(validate_cooperative_documents(incorporation_json))

--- a/legal-api/src/legal_api/services/filings/validations/transition.py
+++ b/legal-api/src/legal_api/services/filings/validations/transition.py
@@ -40,6 +40,7 @@ from legal_api.models import Business, PartyRole
 from legal_api.services.filings.validations.common_validations import (
     validate_offices,
     validate_relationships,
+    validate_share_currency,
     validate_share_structure,
 )
 
@@ -65,6 +66,10 @@ def validate(business: Business, filing_json: dict) -> Optional[Error]:
                                 True))
 
     err = validate_share_structure(filing_json, filing_type, business.legal_type)
+    if err:
+        msg.extend(err)
+
+    err = validate_share_currency(filing_json, filing_type, business)
     if err:
         msg.extend(err)
 

--- a/legal-api/tests/unit/models/test_share_class.py
+++ b/legal-api/tests/unit/models/test_share_class.py
@@ -70,10 +70,32 @@ def test_share_class_json(session):
         'hasParValue': share_class.par_value_flag,
         'parValue': share_class.par_value,
         'currency': share_class.currency,
+        'currencyAdditional': share_class.currency_additional,
         'hasRightsOrRestrictions': share_class.special_rights_flag,
         'series': []
     }
     assert share_class_json == share_class.json
+
+
+def test_share_class_json_with_currency_additional(session):
+    """Assert the json format of share class includes currencyAdditional."""
+    identifier = 'CP1234567'
+    business = factory_business(identifier)
+    share_class = ShareClass(
+        name='Class 1 Shares',
+        priority=1,
+        max_share_flag=True,
+        max_shares=1000,
+        par_value_flag=True,
+        par_value=0.852,
+        currency='OTHER',
+        currency_additional='Bitcoin',
+        special_rights_flag=False,
+        business_id=business.id
+    )
+    share_class.save()
+    assert share_class.json['currency'] == 'OTHER'
+    assert share_class.json['currencyAdditional'] == 'Bitcoin'
 
 
 def test_invalid_share_quantity(session):

--- a/legal-api/tests/unit/models/test_share_series.py
+++ b/legal-api/tests/unit/models/test_share_series.py
@@ -96,6 +96,7 @@ def test_share_series_json(session):
         'hasParValue': share_class.par_value_flag,
         'parValue': share_class.par_value,
         'currency': share_class.currency,
+        'currencyAdditional': share_class.currency_additional,
         'hasRightsOrRestrictions': share_class.special_rights_flag,
         'series': [
             {

--- a/legal-api/tests/unit/services/filings/validations/test_common_validations.py
+++ b/legal-api/tests/unit/services/filings/validations/test_common_validations.py
@@ -1702,7 +1702,7 @@ def test_validate_share_currency_valid_iso_passes(session):
         'series': []
     }])
     result = validate_share_currency(filing, 'incorporationApplication')
-    assert result is None
+    assert result == []
 
 
 def test_validate_share_currency_invalid_currency_rejected(session):
@@ -1757,7 +1757,7 @@ def test_validate_share_currency_existing_other_passthrough(session):
         'series': []
     }])
     result = validate_share_currency(filing, 'alteration', business)
-    assert result is None
+    assert result == []
 
 
 def test_validate_share_currency_new_other_rejected_with_business(session):
@@ -1807,7 +1807,7 @@ def test_validate_share_currency_mixed_classes_unchanged_other_passes(session):
         }
     ])
     result = validate_share_currency(filing, 'alteration', business)
-    assert result is None
+    assert result == []
 
 
 def test_validate_share_currency_new_series_under_other_rejected(session):
@@ -1878,7 +1878,7 @@ def test_validate_share_currency_existing_series_under_other_passes(session):
         }]
     }])
     result = validate_share_currency(filing, 'alteration', business)
-    assert result is None
+    assert result == []
 
 
 def test_validate_share_currency_non_other_changed_to_other_rejected(session):
@@ -1917,5 +1917,5 @@ def test_validate_share_currency_skips_no_par_value(session):
         'series': []
     }])
     result = validate_share_currency(filing, 'incorporationApplication')
-    assert result is None
+    assert result == []
 

--- a/legal-api/tests/unit/services/filings/validations/test_common_validations.py
+++ b/legal-api/tests/unit/services/filings/validations/test_common_validations.py
@@ -18,7 +18,8 @@ from http import HTTPStatus
 from unittest.mock import patch
 
 from legal_api.errors import Error
-from legal_api.models import Business, Party, PartyRole
+from legal_api.models import Business, Party, PartyRole, ShareClass
+from legal_api.models.share_series import ShareSeries
 from legal_api.services import flags
 from legal_api.services.permissions import PermissionService
 import pytest
@@ -54,6 +55,7 @@ from legal_api.services.filings.validations.common_validations import (
     validate_email,
     validate_offices,
     validate_offices_addresses,
+    validate_share_currency,
     validate_parties_addresses,
     validate_party_name,
     validate_party_role_firms,
@@ -1673,4 +1675,247 @@ def test_share_series_max_number_of_shares_validation(session, max_shares, expec
     memoize_names = ['Class A Shares']
     result = validate_series(share_class, memoize_names, 'incorporationApplication', 0)
     assert any(expected_error in e.get('error', '') for e in result)
+
+
+# === validate_share_currency tests ===
+
+
+def _build_filing_with_share_classes(filing_type, share_classes):
+    """Helper to build a minimal filing JSON with share structure."""
+    return {
+        'filing': {
+            filing_type: {
+                'shareStructure': {
+                    'shareClasses': share_classes
+                }
+            }
+        }
+    }
+
+
+def test_validate_share_currency_valid_iso_passes(session):
+    """Assert that share classes with valid ISO 4217 currency pass validation."""
+    filing = _build_filing_with_share_classes('incorporationApplication', [{
+        'name': 'Class A Shares',
+        'hasParValue': True,
+        'currency': 'CAD',
+        'series': []
+    }])
+    result = validate_share_currency(filing, 'incorporationApplication')
+    assert result is None
+
+
+def test_validate_share_currency_invalid_currency_rejected(session):
+    """Assert that an invalid (non-ISO 4217) currency is rejected."""
+    filing = _build_filing_with_share_classes('incorporationApplication', [{
+        'name': 'Class A Shares',
+        'hasParValue': True,
+        'currency': 'BANANA',
+        'series': []
+    }])
+    result = validate_share_currency(filing, 'incorporationApplication')
+    assert result is not None
+    assert any('ISO 4217' in e.get('error', '') for e in result)
+
+
+def test_validate_share_currency_other_rejected_no_business(session):
+    """Assert that OTHER currency is rejected when no business (not a valid ISO code)."""
+    filing = _build_filing_with_share_classes('incorporationApplication', [{
+        'name': 'Class A Shares',
+        'hasParValue': True,
+        'currency': 'OTHER',
+        'series': []
+    }])
+    result = validate_share_currency(filing, 'incorporationApplication')
+    assert result is not None
+    assert any('ISO 4217' in e.get('error', '') for e in result)
+
+
+def test_validate_share_currency_existing_other_passthrough(session):
+    """Assert that an existing OTHER share class passes through when ID matches."""
+    business = factory_business('BC1234567', entity_type='BC')
+    share_class = ShareClass(
+        name='Class A Shares',
+        priority=1,
+        max_share_flag=False,
+        par_value_flag=True,
+        par_value=1.0,
+        currency='OTHER',
+        currency_additional='Bitcoin',
+        special_rights_flag=False,
+        business_id=business.id
+    )
+    share_class.skip_share_class_listener = True
+    share_class.save()
+
+    filing = _build_filing_with_share_classes('alteration', [{
+        'id': share_class.id,
+        'name': 'Class A Shares',
+        'hasParValue': True,
+        'currency': 'OTHER',
+        'currencyAdditional': 'Bitcoin',
+        'series': []
+    }])
+    result = validate_share_currency(filing, 'alteration', business)
+    assert result is None
+
+
+def test_validate_share_currency_new_other_rejected_with_business(session):
+    """Assert that a new share class with OTHER is rejected even when business exists."""
+    business = factory_business('BC1234567', entity_type='BC')
+
+    filing = _build_filing_with_share_classes('alteration', [{
+        'name': 'New Other Shares',
+        'hasParValue': True,
+        'currency': 'OTHER',
+        'series': []
+    }])
+    result = validate_share_currency(filing, 'alteration', business)
+    assert result is not None
+    assert any('ISO 4217' in e.get('error', '') for e in result)
+
+
+def test_validate_share_currency_mixed_classes_unchanged_other_passes(session):
+    """Assert that modifying a non-OTHER class while OTHER class is unchanged passes."""
+    business = factory_business('BC1234567', entity_type='BC')
+    other_class = ShareClass(
+        name='Class B Shares',
+        priority=2,
+        max_share_flag=False,
+        par_value_flag=True,
+        par_value=1.0,
+        currency='OTHER',
+        special_rights_flag=False,
+        business_id=business.id
+    )
+    other_class.skip_share_class_listener = True
+    other_class.save()
+
+    filing = _build_filing_with_share_classes('alteration', [
+        {
+            'name': 'Class A Shares',
+            'hasParValue': True,
+            'currency': 'CAD',
+            'series': []
+        },
+        {
+            'id': other_class.id,
+            'name': 'Class B Shares',
+            'hasParValue': True,
+            'currency': 'OTHER',
+            'series': []
+        }
+    ])
+    result = validate_share_currency(filing, 'alteration', business)
+    assert result is None
+
+
+def test_validate_share_currency_new_series_under_other_rejected(session):
+    """Assert that adding a new series under an OTHER share class is rejected."""
+    business = factory_business('BC1234567', entity_type='BC')
+    other_class = ShareClass(
+        name='Class A Shares',
+        priority=1,
+        max_share_flag=False,
+        par_value_flag=True,
+        par_value=1.0,
+        currency='OTHER',
+        special_rights_flag=True,
+        business_id=business.id
+    )
+    other_class.skip_share_class_listener = True
+    other_class.save()
+
+    filing = _build_filing_with_share_classes('alteration', [{
+        'id': other_class.id,
+        'name': 'Class A Shares',
+        'hasParValue': True,
+        'currency': 'OTHER',
+        'series': [{
+            'name': 'New Series Shares',
+            'hasMaximumShares': False
+        }]
+    }])
+    result = validate_share_currency(filing, 'alteration', business)
+    assert result is not None
+    assert any('series' in e.get('error', '').lower() for e in result)
+
+
+def test_validate_share_currency_existing_series_under_other_passes(session):
+    """Assert that existing series under an OTHER share class pass through."""
+    business = factory_business('BC1234567', entity_type='BC')
+    other_class = ShareClass(
+        name='Class A Shares',
+        priority=1,
+        max_share_flag=False,
+        par_value_flag=True,
+        par_value=1.0,
+        currency='OTHER',
+        special_rights_flag=True,
+        business_id=business.id
+    )
+    other_class.skip_share_class_listener = True
+    other_class.save()
+
+    series = ShareSeries(
+        name='Series 1 Shares',
+        priority=1,
+        max_share_flag=False,
+        special_rights_flag=False,
+        share_class_id=other_class.id
+    )
+    series.save()
+
+    filing = _build_filing_with_share_classes('alteration', [{
+        'id': other_class.id,
+        'name': 'Class A Shares',
+        'hasParValue': True,
+        'currency': 'OTHER',
+        'series': [{
+            'id': series.id,
+            'name': 'Series 1 Shares',
+            'hasMaximumShares': False
+        }]
+    }])
+    result = validate_share_currency(filing, 'alteration', business)
+    assert result is None
+
+
+def test_validate_share_currency_non_other_changed_to_other_rejected(session):
+    """Assert that changing an existing non-OTHER share class to OTHER is rejected."""
+    business = factory_business('BC1234567', entity_type='BC')
+    cad_class = ShareClass(
+        name='Class A Shares',
+        priority=1,
+        max_share_flag=False,
+        par_value_flag=True,
+        par_value=1.0,
+        currency='CAD',
+        special_rights_flag=False,
+        business_id=business.id
+    )
+    cad_class.save()
+
+    filing = _build_filing_with_share_classes('alteration', [{
+        'id': cad_class.id,
+        'name': 'Class A Shares',
+        'hasParValue': True,
+        'currency': 'OTHER',
+        'series': []
+    }])
+    result = validate_share_currency(filing, 'alteration', business)
+    assert result is not None
+    assert any('ISO 4217' in e.get('error', '') for e in result)
+
+
+def test_validate_share_currency_skips_no_par_value(session):
+    """Assert that share classes without par value skip currency validation."""
+    filing = _build_filing_with_share_classes('incorporationApplication', [{
+        'name': 'Class A Shares',
+        'hasParValue': False,
+        'currency': 'GARBAGE',
+        'series': []
+    }])
+    result = validate_share_currency(filing, 'incorporationApplication')
+    assert result is None
 

--- a/legal-api/tests/unit/services/filings/validations/test_incorporation_application.py
+++ b/legal-api/tests/unit/services/filings/validations/test_incorporation_application.py
@@ -2111,4 +2111,39 @@ def test_coop_incorporation_does_not_validate_shares(session, mocker):
 
     mock_share_structure.assert_not_called()
     assert err is None
+
+
+@pytest.mark.parametrize('test_name, currency, expect_error', [
+    ('INVALID_CURRENCY', 'INVALID', True),
+    ('VALID_CURRENCY', 'CAD', False),
+])
+def test_incorporation_share_currency_validation(session, mocker, test_name, currency, expect_error):
+    """Assert that incorporation validates share class currency through the full validate() path."""
+    filing_json = copy.deepcopy(INCORPORATION_FILING_TEMPLATE)
+    filing_json['filing']['header'] = {'name': incorporation_application_name, 'date': '2019-04-08',
+                                       'certifiedBy': 'full name', 'email': 'no_one@never.get', 'filingId': 1}
+    filing_json['filing'][incorporation_application_name] = copy.deepcopy(INCORPORATION)
+    filing_json['filing'][incorporation_application_name]['nameRequest'] = {}
+    filing_json['filing'][incorporation_application_name]['nameRequest']['nrNumber'] = identifier
+    filing_json['filing'][incorporation_application_name]['nameRequest']['legalType'] = Business.LegalTypes.BCOMP.value
+    filing_json['filing'][incorporation_application_name]['shareStructure']['shareClasses'][0]['currency'] = currency
+
+    # Mock everything except share currency validation
+    for func_name in ['validate_offices', 'validate_offices_addresses', 'validate_roles',
+                      'validate_parties_names', 'validate_parties_addresses',
+                      'validate_coop_parties_mailing_address', 'validate_parties_delivery_address',
+                      'validate_name_request', 'validate_share_structure',
+                      'validate_effective_date', 'validate_ia_court_order',
+                      'validate_phone_number', 'validate_email', 'validate_name_translation']:
+        mocker.patch.object(incorporation_application, func_name, return_value=[])
+    mocker.patch.object(flags, 'is_on', return_value=False)
+
+    err = incorporation_application.validate(filing_json)
+
+    if expect_error:
+        assert err is not None
+        assert err.code == HTTPStatus.BAD_REQUEST
+        assert any('ISO 4217' in e.get('error', '') for e in err.msg)
+    else:
+        assert err is None
  


### PR DESCRIPTION
*Issue #:* /bcgov/entity#32211

*Description of changes:*

Adds support for the legacy OTHER currency type on share classes migrated from COLIN and validates that currency values match recognized currency codes. 
- Additional to OTHER type handling, currency validation was previously just done on UI and missing from API (tracked in previous FE/BE validation mismatch analysis and left to this point to handle)

**Model**

- Return `currencyAdditional` in ShareClass.json so UIs can display the OTHER currency text

**Validation** (`validate_share_currency`)

-Validate that share class currency is a recognized currency code (matching the standard currency list used by the UI dropdowns), only when `hasParValue` is true
-Grandfathered **OTHER** share classes pass through when the incoming share class ID matches an existing OTHER record in the DB — this handles the round-trip scenario where an alteration payload includes unchanged OTHER classes alongside modified non-OTHER classes
-New series under grandfathered OTHER share classes are blocked

**Filing coverage**

- Alteration, Correction, Transition: pass business for ID matching (allows existing OTHER pass-through)
- Incorporation Application, Continuation In, Amalgamation (regular): no business context, all currencies must be valid


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
