### PR TITLE
33070 - Fix Certified By Validation for Firms and Coops

### DIFF
--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -65,6 +65,18 @@ EXCLUDED_WORDS_FOR_SERIES = ["share", "shares"]
 SHARE_NAME_SUFFIX = " Shares"
 MAX_SHARE_DIGITS = 16
 
+# Note:
+# - Corrections are handled separately (CLIENT only)
+# - Dissolution is handled separately (voluntary only)
+FILINGS_REQUIRING_CERTIFICATION = {
+    CoreFiling.FilingTypes.ANNUALREPORT,
+    CoreFiling.FilingTypes.CHANGEOFADDRESS,
+    CoreFiling.FilingTypes.CHANGEOFDIRECTORS,
+    CoreFiling.FilingTypes.CHANGEOFREGISTRATION,
+    CoreFiling.FilingTypes.NOTICEOFWITHDRAWAL,
+    CoreFiling.FilingTypes.REGISTRATION,
+    CoreFiling.FilingTypes.SPECIALRESOLUTION,
+}
 
 def validate_resolution_date_in_share_structure(filing_json, filing_type, business) -> list[dict]:
     """Validate the resolution date of a share structure.
@@ -1205,17 +1217,31 @@ def validate_certified_by(filing_json: dict, business: Business) -> list:
 
     if legal_type in Business.CORPS:
         return msg  # certifiedBy is not required for corporations
+    is_cert_filing = filing_type in FILINGS_REQUIRING_CERTIFICATION
 
-    if not certified_by:
-        msg.append({
-            "error": "Certified by field is required.",
-            "path": "/filing/header/certifiedBy"
-        })
-    elif certified_by.strip() and certified_by != certified_by.strip():
-        msg.append({
-            "error": "Certified by field cannot start or end with whitespace.",
-            "path": "/filing/header/certifiedBy"
-        })
+    is_client_correction = (
+        filing_type == CoreFiling.FilingTypes.CORRECTION
+        and filing_json["filing"].get("correction", {}).get("type") == "CLIENT"
+    )
+
+    is_voluntary_dissolution = (
+        filing_type == CoreFiling.FilingTypes.DISSOLUTION
+        and filing_json["filing"].get("dissolution", {}).get("dissolutionType") == "voluntary"
+    )
+
+    certification_required = (is_cert_filing or is_client_correction or is_voluntary_dissolution)
+
+    if certification_required:
+        if not certified_by:
+            msg.append({
+                "error": "Certified by field is required.",
+                "path": "/filing/header/certifiedBy"
+            })
+        elif certified_by.strip() and certified_by != certified_by.strip():
+            msg.append({
+                "error": "Certified by field cannot start or end with whitespace.",
+                "path": "/filing/header/certifiedBy"
+            })
 
     return msg
 

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -1203,6 +1203,7 @@ def validate_certify_name(filing_json) -> bool:
     return True
 
 def validate_certified_by(filing_json: dict, business: Business) -> list:
+    from legal_api.services.filings.validations.dissolution import DissolutionTypes
     """Validate certifiedBy field."""
     msg = []
     certified_by = filing_json["filing"]["header"].get("certifiedBy")
@@ -1226,7 +1227,7 @@ def validate_certified_by(filing_json: dict, business: Business) -> list:
 
     is_voluntary_dissolution = (
         filing_type == CoreFiling.FilingTypes.DISSOLUTION
-        and filing_json["filing"].get("dissolution", {}).get("dissolutionType") == "voluntary"
+        and filing_json["filing"].get("dissolution", {}).get("dissolutionType") == DissolutionTypes.VOLUNTARY.value
     )
 
     certification_required = (is_cert_filing or is_client_correction or is_voluntary_dissolution)

--- a/legal-api/tests/unit/services/filings/validations/test_common_validations.py
+++ b/legal-api/tests/unit/services/filings/validations/test_common_validations.py
@@ -17,6 +17,7 @@ from datetime import datetime
 from http import HTTPStatus
 from unittest.mock import patch
 
+from legal_api.core.filing import Filing as CoreFiling
 from legal_api.errors import Error
 from legal_api.models import Business, Party, PartyRole
 from legal_api.services import flags
@@ -554,8 +555,7 @@ def test_find_updated_keys_for_firms(mock_address, mock_party_role):
     assert edited_result['address_changed'] == False
     assert edited_result['delivery_address_changed'] == True
 
-@pytest.mark.parametrize('legal_type', Business.CORPS + [
-    Business.LegalTypes.COOP, Business.LegalTypes.SOLE_PROP, Business.LegalTypes.PARTNERSHIP])
+@pytest.mark.parametrize('legal_type', Business.CORPS)
 @pytest.mark.parametrize('input_value, expected_error', [
     ('John   Doe', False),
     ('   \t   ', False),
@@ -563,20 +563,12 @@ def test_find_updated_keys_for_firms(mock_address, mock_party_role):
     ('  John Doe', True),
     ('John Doe   ', True),    
 ])
-def test_validate_certified_by(session, legal_type, input_value, expected_error):
+def test_validate_certified_by_corps(session, legal_type, input_value, expected_error):
     """Test that certified by field can be validated."""
     filing = copy.deepcopy(FILING_HEADER)
     filing['filing']['header']['certifiedBy'] = input_value
-
-    if legal_type == Business.LegalTypes.COOP:
-        identifier = 'CP1234567'
-        filing['filing']['incorporationApplication'] = INCORPORATION
-    elif legal_type in [Business.LegalTypes.SOLE_PROP, Business.LegalTypes.PARTNERSHIP]:
-        identifier = 'FM1234567'
-        filing['filing']['registration'] = REGISTRATION
-    else:
-        identifier = 'BC1234567'
-        filing['filing']['incorporationApplication'] = INCORPORATION
+    filing['filing']['incorporationApplication'] = INCORPORATION
+    identifier = 'BC1234567'
 
     business = factory_business(identifier=identifier, entity_type=legal_type)
 
@@ -590,6 +582,140 @@ def test_validate_certified_by(session, legal_type, input_value, expected_error)
             assert errors[0]['error'] == 'Certified by field cannot start or end with whitespace.'
         else:
             assert errors[0]['error'] == 'Certified by field is required.'
+        assert errors[0]['path'] == '/filing/header/certifiedBy'
+
+@pytest.mark.parametrize(
+    'legal_type',
+    [
+        Business.LegalTypes.SOLE_PROP,
+        Business.LegalTypes.PARTNERSHIP,
+    ]
+)
+@pytest.mark.parametrize(
+    'filing_type, sub_type, certified_by, expected_required, expected_error',
+    [
+        # Firm filing types that require certification
+        (CoreFiling.FilingTypes.ANNUALREPORT, None, '', True, 'required'),
+        (CoreFiling.FilingTypes.CHANGEOFREGISTRATION, None, '', True, 'required'),
+        (CoreFiling.FilingTypes.CORRECTION, 'CLIENT', '', True, 'required'),
+        (CoreFiling.FilingTypes.DISSOLUTION, 'voluntary', '', True, 'required'),
+        (CoreFiling.FilingTypes.NOTICEOFWITHDRAWAL, None, '', True, 'required'),
+        (CoreFiling.FilingTypes.REGISTRATION, None, '', True, 'required'),
+        (CoreFiling.FilingTypes.REGISTRATION, None, 'John Doe', True, None),
+        (CoreFiling.FilingTypes.REGISTRATION, None, '  John Doe', True, 'whitespace'),
+        (CoreFiling.FilingTypes.REGISTRATION, None, 'John Doe  ', True, 'whitespace'),
+
+        # Firm filing types that do NOT require certification
+        (CoreFiling.FilingTypes.CONVERSION, None, '', False, None),
+        (CoreFiling.FilingTypes.CORRECTION, 'STAFF', '', False, None),
+        (CoreFiling.FilingTypes.COURTORDER, None, '', False, None),
+        (CoreFiling.FilingTypes.DISSOLUTION, 'administrative', '', False, None),
+        (CoreFiling.FilingTypes.PUTBACKON, None, '', False, None),
+        (CoreFiling.FilingTypes.REGISTRARSNOTATION, None, '', False, None),
+    ]
+)
+def test_validate_certified_by_firms(
+    session,
+    legal_type,
+    filing_type,
+    sub_type,
+    certified_by,
+    expected_required,
+    expected_error
+):
+    """Test certifiedBy validation for firms across filing types."""
+
+    filing = copy.deepcopy(FILING_HEADER)
+
+    # Set filing type
+    filing['filing']['header']['name'] = filing_type
+    filing['filing']['header']['certifiedBy'] = certified_by
+
+    if filing_type == CoreFiling.FilingTypes.CORRECTION:
+        filing['filing']['correction'] = {'type': sub_type}
+    elif filing_type == CoreFiling.FilingTypes.DISSOLUTION:
+        filing['filing']['dissolution'] = {'dissolutionType': sub_type}    
+    else:
+        filing['filing']['registration'] = REGISTRATION
+
+    identifier = 'FM1234567'
+    business = factory_business(identifier=identifier, entity_type=legal_type)
+
+    errors = validate_certified_by(filing, business)
+
+    if not expected_required:
+        assert errors == []
+        return
+    
+    elif expected_error:
+        assert errors
+        if expected_error == 'required':
+            assert errors[0]['error'] == 'Certified by field is required.'
+        elif expected_error == 'whitespace':
+            assert errors[0]['error'] == 'Certified by field cannot start or end with whitespace.'
+
+        assert errors[0]['path'] == '/filing/header/certifiedBy'
+
+@pytest.mark.parametrize(
+    'filing_type, sub_type, certified_by, expected_required, expected_error',
+    [
+        # COOP filing types that require certification
+        (CoreFiling.FilingTypes.ANNUALREPORT, None, '', True, 'required'),
+        (CoreFiling.FilingTypes.CHANGEOFADDRESS, None, '', True, 'required'),
+        (CoreFiling.FilingTypes.CHANGEOFDIRECTORS, None, '', True, 'required'),
+        (CoreFiling.FilingTypes.CORRECTION, 'CLIENT', '', True, 'required'),
+        (CoreFiling.FilingTypes.DISSOLUTION, 'voluntary', '', True, 'required'),
+        (CoreFiling.FilingTypes.NOTICEOFWITHDRAWAL, None, '', True, 'required'),
+        (CoreFiling.FilingTypes.SPECIALRESOLUTION, None, '', True, 'required'),
+        (CoreFiling.FilingTypes.SPECIALRESOLUTION, None, 'John Doe', True, None),
+        (CoreFiling.FilingTypes.SPECIALRESOLUTION, None, '  John Doe', True, 'whitespace'),
+        (CoreFiling.FilingTypes.SPECIALRESOLUTION, None, 'John Doe  ', True, 'whitespace'),
+
+        # COOP filing types that do NOT require certification
+        (CoreFiling.FilingTypes.CORRECTION, 'STAFF', '', False, None),
+        (CoreFiling.FilingTypes.COURTORDER, None, '', False, None),
+        (CoreFiling.FilingTypes.DISSOLUTION, 'administrative', '', False, None),
+        (CoreFiling.FilingTypes.REGISTRARSNOTATION, None, '', False, None),
+    ]
+)
+def test_validate_certified_by_coops(
+    session,
+    filing_type,
+    sub_type,
+    certified_by,
+    expected_required,
+    expected_error
+):
+    """Test certifiedBy validation for coops across filing types."""
+
+    filing = copy.deepcopy(FILING_HEADER)
+
+    filing['filing']['header']['name'] = filing_type
+    filing['filing']['header']['certifiedBy'] = certified_by
+
+    if filing_type == CoreFiling.FilingTypes.CORRECTION:
+        filing['filing']['correction'] = {'type': sub_type}
+    elif filing_type == CoreFiling.FilingTypes.DISSOLUTION:
+        filing['filing']['dissolution'] = {'dissolutionType': sub_type}    
+    else:
+        filing['filing']['registration'] = INCORPORATION
+
+    identifier = 'CP1234567'
+    business = factory_business(identifier=identifier, entity_type=Business.LegalTypes.COOP)
+
+    errors = validate_certified_by(filing, business)
+
+    if not expected_required:
+        assert errors == []
+        return
+    
+    elif expected_error:
+        assert errors
+        if expected_error == 'required':
+            assert errors[0]['error'] == 'Certified by field is required.'
+        elif expected_error == 'whitespace':
+            assert errors[0]['error'] == 'Certified by field cannot start or end with whitespace.'
+
         assert errors[0]['path'] == '/filing/header/certifiedBy'
 
 @pytest.mark.parametrize(

--- a/legal-api/tests/unit/services/filings/validations/test_common_validations.py
+++ b/legal-api/tests/unit/services/filings/validations/test_common_validations.py
@@ -645,7 +645,6 @@ def test_validate_certified_by_firms(
 
     if not expected_required:
         assert errors == []
-        return
     
     elif expected_error:
         assert errors
@@ -707,7 +706,6 @@ def test_validate_certified_by_coops(
 
     if not expected_required:
         assert errors == []
-        return
     
     elif expected_error:
         assert errors


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33070

*Description of changes:*
- `certifiedBy` validation still does **_not_** apply for CORPS
- Only apply `certifiedBy` validation for COOPS/FIRMS for the following filings:
  - Annual Report
  - Change of Address
  - Change of Directors
  - Change of Registration
  - Correction (Client error only)
  - Dissolution (Voluntary only)
  - Notice of Withdrawal
  - Registration
  - Special Resolution
- Update/add unit tests

Example failing on dev:
<img width="1903" height="1034" alt="image" src="https://github.com/user-attachments/assets/35df62c1-86e1-41e2-9625-75660bc75b43" />

Now:
<img width="1508" height="948" alt="image" src="https://github.com/user-attachments/assets/2eb1c72f-6972-4286-840d-8f2566aa5210" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
