### PR TITLE
32920 - Update Filer to Process Directors Based on ID Instead of Name for LEAR Filings

### DIFF
--- a/queue_services/business-filer/src/business_filer/filing_processors/change_of_directors.py
+++ b/queue_services/business-filer/src/business_filer/filing_processors/change_of_directors.py
@@ -35,8 +35,9 @@
 import copy
 from datetime import UTC, datetime
 
-from business_model.models import Business, Filing, PartyRole
 from flask import current_app
+
+from business_model.models import Business, Filing, PartyRole
 
 from business_filer.exceptions import QueueException
 from business_filer.filing_meta import FilingMeta
@@ -83,7 +84,7 @@ def _update_director_using_party_id(director: dict, business_id: int):
                                 party_id, business_id)
         raise QueueException
 
-def process(business: Business, filing_rec: Filing, filing_meta: FilingMeta):  # noqa: PLR0912
+def process(business: Business, filing_rec: Filing, filing_meta: FilingMeta):
     """Render the change_of_directors onto the business model objects."""
     filing_json = copy.deepcopy(filing_rec.filing_json)
     if not (directors := filing_json["filing"]["changeOfDirectors"].get("directors")):

--- a/queue_services/business-filer/src/business_filer/filing_processors/change_of_directors.py
+++ b/queue_services/business-filer/src/business_filer/filing_processors/change_of_directors.py
@@ -43,7 +43,7 @@ from business_filer.filing_meta import FilingMeta
 from business_filer.filing_processors.filing_components import create_party, create_role, update_director
 
 
-def process(business: Business, filing_rec: Filing, filing_meta: FilingMeta):  # noqa: PLR0912
+def process(business: Business, filing_rec: Filing, filing_meta: FilingMeta):  # noqa: PLR0915, PLR0912
     """Render the change_of_directors onto the business model objects."""
     filing_json = copy.deepcopy(filing_rec.filing_json)
     if not (directors := filing_json["filing"]["changeOfDirectors"].get("directors")):

--- a/queue_services/business-filer/src/business_filer/filing_processors/change_of_directors.py
+++ b/queue_services/business-filer/src/business_filer/filing_processors/change_of_directors.py
@@ -88,32 +88,49 @@ def process(business: Business, filing_rec: Filing, filing_meta: FilingMeta):  #
             new_directors.append(director)
 
         elif any([action != "appointed" for action in director["actions"]]):  # noqa: C419
-            # get name of director in json for comparison *
-            if "nameChanged" in director["actions"]:
-                director_name = (director["officer"].get("prevFirstName") +
-                                 director["officer"].get("prevMiddleInitial", "") +
-                                 director["officer"].get("prevLastName"))
-            else:
-                director_name = (director["officer"].get("firstName") +
-                                 director["officer"].get("middleInitial", "") +
-                                 director["officer"].get("lastName"))
-            if not director_name:
-                current_app.logger.error("Could not resolve director name from json %s.", director)
-                raise QueueException
+            if filing_rec.colin_event_ids:
+                # Colin path: retain name-based matching for now.
+                if "nameChanged" in director["actions"]:
+                    director_name = (director["officer"].get("prevFirstName") +
+                                    director["officer"].get("prevMiddleInitial", "") +
+                                    director["officer"].get("prevLastName"))
+                else:
+                    director_name = (director["officer"].get("firstName") +
+                                    director["officer"].get("middleInitial", "") +
+                                    director["officer"].get("lastName"))
+                if not director_name:
+                    current_app.logger.error("Could not resolve director name from json %s.", director)
+                    raise QueueException
 
-            for current_director in PartyRole.get_parties_by_role(business.id, PartyRole.RoleTypes.DIRECTOR.value):
-                # get name of director in database for comparison *
-                current_director_name = (current_director.party.first_name +
-                                        (current_director.party.middle_initial or "") +
-                                         current_director.party.last_name)
-                # Update only an active director
-                if current_director_name.upper() == director_name.upper() and current_director.cessation_date is None:
-                    update_director(director=current_director, new_info=director)
-                    break
+                for current_director in PartyRole.get_parties_by_role(business.id, PartyRole.RoleTypes.DIRECTOR.value):
+                    current_director_name = (current_director.party.first_name +
+                                            (current_director.party.middle_initial or "") +
+                                            current_director.party.last_name)
+                    if current_director_name.upper() == director_name.upper() and current_director.cessation_date is None:
+                        update_director(director=current_director, new_info=director)
+                        break
+            else:
+                # Lear path: match by party ID
+                party_id = director["officer"].get("id")
+                if not party_id:
+                    current_app.logger.error("Could not resolve party id from json %s.", director)
+                    raise QueueException
+
+                matched = False
+                for current_director in PartyRole.get_parties_by_role(business.id, PartyRole.RoleTypes.DIRECTOR.value):
+                    if current_director.party_id == party_id and current_director.cessation_date is None:
+                        update_director(director=current_director, new_info=director)
+                        matched = True
+                        break
+
+                if not matched:
+                    current_app.logger.error("Could not find active director with party id %s for business %s.",
+                                            party_id, business.id)
+                    raise QueueException
 
     for director in new_directors:
         # add new diretor party role to the business
-        party = create_party(business_id=business.id, party_info=director)
+        party = create_party(business_id=business.id, party_info=director, create=False)
         role = {
             "roleType": "Director",
             "appointmentDate": director.get("appointmentDate"),

--- a/queue_services/business-filer/src/business_filer/filing_processors/change_of_directors.py
+++ b/queue_services/business-filer/src/business_filer/filing_processors/change_of_directors.py
@@ -35,13 +35,16 @@
 import copy
 from datetime import UTC, datetime
 
-from flask import current_app
-
 from business_model.models import Business, Filing, PartyRole
+from flask import current_app
 
 from business_filer.exceptions import QueueException
 from business_filer.filing_meta import FilingMeta
-from business_filer.filing_processors.filing_components import create_party, create_role, update_director
+from business_filer.filing_processors.filing_components import (
+    create_party,
+    create_role,
+    update_director
+)
 
 def _update_director_using_name(director: dict, business_id: int):
     """Update director information based on name matching."""
@@ -84,7 +87,7 @@ def _update_director_using_party_id(director: dict, business_id: int):
                                 party_id, business_id)
         raise QueueException
 
-def process(business: Business, filing_rec: Filing, filing_meta: FilingMeta):
+def process(business: Business, filing_rec: Filing, filing_meta: FilingMeta):  # noqa: PLR0912 
     """Render the change_of_directors onto the business model objects."""
     filing_json = copy.deepcopy(filing_rec.filing_json)
     if not (directors := filing_json["filing"]["changeOfDirectors"].get("directors")):

--- a/queue_services/business-filer/src/business_filer/filing_processors/change_of_directors.py
+++ b/queue_services/business-filer/src/business_filer/filing_processors/change_of_directors.py
@@ -42,8 +42,48 @@ from business_filer.exceptions import QueueException
 from business_filer.filing_meta import FilingMeta
 from business_filer.filing_processors.filing_components import create_party, create_role, update_director
 
+def _update_director_using_name(director: dict, business_id: int):
+    """Update director information based on name matching."""
+    if "nameChanged" in director["actions"]:
+        director_name = (director["officer"].get("prevFirstName") +
+                        director["officer"].get("prevMiddleInitial", "") +
+                        director["officer"].get("prevLastName"))
+    else:
+        director_name = (director["officer"].get("firstName") +
+                        director["officer"].get("middleInitial", "") +
+                        director["officer"].get("lastName"))
+    if not director_name:
+        current_app.logger.error("Could not resolve director name from json %s.", director)
+        raise QueueException
 
-def process(business: Business, filing_rec: Filing, filing_meta: FilingMeta):  # noqa: PLR0915, PLR0912
+    for current_director in PartyRole.get_parties_by_role(business_id, PartyRole.RoleTypes.DIRECTOR.value):
+        current_director_name = (current_director.party.first_name +
+                                (current_director.party.middle_initial or "") +
+                                current_director.party.last_name)
+        if current_director_name.upper() == director_name.upper() and current_director.cessation_date is None:
+            update_director(director=current_director, new_info=director)
+            break    
+
+def _update_director_using_party_id(director: dict, business_id: int):
+    """Update director information based on party ID matching."""
+    party_id = director["officer"].get("id")
+    if not party_id:
+        current_app.logger.error("Could not resolve party id from json %s.", director)
+        raise QueueException
+
+    matched = False
+    for current_director in PartyRole.get_parties_by_role(business_id, PartyRole.RoleTypes.DIRECTOR.value):
+        if current_director.party_id == party_id and current_director.cessation_date is None:
+            update_director(director=current_director, new_info=director)
+            matched = True
+            break
+
+    if not matched:
+        current_app.logger.error("Could not find active director with party id %s for business %s.",
+                                party_id, business_id)
+        raise QueueException
+
+def process(business: Business, filing_rec: Filing, filing_meta: FilingMeta):  # noqa: PLR0912
     """Render the change_of_directors onto the business model objects."""
     filing_json = copy.deepcopy(filing_rec.filing_json)
     if not (directors := filing_json["filing"]["changeOfDirectors"].get("directors")):
@@ -90,43 +130,10 @@ def process(business: Business, filing_rec: Filing, filing_meta: FilingMeta):  #
         elif any([action != "appointed" for action in director["actions"]]):  # noqa: C419
             if filing_rec.colin_event_ids:
                 # Colin path: retain name-based matching for now.
-                if "nameChanged" in director["actions"]:
-                    director_name = (director["officer"].get("prevFirstName") +
-                                    director["officer"].get("prevMiddleInitial", "") +
-                                    director["officer"].get("prevLastName"))
-                else:
-                    director_name = (director["officer"].get("firstName") +
-                                    director["officer"].get("middleInitial", "") +
-                                    director["officer"].get("lastName"))
-                if not director_name:
-                    current_app.logger.error("Could not resolve director name from json %s.", director)
-                    raise QueueException
-
-                for current_director in PartyRole.get_parties_by_role(business.id, PartyRole.RoleTypes.DIRECTOR.value):
-                    current_director_name = (current_director.party.first_name +
-                                            (current_director.party.middle_initial or "") +
-                                            current_director.party.last_name)
-                    if current_director_name.upper() == director_name.upper() and current_director.cessation_date is None:
-                        update_director(director=current_director, new_info=director)
-                        break
+                _update_director_using_name(director=director, business_id=business.id)
             else:
-                # Lear path: match by party ID
-                party_id = director["officer"].get("id")
-                if not party_id:
-                    current_app.logger.error("Could not resolve party id from json %s.", director)
-                    raise QueueException
-
-                matched = False
-                for current_director in PartyRole.get_parties_by_role(business.id, PartyRole.RoleTypes.DIRECTOR.value):
-                    if current_director.party_id == party_id and current_director.cessation_date is None:
-                        update_director(director=current_director, new_info=director)
-                        matched = True
-                        break
-
-                if not matched:
-                    current_app.logger.error("Could not find active director with party id %s for business %s.",
-                                            party_id, business.id)
-                    raise QueueException
+                # Lear path: match by party ID instead of name
+                _update_director_using_party_id(director=director, business_id=business.id)
 
     for director in new_directors:
         # add new diretor party role to the business

--- a/queue_services/business-filer/src/business_filer/filing_processors/change_of_directors.py
+++ b/queue_services/business-filer/src/business_filer/filing_processors/change_of_directors.py
@@ -99,7 +99,8 @@ def process(business: Business, filing_rec: Filing, filing_meta: FilingMeta):  #
     new_directors = []
 
     for director in directors:  # pylint: disable=too-many-nested-blocks;
-        # Applies only for filings coming from colin.
+        # Applies to CoD filings originating from COLIN (currently COOPs only).
+        # Continue using name-based matching for directors.
         if filing_rec.colin_event_ids:
             director_found = False
             director_name = (director["officer"].get("firstName") +

--- a/queue_services/business-filer/src/business_filer/filing_processors/change_of_directors.py
+++ b/queue_services/business-filer/src/business_filer/filing_processors/change_of_directors.py
@@ -43,8 +43,9 @@ from business_filer.filing_meta import FilingMeta
 from business_filer.filing_processors.filing_components import (
     create_party,
     create_role,
-    update_director
+    update_director,
 )
+
 
 def _update_director_using_name(director: dict, business_id: int):
     """Update director information based on name matching."""

--- a/queue_services/business-filer/tests/unit/test_filer/test_annual_report.py
+++ b/queue_services/business-filer/tests/unit/test_filer/test_annual_report.py
@@ -182,6 +182,11 @@ def test_process_combined_filing(app, session, mocker):
     directors = PartyRole.get_parties_by_role(business.id, PartyRole.RoleTypes.DIRECTOR.value)
     assert len(directors) == 4
     business_id = business.id
+    COMBINED_FILING['filing']['changeOfDirectors']['directors'][0]['officer']['id'] = director_party1.id
+    COMBINED_FILING['filing']['changeOfDirectors']['directors'][1]['officer']['id'] = director_party2.id
+    COMBINED_FILING['filing']['changeOfDirectors']['directors'][2]['officer']['id'] = director_party3.id
+    COMBINED_FILING['filing']['changeOfDirectors']['directors'][3]['officer']['id'] = director_party4.id
+
     filing_id = (create_filing(payment_id, COMBINED_FILING, business.id)).id
     filing_msg = FilingMessage(filing_identifier=filing_id)
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#32920

*Description of changes:*
- Update filer to use id-based matching instead of name-based matching for director updates for LEAR-native filings
- Maintain the name-based matching for COLIN-native filings as we don't have a way to use id-based matching (to confirm)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
