### PR TITLE
33173 Add coop to tombstone flow + COLIN subset extract script

### DIFF
--- a/data-tool/flows/batch_delete_flow.py
+++ b/data-tool/flows/batch_delete_flow.py
@@ -16,14 +16,14 @@ from sqlalchemy.engine import Engine
 businesses_cnt_query = """
 SELECT COUNT(*) FROM businesses
 WHERE 1 = 1 
-AND legal_type IN ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE', 'BEN')
+AND legal_type IN ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE', 'BEN', 'CP')
 AND legal_name LIKE '%' || :corp_name_suffix
 """
 
 identifiers_query = """
 SELECT id, identifier FROM businesses
 WHERE 1 = 1 
-AND legal_type IN ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE', 'BEN')
+AND legal_type IN ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE', 'BEN', 'CP')
 AND legal_name LIKE '%' || :corp_name_suffix
 LIMIT :batch_size
 """

--- a/data-tool/flows/refresh_extract_subset_flow.py
+++ b/data-tool/flows/refresh_extract_subset_flow.py
@@ -70,7 +70,8 @@ def run_cprd_subset_extract_generator(
     threads: int,
     pg_fastload: bool,
     pg_disable_method: str,
-    out: str | None
+    out: str | None,
+    include_cp: bool = False,
 ) -> subprocess.CompletedProcess:
     """
     Generate Commands
@@ -94,6 +95,8 @@ def run_cprd_subset_extract_generator(
     ]
     if pg_fastload:
         argv.append('--pg-fastload')
+    if include_cp:
+        argv.append('--include-cp')
     out_path = Path(out).expanduser().resolve() if out is not None else _SUBSET.resolve()
     out_path.parent.mkdir(parents=True, exist_ok=True)
     argv.extend(['--out', str(out)])
@@ -130,6 +133,7 @@ def extract_pull_flow(
     run_dbschemacli: bool = False,
     dbschemacli_cmd: str = 'dbschemacli',
     reset_extract_postgres: bool = True,
+    include_cp: bool = False,
 ) -> None:
     """
     Generate files
@@ -144,6 +148,7 @@ def extract_pull_flow(
         chunk_size=chunk_size,
         threads=threads,
         pg_fastload=pg_fastload,
+        include_cp=include_cp,
         pg_disable_method=pg_disable_method,
         out=out,
     )
@@ -169,6 +174,7 @@ if __name__ == '__main__':
     p.add_argument('--chunk-size', type=int, default=900, help='Max items per IN list.')
     p.add_argument('--threads', type=int, default=4, help='DBSchemaCLI transfer threads')
     p.add_argument('--pg-fastload', action='store_true', help='Enable Postgres fast-load')
+    p.add_argument('--include-cp', action='store_true', help='Include corp type CP in subset extract queries')
     p.add_argument('--pg-disable-method', default='replica_role', choices=('table_triggers', 'replica_role'))
     p.add_argument('--out', default=None, help='Output path for generated master script.')
     p.add_argument('--run-dbschemacli', action='store_true')

--- a/data-tool/flows/tombstone/tombstone_mappings.py
+++ b/data-tool/flows/tombstone/tombstone_mappings.py
@@ -28,6 +28,10 @@ class EventFilings(str, Enum):
     FILE_AMALH = 'FILE_AMALH'
     FILE_AMALR = 'FILE_AMALR'
     FILE_AMALV = 'FILE_AMALV'
+    FILE_OTAMA = 'FILE_OTAMA'
+
+    # CONVOTHER Amalgamation Application
+    CONVOTHER_OTAMA = 'CONVOTHER_OTAMA'
 
     FILE_AMLHU = 'FILE_AMLHU'
     FILE_AMLRU = 'FILE_AMLRU'
@@ -40,17 +44,29 @@ class EventFilings(str, Enum):
 
     # Annual Report
     FILE_ANNBC = 'FILE_ANNBC'
+    FILE_OTANN = 'FILE_OTANN'
+
+    # CONVOTHER Annual Report
+    CONVOTHER_OTANN = 'CONVOTHER_OTANN'
 
     # Change of Address
     FILE_APTRA = 'FILE_APTRA'
     FILE_NOERA = 'FILE_NOERA'
     FILE_NOCAD = 'FILE_NOCAD'
+    FILE_OTADD = 'FILE_OTADD'
     FILE_AM_DO = 'FILE_AM_DO'
     FILE_AM_RR = 'FILE_AM_RR'
 
+    # CONVOTHER Change of Address
+    CONVOTHER_OTADD = 'CONVOTHER_OTADD'
+
     # Change of Directors
     FILE_NOCDR = 'FILE_NOCDR'
+    FILE_OTCDR = 'FILE_OTCDR'
     FILE_AM_DI = 'FILE_AM_DI'
+
+    # CONVOTHER Change of Directors
+    CONVOTHER_OTCDR = 'CONVOTHER_OTCDR'
 
     # Consent Continuation Out
     FILE_CONTO = 'FILE_CONTO'
@@ -68,6 +84,7 @@ class EventFilings(str, Enum):
 
     # Conversion
     CONVAMAL_NULL = 'CONVAMAL_NULL'
+    CONVOTHER_NULL = 'CONVOTHER_NULL'
     CONVCIN_NULL = 'CONVCIN_NULL'
     CONVCOUT_NULL = 'CONVCOUT_NULL'
     CONVDS_NULL = 'CONVDS_NULL'
@@ -98,6 +115,12 @@ class EventFilings(str, Enum):
     # Court Order
     FILE_COURT = 'FILE_COURT'
 
+    # Special Resolution
+    FILE_OTSPE = 'FILE_OTSPE'
+
+    # CONVOTHER Special Resolution
+    CONVOTHER_OTSPE = 'CONVOTHER_OTSPE'
+
     # TODO: Delay of Dissolution - unsupported (need confirmation)
     DISD1_DISDE = 'DISD1_DISDE'
     DISD2_DISDE = 'DISD2_DISDE'
@@ -106,6 +129,10 @@ class EventFilings(str, Enum):
     ## voluntary
     FILE_ADVD2 = 'FILE_ADVD2'
     FILE_ADVDS = 'FILE_ADVDS'
+    FILE_OTVDS = 'FILE_OTVDS'
+
+    # CONVOTHER Dissolution
+    CONVOTHER_OTVDS = 'CONVOTHER_OTVDS'
     ## admin
     SYSDA_NULL = 'SYSDA_NULL'
     SYSDS_NULL = 'SYSDS_NULL'
@@ -122,6 +149,10 @@ class EventFilings(str, Enum):
     FILE_ICORP = 'FILE_ICORP'
     FILE_ICORU = 'FILE_ICORU'
     FILE_ICORC = 'FILE_ICORC'
+    FILE_OTINC = 'FILE_OTINC'
+
+    # CONVOTHER Incorporation Application
+    CONVOTHER_OTINC = 'CONVOTHER_OTINC'
 
     # TODO: Legacy Other - unsupported
     ADCORP_NULL = 'ADCORP_NULL'
@@ -158,6 +189,12 @@ class EventFilings(str, Enum):
 
     # Registrar's Order
     FILE_REGSO = 'FILE_REGSO'
+
+    # Restoration Application (Coop)
+    FILE_OTRES = 'FILE_OTRES'
+
+    # CONVOTHER Restoration Application
+    CONVOTHER_OTRES = 'CONVOTHER_OTRES'
 
     # Restoration
     FILE_RESTL = 'FILE_RESTL'
@@ -207,6 +244,11 @@ EVENT_FILING_LEAR_TARGET_MAPPING = {
     EventFilings.FILE_AMALH: ['amalgamationApplication', 'horizontal'],
     EventFilings.FILE_AMALR: ['amalgamationApplication', 'regular'],
     EventFilings.FILE_AMALV: ['amalgamationApplication', 'vertical'],
+    EventFilings.FILE_OTAMA: ['amalgamationApplication', 'unknown'],
+
+    # CONVOTHER Amalgamation Application
+    EventFilings.CONVOTHER_OTAMA: ['amalgamationApplication', 'unknown'],
+
     EventFilings.FILE_AMLHU: ['amalgamationApplication', 'horizontal'],
     EventFilings.FILE_AMLRU: ['amalgamationApplication', 'regular'],
     EventFilings.FILE_AMLVU: ['amalgamationApplication', 'vertical'],
@@ -215,15 +257,27 @@ EVENT_FILING_LEAR_TARGET_MAPPING = {
     EventFilings.FILE_AMLVC: ['amalgamationApplication', 'vertical'],
 
     EventFilings.FILE_ANNBC: 'annualReport',
+    EventFilings.FILE_OTANN: 'annualReport',
+
+    # CONVOTHER Annual Report
+    EventFilings.CONVOTHER_OTANN: 'annualReport',
 
     EventFilings.FILE_APTRA: 'changeOfAddress',
     EventFilings.FILE_NOERA: 'changeOfAddress',
     EventFilings.FILE_NOCAD: 'changeOfAddress',
+    EventFilings.FILE_OTADD: 'changeOfAddress',
     EventFilings.FILE_AM_DO: 'changeOfAddress',
     EventFilings.FILE_AM_RR: 'changeOfAddress',
 
+    # CONVOTHER Change of Address
+    EventFilings.CONVOTHER_OTADD: 'changeOfAddress',
+
     EventFilings.FILE_NOCDR: 'changeOfDirectors',
+    EventFilings.FILE_OTCDR: 'changeOfDirectors',
     EventFilings.FILE_AM_DI: 'changeOfDirectors',
+
+    # CONVOTHER Change of Directors
+    EventFilings.CONVOTHER_OTCDR: 'changeOfDirectors',
 
     EventFilings.FILE_CONTO: 'consentContinuationOut',
     EventFilings.FILE_COUTI: 'continuationOut',
@@ -235,6 +289,7 @@ EVENT_FILING_LEAR_TARGET_MAPPING = {
     EventFilings.FILE_CONVL: 'conversionLedger',
 
     EventFilings.CONVAMAL_NULL: ['conversion', ('amalgamationApplication', 'unknown')],
+    EventFilings.CONVOTHER_NULL: 'legacyOther',
     EventFilings.CONVCIN_NULL: ['conversion', 'continuationIn'],
     EventFilings.CONVCOUT_NULL: ['conversion', 'continuationOut'],
     EventFilings.CONVDS_NULL: ['conversion', ('dissolution', 'voluntary')],
@@ -262,6 +317,10 @@ EVENT_FILING_LEAR_TARGET_MAPPING = {
     EventFilings.FILE_CORRT: 'correction',
 
     EventFilings.FILE_COURT: 'courtOrder',
+    EventFilings.FILE_OTSPE: 'specialResolution',
+
+    # CONVOTHER Special Resolution
+    EventFilings.CONVOTHER_OTSPE: 'specialResolution',
 
     # TODO: Delay of Dissolution - unsupported (need confirmation)
     EventFilings.DISD1_DISDE: 'delayOfDissolution',
@@ -269,6 +328,11 @@ EVENT_FILING_LEAR_TARGET_MAPPING = {
 
     EventFilings.FILE_ADVD2: ['dissolution', 'voluntary'],
     EventFilings.FILE_ADVDS: ['dissolution', 'voluntary'],
+    EventFilings.FILE_OTVDS: ['dissolution', 'voluntary'],
+
+    # CONVOTHER Dissolution
+    EventFilings.CONVOTHER_OTVDS: ['dissolution', 'voluntary'],
+
     EventFilings.SYSDA_NULL: ['dissolution', 'administrative'],
     EventFilings.SYSDS_NULL: ['dissolution', 'administrative'],
     EventFilings.SYSDF_NULL: ['dissolution', 'involuntary'],
@@ -279,8 +343,13 @@ EVENT_FILING_LEAR_TARGET_MAPPING = {
     EventFilings.FILE_ICORP: 'incorporationApplication',
     EventFilings.FILE_ICORU: 'incorporationApplication',
     EventFilings.FILE_ICORC: 'incorporationApplication',
+    EventFilings.FILE_OTINC: 'incorporationApplication',
 
-    # TODO: Legacy Other - unsupported
+    # CONVOTHER Incorporation Application
+    EventFilings.CONVOTHER_OTINC: 'incorporationApplication',
+
+    # Legacy Other
+    EventFilings.CONVOTHER_NULL: 'legacyOther',
     EventFilings.ADCORP_NULL: 'legacyOther',
     EventFilings.ADFIRM_NULL: 'legacyOther',
     EventFilings.ADMIN_NULL: 'legacyOther',
@@ -309,6 +378,10 @@ EVENT_FILING_LEAR_TARGET_MAPPING = {
 
     EventFilings.FILE_REGSN: 'registrarsNotation',
     EventFilings.FILE_REGSO: 'registrarsOrder',
+    EventFilings.FILE_OTRES: 'restorationApplication',
+
+    # CONVOTHER Restoration Application
+    EventFilings.CONVOTHER_OTRES: 'restorationApplication',
 
     EventFilings.FILE_RESTL: ['restoration', 'limitedRestoration'],
     EventFilings.FILE_RESTF: ['restoration', 'fullRestoration'],
@@ -346,6 +419,11 @@ EVENT_FILING_DISPLAY_NAME_MAPPING = {
     EventFilings.FILE_AMALH: 'Amalgamation Application Short Form (Horizontal)',
     EventFilings.FILE_AMALR: 'Amalgamation Application (Regular)',
     EventFilings.FILE_AMALV: 'Amalgamation Application Short Form (Vertical)',
+    EventFilings.FILE_OTAMA: 'Amalgamation Application',
+
+    # CONVOTHER Amalgamation Application
+    EventFilings.CONVOTHER_OTAMA: 'Amalgamation Application',
+
     EventFilings.FILE_AMLHU: 'Amalgamation Application Short Form (Horizontal) for a BC Unlimited Liability Company',
     EventFilings.FILE_AMLRU: 'Amalgamation Application (Regular) for a BC Unlimited Liability Company',
     EventFilings.FILE_AMLVU: 'Amalgamation Application Short Form (Vertical) for a BC Unlimited Liability Company',
@@ -354,15 +432,27 @@ EVENT_FILING_DISPLAY_NAME_MAPPING = {
     EventFilings.FILE_AMLVC: 'Amalgamation Application Short Form (Vertical) for a Community Contribution Company',
 
     EventFilings.FILE_ANNBC: 'BC Annual Report',  # has suffix of date, dynamically add it during formatting
+    EventFilings.FILE_OTANN: 'Annual Report',
+
+    # CONVOTHER Annual Report
+    EventFilings.CONVOTHER_OTANN: 'Annual Report',
 
     EventFilings.FILE_APTRA: 'Application to Transfer Registered Office',
     EventFilings.FILE_NOERA: 'Notice of Elimination of Registered Office',
     EventFilings.FILE_NOCAD: 'Notice of Change of Address',
+    EventFilings.FILE_OTADD: 'Notice of Change of Address',
     EventFilings.FILE_AM_DO: 'Amendment - Dissolved Office',
     EventFilings.FILE_AM_RR: 'Amendment - Registered and Records Offices',
 
+    # CONVOTHER Change of Address
+    EventFilings.CONVOTHER_OTADD: 'Notice of Change of Address',
+
     EventFilings.FILE_NOCDR: 'Notice of Change of Directors', # dynamically add suffix for some scenarios
+    EventFilings.FILE_OTCDR: 'Notice of Change of Directors',
     EventFilings.FILE_AM_DI: 'Amendment - Director',
+
+    # CONVOTHER Change of Directors
+    EventFilings.CONVOTHER_OTCDR: 'Notice of Change of Directors',
 
     EventFilings.FILE_CONTO: '6 Months Consent to Continue Out',
     EventFilings.FILE_COUTI: 'Instrument of Continuation Out',
@@ -384,6 +474,10 @@ EVENT_FILING_DISPLAY_NAME_MAPPING = {
     EventFilings.FILE_CORRT: 'Correction',
 
     EventFilings.FILE_COURT: 'Court Order',
+    EventFilings.FILE_OTSPE: 'Special Resolution',
+
+    # CONVOTHER Special Resolution
+    EventFilings.CONVOTHER_OTSPE: 'Special Resolution',
 
     # TODO: Delay of Dissolution - unsupported (need confirmation)
     # no ledger item in colin
@@ -393,6 +487,11 @@ EVENT_FILING_DISPLAY_NAME_MAPPING = {
 
     EventFilings.FILE_ADVD2: 'Application for Dissolution (Voluntary Dissolution)',
     EventFilings.FILE_ADVDS: 'Application for Dissolution (Voluntary Dissolution)',
+    EventFilings.FILE_OTVDS: 'Voluntary Dissolution',
+
+    # CONVOTHER Dissolution
+    EventFilings.CONVOTHER_OTVDS: 'Voluntary Dissolution',
+
     EventFilings.SYSDA_NULL: None,  # admin - status Administrative Dissolution
     EventFilings.SYSDS_NULL: None,  # admin - status Administrative Dissolution
     EventFilings.SYSDF_NULL: None,  # invol - no ledger in lear & colin
@@ -403,8 +502,13 @@ EVENT_FILING_DISPLAY_NAME_MAPPING = {
     EventFilings.FILE_ICORP: 'Incorporation Application',
     EventFilings.FILE_ICORU: 'Incorporation Application for a BC Unlimited Liability Company',
     EventFilings.FILE_ICORC: 'Incorporation Application for a Community Contribution Company',
+    EventFilings.FILE_OTINC: 'Incorporation Application',
 
-    # TODO: Legacy Other - unsupported
+    # CONVOTHER Incorporation Application
+    EventFilings.CONVOTHER_OTINC: 'Incorporation Application',
+
+    # Legacy Other
+    EventFilings.CONVOTHER_NULL: 'Legacy Other',
     EventFilings.ADCORP_NULL: None,
     EventFilings.ADFIRM_NULL: None,
     EventFilings.ADMIN_NULL: None,
@@ -442,6 +546,10 @@ EVENT_FILING_DISPLAY_NAME_MAPPING = {
 
     EventFilings.FILE_REGSN: "Registrar's Notation",
     EventFilings.FILE_REGSO: "Registrar's Order",
+    EventFilings.FILE_OTRES: 'Restoration Application',
+
+    # CONVOTHER Restoration Application
+    EventFilings.CONVOTHER_OTRES: 'Restoration Application',
 
     EventFilings.FILE_RESTL: 'Restoration Application - Limited',
     EventFilings.FILE_RESTF: 'Restoration Application - Full',

--- a/data-tool/flows/tombstone/tombstone_queries.py
+++ b/data-tool/flows/tombstone/tombstone_queries.py
@@ -103,7 +103,7 @@ def get_unprocessed_corps_query(flow_name, config, batch_size, *, include_accoun
 
     cte_clause, where_clause = get_unprocessed_corps_subquery(flow_name, environment)
 
-    corp_type_filter = "('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')"
+    corp_type_filter = "('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE', 'CP')"
 
     mig_extra_where = ""
     if use_mig_filter:
@@ -229,7 +229,7 @@ def get_total_reservable_count_query(flow_name: str, config) -> str:
 
     cte_clause, where_clause = get_unprocessed_corps_subquery(flow_name, environment)
 
-    corp_type_filter = "('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')"
+    corp_type_filter = "('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE', 'CP')"
 
     mig_extra_where = ""
     if use_mig_filter:

--- a/data-tool/flows/tombstone/tombstone_utils.py
+++ b/data-tool/flows/tombstone/tombstone_utils.py
@@ -468,7 +468,7 @@ def format_filings_data(data: dict) -> dict:
         if (
             raw_filing_type == 'conversion'
             or raw_filing_subtype in ('involuntary', 'voluntaryLiquidation', 'courtOrderedLiquidation')
-            or event_file_type in ['SYSDL_NULL', 'ADCORP_NULL', 'ADFIRM_NULL', 'ADMIN_NULL']
+            or event_file_type in ['SYSDL_NULL', 'CONVOTHER_NULL', 'ADCORP_NULL', 'ADFIRM_NULL', 'ADMIN_NULL']
         ):
             hide_in_ledger = True
         else:
@@ -1034,7 +1034,11 @@ def get_colin_display_name(data: dict) -> str:
     name = EVENT_FILING_DISPLAY_NAME_MAPPING.get(event_file_type)
 
     # Annual Report
-    if event_file_type == EventFilings.FILE_ANNBC.value:
+    if event_file_type in (
+        EventFilings.FILE_ANNBC.value,
+        EventFilings.FILE_OTANN.value,
+        EventFilings.CONVOTHER_OTANN.value
+    ):
         ar_dt_str = data['f_period_end_dt_str']
         ar_dt = datetime.strptime(ar_dt_str, date_format_with_tz)
         suffix = ar_dt.strftime('%b %d, %Y').upper()

--- a/data-tool/scripts/README_COLIN_Corps_Extract.md
+++ b/data-tool/scripts/README_COLIN_Corps_Extract.md
@@ -268,6 +268,19 @@ Generated scripts (gitignored by default):
      --out <lear-repo-base-path>/data-tool/scripts/_generated/subset_refresh.sql
    ```
 
+   **Refresh mode with CP corps included**:
+   ```bash
+   python <lear-repo-base-path>/data-tool/scripts/generate_cprd_subset_extract.py \
+     --corp-file <lear-repo-base-path>/data-tool/scripts/corp_ids.txt \
+     --mode refresh \
+     --chunk-size 500 \
+     --threads 4 \
+     --include-cp \
+     --pg-fastload \ 
+     --pg-disable-method table_triggers \   
+     --out <lear-repo-base-path>/data-tool/scripts/_generated/subset_refresh.sql
+   ```
+
    **Load mode** (load only those corps; no deletes):
    ```bash
    python <lear-repo-base-path>/data-tool/scripts/generate_cprd_subset_extract.py \
@@ -279,6 +292,10 @@ Generated scripts (gitignored by default):
      --pg-disable-method table_triggers \      
      --out <lear-repo-base-path>/data-tool/scripts/_generated/subset_load.sql
    ```
+
+   Optional flags:
+   - Add `--include-cp` to opt in corp type `CP` for the subset transfer queries.
+   - `--include-cp` affects the **subset workflow only**. Full refresh (`transfer_cprd_corps.sql`) and downstream reservation flows still use the historical corp-type cohort unless updated separately.
 
    Optional performance flags:
    - Add `--pg-fastload` to enable Postgres session settings for faster bulk writes (templates `subset_pg_fastload_begin.sql` / `subset_pg_fastload_end.sql`).

--- a/data-tool/scripts/generate_cprd_subset_extract.py
+++ b/data-tool/scripts/generate_cprd_subset_extract.py
@@ -74,6 +74,7 @@ class cfg_GenerationConfig:
     threads: int
     prefix_numeric_bc: bool
     include_cars: bool
+    include_cp: bool
 
     pg_fastload: bool
     pg_disable_method: cfg_PgDisableMethod
@@ -96,6 +97,7 @@ class cfg_GenerationConfig:
 TMPL_TOKEN_CORP_IDS = "&corp_ids_in"  # used by delete template (Postgres-side)
 TMPL_TOKEN_TARGET_PRED = "&target_corp_num_predicate"  # used by transfer template (Oracle-side)
 TMPL_TOKEN_ORACLE_PRED = "&oracle_corp_num_predicate"  # used by transfer template (Oracle-side)
+TMPL_TOKEN_ORACLE_CORP_TYPE_PRED = "&oracle_corp_type_predicate"  # used by transfer template (Oracle-side)
 
 
 @dataclass(frozen=True)
@@ -207,6 +209,13 @@ def corp_to_oracle_ids(target_ids: Sequence[str]) -> List[str]:
 def sql_quote_literal(val: str) -> str:
     escaped = val.replace("'", "''")
     return f"'{escaped}'"
+
+
+def sql_render_oracle_corp_type_predicate(*, include_cp: bool) -> str:
+    supported_types = ['BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE']
+    if include_cp:
+        supported_types.append('CP')
+    return f"c.CORP_TYP_CD in ({sql_render_in_list(supported_types, multiline=False)})"
 
 
 def sql_render_in_list(values: Sequence[str], *, multiline: bool = True, indent: str = "    ") -> str:
@@ -338,7 +347,7 @@ def tmpl_default_bundle(repo_root: Path) -> tmpl_TemplateBundle:
     transfer_chunk = tmpl_TemplateSpec(
         name="subset_transfer_chunk",
         path=subset_dir / "subset_transfer_chunk.sql",
-        required_tokens=(TMPL_TOKEN_TARGET_PRED, TMPL_TOKEN_ORACLE_PRED),
+        required_tokens=(TMPL_TOKEN_TARGET_PRED, TMPL_TOKEN_ORACLE_PRED, TMPL_TOKEN_ORACLE_CORP_TYPE_PRED),
     )
     delete_cars = tmpl_TemplateSpec(
         name="subset_delete_cars",
@@ -451,12 +460,14 @@ def gen_build_chunk_sql(
     corp_ids_sql: str,
     target_predicate_sql: str,
     oracle_predicate_sql: str,
+    oracle_corp_type_predicate_sql: str,
     pg_debug_session_probes: bool,
 ) -> str:
     replacements = {
         TMPL_TOKEN_CORP_IDS: corp_ids_sql,
         TMPL_TOKEN_TARGET_PRED: target_predicate_sql,
         TMPL_TOKEN_ORACLE_PRED: oracle_predicate_sql,
+        TMPL_TOKEN_ORACLE_CORP_TYPE_PRED: oracle_corp_type_predicate_sql,
     }
 
     parts: List[str] = []
@@ -484,7 +495,9 @@ def gen_build_chunk_sql(
 
     if include_transfer:
         rendered_transfer = tmpl_render(transfer_template_text, replacements=replacements)
-        if TMPL_TOKEN_TARGET_PRED in rendered_transfer or TMPL_TOKEN_ORACLE_PRED in rendered_transfer:
+        if (TMPL_TOKEN_TARGET_PRED in rendered_transfer or
+                TMPL_TOKEN_ORACLE_PRED in rendered_transfer or
+                TMPL_TOKEN_ORACLE_CORP_TYPE_PRED in rendered_transfer):
             raise SystemExit(
                 f"Internal error: token(s) remained after rendering transfer template for chunk {chunk.index:03d}."
             )
@@ -503,9 +516,11 @@ def gen_write_chunk_files(
     delete_template_text: str,
     transfer_template_text: str,
     max_in_list: int,
+    include_cp: bool,
     pg_debug_session_probes: bool,
 ) -> List[Path]:
     out_paths: List[Path] = []
+    oracle_corp_type_predicate_sql = sql_render_oracle_corp_type_predicate(include_cp=include_cp)
     for ch in chunks:
         corp_ids_sql = sql_render_in_list(ch.target_ids, multiline=True, indent="    ")
         target_predicate_sql = sql_render_in_predicate(
@@ -533,6 +548,7 @@ def gen_write_chunk_files(
             corp_ids_sql=corp_ids_sql,
             target_predicate_sql=target_predicate_sql,
             oracle_predicate_sql=oracle_predicate_sql,
+            oracle_corp_type_predicate_sql=oracle_corp_type_predicate_sql,
             pg_debug_session_probes=pg_debug_session_probes,
         )
         gen_write_text(ch.chunk_file, chunk_sql)
@@ -783,8 +799,10 @@ def gen_build_master_script_vset(
             multiline=False,
             indent="",
         )
+        oracle_corp_type_pred = sql_render_oracle_corp_type_predicate(include_cp=cfg.include_cp)
         lines.append(f"vset target_corp_num_predicate={target_pred}")
         lines.append(f"vset oracle_corp_num_predicate={oracle_pred}")
+        lines.append(f"vset oracle_corp_type_predicate={oracle_corp_type_pred}")
 
     if cfg.mode == cfg_GenerationMode.REFRESH:
         lines.append("-- delete subset (chunked to keep SQL size manageable)")
@@ -898,6 +916,11 @@ def cli_parse_args(argv: List[str] | None = None) -> argparse.Namespace:
         help="Skip global cars* refresh step (carsfile/carsbox/carsrept/carindiv).",
     )
     parser.set_defaults(include_cars=True)
+    parser.add_argument(
+        "--include-cp",
+        action="store_true",
+        help="Include corp type CP in subset extract queries.",
+    )
 
     parser.add_argument(
         "--pg-fastload",
@@ -990,6 +1013,7 @@ def cfg_build_config(args: argparse.Namespace) -> cfg_GenerationConfig:
         threads=int(args.threads),
         prefix_numeric_bc=bool(args.prefix_numeric_bc),
         include_cars=bool(args.include_cars),
+        include_cp=bool(args.include_cp),
         pg_fastload=bool(args.pg_fastload),
         pg_disable_method=pg_disable_method,
         pg_debug_session_probes=bool(args.pg_debug_session_probes),
@@ -1061,6 +1085,7 @@ def run(cfg: cfg_GenerationConfig) -> int:
                 delete_template_text=delete_template_text,
                 transfer_template_text=transfer_template_text,
                 max_in_list=cfg.chunk_size,
+                include_cp=cfg.include_cp,
                 pg_debug_session_probes=cfg.pg_debug_session_probes,
             )
             transfer_files = combined_files
@@ -1077,6 +1102,7 @@ def run(cfg: cfg_GenerationConfig) -> int:
                     delete_template_text=delete_template_text,
                     transfer_template_text=transfer_template_text,
                     max_in_list=cfg.chunk_size,
+                    include_cp=cfg.include_cp,
                     pg_debug_session_probes=cfg.pg_debug_session_probes,
                 )
 
@@ -1096,6 +1122,7 @@ def run(cfg: cfg_GenerationConfig) -> int:
                 delete_template_text=delete_template_text,
                 transfer_template_text=transfer_template_text,
                 max_in_list=cfg.chunk_size,
+                include_cp=cfg.include_cp,
                 pg_debug_session_probes=cfg.pg_debug_session_probes,
             )
 
@@ -1145,6 +1172,7 @@ def run(cfg: cfg_GenerationConfig) -> int:
             print(" - cars* tables will be globally refreshed (truncate + reload from Oracle).")
         else:
             print(" - cars* tables will NOT be refreshed (--no-cars was set).")
+        print(f" - CP corp type inclusion: {'ENABLED' if cfg.include_cp else 'disabled'} (--include-cp)")
         print(f" - Postgres fast-load session settings: {'ENABLED' if cfg.pg_fastload else 'disabled'} (--pg-fastload)")
         print(f" - Postgres trigger suppression: {cfg.pg_disable_method.value} (--pg-disable-method)")
         print(" - subset runs acquire a session-level advisory lock on the target DB to prevent overlap.")

--- a/data-tool/scripts/subset/subset_transfer_chunk.sql
+++ b/data-tool/scripts/subset/subset_transfer_chunk.sql
@@ -9,6 +9,10 @@
 --                              Examples:
 --                                c.CORP_NUM in ('0460007','A1234567')
 --                                (c.CORP_NUM in (...) OR c.CORP_NUM in (...))
+--   oracle_corp_type_predicate : SQL predicate restricting Oracle corporation.corp_typ_cd (NO trailing semicolon).
+--                              Examples:
+--                                c.CORP_TYP_CD in ('BC','C','ULC','CUL','CC','CCC','QA','QB','QC','QD','QE')
+--                                c.CORP_TYP_CD in ('BC','C','ULC','CUL','CC','CCC','QA','QB','QC','QD','QE','CP')
 --
 -- Intended to be executed from a master DbSchemaCLI script connected to the target Postgres DB (cprd_pg).
 --
@@ -35,7 +39,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		-- altered from BC to BEN then BEN to BC before directed launch
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
@@ -90,7 +94,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -123,7 +127,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -154,7 +158,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -186,7 +190,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -233,7 +237,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -270,7 +274,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -393,7 +397,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -425,7 +429,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -459,7 +463,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -490,7 +494,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -533,7 +537,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -562,7 +566,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -591,7 +595,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -624,7 +628,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -665,7 +669,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -695,7 +699,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -728,7 +732,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -767,7 +771,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -798,7 +802,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -866,7 +870,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -897,7 +901,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -931,7 +935,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -961,7 +965,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -996,7 +1000,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -1027,7 +1031,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -1056,7 +1060,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -1105,7 +1109,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -1147,7 +1151,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -1183,7 +1187,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -1219,7 +1223,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (
@@ -1256,7 +1260,7 @@ with corp_list as (
 	select /*+ materialize */ c.corp_num
 	from corporation c
 	where &oracle_corp_num_predicate
-		and c.CORP_TYP_CD in ('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')
+		and &oracle_corp_type_predicate
 		and c.CORP_NUM not in ('0460007', '1255957', '1186381')
 ),
 corporation_cte as (


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33173

*Description of changes:*
- Add flag `--include-cp` to allow loading of COOP corp types into COLIN extract.  Note full extract script does not support coops currently.  The intended use is to have an existing COLIN extract in place which can then use the subset script in refresh mode to load any required COOPs into the existing COLIN extract.
- Update tombstone pipeline to support COOPs
- Tested that these updates work for migrating CP0001947 to dev/test

Example usage of flag to include Coops in COLIN subset refresh script
```bash
python /Users/argus/h3/git/bcreg/lear/data-tool/scripts/generate_cprd_subset_extract.py \
--corp-file /Users/argus/h3/git/bcreg/lear/data-tool/scripts/subset/corp_ids.txt \
--mode refresh \
--chunk-size 500 \
--threads 4 \
--target-connection cprd_pg \
--pg-fastload \
--include-cp \
--pg-disable-method table_triggers \
--out /Users/argus/h3/git/bcreg/lear/data-tool/scripts/generated/subset_refresh.sql
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
