### PR TITLE
32793 dissolution require canada address

### DIFF
--- a/legal-api/src/legal_api/services/filings/validations/dissolution.py
+++ b/legal-api/src/legal_api/services/filings/validations/dissolution.py
@@ -282,9 +282,10 @@ def validate_dissolution_parties_address(filing_json, legal_type, dissolution_ty
     else:
         msg.append({"error": "Dissolution party is required.", "path": party_path})
 
-    if legal_type == Business.LegalTypes.COOP.value and address_in_ca == 0:
+    if address_in_ca == 0:
         msg.append({"error": "Address must be in Canada.", "path": party_path})
-    elif legal_type in Business.CORPS and address_in_bc == 0:
+
+    if legal_type in Business.CORPS and address_in_bc == 0:
         msg.append({"error": "Address must be in BC.", "path": party_path})
 
     if msg:

--- a/legal-api/src/legal_api/services/filings/validations/dissolution.py
+++ b/legal-api/src/legal_api/services/filings/validations/dissolution.py
@@ -299,27 +299,31 @@ def _validate_address_location(parties, legal_type):
     require_bc = legal_type in Business.CORPS
     for idx, party in enumerate(parties):
         for address_type in Address.JSON_ADDRESS_TYPES:
-            if address_type not in party:
-                msg.append({"error": _(f"{address_type} is required."),
-                            "path": f"/filing/dissolution/parties/{idx}"})
-                continue
+            msg.extend(_validate_party_address(party, idx, address_type, require_bc))
+    return msg
 
-            address_path = f"/filing/dissolution/parties/{idx}/{address_type}"
-            country = get_str(party, f"/{address_type}/addressCountry")
-            try:
-                country_code = pycountry.countries.search_fuzzy(country)[0].alpha_2
-            except LookupError:
-                msg.append({"error": _("Address Country must resolve to a valid ISO-2 country."),
-                            "path": f"{address_path}/addressCountry"})
-                continue
 
-            if country_code != "CA":
-                msg.append({"error": _("Address must be in Canada."),
-                            "path": f"{address_path}/addressCountry"})
+def _validate_party_address(party, idx, address_type, require_bc):
+    address_path = f"/filing/dissolution/parties/{idx}/{address_type}"
+    if address_type not in party:
+        return [{"error": _(f"{address_type} is required."),
+                 "path": address_path}]
 
-            if require_bc and get_str(party, f"/{address_type}/addressRegion") != "BC":
-                msg.append({"error": _("Address must be in BC."),
-                            "path": f"{address_path}/addressRegion"})
+    country = get_str(party, f"/{address_type}/addressCountry")
+    try:
+        country_code = pycountry.countries.search_fuzzy(country)[0].alpha_2
+    except LookupError:
+        return [{"error": _("Address Country must resolve to a valid ISO-2 country."),
+                 "path": f"{address_path}/addressCountry"}]
+
+    msg = []
+    if country_code != "CA":
+        msg.append({"error": _("Address must be in Canada."),
+                    "path": f"{address_path}/addressCountry"})
+
+    if require_bc and get_str(party, f"/{address_type}/addressRegion") != "BC":
+        msg.append({"error": _("Address must be in BC."),
+                    "path": f"{address_path}/addressRegion"})
 
     return msg
 

--- a/legal-api/src/legal_api/services/filings/validations/dissolution.py
+++ b/legal-api/src/legal_api/services/filings/validations/dissolution.py
@@ -269,7 +269,7 @@ def validate_dissolution_parties_address(filing_json, legal_type, dissolution_ty
     custodians = list(filter(lambda x: _is_custodian_role(x.get("roles", [])), parties_json))
 
     if not custodians:
-        # Handle case where there are no custodians, but there is a liquidator role 
+        # Handle case where there are no custodians, but there is a liquidator role
         # (this is not implemented in the Create UI, keeping behavior here)
         if any(_is_liquidator_role(p.get("roles", [])) for p in parties_json):
             return None

--- a/legal-api/src/legal_api/services/filings/validations/dissolution.py
+++ b/legal-api/src/legal_api/services/filings/validations/dissolution.py
@@ -261,73 +261,67 @@ def validate_dissolution_parties_address(filing_json, legal_type, dissolution_ty
 
     if legal_type in [Business.LegalTypes.SOLE_PROP.value, Business.LegalTypes.PARTNERSHIP.value]:
         return None
-    
+
     if "parties" not in filing_json["filing"]["dissolution"]:
         return None
 
     parties_json = filing_json["filing"]["dissolution"]["parties"]
-    parties = list(filter(lambda x: _is_dissolution_party_role(x.get("roles", [])), parties_json))
+    custodians = list(filter(lambda x: _is_custodian_role(x.get("roles", [])), parties_json))
+
+    if not custodians:
+        # Handle case where there are no custodians, but there is a liquidator role 
+        # (this is not implemented in the Create UI, keeping behavior here)
+        if any(_is_liquidator_role(p.get("roles", [])) for p in parties_json):
+            return None
+        return [{"error": "Dissolution party is required.", "path": "/filing/dissolution/parties"}]
+
     msg = []
-    address_in_bc = 0
-    address_in_ca = 0
-    party_path = "/filing/dissolution/parties"
+    msg.extend(_validate_custodian_email(custodians, dissolution_type, legal_type))
+    msg.extend(validate_custodian_org_name(custodians, dissolution_type, legal_type))
+    msg.extend(_validate_address_location(custodians, legal_type))
 
-    if len(parties) > 0:
-        msg.extend(_validate_custodian_email(parties, dissolution_type, legal_type))
-        msg.extend(validate_custodian_org_name(parties, dissolution_type, legal_type))
-
-        err, address_in_bc, address_in_ca = _validate_address_location(parties)
-        if err:
-            msg.extend(err)
-    else:
-        msg.append({"error": "Dissolution party is required.", "path": party_path})
-
-    if address_in_ca == 0:
-        msg.append({"error": "Address must be in Canada.", "path": party_path})
-
-    if legal_type in Business.CORPS and address_in_bc == 0:
-        msg.append({"error": "Address must be in BC.", "path": party_path})
-
-    if msg:
-        return msg
-
-    return None
+    return msg or None
 
 
-def _is_dissolution_party_role(roles: list) -> bool:
-    return any(role.get("roleType", "").lower() in
-               [PartyRole.RoleTypes.CUSTODIAN.value,
-                PartyRole.RoleTypes.LIQUIDATOR.value] for role in roles)
+def _is_custodian_role(roles: list) -> bool:
+    return any(role.get("roleType", "").lower() == PartyRole.RoleTypes.CUSTODIAN.value
+               for role in roles)
 
 
-def _validate_address_location(parties):
+def _is_liquidator_role(roles: list) -> bool:
+    return any(role.get("roleType", "").lower() == PartyRole.RoleTypes.LIQUIDATOR.value
+               for role in roles)
+
+
+def _validate_address_location(parties, legal_type):
+    """Every party address must be in Canada; CORP types also require the BC province."""
     msg = []
-    address_in_bc = 0
-    address_in_ca = 0
-    for idx, party in enumerate(parties):  # pylint: disable=too-many-nested-blocks;
+    require_bc = legal_type in Business.CORPS
+    for idx, party in enumerate(parties):
         for address_type in Address.JSON_ADDRESS_TYPES:
-            if address_type in party:
-                try:
-                    region = get_str(party, f"/{address_type}/addressRegion")
-                    if region == "BC":
-                        address_in_bc += 1
-
-                    country = get_str(party, f"/{address_type}/addressCountry")
-                    country_code = pycountry.countries.search_fuzzy(country)[0].alpha_2
-                    if country_code == "CA":
-                        address_in_ca += 1
-
-                except LookupError:
-                    msg.append({"error": _("Address Country must resolve to a valid ISO-2 country."),
-                                "path": f"/filing/dissolution/parties/{idx}/{address_type}/addressCountry"})
-            else:
+            if address_type not in party:
                 msg.append({"error": _(f"{address_type} is required."),
                             "path": f"/filing/dissolution/parties/{idx}"})
+                continue
 
-    if msg:
-        return msg, address_in_bc, address_in_ca
+            address_path = f"/filing/dissolution/parties/{idx}/{address_type}"
+            country = get_str(party, f"/{address_type}/addressCountry")
+            try:
+                country_code = pycountry.countries.search_fuzzy(country)[0].alpha_2
+            except LookupError:
+                msg.append({"error": _("Address Country must resolve to a valid ISO-2 country."),
+                            "path": f"{address_path}/addressCountry"})
+                continue
 
-    return None, address_in_bc, address_in_ca
+            if country_code != "CA":
+                msg.append({"error": _("Address must be in Canada."),
+                            "path": f"{address_path}/addressCountry"})
+
+            if require_bc and get_str(party, f"/{address_type}/addressRegion") != "BC":
+                msg.append({"error": _("Address must be in BC."),
+                            "path": f"{address_path}/addressRegion"})
+
+    return msg
 
 
 def validate_affidavit(filing_json, legal_type, dissolution_type) -> Optional[list]:

--- a/legal-api/tests/unit/services/filings/validations/test_dissolution.py
+++ b/legal-api/tests/unit/services/filings/validations/test_dissolution.py
@@ -248,6 +248,51 @@ def test_dissolution_address(session, test_status, legal_type, address_validatio
 
 
 @pytest.mark.parametrize(
+    'test_name, legal_type, address_in_bc, address_in_ca, expected_errors',
+    [
+        ('COOP_CA_OK', 'CP', 0, 1, []),
+        ('COOP_NO_CA_FAILS_CA', 'CP', 0, 0, ['Address must be in Canada.']),
+        ('CORP_BC_AND_CA_OK', 'BC', 1, 1, []),
+        ('CORP_NO_BC_FAILS_BC', 'BC', 0, 1, ['Address must be in BC.']),
+        ('CORP_BC_REGION_NON_CA_COUNTRY_FAILS_CA', 'BC', 1, 0, ['Address must be in Canada.']),
+        ('CORP_NO_BC_NO_CA_FAILS_BOTH', 'BC', 0, 0,
+            ['Address must be in Canada.', 'Address must be in BC.']),
+    ]
+)
+def test_validate_dissolution_parties_address_location_counts(
+        test_name, legal_type, address_in_bc, address_in_ca, expected_errors):
+    """Atomic test for the Canada/BC count checks in validate_dissolution_parties_address.
+
+    Mocks _validate_address_location to return arbitrary counts so the two guard lines
+    (CA and BC) can be exercised independently of address-parsing logic.
+    """
+    filing_json = {
+        'filing': {
+            'dissolution': {
+                'parties': [
+                    {'roles': [{'roleType': 'Custodian'}]}
+                ]
+            }
+        }
+    }
+
+    with patch.object(dissolution, '_validate_custodian_email', return_value=[]), \
+            patch.object(dissolution, 'validate_custodian_org_name', return_value=[]), \
+            patch.object(dissolution, '_validate_address_location',
+                         return_value=(None, address_in_bc, address_in_ca)):
+        result = dissolution.validate_dissolution_parties_address(
+            filing_json, legal_type, dissolution.DissolutionTypes.VOLUNTARY)
+
+    if not expected_errors:
+        assert result is None
+    else:
+        assert result is not None
+        assert [m['error'] for m in result] == expected_errors
+        for m in result:
+            assert m['path'] == '/filing/dissolution/parties'
+
+
+@pytest.mark.parametrize(
     'test_name, legal_type, dissolution_type, identifier, has_special_resolution_filing, expected_code, expected_msg',
     [
         ('SUCCESS', 'BC', 'voluntary', 'BC1234567', False, None, None),

--- a/legal-api/tests/unit/services/filings/validations/test_dissolution.py
+++ b/legal-api/tests/unit/services/filings/validations/test_dissolution.py
@@ -203,7 +203,9 @@ def test_dissolution_party_roles(session, legal_type, dissolution_type, roles, e
         ('FAIL', 'BC', 'party_address_required', 'BC1234567',
          HTTPStatus.BAD_REQUEST, 'Dissolution party is required.'),
         ('FAIL', 'CP', 'lookup_error', 'CP1234567',
-         HTTPStatus.BAD_REQUEST, 'Address Country must resolve to a valid ISO-2 country.')
+         HTTPStatus.BAD_REQUEST, 'Address Country must resolve to a valid ISO-2 country.'),
+        ('PASS', 'CP', 'liquidator_only', 'CP1234567', None, None),
+        ('PASS', 'CP', 'liquidator_only_non_ca_address', 'CP1234567', None, None),
     ]
 )
 def test_dissolution_address(session, test_status, legal_type, address_validation,
@@ -233,6 +235,13 @@ def test_dissolution_address(session, test_status, legal_type, address_validatio
         filing['filing']['dissolution']['parties'] = []
     elif address_validation == 'lookup_error':
         filing['filing']['dissolution']['parties'][1]['mailingAddress']['addressCountry'] = 'adssadkj'
+    elif address_validation in ['liquidator_only', 'liquidator_only_non_ca_address']:
+        # COOP voluntary dissolution may appoint a liquidator instead of a custodian.
+        # The address-location rules apply only to custodians, so a liquidator-only
+        # filing — including one with non-CA addresses — should validate.
+        filing['filing']['dissolution']['parties'][1]['roles'][0]['roleType'] = 'Liquidator'
+        if address_validation == 'liquidator_only_non_ca_address':
+            filing['filing']['dissolution']['parties'][1]['mailingAddress']['addressCountry'] = 'US'
 
     with patch.object(dissolution, 'validate_affidavit', return_value=None), \
          patch.object(dissolution, 'validate_dissolution_parties_roles', return_value=None), \
@@ -248,48 +257,35 @@ def test_dissolution_address(session, test_status, legal_type, address_validatio
 
 
 @pytest.mark.parametrize(
-    'test_name, legal_type, address_in_bc, address_in_ca, expected_errors',
+    'test_name, legal_type, country, region, per_address_errors',
     [
-        ('COOP_CA_OK', 'CP', 0, 1, []),
-        ('COOP_NO_CA_FAILS_CA', 'CP', 0, 0, ['Address must be in Canada.']),
-        ('CORP_BC_AND_CA_OK', 'BC', 1, 1, []),
-        ('CORP_NO_BC_FAILS_BC', 'BC', 0, 1, ['Address must be in BC.']),
-        ('CORP_BC_REGION_NON_CA_COUNTRY_FAILS_CA', 'BC', 1, 0, ['Address must be in Canada.']),
-        ('CORP_NO_BC_NO_CA_FAILS_BOTH', 'BC', 0, 0,
+        ('COOP_CA_ANY_PROVINCE_OK', 'CP', 'CA', 'ON', []),
+        ('COOP_US_FAILS_CA', 'CP', 'US', 'ON', ['Address must be in Canada.']),
+        ('CORP_CA_BC_OK', 'BC', 'CA', 'BC', []),
+        ('CORP_CA_AB_FAILS_BC', 'BC', 'CA', 'AB', ['Address must be in BC.']),
+        ('CORP_US_BC_FAILS_CA', 'BC', 'US', 'BC', ['Address must be in Canada.']),
+        ('CORP_US_AB_FAILS_BOTH', 'BC', 'US', 'AB',
             ['Address must be in Canada.', 'Address must be in BC.']),
     ]
 )
-def test_validate_dissolution_parties_address_location_counts(
-        test_name, legal_type, address_in_bc, address_in_ca, expected_errors):
-    """Atomic test for the Canada/BC count checks in validate_dissolution_parties_address.
+def test_validate_dissolution_parties_address_location_per_address(
+        test_name, legal_type, country, region, per_address_errors):
+    """Every party address must be CA; CORP types additionally require BC.
 
-    Mocks _validate_address_location to return arbitrary counts so the two guard lines
-    (CA and BC) can be exercised independently of address-parsing logic.
+    Calls the helper directly with a single custodian party whose mailing and
+    delivery addresses share the same country/region, so expected errors are
+    the per-address list doubled.
     """
-    filing_json = {
-        'filing': {
-            'dissolution': {
-                'parties': [
-                    {'roles': [{'roleType': 'Custodian'}]}
-                ]
-            }
-        }
-    }
+    parties = [{
+        'roles': [{'roleType': 'Custodian'}],
+        'mailingAddress': {'addressCountry': country, 'addressRegion': region},
+        'deliveryAddress': {'addressCountry': country, 'addressRegion': region},
+    }]
 
-    with patch.object(dissolution, '_validate_custodian_email', return_value=[]), \
-            patch.object(dissolution, 'validate_custodian_org_name', return_value=[]), \
-            patch.object(dissolution, '_validate_address_location',
-                         return_value=(None, address_in_bc, address_in_ca)):
-        result = dissolution.validate_dissolution_parties_address(
-            filing_json, legal_type, dissolution.DissolutionTypes.VOLUNTARY)
+    result = dissolution._validate_address_location(parties, legal_type)
 
-    if not expected_errors:
-        assert result is None
-    else:
-        assert result is not None
-        assert [m['error'] for m in result] == expected_errors
-        for m in result:
-            assert m['path'] == '/filing/dissolution/parties'
+    expected = per_address_errors * 2
+    assert [m['error'] for m in result] == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
*Issue #:* /bcgov/entity#32793

*Description of changes:*
For the custodian party of the dissolution ensure Canadian/BC addresses for CORP and COOP different requirements.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
