### PR TITLE
business-emailer: Test coverage

### DIFF
--- a/queue_services/business-emailer/tests/unit/__init__.py
+++ b/queue_services/business-emailer/tests/unit/__init__.py
@@ -29,6 +29,8 @@ from registry_schemas.example_data import (
     AMALGAMATION_APPLICATION,
     AMALGAMATION_OUT,
     ANNUAL_REPORT,
+    APPOINT_RECEIVER,
+    CEASE_RECEIVER,
     CHANGE_OF_DIRECTORS,
     CHANGE_OF_REGISTRATION,
     CONSENT_AMALGAMATION_OUT,
@@ -803,6 +805,58 @@ def prep_intent_to_liquidate_filing(session, identifier, payment_id, legal_type,
     filing.submitter_id = user.id
     if submitter_role:
         filing.submitter_roles = submitter_role
+
+    filing.save()
+    return filing
+
+
+def prep_cease_receiver_filing(session, identifier, payment_id, legal_type, legal_name):
+    """Return a new Cease Receiver filing prepped for email notification."""
+    business = create_business(identifier, legal_type, legal_name)
+    filing_template = copy.deepcopy(FILING_HEADER)
+    filing_template['filing']['header']['name'] = 'ceaseReceiver'
+
+    filing_template['filing']['ceaseReceiver'] = copy.deepcopy(CEASE_RECEIVER)
+    filing_template['filing']['business'] = {
+        'identifier': business.identifier,
+        'legalType': legal_type,
+        'legalName': legal_name
+    }
+
+    filing = create_filing(
+        token=payment_id,
+        filing_json=filing_template,
+        business_id=business.id)
+    filing.payment_completion_date = filing.filing_date
+
+    user = create_user('test_user')
+    filing.submitter_id = user.id
+
+    filing.save()
+    return filing
+
+
+def prep_appoint_receiver_filing(session, identifier, payment_id, legal_type, legal_name):
+    """Return a new Appoint Receiver filing prepped for email notification."""
+    business = create_business(identifier, legal_type, legal_name)
+    filing_template = copy.deepcopy(FILING_HEADER)
+    filing_template['filing']['header']['name'] = 'appointReceiver'
+
+    filing_template['filing']['appointReceiver'] = copy.deepcopy(APPOINT_RECEIVER)
+    filing_template['filing']['business'] = {
+        'identifier': business.identifier,
+        'legalType': legal_type,
+        'legalName': legal_name
+    }
+
+    filing = create_filing(
+        token=payment_id,
+        filing_json=filing_template,
+        business_id=business.id)
+    filing.payment_completion_date = filing.filing_date
+
+    user = create_user('test_user')
+    filing.submitter_id = user.id
 
     filing.save()
     return filing

--- a/queue_services/business-emailer/tests/unit/__init__.py
+++ b/queue_services/business-emailer/tests/unit/__init__.py
@@ -810,7 +810,7 @@ def prep_intent_to_liquidate_filing(session, identifier, payment_id, legal_type,
     return filing
 
 
-def prep_cease_receiver_filing(session, identifier, payment_id, legal_type, legal_name):
+def prep_cease_receiver_filing(identifier, payment_id, legal_type, legal_name):
     """Return a new Cease Receiver filing prepped for email notification."""
     business = create_business(identifier, legal_type, legal_name)
     filing_template = copy.deepcopy(FILING_HEADER)
@@ -836,7 +836,7 @@ def prep_cease_receiver_filing(session, identifier, payment_id, legal_type, lega
     return filing
 
 
-def prep_appoint_receiver_filing(session, identifier, payment_id, legal_type, legal_name):
+def prep_appoint_receiver_filing(identifier, payment_id, legal_type, legal_name):
     """Return a new Appoint Receiver filing prepped for email notification."""
     business = create_business(identifier, legal_type, legal_name)
     filing_template = copy.deepcopy(FILING_HEADER)

--- a/queue_services/business-emailer/tests/unit/email_processors/test_agm_extension_notification.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_agm_extension_notification.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """The Unit Tests for AGM extension email processor."""
+import base64
 from unittest.mock import patch
 
 import pytest
+import requests_mock
 from business_model.models import Business
 
 from business_emailer.email_processors import agm_extension_notification
@@ -52,3 +54,34 @@ def test_agm_extension_notification(app, session, status, legal_name, is_numbere
             assert mock_get_pdfs.call_args[0][1]['legalName'] == legal_name
             assert mock_get_pdfs.call_args[0][1]['legalType'] == Business.LegalTypes.COMP.value
             assert mock_get_pdfs.call_args[0][2] == filing
+
+
+def test_agm_extension_attachments(session, config):
+    """Assert _get_pdfs assembles the AGM Extension letter and receipt."""
+    identifier = 'BC1234567'
+    filing = prep_agm_extension_filing(
+        identifier, '1', Business.LegalTypes.COMP.value, 'test business')
+    token = 'token'
+    with patch.object(agm_extension_notification, 'get_recipient_from_auth',
+                      return_value='recipient@email.com'):
+        with requests_mock.Mocker() as m:
+            m.get(
+                f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+                f'/filings/{filing.id}/documents/letterOfAgmExtension',
+                content=b'pdf_content_1',
+                status_code=200,
+            )
+            m.post(
+                f'{config.get("PAY_API_URL")}/{filing.payment_token}/receipts',
+                content=b'pdf_content_2',
+                status_code=201,
+            )
+            output = agm_extension_notification.process(
+                {'filingId': filing.id, 'type': 'agmExtension', 'option': 'COMPLETED'}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 2
+    assert attachments[0]['fileName'] == 'Letter of AGM Extension Approval.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'
+    assert attachments[1]['fileName'] == 'Receipt.pdf'
+    assert base64.b64decode(attachments[1]['fileBytes']).decode('utf-8') == 'pdf_content_2'

--- a/queue_services/business-emailer/tests/unit/email_processors/test_agm_location_change_notification.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_agm_location_change_notification.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """The Unit Tests for AGM location change email processor."""
+import base64
 from unittest.mock import patch
 
 import pytest
+import requests_mock
 from business_model.models import Business
 
 from business_emailer.email_processors import agm_location_change_notification
@@ -52,3 +54,34 @@ def test_agm_location_change_notification(app, session, status, legal_name, is_n
             assert mock_get_pdfs.call_args[0][1]['legalName'] == legal_name
             assert mock_get_pdfs.call_args[0][1]['legalType'] == Business.LegalTypes.COMP.value
             assert mock_get_pdfs.call_args[0][2] == filing
+
+
+def test_agm_location_change_attachments(session, config):
+    """Assert _get_pdfs assembles the AGM Location Change letter and receipt."""
+    identifier = 'BC1234567'
+    filing = prep_agm_location_change_filing(
+        identifier, '1', Business.LegalTypes.COMP.value, 'test business')
+    token = 'token'
+    with patch.object(agm_location_change_notification, 'get_recipient_from_auth',
+                      return_value='recipient@email.com'):
+        with requests_mock.Mocker() as m:
+            m.get(
+                f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+                f'/filings/{filing.id}/documents/letterOfAgmLocationChange',
+                content=b'pdf_content_1',
+                status_code=200,
+            )
+            m.post(
+                f'{config.get("PAY_API_URL")}/{filing.payment_token}/receipts',
+                content=b'pdf_content_2',
+                status_code=201,
+            )
+            output = agm_location_change_notification.process(
+                {'filingId': filing.id, 'type': 'agmLocationChange', 'option': 'COMPLETED'}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 2
+    assert attachments[0]['fileName'] == 'Letter of AGM Location Change Approval.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'
+    assert attachments[1]['fileName'] == 'Receipt.pdf'
+    assert base64.b64decode(attachments[1]['fileBytes']).decode('utf-8') == 'pdf_content_2'

--- a/queue_services/business-emailer/tests/unit/email_processors/test_amalgamation_notification.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_amalgamation_notification.py
@@ -52,3 +52,27 @@ def test_amalgamation_notification(app, session, mocker, status):
         assert mock_get_pdfs.call_args[0][0] == status
         assert mock_get_pdfs.call_args[0][1] == token
         assert mock_get_pdfs.call_args[0][3] == filing
+
+
+def test_amalgamation_notification_paid_without_business(app, session, mocker):
+    """Assert PAID amalgamation falls back to nameRequest when filing has no business_id."""
+    legal_name = 'test business'
+    filing = prep_amalgamation_filing(session, 'BC1234567', '1', Filing.Status.PAID.value, legal_name)
+    filing.business_id = None
+    filing.save()
+    token = 'token'
+    mocker.patch(
+        'business_emailer.email_processors.amalgamation_notification.get_entity_dashboard_url',
+        return_value='https://dummyurl.gov.bc.ca')
+    with patch.object(amalgamation_notification, '_get_pdfs', return_value=[]) as mock_get_pdfs:
+        email = amalgamation_notification.process(
+            {'filingId': filing.id, 'type': 'amalgamationApplication', 'option': Filing.Status.PAID.value}, token)
+
+        assert 'test@test.com' in email['recipients']
+        assert 'comp_party@email.com' in email['recipients']
+        assert email['content']['subject'] == legal_name + ' - Amalgamation'
+        assert email['content']['body']
+        # business dict passed to _get_pdfs should come from nameRequest with temp_reg identifier
+        passed_business = mock_get_pdfs.call_args[0][2]
+        assert passed_business['legalName'] == legal_name
+        assert passed_business['identifier'] == filing.temp_reg

--- a/queue_services/business-emailer/tests/unit/email_processors/test_amalgamation_notification.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_amalgamation_notification.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """The Unit Tests for the Amalgamation email processor."""
+import base64
 from unittest.mock import patch
 
 import pytest
+import requests_mock
 from business_model.models import Filing
 
 from business_emailer.email_processors import amalgamation_notification
@@ -76,3 +78,67 @@ def test_amalgamation_notification_paid_without_business(app, session, mocker):
         passed_business = mock_get_pdfs.call_args[0][2]
         assert passed_business['legalName'] == legal_name
         assert passed_business['identifier'] == filing.temp_reg
+
+
+def test_amalgamation_attachments_paid(session, mocker, config):
+    """PAID regular: Amalgamation Application (Regular) PDF + receipt."""
+    identifier = 'BC1234567'
+    filing = prep_amalgamation_filing(session, identifier, '1', Filing.Status.PAID.value, 'test business')
+    token = 'token'
+    mocker.patch(
+        'business_emailer.email_processors.amalgamation_notification.get_entity_dashboard_url',
+        return_value='https://dummyurl.gov.bc.ca')
+    with requests_mock.Mocker() as m:
+        m.get(
+            f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+            f'/filings/{filing.id}/documents/amalgamationApplication',
+            content=b'pdf_content_1',
+            status_code=200,
+        )
+        m.post(
+            f'{config.get("PAY_API_URL")}/{filing.payment_token}/receipts',
+            content=b'pdf_content_2',
+            status_code=201,
+        )
+        output = amalgamation_notification.process(
+            {'filingId': filing.id, 'type': 'amalgamationApplication', 'option': Filing.Status.PAID.value}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 2
+    assert attachments[0]['fileName'] == 'Amalgamation Application (Regular).pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'
+    assert attachments[1]['fileName'] == 'Receipt.pdf'
+    assert base64.b64decode(attachments[1]['fileBytes']).decode('utf-8') == 'pdf_content_2'
+
+
+def test_amalgamation_attachments_completed(session, mocker, config):
+    """COMPLETED: Certificate Of Amalgamation + Notice of Articles."""
+    identifier = 'BC1234567'
+    filing = prep_amalgamation_filing(session, identifier, '1', Filing.Status.COMPLETED.value, 'test business')
+    token = 'token'
+    mocker.patch(
+        'business_emailer.email_processors.amalgamation_notification.get_entity_dashboard_url',
+        return_value='https://dummyurl.gov.bc.ca')
+    with requests_mock.Mocker() as m:
+        m.get(
+            f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+            f'/filings/{filing.id}/documents/certificateOfAmalgamation',
+            content=b'pdf_content_1',
+            status_code=200,
+        )
+        m.get(
+            f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+            f'/filings/{filing.id}/documents/noticeOfArticles',
+            content=b'pdf_content_2',
+            status_code=200,
+        )
+        output = amalgamation_notification.process(
+            {'filingId': filing.id, 'type': 'amalgamationApplication', 'option': Filing.Status.COMPLETED.value},
+            token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 2
+    assert attachments[0]['fileName'] == 'Certificate Of Amalgamation.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'
+    assert attachments[1]['fileName'] == 'Notice of Articles.pdf'
+    assert base64.b64decode(attachments[1]['fileBytes']).decode('utf-8') == 'pdf_content_2'

--- a/queue_services/business-emailer/tests/unit/email_processors/test_amalgamation_out_notification.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_amalgamation_out_notification.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """The Unit Tests for the Amalgamation Out email processor."""
+import base64
 from unittest.mock import patch
 
 import pytest
+import requests_mock
 from business_model.models import Business
 
 from business_emailer.email_processors import amalgamation_out_notification
@@ -56,3 +58,26 @@ def test_amalgamation_out_notification(app, session, status, legal_type, submitt
             assert mock_get_pdfs.call_args[0][1]['legalName'] == legal_name
             assert mock_get_pdfs.call_args[0][1]['legalType'] == legal_type
             assert mock_get_pdfs.call_args[0][2] == filing
+
+
+def test_amalgamation_out_attachments(session, config):
+    """Assert _get_pdfs assembles just the receipt (no filing PDF for Amalgamation Out)."""
+    identifier = 'BC1234567'
+    filing = prep_amalgamation_out_filing(
+        session, identifier, '1', Business.LegalTypes.COMP.value, 'test business', None)
+    token = 'token'
+    with patch.object(amalgamation_out_notification, 'get_recipient_from_auth',
+                      return_value='recipient@email.com'):
+        with requests_mock.Mocker() as m:
+            m.post(
+                f'{config.get("PAY_API_URL")}/{filing.payment_token}/receipts',
+                content=b'pdf_content_1',
+                status_code=201,
+            )
+            output = amalgamation_out_notification.process(
+                {'filingId': filing.id, 'type': 'amalgamationOut', 'option': 'COMPLETED'}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 1
+    assert attachments[0]['fileName'] == 'Receipt.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'

--- a/queue_services/business-emailer/tests/unit/email_processors/test_appoint_receiver_notification.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_appoint_receiver_notification.py
@@ -25,7 +25,7 @@ def test_appoint_receiver_notification(app, session, status, legal_name, is_numb
     """Assert that the appoint_receiver email processor builds the expected email."""
     # setup filing + business for email
     filing = prep_appoint_receiver_filing(
-        session, 'BC1234567', '1', Business.LegalTypes.COMP.value, legal_name)
+        'BC1234567', '1', Business.LegalTypes.COMP.value, legal_name)
     token = 'token'
     # test processor
     with patch.object(appoint_receiver_notification, '_get_pdfs', return_value=[]) as mock_get_pdfs:
@@ -55,7 +55,7 @@ def test_appoint_receiver_attachments(session, config):
     """Assert _get_pdfs assembles the Appoint Receiver filing PDF and receipt."""
     identifier = 'BC1234567'
     filing = prep_appoint_receiver_filing(
-        session, identifier, '1', Business.LegalTypes.COMP.value, 'test business')
+        identifier, '1', Business.LegalTypes.COMP.value, 'test business')
     token = 'token'
     with patch.object(appoint_receiver_notification, 'get_recipient_from_auth',
                       return_value='recipient@email.com'):

--- a/queue_services/business-emailer/tests/unit/email_processors/test_appoint_receiver_notification.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_appoint_receiver_notification.py
@@ -1,0 +1,82 @@
+# Copyright © 2026 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""The Unit Tests for the Appoint Receiver email processor."""
+import base64
+from unittest.mock import patch
+
+import pytest
+import requests_mock
+from business_model.models import Business
+
+from business_emailer.email_processors import appoint_receiver_notification
+from tests.unit import prep_appoint_receiver_filing
+
+
+@pytest.mark.parametrize('status,legal_name,is_numbered', [
+    ('COMPLETED', 'test business', False),
+    ('COMPLETED', 'BC1234567', True),
+])
+def test_appoint_receiver_notification(app, session, status, legal_name, is_numbered):
+    """Assert that the appoint_receiver email processor builds the expected email."""
+    # setup filing + business for email
+    filing = prep_appoint_receiver_filing(
+        session, 'BC1234567', '1', Business.LegalTypes.COMP.value, legal_name)
+    token = 'token'
+    # test processor
+    with patch.object(appoint_receiver_notification, '_get_pdfs', return_value=[]) as mock_get_pdfs:
+        with patch.object(appoint_receiver_notification, 'get_recipient_from_auth',
+                          return_value='recipient@email.com'):
+            email = appoint_receiver_notification.process(
+                {'filingId': filing.id, 'type': 'appointReceiver', 'option': status}, token)
+
+            if is_numbered:
+                assert email['content']['subject'] == 'Numbered Company - Receiver appointed'
+            else:
+                assert email['content']['subject'] == f'{legal_name} - Receiver appointed'
+
+            assert email['recipients'] == 'recipient@email.com'
+            assert email['requestBy'] == 'BCRegistries@gov.bc.ca'
+            assert email['content']['body']
+            assert email['content']['attachments'] == []
+
+            assert mock_get_pdfs.call_args[0][0] == token
+            assert mock_get_pdfs.call_args[0][1]['identifier'] == 'BC1234567'
+            assert mock_get_pdfs.call_args[0][1]['legalName'] == legal_name
+            assert mock_get_pdfs.call_args[0][1]['legalType'] == Business.LegalTypes.COMP.value
+            assert mock_get_pdfs.call_args[0][2] == filing
+
+
+def test_appoint_receiver_attachments(session, config):
+    """Assert _get_pdfs assembles the Appoint Receiver filing PDF and receipt."""
+    identifier = 'BC1234567'
+    filing = prep_appoint_receiver_filing(
+        session, identifier, '1', Business.LegalTypes.COMP.value, 'test business')
+    token = 'token'
+    with patch.object(appoint_receiver_notification, 'get_recipient_from_auth',
+                      return_value='recipient@email.com'):
+        with requests_mock.Mocker() as m:
+            m.get(
+                f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+                f'/filings/{filing.id}/documents/appointReceiver',
+                content=b'pdf_content_1',
+                status_code=200,
+            )
+            m.post(
+                f'{config.get("PAY_API_URL")}/{filing.payment_token}/receipts',
+                content=b'pdf_content_2',
+                status_code=201,
+            )
+            output = appoint_receiver_notification.process(
+                {'filingId': filing.id, 'type': 'appointReceiver', 'option': 'COMPLETED'}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 2
+    assert attachments[0]['fileName'] == 'Appoint Receiver.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'
+    assert attachments[1]['fileName'] == 'Receipt.pdf'
+    assert base64.b64decode(attachments[1]['fileBytes']).decode('utf-8') == 'pdf_content_2'

--- a/queue_services/business-emailer/tests/unit/email_processors/test_cease_receiver_notification.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_cease_receiver_notification.py
@@ -25,7 +25,7 @@ def test_cease_receiver_notification(app, session, status, legal_name, is_number
     """Assert that the cease_receiver email processor builds the expected email."""
     # setup filing + business for email
     filing = prep_cease_receiver_filing(
-        session, 'BC1234567', '1', Business.LegalTypes.COMP.value, legal_name)
+        'BC1234567', '1', Business.LegalTypes.COMP.value, legal_name)
     token = 'token'
     # test processor
     with patch.object(cease_receiver_notification, '_get_pdfs', return_value=[]) as mock_get_pdfs:
@@ -55,7 +55,7 @@ def test_cease_receiver_attachments(session, config):
     """Assert _get_pdfs assembles the Cease Receiver filing PDF and receipt."""
     identifier = 'BC1234567'
     filing = prep_cease_receiver_filing(
-        session, identifier, '1', Business.LegalTypes.COMP.value, 'test business')
+        identifier, '1', Business.LegalTypes.COMP.value, 'test business')
     token = 'token'
     with patch.object(cease_receiver_notification, 'get_recipient_from_auth',
                       return_value='recipient@email.com'):

--- a/queue_services/business-emailer/tests/unit/email_processors/test_cease_receiver_notification.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_cease_receiver_notification.py
@@ -6,9 +6,11 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 """The Unit Tests for the Cease Receiver email processor."""
+import base64
 from unittest.mock import patch
 
 import pytest
+import requests_mock
 from business_model.models import Business
 
 from business_emailer.email_processors import cease_receiver_notification
@@ -47,3 +49,34 @@ def test_cease_receiver_notification(app, session, status, legal_name, is_number
             assert mock_get_pdfs.call_args[0][1]['legalName'] == legal_name
             assert mock_get_pdfs.call_args[0][1]['legalType'] == Business.LegalTypes.COMP.value
             assert mock_get_pdfs.call_args[0][2] == filing
+
+
+def test_cease_receiver_attachments(session, config):
+    """Assert _get_pdfs assembles the Cease Receiver filing PDF and receipt."""
+    identifier = 'BC1234567'
+    filing = prep_cease_receiver_filing(
+        session, identifier, '1', Business.LegalTypes.COMP.value, 'test business')
+    token = 'token'
+    with patch.object(cease_receiver_notification, 'get_recipient_from_auth',
+                      return_value='recipient@email.com'):
+        with requests_mock.Mocker() as m:
+            m.get(
+                f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+                f'/filings/{filing.id}/documents/ceaseReceiver',
+                content=b'pdf_content_1',
+                status_code=200,
+            )
+            m.post(
+                f'{config.get("PAY_API_URL")}/{filing.payment_token}/receipts',
+                content=b'pdf_content_2',
+                status_code=201,
+            )
+            output = cease_receiver_notification.process(
+                {'filingId': filing.id, 'type': 'ceaseReceiver', 'option': 'COMPLETED'}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 2
+    assert attachments[0]['fileName'] == 'Cease Receiver.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'
+    assert attachments[1]['fileName'] == 'Receipt.pdf'
+    assert base64.b64decode(attachments[1]['fileBytes']).decode('utf-8') == 'pdf_content_2'

--- a/queue_services/business-emailer/tests/unit/email_processors/test_cease_receiver_notification.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_cease_receiver_notification.py
@@ -1,0 +1,49 @@
+# Copyright © 2026 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""The Unit Tests for the Cease Receiver email processor."""
+from unittest.mock import patch
+
+import pytest
+from business_model.models import Business
+
+from business_emailer.email_processors import cease_receiver_notification
+from tests.unit import prep_cease_receiver_filing
+
+
+@pytest.mark.parametrize('status,legal_name,is_numbered', [
+    ('COMPLETED', 'test business', False),
+    ('COMPLETED', 'BC1234567', True),
+])
+def test_cease_receiver_notification(app, session, status, legal_name, is_numbered):
+    """Assert that the cease_receiver email processor builds the expected email."""
+    # setup filing + business for email
+    filing = prep_cease_receiver_filing(
+        session, 'BC1234567', '1', Business.LegalTypes.COMP.value, legal_name)
+    token = 'token'
+    # test processor
+    with patch.object(cease_receiver_notification, '_get_pdfs', return_value=[]) as mock_get_pdfs:
+        with patch.object(cease_receiver_notification, 'get_recipient_from_auth',
+                          return_value='recipient@email.com'):
+            email = cease_receiver_notification.process(
+                {'filingId': filing.id, 'type': 'ceaseReceiver', 'option': status}, token)
+
+            if is_numbered:
+                assert email['content']['subject'] == 'Numbered Company - Receiver Ceased'
+            else:
+                assert email['content']['subject'] == f'{legal_name} - Receiver Ceased'
+
+            assert email['recipients'] == 'recipient@email.com'
+            assert email['requestBy'] == 'BCRegistries@gov.bc.ca'
+            assert email['content']['body']
+            assert email['content']['attachments'] == []
+
+            assert mock_get_pdfs.call_args[0][0] == token
+            assert mock_get_pdfs.call_args[0][1]['identifier'] == 'BC1234567'
+            assert mock_get_pdfs.call_args[0][1]['legalName'] == legal_name
+            assert mock_get_pdfs.call_args[0][1]['legalType'] == Business.LegalTypes.COMP.value
+            assert mock_get_pdfs.call_args[0][2] == filing

--- a/queue_services/business-emailer/tests/unit/email_processors/test_change_of_registration_notification.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_change_of_registration_notification.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """The Unit Tests for the Change of Registration email processor."""
+import base64
 from unittest.mock import patch
 
 import pytest
+import requests_mock
 from business_model.models import Business
 
 from business_emailer.email_processors import change_of_registration_notification
@@ -76,3 +78,67 @@ def test_change_of_registration_notification(app, session, mocker, status, legal
         if status == 'COMPLETED':
             assert mock_get_pdfs.call_args[0][2]['identifier'] == 'FM1234567'
         assert mock_get_pdfs.call_args[0][3] == filing
+
+
+def _cor_filing(session, identifier='FM1234567'):
+    parties = [{
+        'firstName': 'Jane', 'lastName': 'Doe', 'middleInitial': 'A',
+        'partyType': 'person', 'organizationName': ''
+    }]
+    return prep_change_of_registration_filing(
+        session, identifier, '1', Business.LegalTypes.SOLE_PROP.value, 'test business', None, parties)
+
+
+def test_change_of_registration_attachments_paid(session, mocker, config):
+    """Assert PAID path attaches the filing PDF and the receipt."""
+    identifier = 'FM1234567'
+    filing = _cor_filing(session, identifier)
+    token = 'token'
+    mocker.patch(
+        'business_emailer.email_processors.change_of_registration_notification.get_user_email_from_auth',
+        return_value='user@email.com')
+    with requests_mock.Mocker() as m:
+        m.get(
+            f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+            f'/filings/{filing.id}/documents/changeOfRegistration',
+            content=b'pdf_content_1',
+            status_code=200,
+        )
+        m.post(
+            f'{config.get("PAY_API_URL")}/{filing.payment_token}/receipts',
+            content=b'pdf_content_2',
+            status_code=201,
+        )
+        output = change_of_registration_notification.process(
+            {'filingId': filing.id, 'type': 'changeOfRegistration', 'option': 'PAID'}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 2
+    assert attachments[0]['fileName'] == 'Change of Registration.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'
+    assert attachments[1]['fileName'] == 'Receipt.pdf'
+    assert base64.b64decode(attachments[1]['fileBytes']).decode('utf-8') == 'pdf_content_2'
+
+
+def test_change_of_registration_attachments_completed(session, mocker, config):
+    """Assert COMPLETED path attaches only the Amended Registration Statement."""
+    identifier = 'FM1234567'
+    filing = _cor_filing(session, identifier)
+    token = 'token'
+    mocker.patch(
+        'business_emailer.email_processors.change_of_registration_notification.get_user_email_from_auth',
+        return_value='user@email.com')
+    with requests_mock.Mocker() as m:
+        m.get(
+            f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+            f'/filings/{filing.id}/documents/amendedRegistrationStatement',
+            content=b'pdf_content_1',
+            status_code=200,
+        )
+        output = change_of_registration_notification.process(
+            {'filingId': filing.id, 'type': 'changeOfRegistration', 'option': 'COMPLETED'}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 1
+    assert attachments[0]['fileName'] == 'AmendedRegistrationStatement.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'

--- a/queue_services/business-emailer/tests/unit/email_processors/test_consent_amalgamation_out_notification.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_consent_amalgamation_out_notification.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """The Unit Tests for the Consent Amalgamation Out email processor."""
+import base64
 from unittest.mock import patch
 
 import pytest
+import requests_mock
 from business_model.models import Business
 
 from business_emailer.email_processors import consent_amalgamation_out_notification
@@ -56,3 +58,34 @@ def test_consent_amalgamation_out_notification(app, session, status, legal_type,
             assert mock_get_pdfs.call_args[0][1]['legalName'] == legal_name
             assert mock_get_pdfs.call_args[0][1]['legalType'] == legal_type
             assert mock_get_pdfs.call_args[0][2] == filing
+
+
+def test_consent_amalgamation_out_attachments(session, config):
+    """Assert _get_pdfs assembles the Letter of Consent and receipt."""
+    identifier = 'BC1234567'
+    filing = prep_consent_amalgamation_out_filing(
+        session, identifier, '1', Business.LegalTypes.COMP.value, 'test business', None)
+    token = 'token'
+    with patch.object(consent_amalgamation_out_notification, 'get_recipient_from_auth',
+                      return_value='recipient@email.com'):
+        with requests_mock.Mocker() as m:
+            m.get(
+                f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+                f'/filings/{filing.id}/documents/letterOfConsentAmalgamationOut',
+                content=b'pdf_content_1',
+                status_code=200,
+            )
+            m.post(
+                f'{config.get("PAY_API_URL")}/{filing.payment_token}/receipts',
+                content=b'pdf_content_2',
+                status_code=201,
+            )
+            output = consent_amalgamation_out_notification.process(
+                {'filingId': filing.id, 'type': 'consentAmalgamationOut', 'option': 'COMPLETED'}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 2
+    assert attachments[0]['fileName'] == 'Letter of Consent.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'
+    assert attachments[1]['fileName'] == 'Receipt.pdf'
+    assert base64.b64decode(attachments[1]['fileBytes']).decode('utf-8') == 'pdf_content_2'

--- a/queue_services/business-emailer/tests/unit/email_processors/test_consent_continuation_out_notification.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_consent_continuation_out_notification.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """The Unit Tests for the Consent Continuation Out email processor."""
+import base64
 from unittest.mock import patch
 
 import pytest
+import requests_mock
 from business_model.models import Business
 
 from business_emailer.email_processors import consent_continuation_out_notification
@@ -56,3 +58,34 @@ def test_consent_continuation_out_notification(app, session, status, legal_type,
             assert mock_get_pdfs.call_args[0][1]['legalName'] == legal_name
             assert mock_get_pdfs.call_args[0][1]['legalType'] == legal_type
             assert mock_get_pdfs.call_args[0][2] == filing
+
+
+def test_consent_continuation_out_attachments(session, config):
+    """Assert _get_pdfs assembles the Letter of Consent and receipt."""
+    identifier = 'BC1234567'
+    filing = prep_consent_continuation_out_filing(
+        session, identifier, '1', Business.LegalTypes.COMP.value, 'test business', None)
+    token = 'token'
+    with patch.object(consent_continuation_out_notification, 'get_recipient_from_auth',
+                      return_value='recipient@email.com'):
+        with requests_mock.Mocker() as m:
+            m.get(
+                f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+                f'/filings/{filing.id}/documents/letterOfConsent',
+                content=b'pdf_content_1',
+                status_code=200,
+            )
+            m.post(
+                f'{config.get("PAY_API_URL")}/{filing.payment_token}/receipts',
+                content=b'pdf_content_2',
+                status_code=201,
+            )
+            output = consent_continuation_out_notification.process(
+                {'filingId': filing.id, 'type': 'consentContinuationOut', 'option': 'COMPLETED'}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 2
+    assert attachments[0]['fileName'] == 'Letter of Consent.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'
+    assert attachments[1]['fileName'] == 'Receipt.pdf'
+    assert base64.b64decode(attachments[1]['fileBytes']).decode('utf-8') == 'pdf_content_2'

--- a/queue_services/business-emailer/tests/unit/email_processors/test_continuation_in_notification.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_continuation_in_notification.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """The Unit Tests for the Amalgamation email processor."""
+import base64
 from unittest.mock import patch
 
 import pytest
+import requests_mock
 from business_model.models import Filing
 
 from business_emailer.email_processors import continuation_in_notification
@@ -57,3 +59,90 @@ def test_continuation_in_notification(app, session, mocker, status, subject, con
 
         if status == Filing.Status.PAID.value:
             assert 'comp_party@email.com' in email['recipients']
+
+
+def test_continuation_in_attachments_paid(session, mocker, config):
+    """Assert PAID path attaches the Continuation Application (Pending) and the receipt."""
+    identifier = 'C1234567'
+    filing = prep_continuation_in_filing(session, identifier, '1', Filing.Status.PAID.value)
+    token = 'token'
+    mocker.patch(
+        'business_emailer.email_processors.continuation_in_notification.get_entity_dashboard_url',
+        return_value='https://dummyurl.gov.bc.ca')
+    with requests_mock.Mocker() as m:
+        m.get(
+            f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+            f'/filings/{filing.id}/documents/continuationIn',
+            content=b'pdf_content_1',
+            status_code=200,
+        )
+        m.post(
+            f'{config.get("PAY_API_URL")}/{filing.payment_token}/receipts',
+            content=b'pdf_content_2',
+            status_code=201,
+        )
+        output = continuation_in_notification.process(
+            {'filingId': filing.id, 'type': 'continuationIn', 'option': Filing.Status.PAID.value}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 2
+    assert attachments[0]['fileName'] == 'Continuation Application - Pending.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'
+    assert attachments[1]['fileName'] == 'Receipt.pdf'
+    assert base64.b64decode(attachments[1]['fileBytes']).decode('utf-8') == 'pdf_content_2'
+
+
+def test_continuation_in_attachments_resubmitted(session, mocker, config):
+    """Assert RESUBMITTED path attaches only the Continuation Application (Resubmitted)."""
+    identifier = 'C1234567'
+    filing = prep_continuation_in_filing(session, identifier, '1', 'RESUBMITTED')
+    token = 'token'
+    mocker.patch(
+        'business_emailer.email_processors.continuation_in_notification.get_entity_dashboard_url',
+        return_value='https://dummyurl.gov.bc.ca')
+    with requests_mock.Mocker() as m:
+        m.get(
+            f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+            f'/filings/{filing.id}/documents/continuationIn',
+            content=b'pdf_content_1',
+            status_code=200,
+        )
+        output = continuation_in_notification.process(
+            {'filingId': filing.id, 'type': 'continuationIn', 'option': 'RESUBMITTED'}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 1
+    assert attachments[0]['fileName'] == 'Continuation Application - Resubmitted.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'
+
+
+def test_continuation_in_attachments_completed(session, mocker, config):
+    """Assert COMPLETED path attaches Certificate of Continuation and Notice of Articles."""
+    identifier = 'C1234567'
+    filing = prep_continuation_in_filing(session, identifier, '1', Filing.Status.COMPLETED.value)
+    token = 'token'
+    mocker.patch(
+        'business_emailer.email_processors.continuation_in_notification.get_entity_dashboard_url',
+        return_value='https://dummyurl.gov.bc.ca')
+    with requests_mock.Mocker() as m:
+        m.get(
+            f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+            f'/filings/{filing.id}/documents/certificateOfContinuation',
+            content=b'pdf_content_1',
+            status_code=200,
+        )
+        m.get(
+            f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+            f'/filings/{filing.id}/documents/noticeOfArticles',
+            content=b'pdf_content_2',
+            status_code=200,
+        )
+        output = continuation_in_notification.process(
+            {'filingId': filing.id, 'type': 'continuationIn', 'option': Filing.Status.COMPLETED.value}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 2
+    assert attachments[0]['fileName'] == 'Certificate of Continuation.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'
+    assert attachments[1]['fileName'] == 'Notice of Articles.pdf'
+    assert base64.b64decode(attachments[1]['fileBytes']).decode('utf-8') == 'pdf_content_2'

--- a/queue_services/business-emailer/tests/unit/email_processors/test_continuation_out_notification.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_continuation_out_notification.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """The Unit Tests for the Continuation Out email processor."""
+import base64
 from unittest.mock import patch
 
 import pytest
+import requests_mock
 from business_model.models import Business
 
 from business_emailer.email_processors import continuation_out_notification
@@ -56,3 +58,26 @@ def test_continuation_out_notification(app, session, status, legal_type, submitt
             assert mock_get_pdfs.call_args[0][1]['legalName'] == legal_name
             assert mock_get_pdfs.call_args[0][1]['legalType'] == legal_type
             assert mock_get_pdfs.call_args[0][2] == filing
+
+
+def test_continuation_out_attachments(session, config):
+    """Assert _get_pdfs assembles just the receipt (no filing PDF for Continuation Out)."""
+    identifier = 'BC1234567'
+    filing = prep_continuation_out_filing(
+        session, identifier, '1', Business.LegalTypes.COMP.value, 'test business', None)
+    token = 'token'
+    with patch.object(continuation_out_notification, 'get_recipient_from_auth',
+                      return_value='recipient@email.com'):
+        with requests_mock.Mocker() as m:
+            m.post(
+                f'{config.get("PAY_API_URL")}/{filing.payment_token}/receipts',
+                content=b'pdf_content_1',
+                status_code=201,
+            )
+            output = continuation_out_notification.process(
+                {'filingId': filing.id, 'type': 'continuationOut', 'option': 'COMPLETED'}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 1
+    assert attachments[0]['fileName'] == 'Receipt.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'

--- a/queue_services/business-emailer/tests/unit/email_processors/test_correction_notification.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_correction_notification.py
@@ -22,6 +22,7 @@ from business_model.models import Business
 from business_emailer.email_processors import correction_notification
 from tests.unit import (
     prep_cp_special_resolution_correction_filing,
+    prep_cp_special_resolution_correction_upload_memorandum_filing,
     prep_cp_special_resolution_filing,
     prep_firm_correction_filing,
     prep_incorp_filing,
@@ -267,3 +268,52 @@ def test_paid_special_resolution_correction_on_correction(session, config, legal
         assert 'cp_sr@test.com' in email['recipients']
         assert email['content']['body']
         assert email['content']['attachments'] == []
+
+
+def test_complete_special_resolution_correction_memorandum_attachments(session, config):
+    """Completed CP SR correction with memorandumFileKey → Certified Memorandum attached.
+
+    The upload_memorandum prep adds `memorandumFileKey` but leaves the template's
+    default `rulesFileKey` in place, so `rules_changed` is also True in the
+    processor — we expect Special Resolution + Certified Rules + Certified
+    Memorandum (3 attachments). The point of this test is to exercise the
+    `if memorandum_changed:` branch in special_resolution_helper.get_completed_pdfs.
+    """
+    legal_type = Business.LegalTypes.COOP.value
+    legal_name = 'test cp sr business'
+    token = 'token'
+    original_filing = prep_cp_special_resolution_filing(
+        CP_IDENTIFIER, '1', legal_type, legal_name, submitter_role=None)
+    business = Business.find_by_identifier(CP_IDENTIFIER)
+    filing = prep_cp_special_resolution_correction_upload_memorandum_filing(
+        session, business, original_filing.id, '1', 'COMPLETED', SPECIAL_RESOLUTION_FILING_TYPE)
+    with requests_mock.Mocker() as m:
+        m.get(
+            f'{config.get("LEGAL_API_URL")}/businesses/{CP_IDENTIFIER}'
+            f'/filings/{filing.id}/documents/specialResolution',
+            content=b'pdf_content_1',
+            status_code=200,
+        )
+        m.get(
+            f'{config.get("LEGAL_API_URL")}/businesses/{CP_IDENTIFIER}'
+            f'/filings/{filing.id}/documents/certifiedRules',
+            content=b'pdf_content_2',
+            status_code=200,
+        )
+        m.get(
+            f'{config.get("LEGAL_API_URL")}/businesses/{CP_IDENTIFIER}'
+            f'/filings/{filing.id}/documents/certifiedMemorandum',
+            content=b'pdf_content_3',
+            status_code=200,
+        )
+        output = correction_notification.process(
+            {'filingId': filing.id, 'type': 'correction', 'option': 'COMPLETED'}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 3
+    assert attachments[0]['fileName'] == 'Special Resolution.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'
+    assert attachments[1]['fileName'] == 'Certified Rules.pdf'
+    assert base64.b64decode(attachments[1]['fileBytes']).decode('utf-8') == 'pdf_content_2'
+    assert attachments[2]['fileName'] == 'Certified Memorandum.pdf'
+    assert base64.b64decode(attachments[2]['fileBytes']).decode('utf-8') == 'pdf_content_3'

--- a/queue_services/business-emailer/tests/unit/email_processors/test_dissolution_notification.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_dissolution_notification.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """The Unit Tests for the Dissolution email processor."""
+import base64
 from unittest.mock import patch
 
 import pytest
+import requests_mock
 from business_model.models import Business
 
 from business_emailer.email_processors import dissolution_notification
@@ -116,3 +118,155 @@ def test_firms_dissolution_notification(app, session, status, legal_type, submit
                 assert mock_get_pdfs.call_args[0][2]['legalName'] == 'JANE A DOE'
                 assert mock_get_pdfs.call_args[0][2]['legalType'] == legal_type
                 assert mock_get_pdfs.call_args[0][3] == filing
+
+
+def test_dissolution_attachments_paid_bc(session, config):
+    """PAID BC: Voluntary Dissolution Application + receipt."""
+    identifier = 'BC1234567'
+    filing = prep_dissolution_filing(
+        session, identifier, '1', 'PAID', Business.LegalTypes.COMP.value, 'test business', None)
+    token = 'token'
+    with patch.object(dissolution_notification, 'get_recipient_from_auth', return_value='recipient@email.com'):
+        with patch.object(dissolution_notification, 'get_user_email_from_auth', return_value='user@email.com'):
+            with requests_mock.Mocker() as m:
+                m.get(
+                    f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+                    f'/filings/{filing.id}/documents/dissolution',
+                    content=b'pdf_content_1',
+                    status_code=200,
+                )
+                m.post(
+                    f'{config.get("PAY_API_URL")}/{filing.payment_token}/receipts',
+                    content=b'pdf_content_2',
+                    status_code=201,
+                )
+                output = dissolution_notification.process(
+                    {'filingId': filing.id, 'type': 'dissolution', 'option': 'PAID'}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 2
+    assert attachments[0]['fileName'] == 'Voluntary Dissolution Application.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'
+    assert attachments[1]['fileName'] == 'Receipt.pdf'
+    assert base64.b64decode(attachments[1]['fileBytes']).decode('utf-8') == 'pdf_content_2'
+
+
+def test_dissolution_attachments_paid_sp_receipt_only(session, config):
+    """PAID SP: no filing PDF (SP/GP excluded) — receipt only."""
+    identifier = 'FM1234567'
+    parties = [{
+        'firstName': 'Jane', 'lastName': 'Doe', 'middleInitial': 'A',
+        'partyType': 'person', 'organizationName': ''
+    }]
+    filing = prep_dissolution_filing(
+        session, identifier, '1', 'PAID', Business.LegalTypes.SOLE_PROP.value,
+        'test business', None, parties)
+    token = 'token'
+    with patch.object(dissolution_notification, 'get_recipient_from_auth', return_value='recipient@email.com'):
+        with patch.object(dissolution_notification, 'get_user_email_from_auth', return_value='user@email.com'):
+            with requests_mock.Mocker() as m:
+                m.post(
+                    f'{config.get("PAY_API_URL")}/{filing.payment_token}/receipts',
+                    content=b'pdf_content_1',
+                    status_code=201,
+                )
+                output = dissolution_notification.process(
+                    {'filingId': filing.id, 'type': 'dissolution', 'option': 'PAID'}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 1
+    assert attachments[0]['fileName'] == 'Receipt.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'
+
+
+def test_dissolution_attachments_completed_sp(session, config):
+    """COMPLETED SP: Statement of Dissolution only."""
+    identifier = 'FM1234567'
+    parties = [{
+        'firstName': 'Jane', 'lastName': 'Doe', 'middleInitial': 'A',
+        'partyType': 'person', 'organizationName': ''
+    }]
+    filing = prep_dissolution_filing(
+        session, identifier, '1', 'COMPLETED', Business.LegalTypes.SOLE_PROP.value,
+        'test business', None, parties)
+    token = 'token'
+    with patch.object(dissolution_notification, 'get_recipient_from_auth', return_value='recipient@email.com'):
+        with patch.object(dissolution_notification, 'get_user_email_from_auth', return_value='user@email.com'):
+            with requests_mock.Mocker() as m:
+                m.get(
+                    f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+                    f'/filings/{filing.id}/documents/dissolution',
+                    content=b'pdf_content_1',
+                    status_code=200,
+                )
+                output = dissolution_notification.process(
+                    {'filingId': filing.id, 'type': 'dissolution', 'option': 'COMPLETED'}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 1
+    assert attachments[0]['fileName'] == 'Statement of Dissolution.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'
+
+
+def test_dissolution_attachments_completed_bc(session, config):
+    """COMPLETED BC (non-admin): Certificate of Dissolution."""
+    identifier = 'BC1234567'
+    filing = prep_dissolution_filing(
+        session, identifier, '1', 'COMPLETED', Business.LegalTypes.COMP.value, 'test business', None)
+    token = 'token'
+    with patch.object(dissolution_notification, 'get_recipient_from_auth', return_value='recipient@email.com'):
+        with patch.object(dissolution_notification, 'get_user_email_from_auth', return_value='user@email.com'):
+            with requests_mock.Mocker() as m:
+                m.get(
+                    f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+                    f'/filings/{filing.id}/documents/certificateOfDissolution',
+                    content=b'pdf_content_1',
+                    status_code=200,
+                )
+                output = dissolution_notification.process(
+                    {'filingId': filing.id, 'type': 'dissolution', 'option': 'COMPLETED'}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 1
+    assert attachments[0]['fileName'] == 'Certificate of Dissolution.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'
+
+
+def test_dissolution_attachments_completed_coop(session, config):
+    """COMPLETED COOP: Certificate of Dissolution + Certified Affidavit + Certified Special Resolution."""
+    identifier = 'CP1234567'
+    filing = prep_dissolution_filing(
+        session, identifier, '1', 'COMPLETED', Business.LegalTypes.COOP.value, 'test business', None)
+    token = 'token'
+    with patch.object(dissolution_notification, 'get_recipient_from_auth', return_value='recipient@email.com'):
+        with patch.object(dissolution_notification, 'get_user_email_from_auth', return_value='user@email.com'):
+            with requests_mock.Mocker() as m:
+                m.get(
+                    f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+                    f'/filings/{filing.id}/documents/certificateOfDissolution',
+                    content=b'pdf_content_1',
+                    status_code=200,
+                )
+                m.get(
+                    f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+                    f'/filings/{filing.id}/documents/affidavit',
+                    content=b'pdf_content_2',
+                    status_code=200,
+                )
+                m.get(
+                    f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+                    f'/filings/{filing.id}/documents/specialResolution',
+                    content=b'pdf_content_3',
+                    status_code=200,
+                )
+                output = dissolution_notification.process(
+                    {'filingId': filing.id, 'type': 'dissolution', 'option': 'COMPLETED'}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 3
+    assert attachments[0]['fileName'] == 'Certificate of Dissolution.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'
+    assert attachments[1]['fileName'] == 'Certified Affidavit.pdf'
+    assert base64.b64decode(attachments[1]['fileBytes']).decode('utf-8') == 'pdf_content_2'
+    assert attachments[2]['fileName'] == 'Certified Special Resolution.pdf'
+    assert base64.b64decode(attachments[2]['fileBytes']).decode('utf-8') == 'pdf_content_3'

--- a/queue_services/business-emailer/tests/unit/email_processors/test_email_processors_init.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_email_processors_init.py
@@ -1,0 +1,107 @@
+# Copyright © 2024 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for helpers in business_emailer.email_processors package __init__."""
+import pytest
+import requests_mock
+
+from business_emailer.email_processors import (
+    get_account_by_affiliated_identifier,
+    get_entity_dashboard_url,
+    get_org_id_for_temp_identifier,
+)
+
+
+@pytest.fixture
+def auth_url(app):
+    """Set AUTH_URL / AUTH_WEB_URL to dummy values for the duration of a test."""
+    original_api = app.config.get('AUTH_URL')
+    original_web = app.config.get('AUTH_WEB_URL')
+    app.config['AUTH_URL'] = 'https://auth-api-url'
+    app.config['AUTH_WEB_URL'] = 'https://auth-web-url/'
+    yield app.config['AUTH_URL']
+    app.config['AUTH_URL'] = original_api
+    app.config['AUTH_WEB_URL'] = original_web
+
+
+def test_get_account_by_affiliated_identifier_returns_json(app, auth_url):
+    """Assert the affiliated-account JSON is returned when the auth response is valid JSON."""
+    identifier = 'BC1234567'
+    token = 'token'
+    expected = {'orgs': [{'id': 42, 'name': 'Acme'}]}
+    url = f'{auth_url}/orgs?affiliation={identifier}'
+
+    with app.app_context(), requests_mock.Mocker() as m:
+        m.get(url, json=expected, status_code=200)
+        result = get_account_by_affiliated_identifier(identifier, token)
+
+        assert result == expected
+        assert m.last_request.headers['Authorization'] == f'Bearer {token}'
+        assert m.last_request.headers['Accept'] == 'application/json'
+
+
+def test_get_account_by_affiliated_identifier_returns_none_on_bad_json(app, auth_url):
+    """Assert None is returned when the auth response body is not valid JSON."""
+    identifier = 'BC1234567'
+    url = f'{auth_url}/orgs?affiliation={identifier}'
+
+    with app.app_context(), requests_mock.Mocker() as m:
+        m.get(url, text='not json', status_code=200)
+        result = get_account_by_affiliated_identifier(identifier, 'token')
+
+        assert result is None
+
+
+def test_get_org_id_for_temp_identifier_returns_first_org_id(app, auth_url):
+    """Assert the first org id is returned when orgs are present."""
+    identifier = 'T12345'
+    url = f'{auth_url}/orgs?affiliation={identifier}'
+
+    with app.app_context(), requests_mock.Mocker() as m:
+        m.get(url, json={'orgs': [{'id': 99}, {'id': 100}]}, status_code=200)
+        assert get_org_id_for_temp_identifier(identifier, 'token') == 99
+
+
+@pytest.mark.parametrize('identifier,response_json', [
+    ('T12345', {'orgs': []}),
+    ('BC1234567', {'orgs': []}),
+    ('T12345', {}),
+])
+def test_get_org_id_for_temp_identifier_raises_when_no_orgs(app, auth_url, identifier, response_json):
+    """Assert Exception is raised when orgs are missing or empty (both T and non-T identifiers)."""
+    url = f'{auth_url}/orgs?affiliation={identifier}'
+
+    with app.app_context(), requests_mock.Mocker() as m:
+        m.get(url, json=response_json, status_code=200)
+        with pytest.raises(Exception):
+            get_org_id_for_temp_identifier(identifier, 'token')
+
+
+def test_get_entity_dashboard_url_non_temp_uses_dashboard_url(app, auth_url, config):
+    """Assert non-temp identifiers return DASHBOARD_URL + identifier and make no HTTP calls."""
+    identifier = 'BC1234567'
+    with app.app_context(), requests_mock.Mocker() as m:
+        url = get_entity_dashboard_url(identifier, 'token')
+        assert url == config.get('DASHBOARD_URL') + identifier
+        assert m.call_count == 0
+
+
+def test_get_entity_dashboard_url_temp_uses_auth_web_url(app, auth_url):
+    """Assert temp identifiers resolve to AUTH_WEB_URL + account/<org_id>/business."""
+    identifier = 'T12345'
+    orgs_url = f'{auth_url}/orgs?affiliation={identifier}'
+
+    with app.app_context(), requests_mock.Mocker() as m:
+        m.get(orgs_url, json={'orgs': [{'id': 77}]}, status_code=200)
+        url = get_entity_dashboard_url(identifier, 'token')
+        assert url == 'https://auth-web-url/account/77/business'

--- a/queue_services/business-emailer/tests/unit/email_processors/test_filing_notification.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_filing_notification.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """The Unit Tests for the Incorporation email processor."""
+import base64
 from unittest.mock import patch
 
 import pytest
+import requests_mock
 from business_model.models import Business
 
 from business_emailer.email_processors import filing_notification
@@ -124,3 +126,177 @@ def test_maintenance_notification(app, session, mocker, status, filing_type, sub
             assert mock_get_recipients.call_args[0][0] == status
             assert mock_get_recipients.call_args[0][1] == filing.filing_json
             assert mock_get_recipients.call_args[0][2] == token
+
+
+def test_filing_attachments_ia_paid(session, mocker, config):
+    """IA PAID: filing PDF + receipt."""
+    identifier = 'BC1234567'
+    filing = prep_incorp_filing(session, identifier, '1', 'PAID', 'BC')
+    token = 'token'
+    mocker.patch(
+        'business_emailer.email_processors.filing_notification.get_entity_dashboard_url',
+        return_value='https://dummyurl.gov.bc.ca')
+    with requests_mock.Mocker() as m:
+        m.get(
+            f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+            f'/filings/{filing.id}/documents/incorporationApplication',
+            content=b'pdf_content_1',
+            status_code=200,
+        )
+        m.post(
+            f'{config.get("PAY_API_URL")}/{filing.payment_token}/receipts',
+            content=b'pdf_content_2',
+            status_code=201,
+        )
+        output = filing_notification.process(
+            {'filingId': filing.id, 'type': 'incorporationApplication', 'option': 'PAID'}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 2
+    assert attachments[0]['fileName'] == 'Incorporation Application.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'
+    assert attachments[1]['fileName'] == 'Receipt.pdf'
+    assert base64.b64decode(attachments[1]['fileBytes']).decode('utf-8') == 'pdf_content_2'
+
+
+def test_filing_attachments_ia_completed_bc(session, mocker, config):
+    """IA COMPLETED BC: Notice of Articles + Certificate of Incorporation."""
+    identifier = 'BC1234567'
+    filing = prep_incorp_filing(session, identifier, '1', 'COMPLETED', 'BC')
+    token = 'token'
+    mocker.patch(
+        'business_emailer.email_processors.filing_notification.get_entity_dashboard_url',
+        return_value='https://dummyurl.gov.bc.ca')
+    with requests_mock.Mocker() as m:
+        m.get(
+            f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+            f'/filings/{filing.id}/documents/noticeOfArticles',
+            content=b'pdf_content_1',
+            status_code=200,
+        )
+        m.get(
+            f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+            f'/filings/{filing.id}/documents/certificateOfIncorporation',
+            content=b'pdf_content_2',
+            status_code=200,
+        )
+        output = filing_notification.process(
+            {'filingId': filing.id, 'type': 'incorporationApplication', 'option': 'COMPLETED'}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 2
+    assert attachments[0]['fileName'] == 'Notice of Articles.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'
+    assert attachments[1]['fileName'] == 'Certificate Of Incorporation.pdf'
+    assert base64.b64decode(attachments[1]['fileBytes']).decode('utf-8') == 'pdf_content_2'
+
+
+def test_filing_attachments_ia_completed_coop(session, mocker, config):
+    """IA COMPLETED COOP: Certificate + Certified Rules + Certified Memorandum (no NOA)."""
+    identifier = 'CP1234567'
+    filing = prep_incorp_filing(session, identifier, '1', 'COMPLETED', 'CP')
+    token = 'token'
+    mocker.patch(
+        'business_emailer.email_processors.filing_notification.get_entity_dashboard_url',
+        return_value='https://dummyurl.gov.bc.ca')
+    with requests_mock.Mocker() as m:
+        m.get(
+            f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+            f'/filings/{filing.id}/documents/certificateOfIncorporation',
+            content=b'pdf_content_1',
+            status_code=200,
+        )
+        m.get(
+            f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+            f'/filings/{filing.id}/documents/certifiedRules',
+            content=b'pdf_content_2',
+            status_code=200,
+        )
+        m.get(
+            f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+            f'/filings/{filing.id}/documents/memorandum',
+            content=b'pdf_content_3',
+            status_code=200,
+        )
+        output = filing_notification.process(
+            {'filingId': filing.id, 'type': 'incorporationApplication', 'option': 'COMPLETED'}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 3
+    assert attachments[0]['fileName'] == 'Certificate Of Incorporation.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'
+    assert attachments[1]['fileName'] == 'Certified Rules.pdf'
+    assert base64.b64decode(attachments[1]['fileBytes']).decode('utf-8') == 'pdf_content_2'
+    assert attachments[2]['fileName'] == 'Certified Memorandum.pdf'
+    assert base64.b64decode(attachments[2]['fileBytes']).decode('utf-8') == 'pdf_content_3'
+
+
+def test_filing_attachments_change_of_address_paid(session, mocker, config):
+    """changeOfAddress PAID: filing PDF + receipt."""
+    identifier = 'BC1234567'
+    filing = prep_maintenance_filing(session, identifier, '1', 'PAID', 'changeOfAddress')
+    token = 'token'
+    mocker.patch(
+        'business_emailer.email_processors.filing_notification.get_entity_dashboard_url',
+        return_value='https://dummyurl.gov.bc.ca')
+    with patch.object(filing_notification, 'get_recipients', return_value='test@test.com'):
+        with requests_mock.Mocker() as m:
+            m.get(
+                f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+                f'/filings/{filing.id}/documents/changeOfAddress',
+                content=b'pdf_content_1',
+                status_code=200,
+            )
+            m.post(
+                f'{config.get("PAY_API_URL")}/{filing.payment_token}/receipts',
+                content=b'pdf_content_2',
+                status_code=201,
+            )
+            output = filing_notification.process(
+                {'filingId': filing.id, 'type': 'changeOfAddress', 'option': 'PAID'}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 2
+    assert attachments[0]['fileName'] == 'Change Of Address.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'
+    assert attachments[1]['fileName'] == 'Receipt.pdf'
+    assert base64.b64decode(attachments[1]['fileBytes']).decode('utf-8') == 'pdf_content_2'
+
+
+def test_filing_attachments_alteration_completed_name_change(session, mocker, config):
+    """alteration COMPLETED (BC, with name change): NOA + Certificate of Name Change."""
+    identifier = 'BC1234567'
+    filing = prep_maintenance_filing(session, identifier, '1', 'COMPLETED', 'alteration')
+    # force the name-change branch via meta_data
+    filing._meta_data = {'alteration': {'toLegalName': 'new name'}}
+    filing.save()
+    token = 'token'
+    mocker.patch(
+        'business_emailer.email_processors.filing_notification.get_user_email_from_auth',
+        return_value='user@email.com')
+    mocker.patch(
+        'business_emailer.email_processors.filing_notification.get_entity_dashboard_url',
+        return_value='https://dummyurl.gov.bc.ca')
+    with patch.object(filing_notification, 'get_recipients', return_value='test@test.com'):
+        with requests_mock.Mocker() as m:
+            m.get(
+                f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+                f'/filings/{filing.id}/documents/noticeOfArticles',
+                content=b'pdf_content_1',
+                status_code=200,
+            )
+            m.get(
+                f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+                f'/filings/{filing.id}/documents/certificateOfNameChange',
+                content=b'pdf_content_2',
+                status_code=200,
+            )
+            output = filing_notification.process(
+                {'filingId': filing.id, 'type': 'alteration', 'option': 'COMPLETED'}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 2
+    assert attachments[0]['fileName'] == 'Notice of Articles.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'
+    assert attachments[1]['fileName'] == 'Certificate of Name Change.pdf'
+    assert base64.b64decode(attachments[1]['fileBytes']).decode('utf-8') == 'pdf_content_2'

--- a/queue_services/business-emailer/tests/unit/email_processors/test_intent_to_liquidate_notification.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_intent_to_liquidate_notification.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """The Unit Tests for the Intent to Liquidate email processor."""
+import base64
 from unittest.mock import patch
 
 import pytest
+import requests_mock
 from business_model.models import Business
 
 from business_emailer.email_processors import intent_to_liquidate_notification
@@ -56,3 +58,34 @@ def test_intent_to_liquidate_notification(app, session, status, legal_type, subm
             assert mock_get_pdfs.call_args[0][1]['legalName'] == legal_name
             assert mock_get_pdfs.call_args[0][1]['legalType'] == legal_type
             assert mock_get_pdfs.call_args[0][2] == filing
+
+
+def test_intent_to_liquidate_attachments(session, config):
+    """Assert _get_pdfs assembles the Statement of Intent to Liquidate and receipt."""
+    identifier = 'BC1234567'
+    filing = prep_intent_to_liquidate_filing(
+        session, identifier, '1', Business.LegalTypes.COMP.value, 'test business', 'staff')
+    token = 'token'
+    with patch.object(intent_to_liquidate_notification, 'get_recipient_from_auth',
+                      return_value='recipient@email.com'):
+        with requests_mock.Mocker() as m:
+            m.get(
+                f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+                f'/filings/{filing.id}/documents/intentToLiquidate',
+                content=b'pdf_content_1',
+                status_code=200,
+            )
+            m.post(
+                f'{config.get("PAY_API_URL")}/{filing.payment_token}/receipts',
+                content=b'pdf_content_2',
+                status_code=201,
+            )
+            output = intent_to_liquidate_notification.process(
+                {'filingId': filing.id, 'type': 'intentToLiquidate', 'option': 'COMPLETED'}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 2
+    assert attachments[0]['fileName'] == 'Statement of Intent to Liquidate.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'
+    assert attachments[1]['fileName'] == 'Receipt.pdf'
+    assert base64.b64decode(attachments[1]['fileBytes']).decode('utf-8') == 'pdf_content_2'

--- a/queue_services/business-emailer/tests/unit/email_processors/test_name_request.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_name_request.py
@@ -1,0 +1,170 @@
+# Copyright © 2024 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for business_emailer.email_processors.name_request."""
+import base64
+from unittest.mock import patch
+
+import pytest
+import requests_mock
+
+from business_emailer.email_processors import name_request
+from business_emailer.services.namex import NameXService
+from tests import MockResponse
+
+
+NR_NUMBER = "NR 1234567"
+PAYMENT_TOKEN = "pay-token-abc"
+NR_ID = 99
+PAYMENT_ID = 42
+BEARER = "bearer-token"
+EMAIL_INFO = {"identifier": NR_NUMBER, "request": {"paymentToken": PAYMENT_TOKEN}}
+
+
+@pytest.fixture
+def namex_config(app):
+    """Set NAMEX_* config values for the duration of a test."""
+    keys = {
+        "NAMEX_SVC_URL": "https://namex-svc-url/",
+        "NAMEX_AUTH_SVC_URL": "https://namex-auth-url/token",
+        "NAMEX_SERVICE_CLIENT_USERNAME": "user",
+        "NAMEX_SERVICE_CLIENT_SECRET": "secret",
+    }
+    originals = {k: app.config.get(k) for k in keys}
+    app.config.update(keys)
+    yield app.config
+    for k, v in originals.items():
+        app.config[k] = v
+
+
+def _nr_json(email="test@test.com"):
+    return {"id": NR_ID, "applicants": {"emailAddress": email}}
+
+
+# --- process ---
+
+def test_process_happy_path(app, session, namex_config):
+    """Assert full processor output when NR, pdfs, and recipient are all present."""
+    nr_response = MockResponse(_nr_json(), 200)
+    pdfs = [{"fileName": "Receipt.pdf", "fileBytes": "x", "fileUrl": "", "attachOrder": "1"}]
+
+    with patch.object(NameXService, "query_nr_number", return_value=nr_response), \
+            patch.object(name_request, "_get_pdfs", return_value=pdfs) as mock_pdfs:
+        email = name_request.process(EMAIL_INFO)
+
+        assert email["recipients"] == "test@test.com"
+        assert email["content"]["subject"] == f"{NR_NUMBER} - Receipt from Corporate Registry"
+        assert email["content"]["attachments"] == pdfs
+        assert email["content"]["body"]
+        assert mock_pdfs.call_args[0] == (NR_ID, PAYMENT_TOKEN)
+
+
+def test_process_returns_empty_when_nr_lookup_fails(app, session, namex_config):
+    """Assert {} is returned when NameX responds with a non-200."""
+    with patch.object(NameXService, "query_nr_number", return_value=MockResponse({}, 500)):
+        assert name_request.process(EMAIL_INFO) == {}
+
+
+def test_process_returns_empty_when_no_pdfs(app, session, namex_config):
+    """Assert {} is returned when _get_pdfs yields nothing."""
+    with patch.object(NameXService, "query_nr_number", return_value=MockResponse(_nr_json(), 200)), \
+            patch.object(name_request, "_get_pdfs", return_value=[]):
+        assert name_request.process(EMAIL_INFO) == {}
+
+
+def test_process_returns_empty_when_no_recipients(app, session, namex_config):
+    """Assert {} is returned when the NR has no applicant email."""
+    pdfs = [{"fileName": "Receipt.pdf", "fileBytes": "x", "fileUrl": "", "attachOrder": "1"}]
+    with patch.object(NameXService, "query_nr_number",
+                      return_value=MockResponse(_nr_json(email=""), 200)), \
+            patch.object(name_request, "_get_pdfs", return_value=pdfs):
+        assert name_request.process(EMAIL_INFO) == {}
+
+
+# --- _get_pdfs ---
+
+@pytest.mark.parametrize("token,nr_id,payment_token", [
+    (None, NR_ID, PAYMENT_TOKEN),
+    (BEARER, None, PAYMENT_TOKEN),
+    (BEARER, NR_ID, ""),
+])
+def test_get_pdfs_returns_empty_on_missing_inputs(app, namex_config, token, nr_id, payment_token):
+    """Assert any missing input (token, nr_id, payment_token) short-circuits to []."""
+    with app.app_context(), patch.object(name_request, "get_nr_bearer_token", return_value=token):
+        assert name_request._get_pdfs(nr_id, payment_token) == []
+
+
+def test_get_pdfs_returns_empty_when_payments_lookup_fails(app, namex_config):
+    """Assert [] when the NameX payments endpoint returns non-200."""
+    with app.app_context(), \
+            patch.object(name_request, "get_nr_bearer_token", return_value=BEARER), \
+            requests_mock.Mocker() as m:
+        m.get(f'{namex_config["NAMEX_SVC_URL"]}payments/{NR_ID}', status_code=500)
+        assert name_request._get_pdfs(NR_ID, PAYMENT_TOKEN) == []
+
+
+def test_get_pdfs_returns_empty_when_no_matching_payment(app, namex_config):
+    """Assert [] when no payment record matches the payment token."""
+    with app.app_context(), \
+            patch.object(name_request, "get_nr_bearer_token", return_value=BEARER), \
+            requests_mock.Mocker() as m:
+        m.get(f'{namex_config["NAMEX_SVC_URL"]}payments/{NR_ID}',
+              json=[{"id": 1, "token": "other-token"}], status_code=200)
+        assert name_request._get_pdfs(NR_ID, PAYMENT_TOKEN) == []
+
+
+def test_get_pdfs_returns_empty_when_receipt_fails(app, namex_config):
+    """Assert [] when the receipt POST returns non-200."""
+    with app.app_context(), \
+            patch.object(name_request, "get_nr_bearer_token", return_value=BEARER), \
+            requests_mock.Mocker() as m:
+        m.get(f'{namex_config["NAMEX_SVC_URL"]}payments/{NR_ID}',
+              json=[{"id": PAYMENT_ID, "token": PAYMENT_TOKEN}], status_code=200)
+        m.post(f'{namex_config["NAMEX_SVC_URL"]}payments/{PAYMENT_ID}/receipt', status_code=500)
+        assert name_request._get_pdfs(NR_ID, PAYMENT_TOKEN) == []
+
+
+def test_get_pdfs_happy_path_encodes_receipt(app, namex_config):
+    """Assert the receipt PDF is base64-encoded into the returned attachment."""
+    pdf_bytes = b"%PDF-fake-content"
+    with app.app_context(), \
+            patch.object(name_request, "get_nr_bearer_token", return_value=BEARER), \
+            requests_mock.Mocker() as m:
+        m.get(f'{namex_config["NAMEX_SVC_URL"]}payments/{NR_ID}',
+              json=[{"id": 1, "token": "other"}, {"id": PAYMENT_ID, "token": PAYMENT_TOKEN}],
+              status_code=200)
+        m.post(f'{namex_config["NAMEX_SVC_URL"]}payments/{PAYMENT_ID}/receipt',
+               content=pdf_bytes, status_code=200)
+
+        pdfs = name_request._get_pdfs(NR_ID, PAYMENT_TOKEN)
+
+    assert len(pdfs) == 1
+    assert pdfs[0]["fileName"] == "Receipt.pdf"
+    assert pdfs[0]["attachOrder"] == "1"
+    assert base64.b64decode(pdfs[0]["fileBytes"]) == pdf_bytes
+
+
+# --- get_nr_bearer_token ---
+
+def test_get_nr_bearer_token_returns_access_token(app, namex_config):
+    """Assert the access_token field is extracted from the auth response."""
+    with app.app_context(), requests_mock.Mocker() as m:
+        m.post(namex_config["NAMEX_AUTH_SVC_URL"], json={"access_token": "abc"}, status_code=200)
+        assert name_request.get_nr_bearer_token() == "abc"
+
+
+def test_get_nr_bearer_token_returns_none_on_bad_json(app, namex_config):
+    """Assert None is returned when the auth response body is not valid JSON."""
+    with app.app_context(), requests_mock.Mocker() as m:
+        m.post(namex_config["NAMEX_AUTH_SVC_URL"], text="not json", status_code=200)
+        assert name_request.get_nr_bearer_token() is None

--- a/queue_services/business-emailer/tests/unit/email_processors/test_notice_of_withdrawal_notification.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_notice_of_withdrawal_notification.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """The Unit Tests for Notice of Withdrawal email processor."""
+import base64
 from unittest.mock import patch
 
 import pytest
+import requests_mock
 from business_model.models import RegistrationBootstrap
 from registry_schemas.example_data import (
     ALTERATION_FILING_TEMPLATE,
@@ -74,3 +76,38 @@ def test_notice_of_withdrawal_notification(
             assert mock_get_pdfs.call_args[0][1]['legalName'] == legal_name
             assert mock_get_pdfs.call_args[0][1]['legalType'] == legal_type
             assert mock_get_pdfs.call_args[0][2] == now_filing
+
+
+def test_notice_of_withdrawal_attachments(session, config):
+    """Assert _get_pdfs assembles the Notice of Withdrawal filing PDF and receipt."""
+    identifier = 'BC1234567'
+    legal_type = 'BC'
+    legal_name = 'test business'
+    business = create_business(identifier, legal_type, legal_name)
+    fe_filing = create_future_effective_filing(
+        identifier, legal_type, legal_name, 'changeOfAddress', CHANGE_OF_ADDRESS, False, business.id)
+    now_filing = prep_notice_of_withdraw_filing(identifier, '1', legal_type, legal_name, business.id, fe_filing)
+    token = 'token'
+    with patch.object(notice_of_withdrawal_notification, 'get_recipient_from_auth',
+                      return_value='recipient@email.com'):
+        with requests_mock.Mocker() as m:
+            m.get(
+                f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+                f'/filings/{now_filing.id}/documents/noticeOfWithdrawal',
+                content=b'pdf_content_1',
+                status_code=200,
+            )
+            m.post(
+                f'{config.get("PAY_API_URL")}/{now_filing.payment_token}/receipts',
+                content=b'pdf_content_2',
+                status_code=201,
+            )
+            output = notice_of_withdrawal_notification.process(
+                {'filingId': now_filing.id, 'type': 'noticeOfWithdrawal', 'option': 'COMPLETED'}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 2
+    assert attachments[0]['fileName'] == 'Notice of Withdrawal.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'
+    assert attachments[1]['fileName'] == 'Receipt.pdf'
+    assert base64.b64decode(attachments[1]['fileBytes']).decode('utf-8') == 'pdf_content_2'

--- a/queue_services/business-emailer/tests/unit/email_processors/test_nr_notification.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_nr_notification.py
@@ -27,6 +27,51 @@ default_legal_name = 'TEST COMP'
 default_names_array = [{'name': default_legal_name, 'state': 'NE'}]
 
 
+_is_modernized = nr_notification.__is_modernized
+_is_colin = nr_notification.__is_colin
+_get_instruction_group = nr_notification.__get_instruction_group
+
+
+@pytest.mark.parametrize('legal_type,expected', [
+    ('GP', True), ('DBA', True), ('FR', True), ('CP', True), ('BC', True),
+    ('CR', False), ('SO', False), ('XSO', False), ('', False), ('bc', False), (None, False),
+])
+def test_is_modernized(legal_type, expected):
+    """Assert __is_modernized matches only the modernized legal types (case-sensitive)."""
+    assert _is_modernized(legal_type) is expected
+
+
+@pytest.mark.parametrize('legal_type,expected', [
+    ('CR', True), ('UL', True), ('CC', True), ('XCR', True), ('XUL', True), ('RLC', True),
+    ('BC', False), ('SO', False), ('GP', False), ('', False), ('cr', False), (None, False),
+])
+def test_is_colin(legal_type, expected):
+    """Assert __is_colin matches only the colin legal types (case-sensitive)."""
+    assert _is_colin(legal_type) is expected
+
+
+@pytest.mark.parametrize('legal_type,expected', [
+    ('SO', True), ('XSO', True),
+    ('BC', False), ('CR', False), ('GP', False), ('', False), ('so', False), (None, False),
+])
+def test_is_society(legal_type, expected):
+    """Assert _is_society matches only the society legal types (case-sensitive)."""
+    assert nr_notification._is_society(legal_type) is expected
+
+
+@pytest.mark.parametrize('legal_type,expected', [
+    ('GP', 'modernized'), ('DBA', 'modernized'), ('FR', 'modernized'),
+    ('CP', 'modernized'), ('BC', 'modernized'),
+    ('CR', 'colin'), ('UL', 'colin'), ('CC', 'colin'),
+    ('XCR', 'colin'), ('XUL', 'colin'), ('RLC', 'colin'),
+    ('SO', 'so'), ('XSO', 'so'),
+    ('', ''), ('unknown', ''), (None, ''),
+])
+def test_get_instruction_group(legal_type, expected):
+    """Assert __get_instruction_group returns the correct group or empty string."""
+    assert _get_instruction_group(legal_type) == expected
+
+
 @pytest.mark.parametrize(['option', 'nr_number', 'subject', 'expiration_date', 'refund_value',
                          'expected_legal_name', 'names'], [
     ('before-expiry', 'NR 1234567', 'Expiring Soon', '2021-07-20T00:00:00+00:00', None, 'TEST2 Company Name',
@@ -84,3 +129,32 @@ def test_nr_notification(app, session, option, nr_number, subject, expiration_da
         if option == nr_notification.Option.EXPIRED.value:
             assert nr_number in email['content']['body']
             assert expected_legal_name in email['content']['body']
+
+
+@pytest.mark.parametrize('entity_type_cd', [
+    'BC',       # __is_modernized branch → NR-BEFORE-EXPIRY-MODERNIZED.html
+    'CR',       # __is_colin branch       → NR-BEFORE-EXPIRY-COLIN.html
+    'SO',       # _is_society branch      → NR-BEFORE-EXPIRY-SO.html
+    'UNKNOWN',  # falls through to the default NR-BEFORE-EXPIRY.html
+])
+def test_nr_notification_before_expiry_entity_type(app, session, entity_type_cd):
+    """Assert BEFORE_EXPIRY picks the group-specific template when entity_type_cd is present."""
+    nr_number = 'NR 1234567'
+    nr_json = {
+        'expirationDate': '2021-07-20T00:00:00+00:00',
+        'names': [{'name': 'TEST COMP', 'state': 'APPROVED'}],
+        'legalType': 'BC',
+        'entity_type_cd': entity_type_cd,
+        'applicants': {'emailAddress': 'test@test.com'}
+    }
+
+    with patch.object(NameXService, 'query_nr_number', return_value=MockResponse(nr_json, 200)):
+        email = nr_notification.process({
+            'identifier': nr_number,
+            'request': {'nrNum': nr_number, 'option': 'before-expiry'}
+        }, 'before-expiry')
+
+    assert email['content']['subject'] == f'{nr_number} - Expiring Soon'
+    assert email['content']['body']
+    assert nr_number in email['content']['body']
+    assert 'TEST COMP' in email['content']['body']

--- a/queue_services/business-emailer/tests/unit/email_processors/test_registration_notification.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_registration_notification.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """The Unit Tests for the Registration email processor."""
+import base64
 from unittest.mock import patch
 
 import pytest
+import requests_mock
 from business_model.models import Business
 
 from business_emailer.email_processors import registration_notification
@@ -59,3 +61,52 @@ def test_registration_notification(app, session, mocker, status, legal_type):
         if status == 'COMPLETED':
             assert mock_get_pdfs.call_args[0][2]['identifier'] == 'FM1234567'
         assert mock_get_pdfs.call_args[0][3] == filing
+
+
+def test_registration_attachments_paid(session, mocker, config):
+    """Assert PAID path attaches only the receipt (no filing PDF)."""
+    identifier = 'FM1234567'
+    filing = prep_registration_filing(
+        session, identifier, '1', 'PAID', Business.LegalTypes.SOLE_PROP.value, 'test business')
+    token = 'token'
+    mocker.patch(
+        'business_emailer.email_processors.registration_notification.get_entity_dashboard_url',
+        return_value='https://dummyurl.gov.bc.ca')
+    with requests_mock.Mocker() as m:
+        m.post(
+            f'{config.get("PAY_API_URL")}/{filing.payment_token}/receipts',
+            content=b'pdf_content_1',
+            status_code=201,
+        )
+        output = registration_notification.process(
+            {'filingId': filing.id, 'type': 'registration', 'option': 'PAID'}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 1
+    assert attachments[0]['fileName'] == 'Receipt.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'
+
+
+def test_registration_attachments_completed(session, mocker, config):
+    """Assert COMPLETED path attaches only the Statement of Registration (no receipt)."""
+    identifier = 'FM1234567'
+    filing = prep_registration_filing(
+        session, identifier, '1', 'COMPLETED', Business.LegalTypes.SOLE_PROP.value, 'test business')
+    token = 'token'
+    mocker.patch(
+        'business_emailer.email_processors.registration_notification.get_entity_dashboard_url',
+        return_value='https://dummyurl.gov.bc.ca')
+    with requests_mock.Mocker() as m:
+        m.get(
+            f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+            f'/filings/{filing.id}/documents/registration',
+            content=b'pdf_content_1',
+            status_code=200,
+        )
+        output = registration_notification.process(
+            {'filingId': filing.id, 'type': 'registration', 'option': 'COMPLETED'}, token)
+
+    attachments = output['content']['attachments']
+    assert len(attachments) == 1
+    assert attachments[0]['fileName'] == 'Statement of Registration.pdf'
+    assert base64.b64decode(attachments[0]['fileBytes']).decode('utf-8') == 'pdf_content_1'

--- a/queue_services/business-emailer/tests/unit/meta/test_filing.py
+++ b/queue_services/business-emailer/tests/unit/meta/test_filing.py
@@ -24,14 +24,14 @@ from business_emailer.meta.filing import FilingMeta
 
 def _filing(**kw):
     """Build a lightweight filing stand-in with sensible defaults."""
-    defaults = dict(
-        filing_type=None,
-        filing_sub_type=None,
-        meta_data=None,
-        transaction_id=None,
-        filing_json=None,
-        json_legal_type=None,
-    )
+    defaults = {
+        'filing_type': None,
+        'filing_sub_type': None,
+        'meta_data': None,
+        'transaction_id': None,
+        'filing_json': None,
+        'json_legal_type': None,
+    }
     defaults.update(kw)
     return SimpleNamespace(**defaults)
 

--- a/queue_services/business-emailer/tests/unit/meta/test_filing.py
+++ b/queue_services/business-emailer/tests/unit/meta/test_filing.py
@@ -1,0 +1,424 @@
+# Copyright © 2026 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Unit tests for business_emailer.meta.filing.FilingMeta.
+
+Most FilingMeta staticmethods are pure input/output (operate on dict-shaped
+filing/business objects), so they are tested with SimpleNamespace stand-ins
+instead of real SQLAlchemy models. The few methods that touch the DB
+(`display_name`'s transaction_id branch, `get_corrected_filing_name`) use
+patched versions of VersionService / FilingStorage.
+"""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from business_model.models import Business
+
+from business_emailer.meta.filing import FilingMeta
+
+
+def _filing(**kw):
+    """Build a lightweight filing stand-in with sensible defaults."""
+    defaults = dict(
+        filing_type=None,
+        filing_sub_type=None,
+        meta_data=None,
+        transaction_id=None,
+        filing_json=None,
+        json_legal_type=None,
+    )
+    defaults.update(kw)
+    return SimpleNamespace(**defaults)
+
+
+def _business(legal_type='BC', id=1):  # noqa: A002
+    return SimpleNamespace(legal_type=legal_type, id=id)
+
+
+# --------------------------------------------------------------------------- #
+# get_effective_display_year — pure dict access                               #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize('meta_data,expected', [
+    ({'annualReport': {'annualReportFilingYear': 2024}}, '2024'),
+    ({'annualReport': {'annualReportFilingYear': '2023'}}, '2023'),
+    ({'annualReport': {}}, None),        # KeyError → None
+    ({}, None),                          # KeyError → None
+    (None, None),                        # TypeError → None
+])
+def test_get_effective_display_year(meta_data, expected):
+    assert FilingMeta.get_effective_display_year(meta_data) == expected
+
+
+# --------------------------------------------------------------------------- #
+# alter_outputs_alteration — adds 'certificateOfNameChange' when name change  #
+# --------------------------------------------------------------------------- #
+
+def test_alter_outputs_alteration_adds_cert_on_name_change():
+    filing = _filing(filing_type='alteration', meta_data={'alteration': {'toLegalName': 'new'}})
+    outputs = {'noticeOfArticles'}
+    result = FilingMeta.alter_outputs_alteration(filing, outputs)
+    assert 'certificateOfNameChange' in result
+
+
+def test_alter_outputs_alteration_no_change_when_no_name():
+    filing = _filing(filing_type='alteration', meta_data={'alteration': {}})
+    outputs = {'noticeOfArticles'}
+    result = FilingMeta.alter_outputs_alteration(filing, outputs)
+    assert 'certificateOfNameChange' not in result
+
+
+def test_alter_outputs_alteration_noop_for_other_types():
+    filing = _filing(filing_type='changeOfAddress', meta_data={'alteration': {'toLegalName': 'new'}})
+    outputs = {'noticeOfArticles'}
+    result = FilingMeta.alter_outputs_alteration(filing, outputs)
+    assert 'certificateOfNameChange' not in result
+
+
+# --------------------------------------------------------------------------- #
+# alter_outputs_correction                                                    #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize('correction_meta,expected_additions', [
+    ({'toLegalName': 'new'}, {'certificateOfNameCorrection'}),
+    ({'uploadNewRules': True}, {'certifiedRules'}),
+    ({'uploadNewMemorandum': True}, {'certifiedMemorandum'}),
+    ({'hasResolution': True}, {'specialResolution'}),
+    ({'toLegalName': 'x', 'uploadNewRules': True, 'uploadNewMemorandum': True, 'hasResolution': True},
+     {'certificateOfNameCorrection', 'certifiedRules', 'certifiedMemorandum', 'specialResolution'}),
+    ({}, set()),
+])
+def test_alter_outputs_correction(correction_meta, expected_additions):
+    filing = _filing(filing_type='correction', meta_data={'correction': correction_meta})
+    outputs = set()
+    result = FilingMeta.alter_outputs_correction(filing, _business(), outputs)
+    assert expected_additions.issubset(result)
+
+
+def test_alter_outputs_correction_noop_for_other_types():
+    filing = _filing(filing_type='alteration', meta_data={'correction': {'toLegalName': 'new'}})
+    outputs = set()
+    result = FilingMeta.alter_outputs_correction(filing, _business(), outputs)
+    assert 'certificateOfNameCorrection' not in result
+
+
+# --------------------------------------------------------------------------- #
+# alter_outputs_dissolution                                                   #
+# --------------------------------------------------------------------------- #
+
+def test_alter_outputs_dissolution_administrative_removes_cert():
+    filing = _filing(filing_type='dissolution', filing_sub_type='administrative',
+                     json_legal_type=Business.LegalTypes.COMP)
+    outputs = {'certificateOfDissolution'}
+    result = FilingMeta.alter_outputs_dissolution(filing, outputs)
+    assert 'certificateOfDissolution' not in result
+
+
+def test_alter_outputs_dissolution_coop_voluntary_removes_rules_and_memo():
+    filing = _filing(filing_type='dissolution', filing_sub_type='voluntary',
+                     json_legal_type=Business.LegalTypes.COOP)
+    outputs = {'certificateOfDissolution', 'certifiedRules', 'certifiedMemorandum'}
+    result = FilingMeta.alter_outputs_dissolution(filing, outputs)
+    assert 'certifiedRules' not in result
+    assert 'certifiedMemorandum' not in result
+    assert 'certificateOfDissolution' in result  # not removed for voluntary
+
+
+def test_alter_outputs_dissolution_noop_for_non_dissolution():
+    filing = _filing(filing_type='alteration', filing_sub_type='administrative',
+                     json_legal_type=Business.LegalTypes.COMP)
+    outputs = {'certificateOfDissolution'}
+    result = FilingMeta.alter_outputs_dissolution(filing, outputs)
+    assert 'certificateOfDissolution' in result
+
+
+# --------------------------------------------------------------------------- #
+# alter_outputs_special_resolution                                            #
+# --------------------------------------------------------------------------- #
+
+def test_alter_outputs_special_resolution_with_name_change_and_new_rules():
+    filing = _filing(
+        filing_type='specialResolution',
+        meta_data={'legalFilings': ['changeOfName'], 'alteration': {'uploadNewRules': True}})
+    outputs = {'certifiedMemorandum', 'certifiedRules'}
+    result = FilingMeta.alter_outputs_special_resolution(filing, outputs)
+    assert 'certifiedMemorandum' not in result  # always removed
+    assert 'certifiedRules' in result            # kept because uploadNewRules=True
+    assert 'certificateOfNameChange' in result   # added because changeOfName
+
+
+def test_alter_outputs_special_resolution_without_new_rules_removes_rules():
+    filing = _filing(filing_type='specialResolution',
+                     meta_data={'legalFilings': [], 'alteration': {}})
+    outputs = {'certifiedMemorandum', 'certifiedRules'}
+    result = FilingMeta.alter_outputs_special_resolution(filing, outputs)
+    assert 'certifiedMemorandum' not in result
+    assert 'certifiedRules' not in result
+    assert 'certificateOfNameChange' not in result
+
+
+def test_alter_outputs_special_resolution_noop_for_other_types():
+    filing = _filing(filing_type='alteration',
+                     meta_data={'legalFilings': ['changeOfName']})
+    outputs = {'certifiedMemorandum'}
+    result = FilingMeta.alter_outputs_special_resolution(filing, outputs)
+    assert 'certifiedMemorandum' in result
+
+
+# --------------------------------------------------------------------------- #
+# alter_outputs — orchestrator                                                #
+# --------------------------------------------------------------------------- #
+
+def test_alter_outputs_composes_all_four(mocker):
+    """alter_outputs should call each of the four alter_outputs_* helpers."""
+    m_alt = mocker.patch.object(FilingMeta, 'alter_outputs_alteration', return_value='a')
+    m_cor = mocker.patch.object(FilingMeta, 'alter_outputs_correction', return_value='b')
+    m_sr = mocker.patch.object(FilingMeta, 'alter_outputs_special_resolution', return_value='c')
+    m_dis = mocker.patch.object(FilingMeta, 'alter_outputs_dissolution', return_value='d')
+
+    FilingMeta.alter_outputs(_filing(filing_type='alteration'), _business(), set())
+
+    assert m_alt.called
+    assert m_cor.called
+    assert m_sr.called
+    assert m_dis.called
+
+
+# --------------------------------------------------------------------------- #
+# get_static_documents                                                        #
+# --------------------------------------------------------------------------- #
+
+def test_get_static_documents_continuation_in_with_affidavit_and_files():
+    filing = _filing(filing_type='continuationIn', meta_data={'continuationIn': {
+        'affidavitFileKey': 'AFF123',
+        'authorizationFiles': [
+            {'fileKey': 'AUTH1', 'fileName': 'auth1.pdf'},
+            {'fileKey': 'AUTH2', 'fileName': 'auth2.pdf'},
+        ],
+    }})
+    result = FilingMeta.get_static_documents(filing, 'https://example/docs')
+    assert len(result) == 3
+    assert result[0] == {'name': 'Unlimited Liability Corporation Information',
+                         'url': 'https://example/docs/AFF123'}
+    assert result[1] == {'name': 'auth1.pdf', 'url': 'https://example/docs/AUTH1'}
+    assert result[2] == {'name': 'auth2.pdf', 'url': 'https://example/docs/AUTH2'}
+
+
+def test_get_static_documents_continuation_in_empty_meta():
+    filing = _filing(filing_type='continuationIn', meta_data={'continuationIn': {}})
+    assert FilingMeta.get_static_documents(filing, 'url') == []
+
+
+def test_get_static_documents_noop_for_other_types():
+    filing = _filing(filing_type='incorporationApplication',
+                     meta_data={'continuationIn': {'affidavitFileKey': 'x'}})
+    assert FilingMeta.get_static_documents(filing, 'url') == []
+
+
+# --------------------------------------------------------------------------- #
+# get_display_name                                                            #
+# --------------------------------------------------------------------------- #
+
+def test_get_display_name_simple_string():
+    # "annualReport" has string displayName "Annual Report"
+    assert FilingMeta.get_display_name('BC', 'annualReport') == 'Annual Report'
+
+
+def test_get_display_name_dict_by_legal_type():
+    # "incorporationApplication" has dict displayName keyed by legal_type
+    assert FilingMeta.get_display_name('BC', 'incorporationApplication') == \
+        'BC Limited Company Incorporation Application'
+    assert FilingMeta.get_display_name('CP', 'incorporationApplication') == \
+        'Incorporation Application'
+
+
+def test_get_display_name_with_sub_type():
+    # "dissolution" with "voluntary" sub-type has a dict displayName
+    result = FilingMeta.get_display_name('BC', 'dissolution', 'voluntary')
+    assert result == 'Voluntary Dissolution'
+    # SP/GP map to "Statement of Dissolution"
+    assert FilingMeta.get_display_name('SP', 'dissolution', 'voluntary') == \
+        'Statement of Dissolution'
+
+
+# --------------------------------------------------------------------------- #
+# get_all_outputs                                                             #
+# --------------------------------------------------------------------------- #
+
+def test_get_all_outputs_matching_business_type():
+    # "agmExtension" has additional outputs for BC
+    result = FilingMeta.get_all_outputs('BC', 'agmExtension')
+    assert result == ['letterOfAgmExtension']
+
+
+def test_get_all_outputs_no_match_returns_empty():
+    # "agmExtension" doesn't include SP in its types list
+    result = FilingMeta.get_all_outputs('SP', 'agmExtension')
+    assert result == []
+
+
+def test_get_all_outputs_dissolution_coop_has_affidavit():
+    # "dissolution" has additional outputs for CP including affidavit
+    result = FilingMeta.get_all_outputs('CP', 'dissolution')
+    assert 'certificateOfDissolution' in result
+    assert 'affidavit' in result
+
+
+# --------------------------------------------------------------------------- #
+# display_name — most branches are pure (no transaction_id, no correction)   #
+# --------------------------------------------------------------------------- #
+
+def test_display_name_returns_colin_display_name_when_present():
+    filing = _filing(filing_type='annualReport',
+                     meta_data={'colinDisplayName': 'COLIN Imported Name'})
+    assert FilingMeta.display_name(_business(), filing) == 'COLIN Imported Name'
+
+
+def test_display_name_fallback_for_unknown_filing_type():
+    """Unknown filing_type + no sub_type → capitalized word split fallback."""
+    filing = _filing(filing_type='notAKnownFilingType', meta_data={})
+    # "notAKnownFilingType" → "Not A Known Filing Type"
+    assert FilingMeta.display_name(_business(), filing) == 'Not A Known Filing Type'
+
+
+def test_display_name_annual_report_with_year():
+    filing = _filing(filing_type='annualReport',
+                     meta_data={'annualReport': {'annualReportFilingYear': 2024}})
+    result = FilingMeta.display_name(_business(legal_type='BC'), filing)
+    assert result == 'Annual Report (2024)'
+
+
+def test_display_name_annual_report_without_year():
+    filing = _filing(filing_type='annualReport', meta_data={})
+    assert FilingMeta.display_name(_business(legal_type='BC'), filing) == 'Annual Report'
+
+
+def test_display_name_dissolution_administrative():
+    filing = _filing(filing_type='dissolution', filing_sub_type='administrative',
+                     meta_data={'dissolution': {'dissolutionType': 'administrative'}})
+    result = FilingMeta.display_name(_business(legal_type='BC'), filing)
+    assert result == 'Administrative Dissolution'
+
+
+def test_display_name_dissolution_voluntary_returns_none():
+    """Voluntary dissolution doesn't match the 'administrative' branch, and the
+    top-level FILINGS['dissolution'] entry has no `displayName`, so the function
+    leaves `name` as None. Captures the current behaviour — consumers rely on
+    get_display_name() (which does consult the sub_type dict) for voluntary."""
+    filing = _filing(filing_type='dissolution', filing_sub_type='voluntary',
+                     meta_data={'dissolution': {'dissolutionType': 'voluntary'}})
+    result = FilingMeta.display_name(_business(legal_type='BC'), filing)
+    assert result is None
+
+
+def test_display_name_admin_freeze_unfreeze():
+    filing = _filing(filing_type='adminFreeze',
+                     meta_data={'adminFreeze': {'freeze': False}})
+    assert FilingMeta.display_name(_business(), filing) == 'Admin Unfreeze'
+
+
+def test_display_name_admin_freeze_frozen():
+    filing = _filing(filing_type='adminFreeze',
+                     meta_data={'adminFreeze': {'freeze': True}})
+    assert FilingMeta.display_name(_business(), filing) == 'Admin Freeze'
+
+
+def test_display_name_uses_versioned_business_when_transaction_id_present(mocker):
+    """transaction_id → VersionService.get_business_revision_obj is consulted."""
+    revision = SimpleNamespace(legal_type='CP', id=99)
+    mocker.patch(
+        'business_emailer.meta.filing.VersionService.get_business_revision_obj',
+        return_value=revision)
+    filing = _filing(filing_type='incorporationApplication', transaction_id=123)
+    # legal_type on the *revision* is CP → "Incorporation Application" (CP variant)
+    result = FilingMeta.display_name(_business(legal_type='BC'), filing)
+    assert result == 'Incorporation Application'
+
+
+# --------------------------------------------------------------------------- #
+# get_corrected_filing_name — mocks FilingStorage.find_by_id                  #
+# --------------------------------------------------------------------------- #
+
+def test_get_corrected_filing_name_annual_report(mocker):
+    """Correction of an annualReport → 'Correction - Annual Report (year)'."""
+    corrected = _filing(
+        filing_type='annualReport',
+        meta_data={'annualReport': {'annualReportFilingYear': 2024}})
+    mocker.patch(
+        'business_emailer.meta.filing.FilingStorage.find_by_id', return_value=corrected)
+    correction_filing = _filing(
+        filing_type='correction',
+        filing_json={'filing': {'correction': {
+            'correctedFilingType': 'annualReport',
+            'correctedFilingId': 42,
+        }}})
+    result = FilingMeta.get_corrected_filing_name(
+        correction_filing, _business(legal_type='BC'), 'original')
+    assert result == 'Correction - Annual Report (2024)'
+
+
+def test_get_corrected_filing_name_unrelated_type_returns_original_name():
+    """Non-handled corrected_filing_type just returns the input name."""
+    correction_filing = _filing(
+        filing_type='correction',
+        filing_json={'filing': {'correction': {
+            'correctedFilingType': 'alteration',
+            'correctedFilingId': 42,
+        }}})
+    result = FilingMeta.get_corrected_filing_name(
+        correction_filing, _business(legal_type='BC'), 'Alteration')
+    assert result == 'Alteration'
+
+
+def test_get_corrected_filing_name_recurses_through_chained_corrections(mocker):
+    """correctedFilingType='correction' → recurse through the chain."""
+    annual_report = _filing(
+        filing_type='annualReport',
+        meta_data={'annualReport': {'annualReportFilingYear': 2022}})
+    middle_correction = _filing(
+        filing_type='correction',
+        filing_json={'filing': {'correction': {
+            'correctedFilingType': 'annualReport',
+            'correctedFilingId': 10,
+        }}})
+
+    def fake_find(fid):
+        return {11: middle_correction, 10: annual_report}[fid]
+
+    mocker.patch(
+        'business_emailer.meta.filing.FilingStorage.find_by_id', side_effect=fake_find)
+    outer = _filing(
+        filing_type='correction',
+        filing_json={'filing': {'correction': {
+            'correctedFilingType': 'correction',
+            'correctedFilingId': 11,
+        }}})
+    result = FilingMeta.get_corrected_filing_name(
+        outer, _business(legal_type='BC'), 'original')
+    assert result == 'Correction - Annual Report (2022)'
+
+
+# --------------------------------------------------------------------------- #
+# display_name correction branch (exercises get_corrected_filing_name)        #
+# --------------------------------------------------------------------------- #
+
+def test_display_name_correction_calls_get_corrected_filing_name(mocker):
+    corrected = _filing(
+        filing_type='annualReport',
+        meta_data={'annualReport': {'annualReportFilingYear': 2024}})
+    mocker.patch(
+        'business_emailer.meta.filing.FilingStorage.find_by_id', return_value=corrected)
+    correction = _filing(
+        filing_type='correction',
+        meta_data={},
+        filing_json={'filing': {'correction': {
+            'correctedFilingType': 'annualReport',
+            'correctedFilingId': 42,
+        }}})
+    result = FilingMeta.display_name(_business(legal_type='BC'), correction)
+    assert 'Correction' in result

--- a/queue_services/business-emailer/tests/unit/services/__init__.py
+++ b/queue_services/business-emailer/tests/unit/services/__init__.py
@@ -11,4 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""The Unit Tests for the meta module."""
+"""The Unit Tests for the services."""

--- a/queue_services/business-emailer/tests/unit/services/test_versioned_business_details.py
+++ b/queue_services/business-emailer/tests/unit/services/test_versioned_business_details.py
@@ -11,15 +11,18 @@ These eight staticmethods take a SQLAlchemy revision object (or a filing dict)
 and return a plain dict. They don't touch the session, the network, or
 LaunchDarkly, so we exercise them with `SimpleNamespace` stand-ins.
 """
-from datetime import date, datetime
+import re
+from datetime import date, datetime, timezone
 from types import SimpleNamespace
 
 from business_model.models import Party
-from business_model.utils.legislation_datetime import LegislationDatetime
 
 from business_emailer.services.versioned_business_details import (
     VersionedBusinessDetailsService as VBDS,
 )
+
+
+ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
 # --------------------------------------------------------------------------- #
@@ -114,11 +117,11 @@ def test_resolution_json_formats_date():
 def test_business_revision_json_tombstone_returns_original():
     """When business_revision is None → return the passed business_json unchanged."""
     original = {"legalName": "Old Co", "identifier": "BC123"}
-    assert VBDS.business_revision_json(None, original) is original
+    assert VBDS.business_revision_json(None, original) == original
 
 
 def test_business_revision_json_overlays_all_fields():
-    dt = datetime(2024, 1, 15, 12, 0, 0)
+    dt = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
     rev = SimpleNamespace(
         restriction_ind=True,
         dissolution_date=dt,
@@ -131,14 +134,12 @@ def test_business_revision_json_overlays_all_fields():
         legal_type="BC",
         naics_description="Software",
     )
-    formatted = LegislationDatetime.format_as_legislation_date(dt)
     result = VBDS.business_revision_json(rev, {"legalName": "Old Co"})
     assert result["hasRestrictions"] is True
-    assert result["dissolutionDate"] == formatted
-    assert result["restorationExpiryDate"] == formatted
-    assert result["startDate"] == formatted
-    assert result["continuationOutDate"] == formatted
-    assert result["amalgamationOutDate"] == formatted
+    # Dates are formatted as YYYY-MM-DD in legislation timezone
+    for key in ("dissolutionDate", "restorationExpiryDate", "startDate",
+                "continuationOutDate", "amalgamationOutDate"):
+        assert ISO_DATE_RE.match(result[key]), f"{key}={result[key]!r}"
     assert result["taxId"] == "999000001BC0001"
     assert result["legalName"] == "New Co"      # overridden
     assert result["legalType"] == "BC"

--- a/queue_services/business-emailer/tests/unit/services/test_versioned_business_details.py
+++ b/queue_services/business-emailer/tests/unit/services/test_versioned_business_details.py
@@ -1,0 +1,338 @@
+# Copyright © 2026 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Atomic unit tests for pure-transform helpers on VersionedBusinessDetailsService.
+
+These eight staticmethods take a SQLAlchemy revision object (or a filing dict)
+and return a plain dict. They don't touch the session, the network, or
+LaunchDarkly, so we exercise them with `SimpleNamespace` stand-ins.
+"""
+from datetime import date, datetime
+from types import SimpleNamespace
+
+from business_model.models import Party
+from business_model.utils.legislation_datetime import LegislationDatetime
+
+from business_emailer.services.versioned_business_details import (
+    VersionedBusinessDetailsService as VBDS,
+)
+
+
+# --------------------------------------------------------------------------- #
+# share_class_revision_json                                                   #
+# --------------------------------------------------------------------------- #
+
+def test_share_class_revision_json_all_fields_populated():
+    rev = SimpleNamespace(
+        id=1, name="Common", priority=0,
+        max_share_flag=True, max_shares="1000",
+        par_value_flag=True, par_value=1.5, currency="CAD",
+        special_rights_flag=False,
+    )
+    assert VBDS.share_class_revision_json(rev) == {
+        "id": 1, "name": "Common", "priority": 0,
+        "hasMaximumShares": True, "maxNumberOfShares": 1000,
+        "hasParValue": True, "parValue": 1.5, "currency": "CAD",
+        "hasRightsOrRestrictions": False,
+    }
+
+
+def test_share_class_revision_json_none_max_shares():
+    rev = SimpleNamespace(
+        id=2, name="Preferred", priority=1,
+        max_share_flag=False, max_shares=None,
+        par_value_flag=False, par_value=None, currency=None,
+        special_rights_flag=True,
+    )
+    result = VBDS.share_class_revision_json(rev)
+    assert result["maxNumberOfShares"] is None
+    assert result["hasRightsOrRestrictions"] is True
+
+
+# --------------------------------------------------------------------------- #
+# share_series_revision_json                                                  #
+# --------------------------------------------------------------------------- #
+
+def test_share_series_revision_json_all_fields_populated():
+    rev = SimpleNamespace(
+        id=10, name="Series A", priority=1,
+        max_share_flag=True, max_shares="250",
+        special_rights_flag=True,
+    )
+    assert VBDS.share_series_revision_json(rev) == {
+        "id": 10, "name": "Series A", "priority": 1,
+        "hasMaximumShares": True, "maxNumberOfShares": 250,
+        "hasRightsOrRestrictions": True,
+    }
+
+
+def test_share_series_revision_json_none_max_shares():
+    rev = SimpleNamespace(
+        id=11, name="Series B", priority=2,
+        max_share_flag=False, max_shares=None,
+        special_rights_flag=False,
+    )
+    assert VBDS.share_series_revision_json(rev)["maxNumberOfShares"] is None
+
+
+# --------------------------------------------------------------------------- #
+# name_translations_json                                                      #
+# --------------------------------------------------------------------------- #
+
+def test_name_translations_json_casts_id_to_str():
+    rev = SimpleNamespace(id=42, alias="Le Nom", type="TRANSLATION")
+    assert VBDS.name_translations_json(rev) == {
+        "id": "42",
+        "name": "Le Nom",
+        "type": "TRANSLATION",
+    }
+
+
+# --------------------------------------------------------------------------- #
+# resolution_json                                                             #
+# --------------------------------------------------------------------------- #
+
+def test_resolution_json_formats_date():
+    rev = SimpleNamespace(id=7, resolution_date=date(2024, 3, 5),
+                          resolution_type="SPECIAL")
+    # "%B %-d, %Y" → "March 5, 2024"
+    assert VBDS.resolution_json(rev) == {
+        "id": 7,
+        "date": "March 5, 2024",
+        "type": "SPECIAL",
+    }
+
+
+# --------------------------------------------------------------------------- #
+# business_revision_json                                                      #
+# --------------------------------------------------------------------------- #
+
+def test_business_revision_json_tombstone_returns_original():
+    """When business_revision is None → return the passed business_json unchanged."""
+    original = {"legalName": "Old Co", "identifier": "BC123"}
+    assert VBDS.business_revision_json(None, original) is original
+
+
+def test_business_revision_json_overlays_all_fields():
+    dt = datetime(2024, 1, 15, 12, 0, 0)
+    rev = SimpleNamespace(
+        restriction_ind=True,
+        dissolution_date=dt,
+        restoration_expiry_date=dt,
+        start_date=dt,
+        continuation_out_date=dt,
+        amalgamation_out_date=dt,
+        tax_id="999000001BC0001",
+        legal_name="New Co",
+        legal_type="BC",
+        naics_description="Software",
+    )
+    formatted = LegislationDatetime.format_as_legislation_date(dt)
+    result = VBDS.business_revision_json(rev, {"legalName": "Old Co"})
+    assert result["hasRestrictions"] is True
+    assert result["dissolutionDate"] == formatted
+    assert result["restorationExpiryDate"] == formatted
+    assert result["startDate"] == formatted
+    assert result["continuationOutDate"] == formatted
+    assert result["amalgamationOutDate"] == formatted
+    assert result["taxId"] == "999000001BC0001"
+    assert result["legalName"] == "New Co"      # overridden
+    assert result["legalType"] == "BC"
+    assert result["naicsDescription"] == "Software"
+
+
+def test_business_revision_json_null_dates_become_none():
+    rev = SimpleNamespace(
+        restriction_ind=False,
+        dissolution_date=None,
+        restoration_expiry_date=None,
+        start_date=None,
+        continuation_out_date=None,
+        amalgamation_out_date=None,
+        tax_id=None,
+        legal_name="Co",
+        legal_type="BC",
+        naics_description=None,
+    )
+    result = VBDS.business_revision_json(rev, {})
+    assert result["dissolutionDate"] is None
+    assert result["restorationExpiryDate"] is None
+    assert result["startDate"] is None
+    assert result["continuationOutDate"] is None
+    assert result["amalgamationOutDate"] is None
+    # tax_id falsy → not written to output
+    assert "taxId" not in result
+
+
+# --------------------------------------------------------------------------- #
+# get_incorporation_agreement_json / get_name_request_revision / get_contact_point_revision
+# --------------------------------------------------------------------------- #
+
+def _ia_filing(**ia_keys):
+    """Build a minimal filing object with filing.json structure."""
+    return SimpleNamespace(json={"filing": {"incorporationApplication": ia_keys}})
+
+
+def test_get_incorporation_agreement_json_returns_value():
+    filing = _ia_filing(incorporationAgreement={"type": "sample"})
+    assert VBDS.get_incorporation_agreement_json(filing) == {"type": "sample"}
+
+
+def test_get_incorporation_agreement_json_missing_returns_empty_dict():
+    filing = _ia_filing()
+    assert VBDS.get_incorporation_agreement_json(filing) == {}
+
+
+def test_get_name_request_revision_returns_value():
+    filing = _ia_filing(nameRequest={"legalName": "Newco"})
+    assert VBDS.get_name_request_revision(filing) == {"legalName": "Newco"}
+
+
+def test_get_name_request_revision_missing_returns_empty_dict():
+    filing = _ia_filing()
+    assert VBDS.get_name_request_revision(filing) == {}
+
+
+def test_get_contact_point_revision_returns_value():
+    filing = _ia_filing(contactPoint={"email": "a@b.com"})
+    assert VBDS.get_contact_point_revision(filing) == {"email": "a@b.com"}
+
+
+def test_get_contact_point_revision_missing_returns_empty_dict():
+    filing = _ia_filing()
+    assert VBDS.get_contact_point_revision(filing) == {}
+
+
+# --------------------------------------------------------------------------- #
+# get_header_revision                                                          #
+# --------------------------------------------------------------------------- #
+
+def test_get_header_revision_returns_header_dict():
+    header = {"name": "annualReport", "date": "2024-01-01"}
+    filing = SimpleNamespace(json={"filing": {"header": header}})
+    assert VBDS.get_header_revision(filing) is header
+
+
+# --------------------------------------------------------------------------- #
+# address_revision_json                                                        #
+# --------------------------------------------------------------------------- #
+
+def test_address_revision_json_populated_with_country_description():
+    rev = SimpleNamespace(
+        street="123 Main St", street_additional="Suite 4",
+        address_type="mailing", city="Victoria", region="BC",
+        country="CA", postal_code="V8W 1A1",
+        delivery_instructions="Leave at door",
+    )
+    result = VBDS.address_revision_json(rev)
+    assert result["streetAddress"] == "123 Main St"
+    assert result["streetAddressAdditional"] == "Suite 4"
+    assert result["addressType"] == "mailing"
+    assert result["addressCity"] == "Victoria"
+    assert result["addressRegion"] == "BC"
+    assert result["addressCountry"] == "CA"
+    assert result["addressCountryDescription"] == "Canada"  # pycountry lookup
+    assert result["postalCode"] == "V8W 1A1"
+    assert result["deliveryInstructions"] == "Leave at door"
+
+
+def test_address_revision_json_empty_country_skips_lookup():
+    rev = SimpleNamespace(
+        street=None, street_additional=None,
+        address_type="delivery", city=None, region=None,
+        country=None, postal_code=None, delivery_instructions=None,
+    )
+    result = VBDS.address_revision_json(rev)
+    assert result["streetAddress"] == ""
+    assert result["streetAddressAdditional"] == ""
+    assert result["addressCity"] == ""
+    assert result["addressRegion"] == ""
+    assert result["addressCountry"] == ""
+    assert result["addressCountryDescription"] == ""
+    assert result["postalCode"] == ""
+    assert result["deliveryInstructions"] == ""
+
+
+# --------------------------------------------------------------------------- #
+# party_revision_type_json                                                     #
+# --------------------------------------------------------------------------- #
+
+def test_party_revision_type_json_person_basic():
+    rev = SimpleNamespace(
+        party_type=Party.PartyTypes.PERSON.value,
+        first_name="Jane", last_name="Doe",
+        title=None, middle_initial=None, email=None,
+    )
+    result = VBDS.party_revision_type_json(rev, is_ia_or_after=False)
+    assert result == {
+        "officer": {"firstName": "Jane", "lastName": "Doe",
+                    "partyType": Party.PartyTypes.PERSON.value}
+    }
+
+
+def test_party_revision_type_json_person_with_title_and_email():
+    rev = SimpleNamespace(
+        party_type=Party.PartyTypes.PERSON.value,
+        first_name="Jane", last_name="Doe",
+        title="Director", middle_initial=None, email="j@x.com",
+    )
+    result = VBDS.party_revision_type_json(rev, is_ia_or_after=False)
+    assert result["title"] == "Director"
+    assert result["officer"]["email"] == "j@x.com"
+
+
+def test_party_revision_type_json_person_middle_initial_non_ia():
+    """Non-IA → middleInitial key."""
+    rev = SimpleNamespace(
+        party_type=Party.PartyTypes.PERSON.value,
+        first_name="Jane", last_name="Doe",
+        title=None, middle_initial="A", email=None,
+    )
+    result = VBDS.party_revision_type_json(rev, is_ia_or_after=False)
+    assert result["officer"]["middleInitial"] == "A"
+    assert "middleName" not in result["officer"]
+
+
+def test_party_revision_type_json_person_middle_initial_ia_or_after():
+    """IA-or-after → middleName key (and middleInitial stays)."""
+    rev = SimpleNamespace(
+        party_type=Party.PartyTypes.PERSON.value,
+        first_name="Jane", last_name="Doe",
+        title=None, middle_initial="A", email=None,
+    )
+    result = VBDS.party_revision_type_json(rev, is_ia_or_after=True)
+    assert result["officer"]["middleName"] == "A"
+    assert result["officer"]["middleInitial"] == "A"
+
+
+def test_party_revision_type_json_organization():
+    rev = SimpleNamespace(
+        party_type=Party.PartyTypes.ORGANIZATION.value,
+        organization_name="Acme Ltd",
+        identifier="BC1234",
+        email="contact@acme.com",
+    )
+    result = VBDS.party_revision_type_json(rev, is_ia_or_after=False)
+    assert result == {
+        "officer": {
+            "organizationName": "Acme Ltd",
+            "partyType": Party.PartyTypes.ORGANIZATION.value,
+            "identifier": "BC1234",
+            "email": "contact@acme.com",
+        }
+    }
+
+
+def test_party_revision_type_json_organization_no_email():
+    rev = SimpleNamespace(
+        party_type=Party.PartyTypes.ORGANIZATION.value,
+        organization_name="Acme Ltd",
+        identifier="BC1234",
+        email=None,
+    )
+    result = VBDS.party_revision_type_json(rev, is_ia_or_after=True)
+    assert "email" not in result["officer"]

--- a/queue_services/business-emailer/tests/unit/test_filing_helper.py
+++ b/queue_services/business-emailer/tests/unit/test_filing_helper.py
@@ -1,0 +1,82 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for filing_helper."""
+import pytest
+
+from business_emailer.filing_helper import is_special_resolution_correction_by_filing_json
+
+
+SR_CORRECTION_KEYS = [
+    "rulesInResolution",
+    "resolution",
+    "rulesFileKey",
+    "memorandumFileKey",
+    "memorandumInResolution",
+    "cooperativeAssociationType",
+]
+
+
+@pytest.mark.parametrize("key", SR_CORRECTION_KEYS)
+def test_returns_true_when_sr_correction_key_present(key):
+    """Each SR correction key on its own should return True."""
+    filing = {"correction": {key: "anything"}}
+    assert is_special_resolution_correction_by_filing_json(filing) is True
+
+
+def test_returns_true_when_multiple_sr_correction_keys_present():
+    """Multiple SR correction keys should still return True."""
+    filing = {"correction": {"resolution": "x", "rulesFileKey": "y"}}
+    assert is_special_resolution_correction_by_filing_json(filing) is True
+
+
+def test_returns_true_when_name_request_has_request_type():
+    """nameRequest.requestType without SR keys should return True."""
+    filing = {"correction": {"nameRequest": {"requestType": "CHG"}}}
+    assert is_special_resolution_correction_by_filing_json(filing) is True
+
+
+def test_returns_true_when_sr_key_and_name_request_type_both_present():
+    """Both signals present should return True."""
+    filing = {"correction": {"resolution": "x", "nameRequest": {"requestType": "CHG"}}}
+    assert is_special_resolution_correction_by_filing_json(filing) is True
+
+
+def test_returns_false_for_empty_correction():
+    """Empty correction object should return False."""
+    filing = {"correction": {}}
+    assert is_special_resolution_correction_by_filing_json(filing) is False
+
+
+def test_returns_false_for_unrelated_correction_keys():
+    """Correction with only unrelated keys should return False."""
+    filing = {"correction": {"comment": "typo fix", "legalName": "Acme Inc."}}
+    assert is_special_resolution_correction_by_filing_json(filing) is False
+
+
+def test_returns_false_when_name_request_missing_request_type():
+    """nameRequest without requestType and no SR keys should return False."""
+    filing = {"correction": {"nameRequest": {"legalType": "BC"}}}
+    assert is_special_resolution_correction_by_filing_json(filing) is False
+
+
+def test_returns_false_when_name_request_is_empty():
+    """Empty nameRequest and no SR keys should return False."""
+    filing = {"correction": {"nameRequest": {}}}
+    assert is_special_resolution_correction_by_filing_json(filing) is False
+
+
+def test_raises_type_error_when_correction_missing():
+    """Filing with no 'correction' key raises TypeError (documents current behaviour)."""
+    with pytest.raises(TypeError):
+        is_special_resolution_correction_by_filing_json({})

--- a/queue_services/business-emailer/tests/unit/test_send_email.py
+++ b/queue_services/business-emailer/tests/unit/test_send_email.py
@@ -1,0 +1,307 @@
+# Copyright © 2026 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Unit tests for worker.send_email.
+
+Covers exception paths, recipient-string dedup/parsing, the log_message
+formatting block, and the requests.post call shape.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from business_emailer.exceptions import EmailException, QueueException
+from business_emailer.resources import business_emailer as worker
+
+
+NOTIFY_URL = "https://notify-api-url/"
+TOKEN = "token"
+
+
+def _valid_email(**overrides):
+    """Build a minimally valid email dict; override any top-level/content key."""
+    email = {
+        "recipients": "test@test.com",
+        "content": {"subject": "Subject", "body": "Body", "attachments": []},
+    }
+    content_overrides = overrides.pop("content", None)
+    email.update(overrides)
+    if content_overrides is not None:
+        email["content"].update(content_overrides)
+    return email
+
+
+@pytest.fixture
+def mock_post(mocker):
+    """Mock requests.post inside the worker module; default to a 200 response."""
+    mock = mocker.patch("business_emailer.resources.business_emailer.requests.post")
+    mock.return_value = MagicMock(status_code=200)
+    return mock
+
+
+@pytest.fixture
+def mock_logger_debug(app, mocker):
+    """Patch the Flask app logger's debug method.
+
+    `current_app.logger` resolves to `app.logger` under the test app context,
+    so intercepting here captures every debug call made from send_email.
+    """
+    return mocker.patch.object(app.logger, "debug")
+
+
+@pytest.fixture(autouse=True)
+def _notify_url(app, monkeypatch):
+    """Force a known NOTIFY_API_URL so we can assert the requests.post URL."""
+    monkeypatch.setitem(app.config, "NOTIFY_API_URL", NOTIFY_URL)
+
+
+# --------------------------------------------------------------------------- #
+# Exception paths                                                             #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("email", [
+    None,
+    {},
+    {"content": {"body": "x"}},                                   # missing 'recipients'
+    {"recipients": "a@b.com"},                                    # missing 'content'
+    {"recipients": "a@b.com", "content": {"subject": "s"}},       # missing 'body' in content
+])
+def test_send_email_missing_required_keys_raises(app, email, mock_post):
+    """First guard: any required key missing → QueueException ('empty')."""
+    with pytest.raises(QueueException) as exc:
+        worker.send_email(email, TOKEN)
+    assert "required email object(s) is empty" in str(exc.value)
+    mock_post.assert_not_called()
+
+
+@pytest.mark.parametrize("email", [
+    {"recipients": "", "content": {"body": "x"}},                 # empty recipients
+    {"recipients": "a@b.com", "content": {"body": ""}},           # empty body
+])
+def test_send_email_empty_required_values_raises(app, email, mock_post):
+    """Second guard: empty recipients/content/body → QueueException ('missing')."""
+    with pytest.raises(QueueException) as exc:
+        worker.send_email(email, TOKEN)
+    assert "required email object(s) is missing" in str(exc.value)
+    mock_post.assert_not_called()
+
+
+def test_send_email_non_200_response_raises_email_exception(app, mock_post):
+    """Notify API non-200 → EmailException."""
+    mock_post.return_value = MagicMock(status_code=500)
+
+    with pytest.raises(EmailException) as exc:
+        worker.send_email(_valid_email(), TOKEN)
+    assert "Unsuccessful response when sending email" in str(exc.value)
+
+
+def test_send_email_requests_raises_wrapped_as_email_exception(app, mock_post):
+    """Any exception from requests.post is converted to EmailException."""
+    mock_post.side_effect = ConnectionError("network down")
+
+    with pytest.raises(EmailException) as exc:
+        worker.send_email(_valid_email(), TOKEN)
+    assert "Unsuccessful response when sending email" in str(exc.value)
+
+
+# --------------------------------------------------------------------------- #
+# Recipient string handling (single / multiple / dedup / whitespace / empty)  #
+# --------------------------------------------------------------------------- #
+
+def test_send_email_single_recipient_unchanged(app, mock_post):
+    email = _valid_email(recipients="only@test.com")
+
+    worker.send_email(email, TOKEN)
+
+    posted = mock_post.call_args.kwargs["json"]
+    assert posted["recipients"] == "only@test.com"
+
+
+def test_send_email_single_recipient_whitespace_stripped(app, mock_post):
+    email = _valid_email(recipients="   only@test.com   ")
+
+    worker.send_email(email, TOKEN)
+
+    posted = mock_post.call_args.kwargs["json"]
+    assert posted["recipients"] == "only@test.com"
+
+
+def test_send_email_multiple_recipients_deduped(app, mock_post):
+    email = _valid_email(recipients="a@test.com, b@test.com, a@test.com")
+
+    worker.send_email(email, TOKEN)
+
+    posted_recipients = mock_post.call_args.kwargs["json"]["recipients"]
+    # set ordering is not deterministic; assert membership instead
+    assert sorted(r.strip() for r in posted_recipients.split(",")) == ["a@test.com", "b@test.com"]
+
+
+def test_send_email_multiple_recipients_whitespace_stripped(app, mock_post):
+    email = _valid_email(recipients="  a@test.com  ,   b@test.com  ")
+
+    worker.send_email(email, TOKEN)
+
+    posted_recipients = mock_post.call_args.kwargs["json"]["recipients"]
+    assert sorted(r.strip() for r in posted_recipients.split(",")) == ["a@test.com", "b@test.com"]
+
+
+def test_send_email_multiple_recipients_empty_entries_filtered(app, mock_post):
+    email = _valid_email(recipients="a@test.com, , b@test.com, ")
+
+    worker.send_email(email, TOKEN)
+
+    posted_recipients = mock_post.call_args.kwargs["json"]["recipients"]
+    parts = [r.strip() for r in posted_recipients.split(",")]
+    assert sorted(parts) == ["a@test.com", "b@test.com"]
+    assert "" not in parts
+
+
+def test_send_email_list_recipients_not_mangled(app, mock_post):
+    """Non-string recipients skip the dedup branch entirely."""
+    email = _valid_email(recipients=["a@test.com", "b@test.com"])
+
+    worker.send_email(email, TOKEN)
+
+    posted_recipients = mock_post.call_args.kwargs["json"]["recipients"]
+    assert posted_recipients == ["a@test.com", "b@test.com"]
+
+
+# --------------------------------------------------------------------------- #
+# requests.post invocation shape                                              #
+# --------------------------------------------------------------------------- #
+
+def test_send_email_posts_expected_json_and_headers(app, mock_post):
+    email = _valid_email(
+        recipients="only@test.com",
+        content={"subject": "Hi", "body": "Hello", "attachments": [{"fileName": "f.pdf"}]},
+    )
+
+    worker.send_email(email, TOKEN)
+
+    assert mock_post.call_count == 1
+    args, kwargs = mock_post.call_args
+    assert args == (NOTIFY_URL,)
+    assert kwargs["json"] is email  # posted as-is
+    assert kwargs["json"]["content"]["subject"] == "Hi"
+    assert kwargs["json"]["content"]["body"] == "Hello"
+    assert kwargs["json"]["content"]["attachments"] == [{"fileName": "f.pdf"}]
+    assert kwargs["headers"] == {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {TOKEN}",
+    }
+
+
+def test_send_email_200_returns_normally(app, mock_post):
+    """Happy path: no exception raised."""
+    worker.send_email(_valid_email(), TOKEN)  # does not raise
+
+
+# --------------------------------------------------------------------------- #
+# log_message formatting — the block of lines the user called out             #
+# --------------------------------------------------------------------------- #
+
+def _get_log_message(mock_debug):
+    """Return the first positional arg of the first debug call in the try block."""
+    assert mock_debug.call_args_list, "logger.debug was never called"
+    return mock_debug.call_args_list[0].args[0]
+
+
+def test_log_message_short_subject_and_recipients(app, mock_post, mock_logger_debug):
+    email = _valid_email(
+        recipients="only@test.com",
+        content={"subject": "Hello", "body": "Body", "attachments": []},
+    )
+
+    worker.send_email(email, TOKEN)
+
+    log_message = _get_log_message(mock_logger_debug)
+    assert log_message == "Sending email with subject 'Hello' and 0 attachments to: only@test.com"
+
+
+def test_log_message_attachment_count(app, mock_post, mock_logger_debug):
+    email = _valid_email(
+        content={
+            "subject": "s", "body": "b",
+            "attachments": [{"fileName": "a"}, {"fileName": "b"}, {"fileName": "c"}],
+        },
+    )
+
+    worker.send_email(email, TOKEN)
+
+    assert "and 3 attachments" in _get_log_message(mock_logger_debug)
+
+
+def test_log_message_no_attachments_key(app, mock_post, mock_logger_debug):
+    """content without 'attachments' key → count falls back to 0."""
+    email = _valid_email(content={"subject": "s", "body": "b"})
+    email["content"].pop("attachments", None)
+
+    worker.send_email(email, TOKEN)
+
+    assert "and 0 attachments" in _get_log_message(mock_logger_debug)
+
+
+def test_log_message_missing_subject_falls_back_to_empty(app, mock_post, mock_logger_debug):
+    """Missing 'subject' key → subject_display == '-empty-'."""
+    email = _valid_email(content={"body": "b", "attachments": []})
+    email["content"].pop("subject", None)
+
+    worker.send_email(email, TOKEN)
+
+    assert "subject '-empty-'" in _get_log_message(mock_logger_debug)
+
+
+def test_log_message_truncates_long_subject(app, mock_post, mock_logger_debug):
+    """Subject > 50 chars is truncated to 50 chars + '...'."""
+    long_subject = "A" * 60
+    email = _valid_email(content={"subject": long_subject, "body": "b", "attachments": []})
+
+    worker.send_email(email, TOKEN)
+
+    log_message = _get_log_message(mock_logger_debug)
+    assert f"subject '{'A' * 50}...'" in log_message
+    # full subject is NOT present (would be 60 A's)
+    assert "A" * 60 not in log_message
+
+
+def test_log_message_does_not_truncate_subject_at_exactly_50(app, mock_post, mock_logger_debug):
+    """Boundary: subject of exactly 50 chars is shown verbatim, no '...'."""
+    subject_50 = "A" * 50
+    email = _valid_email(content={"subject": subject_50, "body": "b", "attachments": []})
+
+    worker.send_email(email, TOKEN)
+
+    log_message = _get_log_message(mock_logger_debug)
+    assert f"subject '{subject_50}'" in log_message
+    assert "..." not in log_message
+
+
+def test_log_message_truncates_long_recipients(app, mock_post, mock_logger_debug):
+    """Recipients string > 100 chars is truncated to 100 chars + '...'."""
+    # 12 emails of 11 chars + ", " separators = ~130 chars after dedup
+    recipients = ", ".join(f"a{i:02d}@test.com" for i in range(12))
+    assert len(recipients) > 100
+    email = _valid_email(recipients=recipients)
+
+    worker.send_email(email, TOKEN)
+
+    log_message = _get_log_message(mock_logger_debug)
+    # The displayed substring ends with '...'; check the truncation marker is present
+    # and that the full recipients string is NOT wholly in the log message.
+    posted_recipients = mock_post.call_args.kwargs["json"]["recipients"]
+    assert posted_recipients[:100] + "..." in log_message
+    assert posted_recipients not in log_message
+
+
+def test_log_message_short_recipients_not_truncated(app, mock_post, mock_logger_debug):
+    email = _valid_email(recipients="a@b.com")
+
+    worker.send_email(email, TOKEN)
+
+    log_message = _get_log_message(mock_logger_debug)
+    assert "to: a@b.com" in log_message
+    assert "..." not in log_message

--- a/queue_services/business-emailer/tests/unit/test_services_init.py
+++ b/queue_services/business-emailer/tests/unit/test_services_init.py
@@ -1,0 +1,29 @@
+"""Tests for the simple message-building helpers in business_emailer.services."""
+import pytest
+
+from business_emailer.services import create_email_msg, create_filing_msg, create_gcp_filing_msg
+
+
+@pytest.mark.parametrize("identifier", [1, 123, "BC1234567", 0, None])
+def test_create_filing_msg(identifier):
+    """Assert create_filing_msg wraps the identifier under filing.id."""
+    assert create_filing_msg(identifier) == {"filing": {"id": identifier}}
+
+
+@pytest.mark.parametrize("identifier", [1, 123, "BC1234567", 0, None])
+def test_create_gcp_filing_msg(identifier):
+    """Assert create_gcp_filing_msg wraps the identifier under filingMessage.filingIdentifier."""
+    assert create_gcp_filing_msg(identifier) == {"filingMessage": {"filingIdentifier": identifier}}
+
+
+@pytest.mark.parametrize("identifier,filing_type", [
+    (1, "incorporationApplication"),
+    (42, "dissolution"),
+    ("BC1234567", "amalgamationApplication"),
+    (None, None),
+])
+def test_create_email_msg(identifier, filing_type):
+    """Assert create_email_msg builds an email payload with PAID option."""
+    assert create_email_msg(identifier, filing_type) == {
+        "email": {"filingId": identifier, "type": filing_type, "option": "PAID"},
+    }

--- a/queue_services/business-emailer/tests/unit/test_services_namex.py
+++ b/queue_services/business-emailer/tests/unit/test_services_namex.py
@@ -1,0 +1,60 @@
+# Copyright © 2024 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for business_emailer.services.namex.NameXService."""
+from unittest.mock import patch
+
+import pytest
+import requests_mock
+from business_account.AccountService import AccountService
+
+from business_emailer.services.namex import NameXService
+
+
+@pytest.fixture
+def namex_url(app):
+    """Set NAMEX_SVC_URL to a dummy value for the duration of a test."""
+    original = app.config.get("NAMEX_SVC_URL")
+    app.config["NAMEX_SVC_URL"] = "https://namex-svc-url/"
+    yield app.config["NAMEX_SVC_URL"]
+    app.config["NAMEX_SVC_URL"] = original
+
+
+def test_query_nr_number_returns_response(app, namex_url):
+    """Assert the namex GET is issued with the bearer token and response returned as-is."""
+    identifier = "NR 1234567"
+    token = "token"
+
+    with app.app_context(), \
+            patch.object(AccountService, "get_bearer_token", return_value=token), \
+            requests_mock.Mocker() as m:
+        m.get(f"{namex_url}requests/{identifier}", json={"id": 1}, status_code=200)
+        response = NameXService.query_nr_number(identifier)
+
+        assert response.status_code == 200
+        assert response.json() == {"id": 1}
+        assert m.last_request.headers["Authorization"] == f"Bearer {token}"
+        assert m.last_request.headers["Content-Type"] == "application/json"
+
+
+def test_query_nr_number_returns_non_200_as_is(app, namex_url):
+    """Assert non-OK responses are returned to the caller unchanged (no raise)."""
+    identifier = "NR 9999999"
+
+    with app.app_context(), \
+            patch.object(AccountService, "get_bearer_token", return_value="token"), \
+            requests_mock.Mocker() as m:
+        m.get(f"{namex_url}requests/{identifier}", status_code=404)
+        response = NameXService.query_nr_number(identifier)
+
+        assert response.status_code == 404

--- a/queue_services/business-emailer/tests/unit/test_worker_dispatch.py
+++ b/queue_services/business-emailer/tests/unit/test_worker_dispatch.py
@@ -1,0 +1,476 @@
+# Copyright © 2026 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Dispatch-branch coverage for worker.process_email.
+
+These tests mock every email processor's `process()` so we can verify the
+routing logic in `process_email` without building real filings. They are
+complementary to the integration-style tests in test_worker.py which exercise
+processor internals.
+"""
+from unittest.mock import patch
+
+import pytest
+from simple_cloudevent import SimpleCloudEvent
+
+from business_account.AccountService import AccountService
+from business_model.models import Filing
+
+from business_emailer.email_processors import (
+    affiliation_notification,
+    agm_extension_notification,
+    agm_location_change_notification,
+    amalgamation_notification,
+    amalgamation_out_notification,
+    appoint_receiver_notification,
+    ar_reminder_notification,
+    bn_notification,
+    cease_receiver_notification,
+    change_of_registration_notification,
+    consent_amalgamation_out_notification,
+    consent_continuation_out_notification,
+    continuation_in_notification,
+    continuation_out_notification,
+    correction_notification,
+    dissolution_notification,
+    filing_notification,
+    intent_to_liquidate_notification,
+    intent_to_liquidate_notification as _intent_to_liquidate,  # noqa: F401 (keep alias import-safe)
+    mras_notification,
+    name_request,
+    notice_of_withdrawal_notification,
+    nr_notification,
+    registration_notification,
+    restoration_notification,
+    special_resolution_notification,
+)
+from business_emailer.resources import business_emailer as worker
+from business_emailer.services import flags
+
+
+STUB_EMAIL = {
+    "recipients": "stub@test.com",
+    "content": {"subject": "stub", "body": "stub", "attachments": []},
+}
+TOKEN = "token"
+COMPLETED = Filing.Status.COMPLETED.value
+
+
+@pytest.fixture
+def mock_send_email(mocker):
+    """Patch worker.send_email and return the mock for assertions."""
+    return mocker.patch.object(worker, "send_email", return_value="success")
+
+
+@pytest.fixture(autouse=True)
+def mock_bearer_token(mocker):
+    """Every dispatch path calls AccountService.get_bearer_token() first."""
+    mocker.patch.object(AccountService, "get_bearer_token", return_value=TOKEN)
+
+
+def _ce(data, etype=None):
+    """Build a SimpleCloudEvent. If etype is None, wraps data under 'email'."""
+    if etype:
+        return SimpleCloudEvent(type=etype, data=data)
+    return SimpleCloudEvent(data=data)
+
+
+# --------------------------------------------------------------------------- #
+# bc.registry.* cloud-event types                                             #
+# --------------------------------------------------------------------------- #
+
+def test_affiliation_event_dispatches(app, session, mocker, mock_send_email):
+    """bc.registry.affiliation routes to affiliation_notification.process."""
+    mock_process = mocker.patch.object(affiliation_notification, "process", return_value=STUB_EMAIL)
+    payload = {"some": "affiliation-data"}
+
+    worker.process_email(_ce(payload, etype="bc.registry.affiliation"))
+
+    mock_process.assert_called_once_with(payload, TOKEN)
+    mock_send_email.assert_called_once_with(STUB_EMAIL, TOKEN)
+
+
+def test_bnmove_event_dispatches(app, session, mocker, mock_send_email):
+    """bc.registry.bnmove routes to bn_notification.process_bn_move."""
+    mock_process = mocker.patch.object(bn_notification, "process_bn_move", return_value=STUB_EMAIL)
+    payload = {"some": "bn-move-data"}
+
+    worker.process_email(_ce(payload, etype="bc.registry.bnmove"))
+
+    mock_process.assert_called_once_with(payload, TOKEN)
+    mock_send_email.assert_called_once_with(STUB_EMAIL, TOKEN)
+
+
+@pytest.mark.parametrize("option", [
+    nr_notification.Option.BEFORE_EXPIRY.value,
+    nr_notification.Option.EXPIRED.value,
+    nr_notification.Option.RENEWAL.value,
+    nr_notification.Option.UPGRADE.value,
+    nr_notification.Option.REFUND.value,
+])
+def test_names_request_routes_to_nr_notification(app, session, mocker, mock_send_email, option):
+    """bc.registry.names.request with a recognized option → nr_notification.process."""
+    mock_process = mocker.patch.object(nr_notification, "process", return_value=STUB_EMAIL)
+    payload = {"request": {"option": option}}
+
+    worker.process_email(_ce(payload, etype="bc.registry.names.request"))
+
+    mock_process.assert_called_once_with(payload, option)
+    mock_send_email.assert_called_once_with(STUB_EMAIL, TOKEN)
+
+
+def test_names_request_falls_back_to_name_request(app, session, mocker, mock_send_email):
+    """bc.registry.names.request without a matching option → name_request.process."""
+    mock_nr = mocker.patch.object(nr_notification, "process", return_value=STUB_EMAIL)
+    mock_name_request = mocker.patch.object(name_request, "process", return_value=STUB_EMAIL)
+    payload = {"request": {"option": "something-unknown"}}
+
+    worker.process_email(_ce(payload, etype="bc.registry.names.request"))
+
+    mock_nr.assert_not_called()
+    mock_name_request.assert_called_once_with(payload)
+    mock_send_email.assert_called_once_with(STUB_EMAIL, TOKEN)
+
+
+def test_names_request_missing_option_falls_back(app, session, mocker, mock_send_email):
+    """Missing option → name_request.process (covers the `if option and option in [...]` falsy branch)."""
+    mock_name_request = mocker.patch.object(name_request, "process", return_value=STUB_EMAIL)
+    payload = {"request": {}}
+
+    worker.process_email(_ce(payload, etype="bc.registry.names.request"))
+
+    mock_name_request.assert_called_once_with(payload)
+    mock_send_email.assert_called_once_with(STUB_EMAIL, TOKEN)
+
+
+# --------------------------------------------------------------------------- #
+# Inner email-dict dispatch (email_msg['email']['type'])                      #
+# --------------------------------------------------------------------------- #
+
+def test_business_number_dispatches(app, session, mocker, mock_send_email):
+    mock_process = mocker.patch.object(bn_notification, "process", return_value=STUB_EMAIL)
+    email = {"type": "businessNumber", "option": "whatever"}
+
+    worker.process_email(_ce({"email": email}))
+
+    mock_process.assert_called_once_with(email)
+    mock_send_email.assert_called_once_with(STUB_EMAIL, TOKEN)
+
+
+@pytest.mark.parametrize("etype", [
+    "amalgamationApplication",
+    "continuationIn",
+    "incorporationApplication",
+])
+def test_mras_dispatch(app, session, mocker, mock_send_email, etype):
+    """Any of the three filing types + option='mras' routes to mras_notification."""
+    mock_process = mocker.patch.object(mras_notification, "process", return_value=STUB_EMAIL)
+    email = {"type": etype, "option": "mras"}
+
+    worker.process_email(_ce({"email": email}))
+
+    mock_process.assert_called_once_with(email)
+    mock_send_email.assert_called_once_with(STUB_EMAIL, TOKEN)
+
+
+def test_ar_reminder_dispatch_with_flag_on(app, session, mocker, mock_send_email):
+    mocker.patch.object(flags, "is_on", return_value=True)
+    mock_process = mocker.patch.object(ar_reminder_notification, "process", return_value=STUB_EMAIL)
+    email = {"type": "annualReport", "option": "reminder"}
+
+    worker.process_email(_ce({"email": email}))
+
+    mock_process.assert_called_once_with(email, TOKEN, True)
+    mock_send_email.assert_called_once_with(STUB_EMAIL, TOKEN)
+
+
+def test_ar_reminder_dispatch_with_flag_off(app, session, mocker, mock_send_email):
+    mocker.patch.object(flags, "is_on", return_value=False)
+    mock_process = mocker.patch.object(ar_reminder_notification, "process", return_value=STUB_EMAIL)
+    email = {"type": "annualReport", "option": "reminder"}
+
+    worker.process_email(_ce({"email": email}))
+
+    mock_process.assert_called_once_with(email, TOKEN, False)
+
+
+def test_agm_location_change_completed_dispatches(app, session, mocker, mock_send_email):
+    mock_process = mocker.patch.object(agm_location_change_notification, "process", return_value=STUB_EMAIL)
+    email = {"type": "agmLocationChange", "option": COMPLETED}
+
+    worker.process_email(_ce({"email": email}))
+
+    mock_process.assert_called_once_with(email, TOKEN)
+    mock_send_email.assert_called_once_with(STUB_EMAIL, TOKEN)
+
+
+def test_agm_location_change_non_completed_is_skipped(app, session, mocker, mock_send_email):
+    """Option != COMPLETED falls through to the `else` log-and-skip branch."""
+    mock_process = mocker.patch.object(agm_location_change_notification, "process", return_value=STUB_EMAIL)
+    email = {"type": "agmLocationChange", "option": "PAID"}
+
+    worker.process_email(_ce({"email": email}))
+
+    mock_process.assert_not_called()
+    mock_send_email.assert_not_called()
+
+
+def test_agm_extension_completed_dispatches(app, session, mocker, mock_send_email):
+    mock_process = mocker.patch.object(agm_extension_notification, "process", return_value=STUB_EMAIL)
+    email = {"type": "agmExtension", "option": COMPLETED}
+
+    worker.process_email(_ce({"email": email}))
+
+    mock_process.assert_called_once_with(email, TOKEN)
+    mock_send_email.assert_called_once_with(STUB_EMAIL, TOKEN)
+
+
+def test_dissolution_dispatches(app, session, mocker, mock_send_email):
+    mock_process = mocker.patch.object(dissolution_notification, "process", return_value=STUB_EMAIL)
+    email = {"type": "dissolution", "option": COMPLETED}
+
+    worker.process_email(_ce({"email": email}))
+
+    mock_process.assert_called_once_with(email, TOKEN)
+    mock_send_email.assert_called_once_with(STUB_EMAIL, TOKEN)
+
+
+def test_registration_dispatches(app, session, mocker, mock_send_email):
+    mock_process = mocker.patch.object(registration_notification, "process", return_value=STUB_EMAIL)
+    email = {"type": "registration", "option": "PAID"}
+
+    worker.process_email(_ce({"email": email}))
+
+    mock_process.assert_called_once_with(email, TOKEN)
+    mock_send_email.assert_called_once_with(STUB_EMAIL, TOKEN)
+
+
+def test_restoration_dispatches(app, session, mocker, mock_send_email):
+    mock_process = mocker.patch.object(restoration_notification, "process", return_value=STUB_EMAIL)
+    email = {"type": "restoration", "option": COMPLETED}
+
+    worker.process_email(_ce({"email": email}))
+
+    mock_process.assert_called_once_with(email, TOKEN)
+    mock_send_email.assert_called_once_with(STUB_EMAIL, TOKEN)
+
+
+def test_change_of_registration_dispatches(app, session, mocker, mock_send_email):
+    mock_process = mocker.patch.object(change_of_registration_notification, "process", return_value=STUB_EMAIL)
+    email = {"type": "changeOfRegistration", "option": COMPLETED}
+
+    worker.process_email(_ce({"email": email}))
+
+    mock_process.assert_called_once_with(email, TOKEN)
+    mock_send_email.assert_called_once_with(STUB_EMAIL, TOKEN)
+
+
+def test_correction_dispatches(app, session, mocker, mock_send_email):
+    mock_process = mocker.patch.object(correction_notification, "process", return_value=STUB_EMAIL)
+    email = {"type": "correction", "option": "PAID"}
+
+    worker.process_email(_ce({"email": email}))
+
+    mock_process.assert_called_once_with(email, TOKEN)
+    mock_send_email.assert_called_once_with(STUB_EMAIL, TOKEN)
+
+
+def test_consent_amalgamation_out_dispatches(app, session, mocker, mock_send_email):
+    mock_process = mocker.patch.object(consent_amalgamation_out_notification, "process", return_value=STUB_EMAIL)
+    email = {"type": "consentAmalgamationOut", "option": COMPLETED}
+
+    worker.process_email(_ce({"email": email}))
+
+    mock_process.assert_called_once_with(email, TOKEN)
+    mock_send_email.assert_called_once_with(STUB_EMAIL, TOKEN)
+
+
+def test_amalgamation_out_dispatches(app, session, mocker, mock_send_email):
+    mock_process = mocker.patch.object(amalgamation_out_notification, "process", return_value=STUB_EMAIL)
+    email = {"type": "amalgamationOut", "option": COMPLETED}
+
+    worker.process_email(_ce({"email": email}))
+
+    mock_process.assert_called_once_with(email, TOKEN)
+    mock_send_email.assert_called_once_with(STUB_EMAIL, TOKEN)
+
+
+def test_consent_continuation_out_completed_dispatches(app, session, mocker, mock_send_email):
+    mock_process = mocker.patch.object(consent_continuation_out_notification, "process", return_value=STUB_EMAIL)
+    email = {"type": "consentContinuationOut", "option": COMPLETED}
+
+    worker.process_email(_ce({"email": email}))
+
+    mock_process.assert_called_once_with(email, TOKEN)
+    mock_send_email.assert_called_once_with(STUB_EMAIL, TOKEN)
+
+
+def test_consent_continuation_out_non_completed_skipped(app, session, mocker, mock_send_email):
+    mock_process = mocker.patch.object(consent_continuation_out_notification, "process", return_value=STUB_EMAIL)
+    email = {"type": "consentContinuationOut", "option": "PAID"}
+
+    worker.process_email(_ce({"email": email}))
+
+    mock_process.assert_not_called()
+    mock_send_email.assert_not_called()
+
+
+def test_continuation_out_completed_dispatches(app, session, mocker, mock_send_email):
+    mock_process = mocker.patch.object(continuation_out_notification, "process", return_value=STUB_EMAIL)
+    email = {"type": "continuationOut", "option": COMPLETED}
+
+    worker.process_email(_ce({"email": email}))
+
+    mock_process.assert_called_once_with(email, TOKEN)
+    mock_send_email.assert_called_once_with(STUB_EMAIL, TOKEN)
+
+
+def test_special_resolution_dispatches(app, session, mocker, mock_send_email):
+    mock_process = mocker.patch.object(special_resolution_notification, "process", return_value=STUB_EMAIL)
+    email = {"type": "specialResolution", "option": "PAID"}
+
+    worker.process_email(_ce({"email": email}))
+
+    mock_process.assert_called_once_with(email, TOKEN)
+    mock_send_email.assert_called_once_with(STUB_EMAIL, TOKEN)
+
+
+def test_amalgamation_application_non_mras_dispatches(app, session, mocker, mock_send_email):
+    """amalgamationApplication with a non-'mras' option hits the dedicated branch."""
+    mock_process = mocker.patch.object(amalgamation_notification, "process", return_value=STUB_EMAIL)
+    email = {"type": "amalgamationApplication", "option": COMPLETED}
+
+    worker.process_email(_ce({"email": email}))
+
+    mock_process.assert_called_once_with(email, TOKEN)
+    mock_send_email.assert_called_once_with(STUB_EMAIL, TOKEN)
+
+
+def test_continuation_in_non_mras_dispatches(app, session, mocker, mock_send_email):
+    mock_process = mocker.patch.object(continuation_in_notification, "process", return_value=STUB_EMAIL)
+    email = {"type": "continuationIn", "option": COMPLETED}
+
+    worker.process_email(_ce({"email": email}))
+
+    mock_process.assert_called_once_with(email, TOKEN)
+    mock_send_email.assert_called_once_with(STUB_EMAIL, TOKEN)
+
+
+def test_intent_to_liquidate_dispatches(app, session, mocker, mock_send_email):
+    mock_process = mocker.patch.object(intent_to_liquidate_notification, "process", return_value=STUB_EMAIL)
+    email = {"type": "intentToLiquidate", "option": COMPLETED}
+
+    worker.process_email(_ce({"email": email}))
+
+    mock_process.assert_called_once_with(email, TOKEN)
+    mock_send_email.assert_called_once_with(STUB_EMAIL, TOKEN)
+
+
+def test_notice_of_withdrawal_completed_dispatches(app, session, mocker, mock_send_email):
+    mock_process = mocker.patch.object(notice_of_withdrawal_notification, "process", return_value=STUB_EMAIL)
+    email = {"type": "noticeOfWithdrawal", "option": COMPLETED}
+
+    worker.process_email(_ce({"email": email}))
+
+    mock_process.assert_called_once_with(email, TOKEN)
+    mock_send_email.assert_called_once_with(STUB_EMAIL, TOKEN)
+
+
+def test_appoint_receiver_completed_dispatches(app, session, mocker, mock_send_email):
+    mock_process = mocker.patch.object(appoint_receiver_notification, "process", return_value=STUB_EMAIL)
+    email = {"type": "appointReceiver", "option": COMPLETED}
+
+    worker.process_email(_ce({"email": email}))
+
+    mock_process.assert_called_once_with(email, TOKEN)
+    mock_send_email.assert_called_once_with(STUB_EMAIL, TOKEN)
+
+
+def test_cease_receiver_completed_dispatches(app, session, mocker, mock_send_email):
+    mock_process = mocker.patch.object(cease_receiver_notification, "process", return_value=STUB_EMAIL)
+    email = {"type": "ceaseReceiver", "option": COMPLETED}
+
+    worker.process_email(_ce({"email": email}))
+
+    mock_process.assert_called_once_with(email, TOKEN)
+    mock_send_email.assert_called_once_with(STUB_EMAIL, TOKEN)
+
+
+# --------------------------------------------------------------------------- #
+# FILING_TYPE_CONVERTER branch                                                #
+# --------------------------------------------------------------------------- #
+
+def test_filing_type_converter_dispatches(app, session, mocker, mock_send_email):
+    """An etype in FILING_TYPE_CONVERTER (e.g. 'alteration') that isn't handled
+    earlier routes to filing_notification.process."""
+    mock_process = mocker.patch.object(filing_notification, "process", return_value=STUB_EMAIL)
+    email = {"type": "alteration", "option": "PAID"}
+
+    worker.process_email(_ce({"email": email}))
+
+    mock_process.assert_called_once_with(email, TOKEN)
+    mock_send_email.assert_called_once_with(STUB_EMAIL, TOKEN)
+
+
+def test_filing_type_converter_annual_report_completed_is_skipped(app, session, mocker, mock_send_email):
+    """annualReport + COMPLETED short-circuits before filing_notification is called."""
+    mock_process = mocker.patch.object(filing_notification, "process", return_value=STUB_EMAIL)
+    email = {"type": "annualReport", "option": COMPLETED}
+
+    worker.process_email(_ce({"email": email}))
+
+    mock_process.assert_not_called()
+    mock_send_email.assert_not_called()
+
+
+def test_filing_type_converter_coops_none_return_is_skipped(app, session, mocker, mock_send_email):
+    """When filing_notification.process returns None (coops filing), send_email is skipped."""
+    mocker.patch.object(filing_notification, "process", return_value=None)
+    email = {"type": "alteration", "option": "PAID"}
+
+    worker.process_email(_ce({"email": email}))
+
+    mock_send_email.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# Unrecognized types / dissolution furnishing skip                            #
+# --------------------------------------------------------------------------- #
+
+def test_unknown_email_type_is_skipped(app, session, mock_send_email):
+    """An etype that matches none of the elif branches silently no-ops."""
+    email = {"type": "totallyUnknownFilingType", "option": "PAID"}
+
+    worker.process_email(_ce({"email": email}))
+
+    mock_send_email.assert_not_called()
+
+
+def test_dissolution_event_with_invalid_furnishing_name_is_skipped(app, session, mocker, mock_send_email):
+    """bc.registry.dissolution with a furnishingName not in PROCESSABLE_FURNISHING_NAMES is skipped."""
+    from business_emailer.email_processors import involuntary_dissolution_stage_1_notification as ivd
+    mock_process = mocker.patch.object(ivd, "process", return_value=STUB_EMAIL)
+    mock_post_process = mocker.patch.object(ivd, "post_process")
+    payload = {"furnishing": {"furnishingName": "TOTALLY_NOT_A_REAL_FURNISHING"}}
+
+    worker.process_email(_ce(payload, etype="bc.registry.dissolution"))
+
+    mock_process.assert_not_called()
+    mock_post_process.assert_not_called()
+    mock_send_email.assert_not_called()
+
+
+def test_dissolution_event_missing_furnishing_name_is_skipped(app, session, mocker, mock_send_email):
+    """No furnishingName at all → skipped (covers the `if furnishing_name and ...` falsy branch)."""
+    from business_emailer.email_processors import involuntary_dissolution_stage_1_notification as ivd
+    mock_process = mocker.patch.object(ivd, "process", return_value=STUB_EMAIL)
+    payload = {"furnishing": {}}
+
+    worker.process_email(_ce(payload, etype="bc.registry.dissolution"))
+
+    mock_process.assert_not_called()
+    mock_send_email.assert_not_called()


### PR DESCRIPTION
*Issue #:* N/A

*Description of changes:*
No changes to built service code or dependencies (no deployments needed), just unit tests.

Kept seeing the business-emailer fail the coverage CI on various PRs so add a bunch of unit testing here to get above the threshold.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
