### PR TITLE
API enable replacing of ledger filing reports, update report config.

### DIFF
--- a/legal-api/pyproject.toml
+++ b/legal-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "legal-api"
-version = "3.0.2"
+version = "3.0.3"
 description = ""
 authors = [
     {name = "thor",email = "1042854+thorwolpert@users.noreply.github.com"}

--- a/legal-api/src/legal_api/reports/__init__.py
+++ b/legal-api/src/legal_api/reports/__init__.py
@@ -17,10 +17,10 @@ from flask_babel import _
 from .report import Report
 
 
-def get_pdf(filing, report_type=None):
+def get_pdf(filing, report_type=None, regenerate: bool = False):
     """Render a PDF for the supplied filing."""
     try:
-        return Report(filing).get_pdf(report_type)
+        return Report(filing).get_pdf(report_type, regenerate)
     except FileNotFoundError:
         # We don't have a template for it, so it must only be available on paper.
         return jsonify({"message": _("Available on paper only.")}), HTTPStatus.NOT_FOUND

--- a/legal-api/src/legal_api/reports/document_service.py
+++ b/legal-api/src/legal_api/reports/document_service.py
@@ -17,6 +17,7 @@ from typing import Optional
 import requests
 from flask import current_app, jsonify
 
+from legal_api.core.meta.filing import FILINGS
 from legal_api.exceptions import BusinessException
 from legal_api.models import Business, Document, Filing
 from legal_api.services import AccountService
@@ -24,6 +25,7 @@ from legal_api.utils.base import BaseEnum
 
 BUSINESS_DOCS_PATH: str = "{url}/application-reports/history/{product}/{business_id}?includeDocuments=true"
 GET_REPORT_PATH: str = "{url}/application-reports/{product}/{drsId}"
+PUT_REPORT_PATH: str = "{url}/application-reports/{product}/{drsId}"
 GET_REPORT_CERTIFIED_PATH: str = "{url}/application-reports/{product}/{drsId}?certifiedCopy=true"
 POST_REPORT_PATH: str = "{url}/application-reports/{product}/{bus_id}/{filing_id}/{report_type}"
 POST_REPORT_PARAMS: str = "?consumerFilingDate={filing_date}&consumerFilename={filename}"
@@ -68,6 +70,9 @@ class ReportTypes(BaseEnum):
 
     CERT = "CERT"
     FILING = "FILING"
+    FILING_2 = "FILING-2"
+    FILING_3 = "FILING-3"
+    FILING_4 = "FILING-4"
     NOA = "NOA"
     RECEIPT = "RECEIPT"
 
@@ -251,7 +256,7 @@ class DocumentService:
         except Exception:
             return []
 
-    def update_document_list(self, drs_docs: list, document_list: list) -> list:
+    def update_document_list(self, drs_docs: list, document_list: list, filing: Filing) -> list:
         """
         Update document_list urls with DRS information if a filing document maps to a DRS output or document.
 
@@ -262,26 +267,27 @@ class DocumentService:
         if not drs_docs or not document_list or not document_list.get("documents"):
             return document_list
         doc_list = document_list.get("documents")
+        receipt_exists: bool = False  # Some colin filings have no receipt - remove if not found.
         for doc in drs_docs:
-            if doc.get("reportType") and doc.get("reportType") == "RECEIPT" and doc_list.get("receipt"):
-                query_params: str = DRS_REPORT_PARAMS.format(report_type="RECEIPT", drs_id=doc.get("identifier"))
+            report_type: str = doc.get("reportType", "")
+            query_params: str = DRS_REPORT_PARAMS.format(report_type=report_type, drs_id=doc.get("identifier"))
+            if report_type == "RECEIPT" and doc_list.get("receipt"):
                 doc_list["receipt"] = doc_list["receipt"] + query_params
-            elif doc.get("reportType") and doc.get("reportType") == "NOA" and doc_list.get("noticeOfArticles"):
-                query_params: str = DRS_REPORT_PARAMS.format(report_type="NOA", drs_id=doc.get("identifier"))
+                receipt_exists = True
+            elif report_type == "NOA" and doc_list.get("noticeOfArticles"):
                 doc_list["noticeOfArticles"] = doc_list["noticeOfArticles"] + query_params
-            elif doc.get("reportType") and doc.get("reportType") == "FILING" and doc_list.get("legalFilings"):
-                query_params: str = DRS_REPORT_PARAMS.format(report_type="FILING", drs_id=doc.get("identifier"))
-                filing = doc_list["legalFilings"][0]
-                filing_key = next(iter(filing.keys()))
-                filing[filing_key] = filing[filing_key] + query_params
-            elif doc.get("reportType") and doc.get("reportType") == "CERT":
-                query_params: str = DRS_REPORT_PARAMS.format(report_type="CERT", drs_id=doc.get("identifier"))
-                for key in doc_list:
-                    if str(key).find("certificate") > -1:
-                        doc_list[key] = doc_list[key] + query_params
-                        break
+            elif report_type == "FILING":
+                doc_list = self._update_legal_filing(doc_list, query_params)
+            elif report_type.startswith("FILING"):
+                # Additional filings
+                doc_list = self._update_additional_filing(doc_list, query_params)
+            elif report_type == "CERT":
+                doc_list = self._update_certificate(doc_list, query_params)
             elif doc.get("documentClass"):
                 doc_list = self._update_static_document(doc, doc_list)
+        colin_filing: bool = filing and filing.storage and filing.storage.source == filing.storage.Source.COLIN.value
+        if colin_filing and not receipt_exists and doc_list.get("receipt"):
+            del doc_list["receipt"]
         return document_list
 
     def update_filing_documents(self, drs_docs: list, filing_docs: list, filing: Filing) -> list:  # noqa: PLR0912
@@ -304,27 +310,27 @@ class DocumentService:
             if meta_data and meta_data.get("colinFilingInfo") and meta_data["colinFilingInfo"].get("eventId"):
                 drs_filing_id = meta_data["colinFilingInfo"].get("eventId")
 
+        receipt_exists: bool = False  # Some colin filings have no receipt - remove if not found.
         for doc in drs_docs:
             if doc.get("eventIdentifier", 0) == drs_filing_id:
-                if doc.get("reportType") and doc.get("reportType") == "RECEIPT" and doc_list.get("receipt"):
-                    query_params: str = DRS_REPORT_PARAMS.format(report_type="RECEIPT", drs_id=doc.get("identifier"))
+                report_type: str = doc.get("reportType", "")
+                query_params: str = DRS_REPORT_PARAMS.format(report_type=report_type, drs_id=doc.get("identifier"))
+                if report_type == "RECEIPT" and doc_list.get("receipt"):
                     doc_list["receipt"] = doc_list["receipt"] + query_params
-                elif doc.get("reportType") and doc.get("reportType") == "NOA" and doc_list.get("noticeOfArticles"):
-                    query_params: str = DRS_REPORT_PARAMS.format(report_type="NOA", drs_id=doc.get("identifier"))
+                    receipt_exists = True
+                elif report_type == "NOA" and doc_list.get("noticeOfArticles"):
                     doc_list["noticeOfArticles"] = doc_list["noticeOfArticles"] + query_params
-                elif doc.get("reportType") and doc.get("reportType") == "FILING" and doc_list.get("legalFilings"):
-                    query_params: str = DRS_REPORT_PARAMS.format(report_type="FILING", drs_id=doc.get("identifier"))
-                    legal_filing = doc_list["legalFilings"][0]
-                    filing_key = next(iter(legal_filing.keys()))
-                    legal_filing[filing_key] = legal_filing[filing_key] + query_params
-                elif doc.get("reportType") and doc.get("reportType") == "CERT":
-                    query_params: str = DRS_REPORT_PARAMS.format(report_type="CERT", drs_id=doc.get("identifier"))
-                    for key in doc_list:
-                        if str(key).find("certificate") > -1:
-                            doc_list[key] = doc_list[key] + query_params
-                            break
+                elif report_type == "FILING":
+                    doc_list = self._update_legal_filing(doc_list, query_params)
+                elif report_type.startswith("FILING"):
+                    # Additional filings
+                    doc_list = self._update_additional_filing(doc_list, query_params)
+                elif report_type == "CERT":
+                    doc_list = self._update_certificate(doc_list, query_params)
                 elif doc.get("documentClass"):
                     doc_list = self._update_static_document(doc, doc_list)
+        if not receipt_exists and doc_list.get("receipt") and filing and filing.source == filing.Source.COLIN.value:
+            del doc_list["receipt"]
         return doc_list
 
     def get_filing_report(self, drs_id: str, report_type: str):
@@ -338,7 +344,7 @@ class DocumentService:
         headers = self._get_request_headers(BUSINESS_API_ACCOUNT_ID, APP_PDF)
         url: str = self.url.replace(DOC_PATH, "")
         get_url = GET_REPORT_PATH
-        if report_type in (ReportTypes.FILING.value, ReportTypes.NOA.value):
+        if report_type.startswith(ReportTypes.FILING.value) or report_type == ReportTypes.NOA.value:
             get_url = GET_REPORT_CERTIFIED_PATH
         get_url = get_url.format(url=url, product=self.product_code, drsId=drs_id)
         response = requests.get(url=get_url, headers=headers)
@@ -346,17 +352,16 @@ class DocumentService:
             current_app.logger.error(f"DRS call {get_url} failed status={response.status_code}: {response.content}")
         return response
 
-    def get_filing_report_by_filing_id(self, business_identifier: str, filing_identifier: int, report_type: str):
+    def get_drs_id(self, business_identifier: str, filing_identifier: int, report_type: str) -> str:
         """
-        Try to get a filing report document from the DRS by filing identifier and report type.
+        Try to get a DRS ID by business identifier, filing identifier and report type.
 
         business_identifier: The business identifier.
         filing_identifier: The filing identifier.
         report_type: The report type.
-        return: The report binary data status is OK.
+        return: The DRS identifier if matching record data found.
         """
-        if not business_identifier or not filing_identifier or not report_type:
-            return None, HTTPStatus.NOT_FOUND
+        drs_id = None
         headers = self._get_request_headers(BUSINESS_API_ACCOUNT_ID)
         url: str = self.url.replace(DOC_PATH, "")
         get_url = FILING_DOCS_PATH.format(
@@ -369,11 +374,24 @@ class DocumentService:
         if response.status_code != HTTPStatus.OK:
             return response.content, response.status_code
         response_json = json.loads(response.content)
-        drs_id = None
         for doc in response_json:
             if doc.get("reportType") == report_type and doc.get("eventIdentifier") == filing_identifier:
                 drs_id = doc.get("identifier")
                 break
+        return drs_id
+
+    def get_filing_report_by_filing_id(self, business_identifier: str, filing_identifier: int, report_type: str):
+        """
+        Try to get a filing report document from the DRS by filing identifier and report type.
+
+        business_identifier: The business identifier.
+        filing_identifier: The filing identifier.
+        report_type: The report type.
+        return: The report binary data status is OK.
+        """
+        if not business_identifier or not filing_identifier or not report_type:
+            return None, HTTPStatus.NOT_FOUND
+        drs_id = self.get_drs_id(business_identifier, filing_identifier, report_type)
         if drs_id:
             response = self.get_filing_report(drs_id, report_type)
             return response.content, response.status_code
@@ -445,6 +463,48 @@ class DocumentService:
                 return response2
         return report_response
 
+    def replace_filing_report(
+        self,
+        business_identifier: str,
+        filing: Filing,
+        report_meta: dict,
+        report_response
+    ):
+        """
+        Replace an existing DRS application report record document with a report service report.
+
+        business_identifier: Required - associates the report with the business.
+        filing: Required - contains the filing ID and filing date.
+        report_type: Required - the DRS report type.
+        report_response: Required - contains the report binary data
+        return: The DRS API response.
+        """
+        if not business_identifier or not filing or not report_meta or not report_meta.get("reportType"):
+            return report_response
+
+        report_type: str = report_meta.get("reportType")
+        drs_id = self.get_drs_id(business_identifier, filing.id, report_type)
+        if not drs_id:
+            return self.create_filing_report(business_identifier, filing, report_meta, report_response)
+
+        headers = self._get_request_headers(BUSINESS_API_ACCOUNT_ID)
+        url: str = self.url.replace(DOC_PATH, "")
+        put_url = PUT_REPORT_PATH.format(url=url, product=self.product_code, drsId=drs_id)
+        response = requests.put(url=put_url, headers=headers, data=report_response.content)
+        if response.status_code not in (HTTPStatus.OK, HTTPStatus.CREATED):
+            current_app.logger.error(f"DRS call {put_url} failed status={response.status_code}: {response.content}")
+            return report_response
+        if report_type == ReportTypes.CERT.value:
+            return report_response
+        # Get the certified copy of the NOA and FILING report types.
+        response_json = json.loads(response.content)
+        if response_json and response_json.get("identifier"):
+            response2 = self.get_filing_report(response_json.get("identifier"), report_type)
+            if response2.status_code == HTTPStatus.OK:
+                return response2
+        return report_response
+
+
     def _update_static_document(self, doc: dict, doc_list: list) -> list:
         """
         Update static document urls in the document_list if a DRS match is found.
@@ -477,7 +537,6 @@ class DocumentService:
                 break
         return doc_list
 
-
     def _get_request_headers(self, account_id: str, accept_mime_type = None) -> dict:
         """
         Get request headers for the DRS api call.
@@ -495,3 +554,41 @@ class DocumentService:
         if accept_mime_type:
             headers["Accept"] = accept_mime_type
         return headers
+
+    def _update_legal_filing(self, doc_list: dict, drs_params: str) -> dict:
+        """Add the DRS params to the legal filing document url."""
+        if doc_list and doc_list.get("legalFilings"):
+            legal_filing = doc_list["legalFilings"][0]
+            filing_key = next(iter(legal_filing.keys()))
+            legal_filing[filing_key] = legal_filing[filing_key] + drs_params
+        return doc_list
+
+    def _update_additional_filing(self, doc_list: dict, drs_params: str) -> dict:
+        """Conditionally add the DRS params to the additional filing document url."""
+        if doc_list.get("specialResolutionApplication"):  # Not in configuration
+            doc_list["specialResolutionApplication"] = doc_list["specialResolutionApplication"] + drs_params
+            return doc_list
+        if doc_list.get("legalFilings"):
+            legal_filing = doc_list["legalFilings"][0]
+            filing_key = next(iter(legal_filing.keys()))
+            if FILINGS.get(filing_key) and FILINGS[filing_key].get("additional"):
+                for add in FILINGS[filing_key].get("additional"):
+                    if add.get("outputs"):
+                        for output in add.get("outputs"):
+                            if (
+                                output != "noticeOfArticles" and
+                                not str(output).startswith("certificate") and
+                                doc_list.get(output)
+                            ):
+                                doc_list[output] = doc_list[output] + drs_params
+                                break
+        return doc_list
+
+    def _update_certificate(self, doc_list: dict, drs_params: str) -> dict:
+        """Add the DRS params to the certificate document url."""
+        if doc_list:
+            for key in list(doc_list.keys()):
+                if str(key).find("certificate") > -1:
+                    doc_list[key] = doc_list[key] + drs_params
+                    break
+        return doc_list

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -59,12 +59,15 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
         self._report_date_time = LegislationDatetime.now()
         self._document_service = DocumentService()
 
-    def get_pdf(self, report_type=None):
-        """Render a pdf for the report."""
+    def get_pdf(self, report_type=None, regenerate: bool=False):
+        """
+        Render a pdf for the report.
+        Regenerate if true will replace a report in the DRS if a DRS record already exists.
+        """
         self._report_key = report_type if report_type else self._filing.filing_type
         if self._report_key in ReportMeta.static_reports:
             return self._get_static_report()
-        return self._get_report()
+        return self._get_report(regenerate)
 
     def _get_static_report(self):
         document_type = ReportMeta.static_reports[self._report_key]["documentType"]
@@ -77,7 +80,7 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
             mimetype="application/pdf"
         )
 
-    def _get_report(self):
+    def _get_report(self, regenerate: bool = False):
         # Try to get report from DRS first: get to here if duplicate UI request before refreshing filing documents.
         if self._filing.business_id:
             self._business = Business.find_by_internal_id(self._filing.business_id)
@@ -87,7 +90,7 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
         if not report_meta:
             report_meta = ReportMeta.reports.get("default")
         report_type = report_meta.get("reportType")
-        if business_identifier:
+        if business_identifier and not regenerate:  # Skip if regenerating and replacing DRS doc.
             document, status = self._document_service.get_filing_report_by_filing_id(
                 business_identifier,
                 self._filing.id,
@@ -117,12 +120,20 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
         if response.status_code != HTTPStatus.OK:
             return jsonify(message=str(response.content)), response.status_code
 
-        response_drs = self._document_service.create_filing_report(
-            business_identifier,
-            self._filing,
-            report_meta,
-            response
-        )
+        if regenerate:
+            response_drs = self._document_service.replace_filing_report(
+                business_identifier,
+                self._filing,
+                report_meta,
+                response
+            )
+        else:
+            response_drs = self._document_service.create_filing_report(
+                business_identifier,
+                self._filing,
+                report_meta,
+                response
+            )
         return current_app.response_class(
             response=response_drs.content,
             status=response_drs.status_code,
@@ -289,7 +300,6 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
         self._set_meta_info(filing)
         self._set_registrar_info(filing)
         self._set_completing_party(filing)
-        self._set_corp_flag(filing)
 
         filing["enable_new_ben_statements"] = flags.is_on("enable-new-ben-statements")
         filing["enable_sandbox"] = flags.is_on("enable-sandbox")
@@ -359,16 +369,6 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
             self._format_special_resolution(filing)
         elif self._report_key == "specialResolutionApplication":
             self._format_special_resolution_application(filing, "alteration")
-
-    def _set_corp_flag(self, filing):
-        """Set a flag indicating whether the entity is a corporation."""
-        if self._business:
-            legal_type = self._business.legal_type
-        else:
-            filing_json = self._filing.filing_json.get("filing", {})
-            filing_type = self._filing.filing_type
-            legal_type = filing_json.get(filing_type, {}).get("nameRequest", {}).get("legalType")
-        filing["business"]["isCorp"] = legal_type in Business.CORPS
 
     def _set_completing_party(self, filing):
         completing_party_role = PartyRole.get_party_roles_by_filing(
@@ -477,14 +477,12 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
             filing["listOfDirectors"] = filing["changeOfDirectors"]
         else:
             filing["listOfDirectors"] = {
-                "directors": filing["annualReport"].get("directors", [])
+                "directors": filing["annualReport"]["directors"]
             }
-
-        if filing["listOfDirectors"]["directors"]:
-            # create helper lists of appointed and ceased directors
-            directors = self._format_directors(filing["listOfDirectors"]["directors"])
-            filing["listOfDirectors"]["directorsAppointed"] = [el for el in directors if "appointed" in el["actions"]]
-            filing["listOfDirectors"]["directorsCeased"] = [el for el in directors if "ceased" in el["actions"]]
+        # create helper lists of appointed and ceased directors
+        directors = self._format_directors(filing["listOfDirectors"]["directors"])
+        filing["listOfDirectors"]["directorsAppointed"] = [el for el in directors if "appointed" in el["actions"]]
+        filing["listOfDirectors"]["directorsCeased"] = [el for el in directors if "ceased" in el["actions"]]
 
     def _format_directors(self, directors):
         for director in directors:
@@ -1603,7 +1601,7 @@ class ReportMeta:  # pylint: disable=too-few-public-methods
         "specialResolutionApplication": {
             "filingDescription": "Special Resolution Application",
             "fileName": "specialResolutionApplication",
-            "reportType": ReportTypes.FILING.value
+            "reportType": ReportTypes.FILING_2.value
         },
         "voluntaryDissolution": {
             "filingDescription": "Voluntary Dissolution",
@@ -1638,12 +1636,12 @@ class ReportMeta:  # pylint: disable=too-few-public-methods
         "amendedRegistrationStatement": {
             "filingDescription": "Amended Registration Statement",
             "fileName": "amendedRegistrationStatement",
-            "reportType": ReportTypes.FILING.value
+            "reportType": ReportTypes.FILING_2.value
         },
         "correctedRegistrationStatement": {
             "filingDescription": "Corrected Registration Statement",
             "fileName": "amendedRegistrationStatement",
-            "reportType": ReportTypes.FILING.value
+            "reportType": ReportTypes.FILING_2.value
         },
         "changeOfRegistration": {
             "filingDescription": "Change of Registration",
@@ -1677,22 +1675,22 @@ class ReportMeta:  # pylint: disable=too-few-public-methods
         "letterOfConsent": {
             "filingDescription": "Letter Of Consent",
             "fileName": "letterOfConsent",
-            "reportType": ReportTypes.FILING.value
+            "reportType": ReportTypes.FILING_2.value
         },
         "letterOfConsentAmalgamationOut": {
             "filingDescription": "Letter Of Consent",
             "fileName": "letterOfConsentAmalgamationOut",
-            "reportType": ReportTypes.FILING.value
+            "reportType": ReportTypes.FILING_2.value
         },
         "letterOfAgmExtension": {
             "filingDescription": "Letter Of AGM Extension",
             "fileName": "letterOfAgmExtension",
-            "reportType": ReportTypes.FILING.value
+            "reportType": ReportTypes.FILING_2.value
         },
         "letterOfAgmLocationChange": {
             "filingDescription": "Letter Of AGM Location Change",
             "fileName": "letterOfAgmLocationChange",
-            "reportType": ReportTypes.FILING.value
+            "reportType": ReportTypes.FILING_2.value
         },
         "continuationIn": {
             "filingDescription": "Continuation Application",

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -300,6 +300,7 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
         self._set_meta_info(filing)
         self._set_registrar_info(filing)
         self._set_completing_party(filing)
+        self._set_corp_flag(filing)
 
         filing["enable_new_ben_statements"] = flags.is_on("enable-new-ben-statements")
         filing["enable_sandbox"] = flags.is_on("enable-sandbox")
@@ -369,6 +370,16 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
             self._format_special_resolution(filing)
         elif self._report_key == "specialResolutionApplication":
             self._format_special_resolution_application(filing, "alteration")
+
+    def _set_corp_flag(self, filing):
+        """Set a flag indicating whether the entity is a corporation."""
+        if self._business:
+            legal_type = self._business.legal_type
+        else:
+            filing_json = self._filing.filing_json.get("filing", {})
+            filing_type = self._filing.filing_type
+            legal_type = filing_json.get(filing_type, {}).get("nameRequest", {}).get("legalType")
+        filing["business"]["isCorp"] = legal_type in Business.CORPS
 
     def _set_completing_party(self, filing):
         completing_party_role = PartyRole.get_party_roles_by_filing(
@@ -477,12 +488,14 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
             filing["listOfDirectors"] = filing["changeOfDirectors"]
         else:
             filing["listOfDirectors"] = {
-                "directors": filing["annualReport"]["directors"]
+                "directors": filing["annualReport"].get("directors", [])
             }
-        # create helper lists of appointed and ceased directors
-        directors = self._format_directors(filing["listOfDirectors"]["directors"])
-        filing["listOfDirectors"]["directorsAppointed"] = [el for el in directors if "appointed" in el["actions"]]
-        filing["listOfDirectors"]["directorsCeased"] = [el for el in directors if "ceased" in el["actions"]]
+
+        if filing["listOfDirectors"]["directors"]:
+            # create helper lists of appointed and ceased directors
+            directors = self._format_directors(filing["listOfDirectors"]["directors"])
+            filing["listOfDirectors"]["directorsAppointed"] = [el for el in directors if "appointed" in el["actions"]]
+            filing["listOfDirectors"]["directorsCeased"] = [el for el in directors if "ceased" in el["actions"]]
 
     def _format_directors(self, directors):
         for director in directors:

--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_documents.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_documents.py
@@ -37,13 +37,14 @@ from legal_api.utils.util import cors_preflight
 # noqa: I003; the multiple route decorators cause an erroneous error in line space counting
 
 
-DOCUMENTS_BASE_ROUTE: Final = "/<string:identifier>/filings/<int:filing_id>/documents"
-PARAM_REPORT_TYPE: str = "reportType"
-PARAM_DOC_CLASS = "documentClass"
-PARAM_DRS_ID = "drsId"
-APP_PDF =  "application/pdf"
-CONTENT_JSON = {"Content-Type": "application/json"}
-CONTENT_PDF = {"Content-Type": APP_PDF}
+DOCUMENTS_BASE_ROUTE: Final[str] = "/<string:identifier>/filings/<int:filing_id>/documents"
+PARAM_REPORT_TYPE: Final[str] = "reportType"
+PARAM_DOC_CLASS: Final[str] = "documentClass"
+PARAM_DRS_ID: Final[str] = "drsId"
+PARAM_REGENERATE: Final[str] = "regenerate"
+APP_PDF: Final[str] =  "application/pdf"
+CONTENT_JSON: Final = {"Content-Type": "application/json"}
+CONTENT_PDF: Final = {"Content-Type": APP_PDF}
 
 
 @cors_preflight("GET, POST")
@@ -101,6 +102,9 @@ def get_documents(identifier: str, # noqa: PLR0911, PLR0912
                                           file_name=file_name, filing_id=filing_id, identifier=identifier)
             ), HTTPStatus.NOT_FOUND
 
+        if _regenerate(legal_filing_name):
+            return get_pdf(filing.storage, legal_filing_name, True)
+
         if drs_params := _get_drs_params():
             return _get_drs_documents(drs_params)
 
@@ -131,6 +135,13 @@ def _get_drs_params() -> dict:
     if request.args.get(PARAM_DOC_CLASS):
         params["documentClass"] = request.args.get(PARAM_DOC_CLASS)
     return params
+
+
+def _regenerate(legal_filing_name: str) -> bool:
+    """Determine if individual report request should regenerate and update the DRS."""
+    if legal_filing_name and legal_filing_name.lower().startswith("receipt"):
+        return False
+    return request.args.get(PARAM_REGENERATE, False)
 
 
 def _get_drs_documents(drs_params: dict):
@@ -179,7 +190,7 @@ def _get_document_list(business: Business, filing: Filing):
         identifier = business.identifier if business else storage.temp_reg
         doc_service: DocumentService = DocumentService()
         drs_docs: list = doc_service.get_documents_by_filing_id(identifier, drs_filing_id)
-        document_list = doc_service.update_document_list(drs_docs, document_list)
+        document_list = doc_service.update_document_list(drs_docs, document_list, filing)
     return jsonify(document_list), HTTPStatus.OK
 
 

--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_documents.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_documents.py
@@ -141,7 +141,10 @@ def _regenerate(legal_filing_name: str) -> bool:
     """Determine if individual report request should regenerate and update the DRS."""
     if legal_filing_name and legal_filing_name.lower().startswith("receipt"):
         return False
-    return request.args.get(PARAM_REGENERATE, False)
+    regen_doc = request.args.get(PARAM_REGENERATE)
+    if regen_doc is not None and isinstance(regen_doc, bool) and regen_doc:
+       return True
+    return regen_doc is not None and isinstance(regen_doc, str) and regen_doc.lower() in ["true", "1", "y", "yes"]
 
 
 def _get_drs_documents(drs_params: dict):

--- a/legal-api/tests/unit/reports/test_document_service.py
+++ b/legal-api/tests/unit/reports/test_document_service.py
@@ -258,22 +258,22 @@ TEST_REPORT_META_DATA = [
     (True, "annualReport", "FILING"),
     (True, "changeOfName", "FILING"),
     (True, "specialResolution", "FILING"),
-    (True, "specialResolutionApplication", "FILING"),
+    (True, "specialResolutionApplication", "FILING-2"),
     (True, "voluntaryDissolution", "FILING"),
     (True, "certificateOfNameChange", "CERT"),
     (True, "certificateOfNameCorrection", "CERT"),
     (True, "certificateOfDissolution", "CERT"),
     (True, "dissolution", "FILING"),
     (True, "registration", "FILING"),
-    (True, "amendedRegistrationStatement", "FILING"),
-    (True, "correctedRegistrationStatement", "FILING"),
+    (True, "amendedRegistrationStatement", "FILING-2"),
+    (True, "correctedRegistrationStatement", "FILING-2"),
     (True, "changeOfRegistration", "FILING"),
     (True, "correction", "FILING"),
     (True, "certificateOfRestoration", "CERT"),
-    (True, "letterOfConsent", "FILING"),
-    (True, "letterOfConsentAmalgamationOut", "FILING"),
-    (True, "letterOfAgmExtension", "FILING"),
-    (True, "letterOfAgmLocationChange", "FILING"),
+    (True, "letterOfConsent", "FILING-2"),
+    (True, "letterOfConsentAmalgamationOut", "FILING-2"),
+    (True, "letterOfAgmExtension", "FILING-2"),
+    (True, "letterOfAgmLocationChange", "FILING-2"),
     (True, "continuationIn", "FILING"),
     (True, "certificateOfContinuation", "CERT"),
     (True, "noticeOfWithdrawal", "FILING"),
@@ -299,7 +299,7 @@ def test_update_filing_docs(session, desc, doc_data, drs_data, receipt, filing, 
     """Assert that updating filing output url's with DRS info works as expected."""
     doc_service: DocumentService = DocumentService()
     filing_docs = copy.deepcopy(doc_data)
-    results = doc_service.update_document_list(drs_data, filing_docs)
+    results = doc_service.update_document_list(drs_data, filing_docs, None)
     assert results
     text_results: str = json.dumps(results)
     if not receipt:


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33217

*Description of changes:*
Add the ability to regenerate a filing report when the report data changes, such as when a BN is assigned to a new business. Add a new optional boolean request parameter regenerate=true to GET filing report requests. If this parameter is true the API will:

Regenerate the report with a report service call.
With the existing DRS record ID replace the pdf data with a recently added DRS API PUT endpoint call: PUT /doc/api/v1/application-reports/BUSINESS/{identifier}
Also update the API reports configuration so additional filings work properly - as a distinct DRS API report type.


*Issue #:* /bcgov/entity#33171

*Description of changes:*
Not all migrated Colin filings have receipts. For example, in TEST the 2025 AR for BC1252030 has no receipt: a screenshot of the PROD colin ledger is attached to the ticket. The business api assumes that all filings have receipts, so if a colin migrated filing has no receipt the business api is trying to get the receipt from the pay api and returning an error.

Fix: update the business api to conditionally remove the receipt link from the ledger filing documents when the filing documents have migrated from colin and no receipt exists in the DRS.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
