### PR TITLE
33224 business-registry-model: Add additional currency serialization

### DIFF
--- a/python/common/business-registry-model/pyproject.toml
+++ b/python/common/business-registry-model/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "business-model"
-version = "3.3.24"
+version = "3.3.25"
 description = ""
 authors = [
     {name = "thor",email = "1042854+thorwolpert@users.noreply.github.com"}

--- a/python/common/business-registry-model/src/business_model/models/share_class.py
+++ b/python/common/business-registry-model/src/business_model/models/share_class.py
@@ -67,6 +67,7 @@ class ShareClass(db.Model, Versioned):  # pylint: disable=too-many-instance-attr
             'hasParValue': self.par_value_flag,
             'parValue': self.par_value,
             'currency': self.currency,
+            'currencyAdditional': self.currency_additional,
             'hasRightsOrRestrictions': self.special_rights_flag
         }
 
@@ -119,6 +120,8 @@ def receive_before_change(mapper, connection, target):  # pylint: disable=unused
                 error=f'The share class {share_class.name} must specify currency.',
                 status_code=HTTPStatus.BAD_REQUEST
             )
+        if share_class.currency.upper() != 'OTHER':
+            share_class.currency_additional = None
     else:
         share_class.par_value = None
         share_class.currency = None

--- a/python/common/business-registry-model/tests/models/test_share_class.py
+++ b/python/common/business-registry-model/tests/models/test_share_class.py
@@ -70,10 +70,74 @@ def test_share_class_json(session):
         'hasParValue': share_class.par_value_flag,
         'parValue': share_class.par_value,
         'currency': share_class.currency,
+        'currencyAdditional': share_class.currency_additional,
         'hasRightsOrRestrictions': share_class.special_rights_flag,
         'series': []
     }
     assert share_class_json == share_class.json
+
+
+def test_share_class_json_with_currency_additional(session):
+    """Assert the json format of share class includes currencyAdditional."""
+    identifier = 'CP1234567'
+    business = factory_business(identifier)
+    share_class = ShareClass(
+        name='Class 1 Shares',
+        priority=1,
+        max_share_flag=True,
+        max_shares=1000,
+        par_value_flag=True,
+        par_value=0.852,
+        currency='OTHER',
+        currency_additional='Bitcoin',
+        special_rights_flag=False,
+        business_id=business.id
+    )
+    share_class.save()
+    assert share_class.json['currency'] == 'OTHER'
+    assert share_class.json['currencyAdditional'] == 'Bitcoin'
+
+
+def test_listener_clears_currency_additional_when_currency_not_other(session):
+    """Assert the listener nulls currency_additional when currency is set to a non-OTHER code."""
+    identifier = 'CP1234567'
+    business = factory_business(identifier)
+    share_class = ShareClass(
+        name='Class 1 Shares',
+        priority=1,
+        max_share_flag=True,
+        max_shares=1000,
+        par_value_flag=True,
+        par_value=0.852,
+        currency='CAD',
+        currency_additional='Stale',
+        special_rights_flag=False,
+        business_id=business.id
+    )
+    share_class.save()
+    assert share_class.currency == 'CAD'
+    assert share_class.currency_additional is None
+
+
+def test_listener_preserves_currency_additional_when_currency_other(session):
+    """Assert the listener preserves currency_additional when currency is OTHER."""
+    identifier = 'CP1234567'
+    business = factory_business(identifier)
+    share_class = ShareClass(
+        name='Class 1 Shares',
+        priority=1,
+        max_share_flag=True,
+        max_shares=1000,
+        par_value_flag=True,
+        par_value=0.852,
+        currency='OTHER',
+        currency_additional='Bitcoin',
+        special_rights_flag=False,
+        business_id=business.id
+    )
+    share_class.save()
+    assert share_class.currency == 'OTHER'
+    assert share_class.currency_additional == 'Bitcoin'
 
 
 def test_invalid_share_quantity(session):

--- a/python/common/business-registry-model/tests/models/test_share_series.py
+++ b/python/common/business-registry-model/tests/models/test_share_series.py
@@ -96,6 +96,7 @@ def test_share_series_json(session):
         'hasParValue': share_class.par_value_flag,
         'parValue': share_class.par_value,
         'currency': share_class.currency,
+        'currencyAdditional': share_class.currency_additional,
         'hasRightsOrRestrictions': share_class.special_rights_flag,
         'series': [
             {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33224

*Description of changes:*
Match the changes made to the legal-api models for `currency_additional`. Some were never made in this `business-registry-model` duplicate.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
