### PR TITLE
33224: Clear out currency_additional when altering currency to valid type

### DIFF
--- a/legal-api/src/legal_api/models/share_class.py
+++ b/legal-api/src/legal_api/models/share_class.py
@@ -120,6 +120,8 @@ def receive_before_change(mapper, connection, target):  # pylint: disable=unused
                 error=f"The share class {share_class.name} must specify currency.",
                 status_code=HTTPStatus.BAD_REQUEST
             )
+        if share_class.currency.upper() != "OTHER":
+            share_class.currency_additional = None
     else:
         share_class.par_value = None
         share_class.currency = None

--- a/legal-api/src/legal_api/services/business_details_version.py
+++ b/legal-api/src/legal_api/services/business_details_version.py
@@ -593,6 +593,7 @@ class VersionedBusinessDetailsService:  # pylint: disable=too-many-public-method
             "hasParValue": share_class_revision.par_value_flag,
             "parValue": share_class_revision.par_value,
             "currency": share_class_revision.currency,
+            "currencyAdditional": share_class_revision.currency_additional,
             "hasRightsOrRestrictions": share_class_revision.special_rights_flag
         }
         return share_class

--- a/legal-api/tests/unit/models/test_share_class.py
+++ b/legal-api/tests/unit/models/test_share_class.py
@@ -98,6 +98,48 @@ def test_share_class_json_with_currency_additional(session):
     assert share_class.json['currencyAdditional'] == 'Bitcoin'
 
 
+def test_listener_clears_currency_additional_when_currency_not_other(session):
+    """Assert the listener nulls currency_additional when currency is set to a non-OTHER code."""
+    identifier = 'CP1234567'
+    business = factory_business(identifier)
+    share_class = ShareClass(
+        name='Class 1 Shares',
+        priority=1,
+        max_share_flag=True,
+        max_shares=1000,
+        par_value_flag=True,
+        par_value=0.852,
+        currency='CAD',
+        currency_additional='Stale',
+        special_rights_flag=False,
+        business_id=business.id
+    )
+    share_class.save()
+    assert share_class.currency == 'CAD'
+    assert share_class.currency_additional is None
+
+
+def test_listener_preserves_currency_additional_when_currency_other(session):
+    """Assert the listener preserves currency_additional when currency is OTHER."""
+    identifier = 'CP1234567'
+    business = factory_business(identifier)
+    share_class = ShareClass(
+        name='Class 1 Shares',
+        priority=1,
+        max_share_flag=True,
+        max_shares=1000,
+        par_value_flag=True,
+        par_value=0.852,
+        currency='OTHER',
+        currency_additional='Bitcoin',
+        special_rights_flag=False,
+        business_id=business.id
+    )
+    share_class.save()
+    assert share_class.currency == 'OTHER'
+    assert share_class.currency_additional == 'Bitcoin'
+
+
 def test_invalid_share_quantity(session):
     """Assert that model validates share class share quantity."""
     identifier = 'CP1234567'


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33224

*Description of changes:*
If there's an additional currency in a share and you fix from OTHER to a valid type, remove that additional.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
