### PR TITLE
33002 - Remove certified copy stamp from Letter of Consent

### DIFF
--- a/legal-api/src/legal_api/reports/document_service.py
+++ b/legal-api/src/legal_api/reports/document_service.py
@@ -344,7 +344,7 @@ class DocumentService:
         headers = self._get_request_headers(BUSINESS_API_ACCOUNT_ID, APP_PDF)
         url: str = self.url.replace(DOC_PATH, "")
         get_url = GET_REPORT_PATH
-        if report_type.startswith(ReportTypes.FILING.value) or report_type == ReportTypes.NOA.value:
+        if report_type in [ReportTypes.FILING.value, ReportTypes.FILING_2.value, ReportTypes.NOA.value]:
             get_url = GET_REPORT_CERTIFIED_PATH
         get_url = get_url.format(url=url, product=self.product_code, drsId=drs_id)
         response = requests.get(url=get_url, headers=headers)

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -1688,22 +1688,22 @@ class ReportMeta:  # pylint: disable=too-few-public-methods
         "letterOfConsent": {
             "filingDescription": "Letter Of Consent",
             "fileName": "letterOfConsent",
-            "reportType": ReportTypes.FILING_2.value
+            "reportType": ReportTypes.FILING_3.value
         },
         "letterOfConsentAmalgamationOut": {
             "filingDescription": "Letter Of Consent",
             "fileName": "letterOfConsentAmalgamationOut",
-            "reportType": ReportTypes.FILING_2.value
+            "reportType": ReportTypes.FILING_2.value  # change to filing-3 to omit stamp
         },
         "letterOfAgmExtension": {
             "filingDescription": "Letter Of AGM Extension",
             "fileName": "letterOfAgmExtension",
-            "reportType": ReportTypes.FILING_2.value
+            "reportType": ReportTypes.FILING_2.value  # change to filing-3 to omit stamp
         },
         "letterOfAgmLocationChange": {
             "filingDescription": "Letter Of AGM Location Change",
             "fileName": "letterOfAgmLocationChange",
-            "reportType": ReportTypes.FILING_2.value
+            "reportType": ReportTypes.FILING_2.value  # change to filing-3 to omit stamp
         },
         "continuationIn": {
             "filingDescription": "Continuation Application",

--- a/legal-api/tests/unit/reports/test_document_service.py
+++ b/legal-api/tests/unit/reports/test_document_service.py
@@ -270,7 +270,7 @@ TEST_REPORT_META_DATA = [
     (True, "changeOfRegistration", "FILING"),
     (True, "correction", "FILING"),
     (True, "certificateOfRestoration", "CERT"),
-    (True, "letterOfConsent", "FILING-2"),
+    (True, "letterOfConsent", "FILING-3"),
     (True, "letterOfConsentAmalgamationOut", "FILING-2"),
     (True, "letterOfAgmExtension", "FILING-2"),
     (True, "letterOfAgmLocationChange", "FILING-2"),

--- a/legal-api/tests/unit/reports/test_filing_report_url.py
+++ b/legal-api/tests/unit/reports/test_filing_report_url.py
@@ -1,0 +1,51 @@
+
+import pytest
+import requests_mock
+from flask import current_app
+from legal_api.reports.document_service import DocumentService, ReportTypes
+
+@pytest.mark.parametrize('report_type, expected_certified', [
+    # Legal Filings and Notices of Articles are official summaries that must be certified 
+    # as they represent the "state of record" for a business.
+    (ReportTypes.FILING.value, True),
+    (ReportTypes.FILING_2.value, True),
+    (ReportTypes.NOA.value, True),
+    
+    # FILING-3 is used for Letters (e.g., Letter of Consent). These are correspondence
+    # items where a "Certified Copy" stamp is not appropriate and can obscure text.
+    (ReportTypes.FILING_3.value, False),
+    
+    # Receipts are financial records and should not be stamped with a "Certified Copy" watermark.
+    (ReportTypes.RECEIPT.value, False),
+])
+def test_get_filing_report_url_params(app, mocker, report_type, expected_certified):
+    """
+    Verify that the Document Service correctly decides whether to request a 'Certified Copy'.
+    
+    This is critical because the downstream Document Retrieval Service (DRS) uses the 
+    'certifiedCopy' query parameter to burn a permanent watermark into the PDF binary.
+    """
+    mocker.patch('legal_api.services.AccountService.get_bearer_token', return_value='fake-token')
+    with app.app_context():
+        doc_service = DocumentService()
+        drs_id = "test-drs-id"
+        
+        with requests_mock.Mocker() as m:
+            base_url = current_app.config.get("DOCUMENT_SVC_URL").replace("/documents", "")
+            product = current_app.config.get("DOCUMENT_PRODUCT_CODE")
+            
+            # Construct the expected URL based on the logic we are testing
+            if expected_certified:
+                expected_url = f"{base_url}/application-reports/{product}/{drs_id}?certifiedCopy=true"
+            else:
+                expected_url = f"{base_url}/application-reports/{product}/{drs_id}"
+            
+            m.get(expected_url, status_code=200, content=b"pdf-binary-data")
+            
+            response = doc_service.get_filing_report(drs_id, report_type)
+            
+            # Verification:
+            # 1. The service reached the correct endpoint with the correct parameters
+            assert m.request_history[-1].url == expected_url
+            # 2. The binary data is returned correctly regardless of the stamp status
+            assert response.content == b"pdf-binary-data"


### PR DESCRIPTION
#33002 : /bcgov/entity#33002

*Description of changes:*
The "Certified Copy" stamp is triggered when the code calls the Document Retrieval Service (DRS) using a URL that includes the `?certifiedCopy=true` query parameter. By creating the FILING-3 report type, we are able to adjust the logic to omit that specific query parameter from the URL for `letterOfConsent`, which prevents DRS from injecting the stamp into the PDF.

For verification, implemented a parameterized unit test that enforces the correct URL structure is generated for each specific report type, so it is ensured that the `?certifiedCopy=true` query parameter is only applied to ` FILING, FILING-2, and NOA`, and explicitly omitted for `letterOfConsent` using FILING-3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
