### PR TITLE
DBC: Valid party roles restriction in legal-api

### DIFF
--- a/legal-api/src/legal_api/services/digital_credentials_helpers.py
+++ b/legal-api/src/legal_api/services/digital_credentials_helpers.py
@@ -146,10 +146,8 @@ def get_roles(user: User,
     may_attach_role = not has_preconditions or only_use_self_attested_roles
 
     if may_attach_role:
-        if rules.user_has_business_party_role(user, business):
-            party_roles += rules.user_business_party_roles(user, business)
-        if rules.user_has_filing_party_role(user, business):
-            party_roles += rules.user_filing_party_roles(user, business)
+        party_roles += rules.user_business_party_roles(user, business)
+        party_roles += rules.user_filing_party_roles(user, business)
 
         if only_use_self_attested_roles:
             # Ensures that the user cant attach roles that are not stated in the preconditions

--- a/legal-api/src/legal_api/services/digital_credentials_rules.py
+++ b/legal-api/src/legal_api/services/digital_credentials_rules.py
@@ -67,10 +67,8 @@ class DigitalCredentialsRulesService:
         """
         preconditions = []
         if not self.user_is_completing_party(user, business):
-            if self.user_has_business_party_role(user, business):
-                preconditions += self.user_business_party_roles(user, business)
-            if self.user_has_filing_party_role(user, business):
-                preconditions += self.user_filing_party_roles(user, business)
+            preconditions += self.user_business_party_roles(user, business)
+            preconditions += self.user_filing_party_roles(user, business)
         return [party_role.role for party_role in preconditions]
 
     def _has_general_access(self, user: User) -> bool:
@@ -100,8 +98,8 @@ class DigitalCredentialsRulesService:
         )
 
         if business.legal_type in allowed_business_types:
-            return (self.user_has_filing_party_role(user, business)
-                    or self.user_has_business_party_role(user, business))
+            return bool(self.user_filing_party_roles(user, business)
+                        or self.user_business_party_roles(user, business))
 
         current_app.logger.debug("No specific DBC access rules are met.")
         return False
@@ -115,22 +113,6 @@ class DigitalCredentialsRulesService:
 
         filing = filings.pop(0)
         return self.user_submitted_filing(user, filing) and self.user_matches_completing_party(user, filing)
-
-    def user_has_filing_party_role(self, user: User, business: Business) -> bool:
-        """
-        Return True if the user has a filing party role in the business. Excludes the completing party role.
-
-        For example: if a user is an incorporator.
-        """
-        return len(self.user_filing_party_roles(user, business)) > 0
-
-    def user_has_business_party_role(self, user: User, business: Business) -> bool:
-        """
-        Return True if the user has a business party role in the business.
-
-        For example: if a user is a director.
-        """
-        return len(self.user_business_party_roles(user, business)) > 0
 
     def user_filing_party_roles(self, user: User, business: Business) -> list[PartyRole]:
         """Return the valid filing roles of the user for the business, if any.

--- a/legal-api/src/legal_api/services/digital_credentials_rules.py
+++ b/legal-api/src/legal_api/services/digital_credentials_rules.py
@@ -49,6 +49,12 @@ class DigitalCredentialsRulesService:
         Business.LegalTypes.BCOMP_CONTINUE_IN.value
     ]
 
+    valid_role_types = [
+        PartyRole.RoleTypes.PROPRIETOR.value,
+        PartyRole.RoleTypes.DIRECTOR.value,
+        PartyRole.RoleTypes.PARTNER.value,
+    ]
+
     def are_digital_credentials_allowed(self, user: User, business: Business) -> bool:
         """Return True if the user is allowed to access digital credentials."""
         return self._has_general_access(user) and self._has_specific_access(user, business)
@@ -127,7 +133,10 @@ class DigitalCredentialsRulesService:
         return len(self.user_business_party_roles(user, business)) > 0
 
     def user_filing_party_roles(self, user: User, business: Business) -> list[PartyRole]:
-        """Return the filing roles of the user for the business, if any."""
+        """Return the valid filing roles of the user for the business, if any.
+
+        Only returns roles that are in valid_role_types (proprietor, director, partner).
+        """
         if len(filings := self.valid_filings(business)) <= 0:
             current_app.logger.debug(
                 "No registration or incorporation filing found for the business.")
@@ -139,12 +148,19 @@ class DigitalCredentialsRulesService:
         filing = filings.pop(0)
         roles = filing.filing_party_roles.filter(
             PartyRole.role != PartyRole.RoleTypes.COMPLETING_PARTY.value).all()
-        return list(filter(lambda role: self.user_matches_party(user, role.party), roles))
+        return list(
+            filter(lambda role: role.role in self.valid_role_types and self.user_matches_party(user, role.party), roles)
+        )
 
     def user_business_party_roles(self, user: User, business: Business) -> list[PartyRole]:
-        """Return the party roles of the user for the business, if any."""
+        """Return the valid party roles of the user for the business, if any.
+
+        Only returns roles that are in valid_role_types (proprietor, director, partner).
+        """
         roles = business.party_roles.all()
-        return list(filter(lambda role: self.user_matches_party(user, role.party), roles))
+        return list(
+            filter(lambda role: role.role in self.valid_role_types and self.user_matches_party(user, role.party), roles)
+        )
 
     def user_submitted_filing(self, user: User, filing: Filing) -> bool:
         """Return True if the user submitted the filing."""

--- a/legal-api/tests/unit/services/test_digital_credentials.py
+++ b/legal-api/tests/unit/services/test_digital_credentials.py
@@ -333,7 +333,7 @@ def test_data_helper_user_with_business_party_role(app, session, test_data, expe
         {'name': 'role', 'value': ''}
     ])
 ])
-def test_data_helper_user_has_filing_party_role(app, session, test_data, expected):
+def test_data_helper_user_filing_party_roles(app, session, test_data, expected):
     """Assert that the data helper returns the correct data when the user has a filing party role."""
     # Arrange
     credential_type = DCDefinition.CredentialType.business

--- a/legal-api/tests/unit/services/test_digital_credentials.py
+++ b/legal-api/tests/unit/services/test_digital_credentials.py
@@ -282,7 +282,7 @@ def test_data_helper_user_with_business_party_role(app, session, test_data, expe
         'user_extra': test_user_extra,
     }, base_expected + [
         {'name': 'business_type', 'value': 'BC Benefit Company'},
-        {'name': 'role', 'value': 'Director, Incorporator'}
+        {'name': 'role', 'value': 'Director, Director'}
     ]),
     ({
         'business': sp_business,
@@ -309,7 +309,7 @@ def test_data_helper_user_with_business_party_role(app, session, test_data, expe
         'user_extra': test_user_extra,
     }, base_expected + [
         {'name': 'business_type', 'value': 'BC Benefit Company'},
-        {'name': 'role', 'value': 'Incorporator'}
+        {'name': 'role', 'value': 'Director'}
     ]),
     ({
         'business': sp_business_historical,
@@ -343,7 +343,7 @@ def test_data_helper_user_has_filing_party_role(app, session, test_data, expecte
     type = 'registration'
 
     if test_data['business']['entity_type'] == 'BEN':
-        roles.append(PartyRole.RoleTypes.INCORPORATOR)
+        roles.append(PartyRole.RoleTypes.DIRECTOR)
         type = 'incorporationApplication'
 
     setup_filing(business, user, roles, type)
@@ -429,7 +429,7 @@ def test_data_helper_role_added_if_preconditions_met(app, session):
     credential_type = DCDefinition.CredentialType.business
 
     test_preconditions = [
-        PartyRole.RoleTypes.INCORPORATOR.value
+        PartyRole.RoleTypes.PARTNER.value
     ]
     test_data = {
         'user': test_user,
@@ -445,7 +445,7 @@ def test_data_helper_role_added_if_preconditions_met(app, session):
     setup_parties_and_roles(business, [test_party_data])
     setup_filing(business, user, [
         PartyRole.RoleTypes.COMPLETING_PARTY,
-        PartyRole.RoleTypes.INCORPORATOR
+        PartyRole.RoleTypes.PARTNER
     ], 'incorporationApplication')
 
     with patch.object(DigitalCredentialsRulesService, 'get_preconditions', return_value=test_preconditions):
@@ -453,5 +453,5 @@ def test_data_helper_role_added_if_preconditions_met(app, session):
         credential_data = get_digital_credential_data(business_user, credential_type, test_preconditions + [PartyRole.RoleTypes.DIRECTOR.value])
 
         # Assert
-        assert {'name': 'role', 'value': 'Incorporator'} in credential_data
-        assert {'name': 'role', 'value': 'Director, Incorporator'} not in credential_data
+        assert {'name': 'role', 'value': 'Partner'} in credential_data
+        assert {'name': 'role', 'value': 'Director, Partner'} not in credential_data

--- a/legal-api/tests/unit/services/test_digital_credentials_helpers_and_utils.py
+++ b/legal-api/tests/unit/services/test_digital_credentials_helpers_and_utils.py
@@ -277,13 +277,12 @@ def test_get_roles_no_preconditions(mock_rules_class, app):
     
     mock_rules = MagicMock()
     mock_rules.get_preconditions.return_value = []
-    mock_rules.user_has_business_party_role.return_value = True
-    mock_rules.user_has_filing_party_role.return_value = False
-    
+
     mock_party_role = MagicMock()
     mock_party_role.role = 'proprietor'
     mock_rules.user_business_party_roles.return_value = [mock_party_role]
-    
+    mock_rules.user_filing_party_roles.return_value = []
+
     with app.app_context():
         result = get_roles(user, business, mock_rules, None)
         assert result == ['Proprietor']
@@ -297,15 +296,14 @@ def test_get_roles_with_self_attested(mock_rules_class, app):
     
     mock_rules = MagicMock()
     mock_rules.get_preconditions.return_value = ['proprietor', 'director']
-    mock_rules.user_has_business_party_role.return_value = True
-    mock_rules.user_has_filing_party_role.return_value = False
-    
+
     mock_party_role1 = MagicMock()
     mock_party_role1.role = 'proprietor'
     mock_party_role2 = MagicMock()
     mock_party_role2.role = 'director'
     mock_rules.user_business_party_roles.return_value = [mock_party_role1, mock_party_role2]
-    
+    mock_rules.user_filing_party_roles.return_value = []
+
     with app.app_context():
         result = get_roles(user, business, mock_rules, ['proprietor'])
         assert result == ['Proprietor']
@@ -321,9 +319,9 @@ def test_get_digital_credential_data(mock_rules_class, app, session):
     mock_rules = MagicMock()
     mock_rules_class.return_value = mock_rules
     mock_rules.get_preconditions.return_value = []
-    mock_rules.user_has_business_party_role.return_value = False
-    mock_rules.user_has_filing_party_role.return_value = False
-    
+    mock_rules.user_business_party_roles.return_value = []
+    mock_rules.user_filing_party_roles.return_value = []
+
     with app.app_context():
         result = get_digital_credential_data(business_user, DCDefinition.CredentialType.business, None)
         

--- a/legal-api/tests/unit/services/test_digital_credentials_rules.py
+++ b/legal-api/tests/unit/services/test_digital_credentials_rules.py
@@ -368,16 +368,16 @@ def test_user_has_filing_party_role_false_when_user_not_matching_filer(app, sess
     user = factory_user(**user)
     business = create_business(
         Business.LegalTypes.BCOMP.value, Business.State.ACTIVE)
-    incoroporator_role = create_party_role(
-        PartyRole.RoleTypes.INCORPORATOR,
+    director_role = create_party_role(
+        PartyRole.RoleTypes.DIRECTOR,
         **create_test_user(**party, default_middle=False)
     )
     filing = factory_completed_filing(
         business=business,
-        data_dict={'filing': {'header': {'name': 'registration'}}},
-        filing_date=datetime.now(timezone.utc), filing_type='registration'
+        data_dict={'filing': {'header': {'name': 'incorporationApplication'}}},
+        filing_date=datetime.now(timezone.utc), filing_type='incorporationApplication'
     )
-    filing.filing_party_roles.append(incoroporator_role)
+    filing.filing_party_roles.append(director_role)
     filing.submitter_id = user.id
     filing.save()
 
@@ -410,8 +410,8 @@ def test_user_has_filing_party_role_true(app, session, user, party, rules):
     user = factory_user(**user)
     business = create_business(
         Business.LegalTypes.BCOMP.value, Business.State.ACTIVE)
-    incoroporator_role = create_party_role(
-        PartyRole.RoleTypes.INCORPORATOR,
+    director_role = create_party_role(
+        PartyRole.RoleTypes.DIRECTOR,
         **create_test_user(**party, default_middle=False)
     )
     filing = factory_completed_filing(
@@ -419,7 +419,7 @@ def test_user_has_filing_party_role_true(app, session, user, party, rules):
         data_dict={'filing': {'header': {'name': 'incorporationApplication'}}},
         filing_date=datetime.now(timezone.utc), filing_type='incorporationApplication'
     )
-    filing.filing_party_roles.append(incoroporator_role)
+    filing.filing_party_roles.append(director_role)
     filing.submitter_id = user.id
     filing.save()
 
@@ -431,8 +431,8 @@ def test_user_has_filing_party_role_and_user_has_business_party_role_true(app, s
     user = factory_user(**user)
     business = create_business(
         Business.LegalTypes.BCOMP.value, Business.State.ACTIVE)
-    incorporator_role = create_party_role(
-        PartyRole.RoleTypes.INCORPORATOR,
+    filing_director_role = create_party_role(
+        PartyRole.RoleTypes.DIRECTOR,
         **create_test_user(**party, default_middle=False)
     )
     filing = factory_completed_filing(
@@ -440,7 +440,7 @@ def test_user_has_filing_party_role_and_user_has_business_party_role_true(app, s
         data_dict={'filing': {'header': {'name': 'incorporationApplication'}}},
         filing_date=datetime.now(timezone.utc), filing_type='incorporationApplication'
     )
-    filing.filing_party_roles.append(incorporator_role)
+    filing.filing_party_roles.append(filing_director_role)
     filing.submitter_id = user.id
     filing.save()
     director_role = create_party_role(

--- a/legal-api/tests/unit/services/test_digital_credentials_rules.py
+++ b/legal-api/tests/unit/services/test_digital_credentials_rules.py
@@ -363,6 +363,27 @@ def test_user_business_party_roles_non_empty(app, session, user, proprietor, rul
     assert len(rules.user_business_party_roles(user, business)) > 0
 
 
+@pytest.mark.parametrize('invalid_role', [
+    PartyRole.RoleTypes.OFFICER,
+    PartyRole.RoleTypes.SECRETARY,
+    PartyRole.RoleTypes.CUSTODIAN,
+    PartyRole.RoleTypes.INCORPORATOR,
+])
+def test_user_business_party_roles_excludes_invalid_roles(app, session, invalid_role, rules):
+    user_data, party_data = valid_data[0]
+    user = factory_user(**user_data)
+    business = create_business(
+        Business.LegalTypes.BCOMP.value, Business.State.ACTIVE)
+    party_role = create_party_role(
+        invalid_role,
+        **create_test_user(**party_data, default_middle=False)
+    )
+    party_role.business_id = business.id
+    party_role.save()
+
+    assert rules.user_business_party_roles(user, business) == []
+
+
 @pytest.mark.parametrize('user, party', invalid_data)
 def test_user_filing_party_roles_empty_when_user_not_matching_filer(app, session, user, party, rules):
     user = factory_user(**user)
@@ -424,6 +445,32 @@ def test_user_filing_party_roles_non_empty(app, session, user, party, rules):
     filing.save()
 
     assert len(rules.user_filing_party_roles(user, business)) > 0
+
+
+@pytest.mark.parametrize('invalid_role', [
+    PartyRole.RoleTypes.INCORPORATOR,
+    PartyRole.RoleTypes.OFFICER,
+    PartyRole.RoleTypes.APPLICANT,
+])
+def test_user_filing_party_roles_excludes_invalid_roles(app, session, invalid_role, rules):
+    user_data, party_data = valid_data[0]
+    user = factory_user(**user_data)
+    business = create_business(
+        Business.LegalTypes.BCOMP.value, Business.State.ACTIVE)
+    party_role = create_party_role(
+        invalid_role,
+        **create_test_user(**party_data, default_middle=False)
+    )
+    filing = factory_completed_filing(
+        business=business,
+        data_dict={'filing': {'header': {'name': 'incorporationApplication'}}},
+        filing_date=datetime.now(timezone.utc), filing_type='incorporationApplication'
+    )
+    filing.filing_party_roles.append(party_role)
+    filing.submitter_id = user.id
+    filing.save()
+
+    assert rules.user_filing_party_roles(user, business) == []
 
 
 @pytest.mark.parametrize('user, party', valid_data)

--- a/legal-api/tests/unit/services/test_digital_credentials_rules.py
+++ b/legal-api/tests/unit/services/test_digital_credentials_rules.py
@@ -112,10 +112,10 @@ def test_has_general_access_true(monkeypatch, app, session, jwt, rules):
 
 
 @patch('legal_api.models.User.find_by_jwt_token', return_value=User(id=1, login_source='BCSC'))
-@patch.object(DigitalCredentialsRulesService, 'user_has_filing_party_role', return_value=True)
-@patch.object(DigitalCredentialsRulesService, 'user_has_business_party_role', return_value=True)
-def test_has_specific_access_false_when_no_business(mock_user_has_business_party_role,
-                                                    mock_user_has_filing_party_role,
+@patch.object(DigitalCredentialsRulesService, 'user_filing_party_roles', return_value=[MagicMock()])
+@patch.object(DigitalCredentialsRulesService, 'user_business_party_roles', return_value=[MagicMock()])
+def test_has_specific_access_false_when_no_business(mock_user_business_party_roles,
+                                                    mock_user_filing_party_roles,
                                                     monkeypatch, app, session, jwt, rules):
     token_json = {'username': 'test'}
     setup_mock_auth(monkeypatch, jwt, token_json)
@@ -126,10 +126,10 @@ def test_has_specific_access_false_when_no_business(mock_user_has_business_party
 
 
 @patch('legal_api.models.User.find_by_jwt_token', return_value=User(id=1, login_source='BCSC'))
-@patch.object(DigitalCredentialsRulesService, 'user_has_filing_party_role', return_value=True)
-@patch.object(DigitalCredentialsRulesService, 'user_has_business_party_role', return_value=True)
-def test_has_specific_access_false_when_wrong_business_type(mock_user_has_business_party_role,
-                                                            mock_user_has_filing_party_role,
+@patch.object(DigitalCredentialsRulesService, 'user_filing_party_roles', return_value=[MagicMock()])
+@patch.object(DigitalCredentialsRulesService, 'user_business_party_roles', return_value=[MagicMock()])
+def test_has_specific_access_false_when_wrong_business_type(mock_user_business_party_roles,
+                                                            mock_user_filing_party_roles,
                                                             monkeypatch, app, session, jwt, rules):
     token_json = {'username': 'test'}
     setup_mock_auth(monkeypatch, jwt, token_json)
@@ -148,10 +148,10 @@ def test_has_specific_access_false_when_wrong_business_type(mock_user_has_busine
     Business.LegalTypes.BCOMP.value,
 ])
 @patch('legal_api.models.User.find_by_jwt_token', return_value=User(id=1, login_source='BCSC'))
-@patch.object(DigitalCredentialsRulesService, 'user_has_filing_party_role', return_value=False)
-@patch.object(DigitalCredentialsRulesService, 'user_has_business_party_role', return_value=False)
-def test_has_specific_access_false_when_correct_business_type_but_no_role(mock_user_has_business_party_role,
-                                                                          mock_user_has_filing_party_role,
+@patch.object(DigitalCredentialsRulesService, 'user_filing_party_roles', return_value=[])
+@patch.object(DigitalCredentialsRulesService, 'user_business_party_roles', return_value=[])
+def test_has_specific_access_false_when_correct_business_type_but_no_role(mock_user_business_party_roles,
+                                                                          mock_user_filing_party_roles,
                                                                           monkeypatch, app, session, legal_type, jwt, rules):
     token_json = {'username': 'test'}
     setup_mock_auth(monkeypatch, jwt, token_json)
@@ -170,12 +170,12 @@ def test_has_specific_access_false_when_correct_business_type_but_no_role(mock_u
     Business.LegalTypes.BCOMP.value,
 ])
 @patch('legal_api.models.User.find_by_jwt_token', return_value=User(id=1, login_source='BCSC'))
-@patch.object(DigitalCredentialsRulesService, 'user_has_filing_party_role', return_value=True)
-@patch.object(DigitalCredentialsRulesService, 'user_has_business_party_role', return_value=False)
+@patch.object(DigitalCredentialsRulesService, 'user_filing_party_roles', return_value=[MagicMock()])
+@patch.object(DigitalCredentialsRulesService, 'user_business_party_roles', return_value=[])
 @patch('legal_api.services.digital_credentials_rules.determine_allowed_business_types', return_value=['SP', 'BEN', 'GP'])
 def test_has_specific_access_true_when_correct_business_type_and_filing_role(mock_determine_allowed_business_types,
-                                                                             mock_user_has_business_party_role,
-                                                                             mock_user_has_filing_party_role,
+                                                                             mock_user_business_party_roles,
+                                                                             mock_user_filing_party_roles,
                                                                              monkeypatch, app, session, legal_type, jwt, rules):
     token_json = {'username': 'test'}
     setup_mock_auth(monkeypatch, jwt, token_json)
@@ -194,12 +194,12 @@ def test_has_specific_access_true_when_correct_business_type_and_filing_role(moc
     Business.LegalTypes.BCOMP.value,
 ])
 @patch('legal_api.models.User.find_by_jwt_token', return_value=User(id=1, login_source='BCSC'))
-@patch.object(DigitalCredentialsRulesService, 'user_has_filing_party_role', return_value=False)
-@patch.object(DigitalCredentialsRulesService, 'user_has_business_party_role', return_value=True)
+@patch.object(DigitalCredentialsRulesService, 'user_filing_party_roles', return_value=[])
+@patch.object(DigitalCredentialsRulesService, 'user_business_party_roles', return_value=[MagicMock()])
 @patch('legal_api.services.digital_credentials_rules.determine_allowed_business_types', return_value=['SP', 'BEN', 'GP'])
 def test_has_specific_access_true_when_correct_business_type_and_party_role(mock_determine_allowed_business_types,
-                                                                            mock_user_has_business_party_role,
-                                                                            mock_user_has_filing_party_role,
+                                                                            mock_user_business_party_roles,
+                                                                            mock_user_filing_party_roles,
                                                                             monkeypatch, app, session, legal_type, jwt, rules):
     token_json = {'username': 'test'}
     setup_mock_auth(monkeypatch, jwt, token_json)
@@ -313,28 +313,28 @@ def test_user_is_completing_party_false_when_user_not_matching_completing_party(
     assert rules.user_is_completing_party(user, business) is False
 
 
-def test_user_has_business_party_role_false_when_no_proprietors(app, session, rules):
+def test_user_business_party_roles_empty_when_no_proprietors(app, session, rules):
     user = factory_user(username='test', firstname='Test', lastname='User')
     business = create_business(
         Business.LegalTypes.SOLE_PROP.value, Business.State.ACTIVE)
     # Skip creating a proprietor
 
-    assert rules.user_has_business_party_role(user, business) is False
+    assert rules.user_business_party_roles(user, business) == []
 
 
 @patch('legal_api.models.PartyRole.get_parties_by_role',
        return_value=[PartyRole(role=PartyRole.RoleTypes.PROPRIETOR.value)])
-def test_user_has_business_party_role_false_when_no_proprietor(app, session, rules):
+def test_user_business_party_roles_empty_when_no_proprietor(app, session, rules):
     user = factory_user(username='test', firstname='Test', lastname='User')
     business = create_business(
         Business.LegalTypes.SOLE_PROP.value, Business.State.ACTIVE)
     # Skip creating a proprietor
 
-    assert rules.user_has_business_party_role(user, business) is False
+    assert rules.user_business_party_roles(user, business) == []
 
 
 @pytest.mark.parametrize('user, proprietor', invalid_data)
-def test_user_has_business_party_role_false_when_user_not_matching_proprietor(app, session, user, proprietor, rules):
+def test_user_business_party_roles_empty_when_user_not_matching_proprietor(app, session, user, proprietor, rules):
     user = factory_user(**user)
     business = create_business(
         Business.LegalTypes.SOLE_PROP.value, Business.State.ACTIVE)
@@ -345,11 +345,11 @@ def test_user_has_business_party_role_false_when_user_not_matching_proprietor(ap
     proprietor_role.business_id = business.id
     proprietor_role.save()
 
-    assert rules.user_has_business_party_role(user, business) is False
+    assert rules.user_business_party_roles(user, business) == []
 
 
 @pytest.mark.parametrize('user, proprietor', valid_data)
-def test_user_has_business_party_role_true(app, session, user, proprietor, rules):
+def test_user_business_party_roles_non_empty(app, session, user, proprietor, rules):
     user = factory_user(**user)
     business = create_business(
         Business.LegalTypes.SOLE_PROP.value, Business.State.ACTIVE)
@@ -360,11 +360,11 @@ def test_user_has_business_party_role_true(app, session, user, proprietor, rules
     proprietor_party_role.business_id = business.id
     proprietor_party_role.save()
 
-    assert rules.user_has_business_party_role(user, business) is True
+    assert len(rules.user_business_party_roles(user, business)) > 0
 
 
 @pytest.mark.parametrize('user, party', invalid_data)
-def test_user_has_filing_party_role_false_when_user_not_matching_filer(app, session, user, party, rules):
+def test_user_filing_party_roles_empty_when_user_not_matching_filer(app, session, user, party, rules):
     user = factory_user(**user)
     business = create_business(
         Business.LegalTypes.BCOMP.value, Business.State.ACTIVE)
@@ -381,16 +381,16 @@ def test_user_has_filing_party_role_false_when_user_not_matching_filer(app, sess
     filing.submitter_id = user.id
     filing.save()
 
-    assert rules.user_has_filing_party_role(user, business) is False
+    assert rules.user_filing_party_roles(user, business) == []
 
 
 @pytest.mark.parametrize('user, party', valid_data)
-def test_user_has_filing_party_role_false_invalid_business_type(app, session, user, party, rules):
+def test_user_filing_party_roles_empty_invalid_business_type(app, session, user, party, rules):
     user = factory_user(**user)
     business = create_business(
         Business.LegalTypes.SOLE_PROP.value, Business.State.ACTIVE)
-    incoroporator_role = create_party_role(
-        PartyRole.RoleTypes.INCORPORATOR,
+    director_role = create_party_role(
+        PartyRole.RoleTypes.DIRECTOR,
         **create_test_user(**party, default_middle=False)
     )
     filing = factory_completed_filing(
@@ -398,15 +398,15 @@ def test_user_has_filing_party_role_false_invalid_business_type(app, session, us
         data_dict={'filing': {'header': {'name': 'registration'}}},
         filing_date=datetime.now(timezone.utc), filing_type='registration'
     )
-    filing.filing_party_roles.append(incoroporator_role)
+    filing.filing_party_roles.append(director_role)
     filing.submitter_id = user.id
     filing.save()
 
-    assert rules.user_has_filing_party_role(user, business) is False
+    assert rules.user_filing_party_roles(user, business) == []
 
 
 @pytest.mark.parametrize('user, party', valid_data)
-def test_user_has_filing_party_role_true(app, session, user, party, rules):
+def test_user_filing_party_roles_non_empty(app, session, user, party, rules):
     user = factory_user(**user)
     business = create_business(
         Business.LegalTypes.BCOMP.value, Business.State.ACTIVE)
@@ -423,11 +423,11 @@ def test_user_has_filing_party_role_true(app, session, user, party, rules):
     filing.submitter_id = user.id
     filing.save()
 
-    assert rules.user_has_filing_party_role(user, business) is True
+    assert len(rules.user_filing_party_roles(user, business)) > 0
 
 
 @pytest.mark.parametrize('user, party', valid_data)
-def test_user_has_filing_party_role_and_user_has_business_party_role_true(app, session, user, party, rules):
+def test_user_filing_party_roles_and_user_business_party_roles_non_empty(app, session, user, party, rules):
     user = factory_user(**user)
     business = create_business(
         Business.LegalTypes.BCOMP.value, Business.State.ACTIVE)
@@ -450,5 +450,5 @@ def test_user_has_filing_party_role_and_user_has_business_party_role_true(app, s
     director_role.business_id = business.id
     director_role.save()
 
-    assert rules.user_has_filing_party_role(user, business) is True
-    assert rules.user_has_business_party_role(user, business) is True
+    assert len(rules.user_filing_party_roles(user, business)) > 0
+    assert len(rules.user_business_party_roles(user, business)) > 0


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33427

*Description of changes:*
Do the same valid party roles code as the python common implementation. (Soon these will be synced up and un-duplicated anyways)

Add some additional code simplification that was done in python/common as well to get ready to un-duplicate.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
