### PR TITLE
32907: require at least one share class on regular amalgamation appli…

### DIFF
--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -163,8 +163,9 @@ def validate_share_structure(incorporation_json, filing_type, legal_type) -> Err
     msg = []
     memoize_names = []
 
-    # For incorporation applications, at least one share class is required, for Alteration can not include if not changing
-    if filing_type == CoreFiling.FilingTypes.INCORPORATIONAPPLICATION.value and len(share_classes) == 0:
+    # For incorporation and amalgamation applications, at least one share class is required, for Alteration can not include if not changing
+    if filing_type in (CoreFiling.FilingTypes.INCORPORATIONAPPLICATION.value,
+                       CoreFiling.FilingTypes.AMALGAMATIONAPPLICATION.value) and len(share_classes) == 0:
         msg.append({
             "error": "A company must have at least one Class of Shares.",
             "path": f"/filing/{filing_type}/shareStructure/shareClasses"

--- a/legal-api/tests/unit/services/filings/validations/test_amalgamation_application.py
+++ b/legal-api/tests/unit/services/filings/validations/test_amalgamation_application.py
@@ -379,6 +379,34 @@ def test_validate_amalgamation_office(session, mocker, test_name, legal_type, de
         assert err is None
 
 
+def test_amalgamation_regular_requires_at_least_one_share_class(mocker, app, session):
+    """Assert that a regular amalgamation with empty shareClasses returns a validation error."""
+    filing = {'filing': {}}
+    filing['filing']['header'] = {
+        'name': 'amalgamationApplication',
+        'date': '2019-04-08',
+        'certifiedBy': 'full name',
+        'authorizationReceived': True,
+        'email': 'no_one@never.get',
+        'filingId': 1
+    }
+    filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
+    filing['filing']['amalgamationApplication']['type'] = Amalgamation.AmalgamationTypes.regular.name
+    filing['filing']['amalgamationApplication']['shareStructure'] = {'shareClasses': []}
+
+    mocker.patch('legal_api.services.filings.validations.amalgamation_application.validate_name_request',
+                 return_value=[])
+    mocker.patch('legal_api.services.filings.validations.amalgamation_application.validate_amalgamating_businesses',
+                 return_value=[])
+
+    err = validate(None, filing)
+
+    assert err is not None
+    assert any(e['error'] == 'A company must have at least one Class of Shares.' and
+               e['path'] == '/filing/amalgamationApplication/shareStructure/shareClasses'
+               for e in err.msg)
+
+
 @pytest.mark.parametrize(
     'test_name, legal_type,'
     'class_name_1,class_has_max_shares,class_max_shares,has_par_value,par_value,currency,'


### PR DESCRIPTION
#32907 : /bcgov/entity#32907

*Description of changes:*
Posting a regular amalgamation application via POST `http://127.0.0.1:5000/api/v2/businesses/T0nRimgoiH/filings?only_validate=true` with the payload adjusted to  `"shareStructure": { "shareClasses": [] }` previously succeeded. After this change, the same request returns a 400 containing the error `"A company must have at least one Class of Shares."`, now aligning with front end logic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
