### PR TITLE
33278 Add is_bad_email to mv_legacy_corps_data

### DIFF
--- a/data-tool/backup_extract_tables.sh
+++ b/data-tool/backup_extract_tables.sh
@@ -19,7 +19,7 @@ PGDATABASE="${PGDATABASE:-colin-mig-corps-test}"     # or ‑‑dbname
 ##############################################################################
 
 # -- Tables to keep ------------------------------------------------------------
-KEEP=(corp_processing colin_tracking mig_group mig_batch mig_corp_batch mig_corp_account corps_with_third_party email_domain_groups bar_corps)
+KEEP=(corp_processing colin_tracking mig_group mig_batch mig_corp_batch mig_corp_account corps_with_third_party email_domain_groups bar_corps bad_emails)
 
 # -- Runtime options -----------------------------------------------------------
 BACKUP_DIR="${BACKUP_DIR:-/backups}"

--- a/data-tool/notebooks/corps_onboarding_process_flow/onboarding_bi.ipynb
+++ b/data-tool/notebooks/corps_onboarding_process_flow/onboarding_bi.ipynb
@@ -141,6 +141,7 @@
     "       email_domain,\n",
     "       admin_email,\n",
     "       email_used_count,\n",
+    "       is_bad_email,\n",
     "       corp_num,\n",
     "       corp_name,\n",
     "       corp_type_cd,\n",

--- a/data-tool/restore_extract.sh
+++ b/data-tool/restore_extract.sh
@@ -20,7 +20,7 @@ PGDATABASE="${PGDATABASE:-colin-mig-corps-test}"     # or ‑‑dbname
 ##############################################################################
 
 # -- Tables to restore ------------------------------------------------------------
-RESTORE=(corp_processing colin_tracking mig_group mig_batch mig_corp_batch mig_corp_account corps_with_third_party email_domain_groups bar_corps)
+RESTORE=(corp_processing colin_tracking mig_group mig_batch mig_corp_batch mig_corp_account corps_with_third_party email_domain_groups bar_corps bad_emails)
 
 # -- Runtime options -----------------------------------------------------------
 DUMP="${DUMP}"

--- a/data-tool/scripts/colin_corps_extract_postgres_ddl
+++ b/data-tool/scripts/colin_corps_extract_postgres_ddl
@@ -30,6 +30,10 @@ create sequence if not exists mig_corp_account_id_seq;
 
 alter sequence mig_corp_account_id_seq owner to postgres;
 
+create sequence if not exists bad_emails_id_seq;
+
+alter sequence bad_emails_id_seq owner to postgres;
+
 create table if not exists address
 (
     addr_id                numeric(10)
@@ -1119,6 +1123,16 @@ CREATE TABLE IF NOT EXISTS email_domain_groups (
 );
 
 alter table email_domain_groups
+    owner to postgres;
+
+CREATE TABLE IF NOT EXISTS bad_emails (
+	id integer default nextval('bad_emails_id_seq'::regclass) not null
+		constraint pk_bad_emails primary key,
+    email varchar(255) NOT NULL UNIQUE,
+    notes text
+);
+
+alter table bad_emails
     owner to postgres;
 
 CREATE INDEX if not exists ix_conv_event_event_id ON conv_event (event_id);

--- a/data-tool/scripts/colin_corps_extract_postgres_views_ddl
+++ b/data-tool/scripts/colin_corps_extract_postgres_views_ddl
@@ -832,6 +832,12 @@ SELECT COALESCE(edg.group_name, NULL) AS group_name,
         tblFe.email_domain,
         admin_email,
         CAST(email_used_count as integer) as email_used_count,
+        CAST(EXISTS (
+          SELECT 1
+          FROM bad_emails be
+          WHERE btrim(tblFe.admin_email) <> ''
+            AND lower(btrim(be.email)) = lower(btrim(tblFe.admin_email))
+        ) AS boolean) AS is_bad_email,
         corp_num,
         corp_name,
         corp_type_cd,
@@ -989,17 +995,17 @@ FROM (
       GROUP BY corp_num
     ) cprt_dir ON cprt_dir.corp_num = c.corp_num
     LEFT OUTER JOIN (
-      SELECT 
+      SELECT
         cp.corp_num,
         COUNT(*) AS dir_cnt,
         COUNT(*) Filter (
-          WHERE cp.mailing_addr_id IS NOT NULL 
-            AND cp.mailing_addr_id <> 1 
+          WHERE cp.mailing_addr_id IS NOT NULL
+            AND cp.mailing_addr_id <> 1
             AND UPPER(TRIM(ma.province)) = 'BC'
         ) AS dir_bc_mailing_cnt,
         COUNT(*) Filter (
           WHERE cp.mailing_addr_id IS NOT NULL
-            AND cp.mailing_addr_id <> 1 
+            AND cp.mailing_addr_id <> 1
             AND UPPER(TRIM(ma.country_typ_cd)) = 'CA'
         ) AS dir_ca_mailing_cnt
       FROM corp_party cp


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33278

*Description of changes:*
- Add `bad_emails` table to COLIN extract ddl
- Add `is_bad_email` column to `mv_legacy_corps_data`
- Update backup_extract_table.sh and restore_extract.sh to include `bad_emails` table
- Add `is_bad_email` column to onboarding bi notebook

Example of how **bad_emails** notes field is used
<img width="1009" height="317" alt="image" src="https://github.com/user-attachments/assets/34098ca6-0d1c-41eb-97b0-26e59008fc7d" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
