### PR TITLE
32911 - Add validation for foreign business legal name length

### DIFF
--- a/legal-api/src/legal_api/services/filings/validations/amalgamation_application.py
+++ b/legal-api/src/legal_api/services/filings/validations/amalgamation_application.py
@@ -267,6 +267,16 @@ def _validate_foreign_businesses(  # noqa: PLR0913
         amalgamating_business,
         amalgamating_business_path) -> list:
     msg = []
+
+    # Frontend enforces these bounds on the foreign business legal name; mirror them here.
+    min_legal_name_length: Final = 3
+    max_legal_name_length: Final = 150
+    if not min_legal_name_length <= len(foreign_legal_name) <= max_legal_name_length:
+        msg.append({
+            "error": "Length of foreign business legal name must be from 3 to 150 characters.",
+            "path": f"{amalgamating_business_path}/legalName"
+        })
+
     if is_staff:
         msg.extend(validate_foreign_jurisdiction(amalgamating_business["foreignJurisdiction"],
                                                  f"{amalgamating_business_path}/foreignJurisdiction",

--- a/legal-api/tests/unit/services/filings/validations/test_amalgamation_application.py
+++ b/legal-api/tests/unit/services/filings/validations/test_amalgamation_application.py
@@ -27,6 +27,7 @@ from registry_schemas.example_data import AMALGAMATION_APPLICATION
 from legal_api.models import AmalgamatingBusiness, Amalgamation, Business, Filing
 from legal_api.services import NameXService, STAFF_ROLE, BASIC_USER, flags
 from legal_api.services.filings.validations.validation import validate
+from legal_api.services.filings.validations.amalgamation_application import _validate_foreign_businesses
 
 from tests.unit.services.filings.validations import create_party, create_party_address, lists_are_equal
 
@@ -1143,6 +1144,35 @@ def test_amalgamating_foreign_business(mocker, app, session, jwt, test_status, r
         assert expected_code == err.code
         error_msg = err.msg[0].get('error') or err.msg[0].get('message')
         assert expected_msg == error_msg
+
+
+@pytest.mark.parametrize(
+    'legal_name, expects_error',
+    [
+        ('AB', True),          # 2 chars - below the 3 minimum
+        ('ABC', False),        # 3 chars - minimum boundary
+        ('A' * 150, False),    # 150 chars - maximum boundary
+        ('A' * 151, True),     # 151 chars - above the 150 maximum
+    ]
+)
+def test_foreign_business_legal_name_length(legal_name, expects_error):
+    """Assert _validate_foreign_businesses enforces a 3 to 150 character legal name."""
+    path = '/filing/amalgamationApplication/amalgamatingBusinesses/0'
+    msg = _validate_foreign_businesses(
+        is_staff=True,
+        is_any_bc_company=False,
+        is_any_ulc=False,
+        legal_type=Business.LegalTypes.BCOMP.value,
+        foreign_legal_name=legal_name,
+        amalgamating_business={'role': AmalgamatingBusiness.Role.amalgamating.name,
+                               'foreignJurisdiction': {'country': 'CA', 'region': 'AB'}},
+        amalgamating_business_path=path)
+
+    length_error = {
+        'error': 'Length of foreign business legal name must be from 3 to 150 characters.',
+        'path': f'{path}/legalName'
+    }
+    assert (length_error in msg) is expects_error
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#32911 : /bcgov/entity#32911

*Description of changes:*
We discovered that the backend wasn’t validating the length of a foreign amalgamating business’s legalName. The frontend correctly blocked names shorter than 3 characters or longer than 150, but the backend didn’t — so invalid values could still slip through and get saved.

The backend now enforces the same 3–150 character limit. If the name is outside that range, it returns a 400 error with the message “Length of foreign business legal name must be from 3 to 150 characters.”

Example:
when making a POST to url `/api/v2/businesses/<T-id>/filings?only_validate=true`
`"legalName": "AA"` in payload throws 400 error “Length of foreign business legal name must be from 3 to 150 characters.”
`"legalName": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"` in payload throws 400 error “Length of foreign business legal name must be from 3 to 150 characters.”


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
