### PR TITLE
31675: Update business schema import

### DIFF
--- a/legal-api/poetry.lock
+++ b/legal-api/poetry.lock
@@ -1824,7 +1824,7 @@ fqdn = {version = "*", optional = true, markers = "extra == \"format\""}
 idna = {version = "*", optional = true, markers = "extra == \"format\""}
 isoduration = {version = "*", optional = true, markers = "extra == \"format\""}
 jsonpointer = {version = ">1.13", optional = true, markers = "extra == \"format\""}
-jsonschema-specifications = ">=2023.03.6"
+jsonschema-specifications = ">=2023.3.6"
 referencing = ">=0.28.4"
 rfc3339-validator = {version = "*", optional = true, markers = "extra == \"format\""}
 rfc3987 = {version = "*", optional = true, markers = "extra == \"format\""}
@@ -3120,7 +3120,7 @@ typing-extensions = {version = ">=4.4.0", markers = "python_version < \"3.13\""}
 
 [[package]]
 name = "registry_schemas"
-version = "2.18.67"
+version = "2.18.68"
 description = "A short description of the project"
 optional = false
 python-versions = ">=3.6"
@@ -3138,8 +3138,8 @@ strict-rfc3339 = "*"
 [package.source]
 type = "git"
 url = "https://github.com/bcgov/business-schemas.git"
-reference = "2.18.67"
-resolved_reference = "bd6808dbb26807ab2e5dc8bcdf0d28276b1f8e39"
+reference = "2.18.68"
+resolved_reference = "3cd771a26e1ed74cc5e45c10235526be3f0ee7cb"
 
 [[package]]
 name = "reportlab"
@@ -4201,4 +4201,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9.22,<3.10"
-content-hash = "a9a28e335903ce44bd9ecec5f7762c55497591ab685a9585c9f627c77bf7b46d"
+content-hash = "08e9b370c31d98dc62e820737af9d3663b65c0c3595fd4d340b4c05d36c3dc20"

--- a/legal-api/pyproject.toml
+++ b/legal-api/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "blinker (==1.4)",
     "pyjwt (==2.8.0)",
 
-    "registry_schemas @ git+https://github.com/bcgov/business-schemas.git@2.18.67#egg=registry_schemas",
+    "registry_schemas @ git+https://github.com/bcgov/business-schemas.git@2.18.68#egg=registry_schemas",
     "sql-versioning @ git+https://github.com/bcgov/lear.git@main#subdirectory=python/common/sql-versioning",
     "gcp-queue @ git+https://github.com/bcgov/sbc-connect-common.git@main#subdirectory=python/gcp-queue",
     "structured-logging @ git+https://github.com/bcgov/sbc-connect-common.git@main#subdirectory=python/structured-logging",

--- a/python/common/business-registry-model/poetry.lock
+++ b/python/common/business-registry-model/poetry.lock
@@ -1490,8 +1490,8 @@ strict-rfc3339 = "*"
 [package.source]
 type = "git"
 url = "https://github.com/bcgov/business-schemas.git"
-reference = "2.18.67"
-resolved_reference = "bd6808dbb26807ab2e5dc8bcdf0d28276b1f8e39"
+reference = "2.18.68"
+resolved_reference = "3cd771a26e1ed74cc5e45c10235526be3f0ee7cb"
 
 [[package]]
 name = "requests"
@@ -2085,4 +2085,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<3.14"
-content-hash = "0b62ad5140bd575b7d74648f227d0c50346617e524196f097067482e7e328ddc"
+content-hash = "77ff652ce1d0ac21a19f2f95798d18b6acbe638d17584f1c9b5b97d6da493cf6"

--- a/python/common/business-registry-model/pyproject.toml
+++ b/python/common/business-registry-model/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "business-model"
-version = "3.3.28"
+version = "3.3.29"
 description = ""
 authors = [
     {name = "thor",email = "1042854+thorwolpert@users.noreply.github.com"}
@@ -9,7 +9,7 @@ readme = "README.md"
 requires-python = ">=3.13,<3.14"
 dependencies = [
     "sql-versioning @ git+https://github.com/bcgov/lear.git@main#subdirectory=python/common/sql-versioning-alt",
-    "registry-schemas @ git+https://github.com/bcgov/business-schemas.git@2.18.67",
+    "registry-schemas @ git+https://github.com/bcgov/business-schemas.git@2.18.68",
     "flask-migrate (>=4.1.0,<5.0.0)",
     "pg8000 (>=1.31.2,<2.0.0)",
     "pydantic (>=2.10.6,<3.0.0)",


### PR DESCRIPTION
*Issue #:* /bcgov/entity#31675

*Description of changes:*
Use `2.18.68` business-schema in legal-api and registry models

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
