### PR TITLE
33494 fix colin freeze bug for non-migration filter path

### DIFF
--- a/data-tool/flows/colin_freeze_flow.py
+++ b/data-tool/flows/colin_freeze_flow.py
@@ -119,7 +119,7 @@ def get_unprocessed_corps_query(flow_name, config, batch_size):
     LEFT JOIN colin_tracking ct
     ON ct.corp_num = c.corp_num
     AND ct.flow_name = '{flow_name}'
-    AND ct.environment = '{environment}'z
+    AND ct.environment = '{environment}'
     WHERE 1 = 1
     {where_clause}
     AND ct.corp_num IS NULL


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33494

*Description of changes:*
- Remove typo from non-migration filter path

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
