### PR TITLE
33411 - Add Foreign Jurisdiction Validation for Continuation In

### DIFF
--- a/legal-api/src/legal_api/services/filings/validations/continuation_in.py
+++ b/legal-api/src/legal_api/services/filings/validations/continuation_in.py
@@ -40,6 +40,8 @@ from legal_api.services.filings.validations.incorporation_application import (
 from legal_api.services.utils import get_bool, get_str
 from legal_api.utils.datetime import datetime as dt
 
+FOREIGN_JURISDICTION_IDENTIFIER_MAX_LENGTH = 50
+FOREIGN_JURISDICTION_LEGAL_NAME_MAX_LENGTH = 1000
 
 def validate(filing_json: dict) -> Optional[Error]:  # pylint: disable=too-many-branches;
     """Validate the Continuation In filing."""
@@ -138,6 +140,27 @@ def validate_roles(filing_dict: dict, legal_type: str, filing_type: str) -> list
     return msg
 
 
+def _validate_incorporation_date(incorporation_date: str, incorporation_date_path: str) -> list:
+    """Validate incorporation date."""
+    msg = []
+    try:
+        # Check the incorporation date is in valid format
+        incorporation_date_formatted = dt.fromisoformat(incorporation_date)
+        
+        # Check if the date is today or before
+        if incorporation_date_formatted > dt.now():
+            msg.append({
+                "error": "Incorporation date cannot be in the future.",
+                "path": incorporation_date_path
+            })
+    except ValueError:
+        msg.append({
+            "error": f"{incorporation_date} is an invalid ISO format for incorporation date.",
+            "path": incorporation_date_path
+        })
+    return msg
+
+
 def _validate_foreign_jurisdiction(filing_json: dict, filing_type: str, legal_type: str) -> list:
     """Validate continuation in foreign jurisdiction."""
     msg = []
@@ -145,6 +168,28 @@ def _validate_foreign_jurisdiction(filing_json: dict, filing_type: str, legal_ty
     incorporation_date = filing_json["filing"][filing_type]["foreignJurisdiction"]["incorporationDate"]
     foreign_jurisdiction_path = f"/filing/{filing_type}/foreignJurisdiction"
     incorporation_date_path = f"/filing/{filing_type}/foreignJurisdiction/incorporationDate"
+
+    if not (identifier := foreign_jurisdiction.get("identifier")):
+        msg.append({
+            "error": "Identifier is required.",
+            "path": f"{foreign_jurisdiction_path}/identifier"
+        })
+    elif len(identifier) > FOREIGN_JURISDICTION_IDENTIFIER_MAX_LENGTH:
+        msg.append({
+            "error": f"Identifier must not exceed {FOREIGN_JURISDICTION_IDENTIFIER_MAX_LENGTH} characters.",
+            "path": f"{foreign_jurisdiction_path}/identifier"
+        })
+
+    if not (legal_name := foreign_jurisdiction.get("legalName")):
+        msg.append({
+            "error": "Legal name is required.",
+            "path": f"{foreign_jurisdiction_path}/legalName"
+        })
+    elif len(legal_name) > FOREIGN_JURISDICTION_LEGAL_NAME_MAX_LENGTH:
+        msg.append({
+            "error": f"Legal name must not exceed {FOREIGN_JURISDICTION_LEGAL_NAME_MAX_LENGTH} characters.",
+            "path": f"{foreign_jurisdiction_path}/legalName"
+        })
 
     if err := validate_foreign_jurisdiction(foreign_jurisdiction, foreign_jurisdiction_path):
         msg.extend(err)
@@ -157,21 +202,8 @@ def _validate_foreign_jurisdiction(filing_json: dict, filing_type: str, legal_ty
                 msg.extend(err)
         else:
             msg.append({"error": "Affidavit from the directors is required.", "path": affidavit_file_key_path})
-    try:
-        # Check the incorporation date is in valid format
-        incorporation_date_formatted = dt.fromisoformat(incorporation_date)
 
-        # Check if the date is today or before
-        if incorporation_date_formatted > dt.now():
-            msg.append({
-                "error": "Incorporation date cannot be in the future.",
-                "path": incorporation_date_path
-            })
-    except ValueError:
-        msg.append({
-            "error": f"{incorporation_date} is an invalid ISO format for incorporation date.",
-            "path": incorporation_date_path
-        })
+    msg.extend(_validate_incorporation_date(incorporation_date, incorporation_date_path))
 
     return msg
 

--- a/legal-api/tests/unit/services/filings/validations/test_continuation_in.py
+++ b/legal-api/tests/unit/services/filings/validations/test_continuation_in.py
@@ -894,7 +894,9 @@ def test_validate_foreign_jurisdiction_incorporation_date(mocker, app, session):
                 'foreignJurisdiction': {
                     'country': 'USA',
                     'region': 'WA',
-                    'incorporationDate': future_date
+                    'incorporationDate': future_date,
+                    'identifier': '123456789',
+                    'legalName': 'Test Company'
                 }
             },
             'header': {
@@ -1127,4 +1129,136 @@ def test_validate_continuation_in_effective_date(mocker, app, session, test_name
     else:
         assert err is None
 
+@pytest.mark.parametrize(
+    'test_name, identifier, legal_name, expected_errors',
+    [
+        (
+            'SUCCESS',
+            'C1234567',
+            'Test',
+            []
+        ),
+        (
+            'SUCCESS_IDENTIFIER_AT_MAX_LENGTH',
+            'A' * 50,
+            'Test',
+            []
+        ),
+        (
+            'SUCCESS_LEGAL_NAME_AT_MAX_LENGTH',
+            'C1234567',
+            'A' * 1000,
+            []
+        ),
+        (
+            'FAIL_IDENTIFIER_MISSING',
+            None,
+            'Test',
+            [
+                {
+                    'error': 'Identifier is required.',
+                    'path': '/filing/continuationIn/foreignJurisdiction/identifier'
+                }
+            ]
+        ),
+        (
+            'FAIL_LEGAL_NAME_MISSING',
+            'C1234567',
+            None,
+            [
+                {
+                    'error': 'Legal name is required.',
+                    'path': '/filing/continuationIn/foreignJurisdiction/legalName'
+                }
+            ]
+        ),
+        (
+            'FAIL_BOTH_MISSING',
+            None,
+            None,
+            [
+                {
+                    'error': 'Identifier is required.',
+                    'path': '/filing/continuationIn/foreignJurisdiction/identifier'
+                },
+                {
+                    'error': 'Legal name is required.',
+                    'path': '/filing/continuationIn/foreignJurisdiction/legalName'
+                }
+            ]
+        ),
+        (
+            'FAIL_IDENTIFIER_EXCEEDS_MAX_LENGTH',
+            'A' * 51,
+            'Test',
+            [
+                {
+                    'error': 'Identifier must not exceed 50 characters.',
+                    'path': '/filing/continuationIn/foreignJurisdiction/identifier'
+                }
+            ]
+        ),
+        (
+            'FAIL_LEGAL_NAME_EXCEEDS_MAX_LENGTH',
+            'C1234567',
+            'A' * 1001,
+            [
+                {
+                    'error': 'Legal name must not exceed 1000 characters.',
+                    'path': '/filing/continuationIn/foreignJurisdiction/legalName'
+                }
+            ]
+        ),
+        (
+            'FAIL_BOTH_EXCEED_MAX_LENGTH',
+            'A' * 51,
+            'A' * 1001,
+            [
+                {
+                    'error': 'Identifier must not exceed 50 characters.',
+                    'path': '/filing/continuationIn/foreignJurisdiction/identifier'
+                },
+                {
+                    'error': 'Legal name must not exceed 1000 characters.',
+                    'path': '/filing/continuationIn/foreignJurisdiction/legalName'
+                }
+            ]
+        ),
+    ]
+)
+def test_validate_foreign_jurisdiction_field_lengths(mocker, app, session,
+                                                     test_name, identifier, legal_name, expected_errors):
+    """Assert that identifier and legalName are required and enforce max length for continuation in filings."""
+    filing = {
+        'filing': {
+            'continuationIn': {
+                'foreignJurisdiction': {
+                    'country': 'US',
+                    'region': 'WA',
+                    'incorporationDate': dt.now().date().isoformat()
+                }
+            },
+            'header': {
+                'name': 'continuationIn',
+                'date': '2019-04-08',
+                'certifiedBy': 'full name',
+                'authorizationReceived': True,
+                'email': 'no_one@never.get',
+                'filingId': 1
+            }
+        }
+    }
 
+    if identifier is not None:
+        filing['filing']['continuationIn']['foreignJurisdiction']['identifier'] = identifier
+
+    if legal_name is not None:
+        filing['filing']['continuationIn']['foreignJurisdiction']['legalName'] = legal_name
+
+    mocker.patch('legal_api.services.filings.validations.continuation_in.validate_foreign_jurisdiction',
+                 return_value=[])
+    mocker.patch('legal_api.services.filings.validations.continuation_in.validate_pdf', return_value=None)
+
+    err = _validate_foreign_jurisdiction(filing, 'continuationIn', 'C')
+
+    assert err == expected_errors


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33411

*Description of changes:*
- Add required field and max length validation for foreign jurisdiction `identifier`(50) and `legalName`(1000) in `_validate_foreign_jurisdiction`
- Extract incorporation date validation into `_validate_incorporation_date` helper to stay within branch limits
- Add/update unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
