### PR TITLE
33536 adjust share structure par val output format

### DIFF
--- a/legal-api/report-templates/template-parts/common/shareStructure.html
+++ b/legal-api/report-templates/template-parts/common/shareStructure.html
@@ -35,12 +35,14 @@
             </td>
             <td class="right-align">
                {% if share_class.hasParValue %}
+                  {% set pv_parts = (share_class.parValue|string).split('.') %}
+                  {% set frac_part = pv_parts[1] if pv_parts|length > 1 else '' %}
                   {% if share_class.currency in dollar_currencies %}
-                     {% set pv_parts = (share_class.parValue|string).split('.') %}
-                     {% set frac_part = pv_parts[1] if pv_parts|length > 1 else '' %}
-                     $ {{ '{:,}'.format(pv_parts[0]|int) }}.{{ frac_part.ljust(2, '0') }}
+                     ${{ '{:,}'.format(pv_parts[0]|int) }}.{{ frac_part.ljust(2, '0') }}
+                  {% elif not frac_part or frac_part|int == 0 %}
+                     {{ '{:,}'.format(pv_parts[0]|int) }}
                   {% else %}
-                     {{ share_class.parValue }}
+                     {{ '{:,}'.format(pv_parts[0]|int) }}.{{ frac_part }}
                   {% endif %}
                {% else %}
                   No Par Value
@@ -87,12 +89,14 @@
                <td class="right-align">
                   <!-- hasParValue, parValue and currency are in share_class -->
                   {% if share_class.hasParValue %}
+                     {% set pv_parts = (share_class.parValue|string).split('.') %}
+                     {% set frac_part = pv_parts[1] if pv_parts|length > 1 else '' %}
                      {% if share_class.currency in dollar_currencies %}
-                        {% set pv_parts = (share_class.parValue|string).split('.') %}
-                        {% set frac_part = pv_parts[1] if pv_parts|length > 1 else '' %}
-                        $ {{ '{:,}'.format(pv_parts[0]|int) }}.{{ frac_part.ljust(2, '0') }}
+                        ${{ '{:,}'.format(pv_parts[0]|int) }}.{{ frac_part.ljust(2, '0') }}
+                     {% elif not frac_part or frac_part|int == 0 %}
+                        {{ '{:,}'.format(pv_parts[0]|int) }}
                      {% else %}
-                        {{ share_class.parValue }}
+                        {{ '{:,}'.format(pv_parts[0]|int) }}.{{ frac_part }}
                      {% endif %}
                   {% else %}
                      No Par Value

--- a/legal-api/tests/unit/reports/templates/test_share_structure.py
+++ b/legal-api/tests/unit/reports/templates/test_share_structure.py
@@ -59,28 +59,28 @@ def _render(share_classes, header_name='noticeOfArticles'):
 
 
 @pytest.mark.parametrize('par_value,currency,expected', [
-    (1, 'USD', '$ 1.00'),
-    (1.0, 'USD', '$ 1.00'),
-    (1.5, 'CAD', '$ 1.50'),
-    (Decimal('0.5'), 'AUD', '$ 0.50'),
-    ('2', 'AUD', '$ 2.00'),
-    (1000, 'CAD', '$ 1,000.00'),
-    (1234567, 'USD', '$ 1,234,567.00'),
-    (1111112321434241, 'USD', '$ 1,111,112,321,434,241.00'),
-    ('1234567.5', 'AUD', '$ 1,234,567.50'),
+    (1, 'USD', '$1.00'),
+    (1.0, 'USD', '$1.00'),
+    (1.5, 'CAD', '$1.50'),
+    (Decimal('0.5'), 'AUD', '$0.50'),
+    ('2', 'AUD', '$2.00'),
+    (1000, 'CAD', '$1,000.00'),
+    (1234567, 'USD', '$1,234,567.00'),
+    (1111112321434241, 'USD', '$1,111,112,321,434,241.00'),
+    ('1234567.5', 'AUD', '$1,234,567.50'),
 ])
 def test_dollar_currency_formats_with_min_two_decimals_and_commas(session, par_value, currency, expected):
-    """Dollar-denominated currencies render parValue padded to AT LEAST 2 decimals with $ prefix and thousands separators."""
+    """Dollar-denominated currencies render parValue padded to AT LEAST 2 decimals with $ prefix (no space) and thousands separators."""
     rendered = _render([_share_class(par_value, currency=currency)])
     assert expected in rendered
 
 
 @pytest.mark.parametrize('par_value,currency,expected', [
-    ('1.00000000002342', 'CAD', '$ 1.00000000002342'),
-    ('1.234', 'CAD', '$ 1.234'),
-    ('0.0001', 'USD', '$ 0.0001'),
-    ('1234567.123456', 'AUD', '$ 1,234,567.123456'),
-    ('0.000000000000000001', 'USD', '$ 0.000000000000000001'),
+    ('1.00000000002342', 'CAD', '$1.00000000002342'),
+    ('1.234', 'CAD', '$1.234'),
+    ('0.0001', 'USD', '$0.0001'),
+    ('1234567.123456', 'AUD', '$1,234,567.123456'),
+    ('0.000000000000000001', 'USD', '$0.000000000000000001'),
 ])
 def test_dollar_currency_preserves_extra_decimals(session, par_value, currency, expected):
     """parValues with more than 2 decimal places must NOT be truncated — match UI's FormatDecimal behavior.
@@ -92,11 +92,33 @@ def test_dollar_currency_preserves_extra_decimals(session, par_value, currency, 
     assert expected in rendered
 
 
-@pytest.mark.parametrize('currency', ['EUR', 'GBP', 'JPY', 'INR'])
-def test_non_dollar_currency_renders_raw_no_dollar_sign(session, currency):
-    """Non-dollar currencies render the raw parValue and no $ prefix."""
+@pytest.mark.parametrize('currency', ['EUR', 'GBP', 'JPY', 'INR', 'AED'])
+def test_non_dollar_currency_renders_no_dollar_sign(session, currency):
+    """Non-dollar currencies render with no $ prefix."""
     rendered = _render([_share_class(1.5, currency=currency)])
     assert '1.5' in rendered
+    assert '$' not in rendered
+
+
+@pytest.mark.parametrize('par_value,currency,expected', [
+    # whole numbers drop trailing decimal zeros
+    (1, 'AED', '1'),
+    (1.0, 'EUR', '1'),
+    ('1.0', 'AED', '1'),
+    ('1.00', 'AED', '1'),
+    ('1345345345.0', 'AED', '1,345,345,345'),
+    (1000, 'JPY', '1,000'),
+    (1234567, 'INR', '1,234,567'),
+    # non-whole numbers keep decimals as entered, with commas on integer part
+    (1.5, 'AED', '1.5'),
+    ('1234.50', 'GBP', '1,234.50'),
+    ('1234567.123', 'EUR', '1,234,567.123'),
+    (Decimal('0.5'), 'AED', '0.5'),
+])
+def test_non_dollar_currency_formats_commas_and_drops_whole_decimals(session, par_value, currency, expected):
+    """Non-dollar currencies: thousands separators, and decimals stripped only when the value is a whole number."""
+    rendered = _render([_share_class(par_value, currency=currency)])
+    assert expected in rendered
     assert '$' not in rendered
 
 
@@ -125,7 +147,7 @@ def test_series_inherits_parent_share_class_par_value_format(session):
         'hasRightsOrRestrictions': False,
     }]
     rendered = _render([_share_class(par_value=3, currency='USD', series=series)])
-    assert rendered.count('$ 3.00') == 2
+    assert rendered.count('$3.00') == 2
     assert 'Series 1' in rendered
 
 
@@ -155,4 +177,4 @@ def test_par_value_formatting_consistent_across_header_types(session, header_nam
         [_share_class(par_value=1234.5, currency='CAD', series=series)],
         header_name=header_name
     )
-    assert rendered.count('$ 1,234.50') == 2
+    assert rendered.count('$1,234.50') == 2


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33536

*Description of changes:*
Tweaks to number format (no space before $, correct decimals for non-dollars)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
