### PR TITLE
fix: add pg8000 graceful shutdown on Cloud Run scale-down

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -13,23 +13,15 @@ coverage:
       backend:
         target: auto
         flags:
-          - business-api
-          - business-bn
-          - business-bn-retry
-          - business-digital-credentials
-          - business-email-reminder
-          - business-emailer
-          - business-entity-bn
-          - business-expired-limited-restoration
-          - business-filer
-          - business-filings-notebook-report
-          - business-furnishings
-          - business-future-effective-filings
-          - business-involuntary-dissolutions
-          - business-pay
-          - business-registry-model
-          - business-update-colin-filings
-          - business-update-legal-filings
+          - colinapi
+          - legalapi
+          - entityemailer
+          - entityfiler
+          - entitypay
+          - entitybn
+          - entity-digital-credentials
+          - furnishings
+          - involuntary-dissolutions
 
 ignore:
   - "^/tests/**/*" # ignore test harness code
@@ -48,71 +40,39 @@ comment:
   require_changes: true
 
 flags:
-  business-api:
+  colinapi:
+    paths:
+      - colin-api/src/colin_api
+    carryforward: true
+  legalapi:
     paths:
       - legal-api/src/legal_api
     carryforward: true
-  business-bn:
+  entityemailer:
     paths:
-      - queue_services/business-bn/src/business_bn
+      - queue_services/entity-emailer/src/entity_emailer
     carryforward: true
-  business-bn-retry:
+  entityfiler:
     paths:
-      - gcp-jobs/bn-retry/src/bn_retry
+      - queue_services/entity-filer/src/entity_filer
     carryforward: true
-  business-digital-credentials:
+  entitypay:
     paths:
-      - queue_services/business-digital-credentials/src/business_digital_credentials
+      - queue_services/entity-pay/src/entity_pay
     carryforward: true
-  business-email-reminder:
+  entitybn:
     paths:
-      - gcp-jobs/email-reminder/src/email_reminder
+      - queue_services/entity-bn/src/entity_bn
     carryforward: true
-  business-emailer:
+  entity-digital-credentials:
     paths:
-      - queue_services/business-emailer/src/business_emailer
+      - queue_services/entity-digital-credentials/src/entity_digital_credentials
     carryforward: true
-  business-entity-bn:
+  furnishings:
     paths:
-      - gcp-jobs/entity-bn/src/entity-bn
+      - jobs/furnishings
     carryforward: true
-  business-expired-limited-restoration:
+  involuntary-dissolutions:
     paths:
-      - gcp-jobs/expired-limited-restoration/src/expired_limited_restoration
-    carryforward: true
-  business-filer:
-    paths:
-      - queue_services/business-filer/src/business_filer
-    carryforward: true
-  business-filings-notebook-report:
-    paths:
-      - gcp-jobs/filings-notebook-report/src/notebookreport
-    carryforward: true
-  business-furnishings:
-    paths:
-      - gcp-jobs/furnishings/src/furnishings
-    carryforward: true
-  business-future-effective-filings:
-    paths:
-      - gcp-jobs/future-effective-filings/src/future_effective_filings
-    carryforward: true
-  business-involuntary-dissolutions:
-    paths:
-      - gcp-jobs/involuntary-dissolutions/src/involuntary_dissolutions
-    carryforward: true
-  business-pay:
-    paths:
-      - queue_services/business-pay/src/business_pay
-    carryforward: true
-  business-registry-model:
-    paths:
-      - python/common/business-registry-model/src/business_model
-    carryforward: true
-  business-update-colin-filings:
-    paths:
-      - gcp-jobs/update-colin-filings/src/update_colin_filings
-    carryforward: true
-  business-update-legal-filings:
-    paths:
-      - gcp-jobs/update-legal-filings/src/update_legal_filings
+      - jobs/involuntary-dissolutions
     carryforward: true

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -13,15 +13,23 @@ coverage:
       backend:
         target: auto
         flags:
-          - colinapi
-          - legalapi
-          - entityemailer
-          - entityfiler
-          - entitypay
-          - entitybn
-          - entity-digital-credentials
-          - furnishings
-          - involuntary-dissolutions
+          - business-api
+          - business-bn
+          - business-bn-retry
+          - business-digital-credentials
+          - business-email-reminder
+          - business-emailer
+          - business-entity-bn
+          - business-expired-limited-restoration
+          - business-filer
+          - business-filings-notebook-report
+          - business-furnishings
+          - business-future-effective-filings
+          - business-involuntary-dissolutions
+          - business-pay
+          - business-registry-model
+          - business-update-colin-filings
+          - business-update-legal-filings
 
 ignore:
   - "^/tests/**/*" # ignore test harness code
@@ -40,39 +48,71 @@ comment:
   require_changes: true
 
 flags:
-  colinapi:
-    paths:
-      - colin-api/src/colin_api
-    carryforward: true
-  legalapi:
+  business-api:
     paths:
       - legal-api/src/legal_api
     carryforward: true
-  entityemailer:
+  business-bn:
     paths:
-      - queue_services/entity-emailer/src/entity_emailer
+      - queue_services/business-bn/src/business_bn
     carryforward: true
-  entityfiler:
+  business-bn-retry:
     paths:
-      - queue_services/entity-filer/src/entity_filer
+      - gcp-jobs/bn-retry/src/bn_retry
     carryforward: true
-  entitypay:
+  business-digital-credentials:
     paths:
-      - queue_services/entity-pay/src/entity_pay
+      - queue_services/business-digital-credentials/src/business_digital_credentials
     carryforward: true
-  entitybn:
+  business-email-reminder:
     paths:
-      - queue_services/entity-bn/src/entity_bn
+      - gcp-jobs/email-reminder/src/email_reminder
     carryforward: true
-  entity-digital-credentials:
+  business-emailer:
     paths:
-      - queue_services/entity-digital-credentials/src/entity_digital_credentials
+      - queue_services/business-emailer/src/business_emailer
     carryforward: true
-  furnishings:
+  business-entity-bn:
     paths:
-      - jobs/furnishings
+      - gcp-jobs/entity-bn/src/entity-bn
     carryforward: true
-  involuntary-dissolutions:
+  business-expired-limited-restoration:
     paths:
-      - jobs/involuntary-dissolutions
+      - gcp-jobs/expired-limited-restoration/src/expired_limited_restoration
+    carryforward: true
+  business-filer:
+    paths:
+      - queue_services/business-filer/src/business_filer
+    carryforward: true
+  business-filings-notebook-report:
+    paths:
+      - gcp-jobs/filings-notebook-report/src/notebookreport
+    carryforward: true
+  business-furnishings:
+    paths:
+      - gcp-jobs/furnishings/src/furnishings
+    carryforward: true
+  business-future-effective-filings:
+    paths:
+      - gcp-jobs/future-effective-filings/src/future_effective_filings
+    carryforward: true
+  business-involuntary-dissolutions:
+    paths:
+      - gcp-jobs/involuntary-dissolutions/src/involuntary_dissolutions
+    carryforward: true
+  business-pay:
+    paths:
+      - queue_services/business-pay/src/business_pay
+    carryforward: true
+  business-registry-model:
+    paths:
+      - python/common/business-registry-model/src/business_model
+    carryforward: true
+  business-update-colin-filings:
+    paths:
+      - gcp-jobs/update-colin-filings/src/update_colin_filings
+    carryforward: true
+  business-update-legal-filings:
+    paths:
+      - gcp-jobs/update-legal-filings/src/update_legal_filings
     carryforward: true

--- a/legal-api/poetry.lock
+++ b/legal-api/poetry.lock
@@ -556,7 +556,7 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cloud-sql-connector"
-version = "0.2.2"
+version = "0.2.3"
 description = "Cloud SQL connection utilities for database connectivity with authentication and schema management"
 optional = false
 python-versions = "^3.9"
@@ -573,7 +573,7 @@ sqlalchemy = ">=1.4.0,<3.0.0"
 type = "git"
 url = "https://github.com/bcgov/sbc-connect-common.git"
 reference = "cloud-sql-connector-python3.9"
-resolved_reference = "e82cd710c818e55f7b468472b4908e4d14a25a79"
+resolved_reference = "c4a2d6b465ecbb0d09695f91c44a1ee6fb0f970e"
 subdirectory = "python/cloud-sql-connector"
 
 [[package]]

--- a/legal-api/poetry.lock
+++ b/legal-api/poetry.lock
@@ -556,7 +556,7 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cloud-sql-connector"
-version = "0.2.3"
+version = "0.2.2"
 description = "Cloud SQL connection utilities for database connectivity with authentication and schema management"
 optional = false
 python-versions = "^3.9"
@@ -573,7 +573,7 @@ sqlalchemy = ">=1.4.0,<3.0.0"
 type = "git"
 url = "https://github.com/bcgov/sbc-connect-common.git"
 reference = "cloud-sql-connector-python3.9"
-resolved_reference = "c4a2d6b465ecbb0d09695f91c44a1ee6fb0f970e"
+resolved_reference = "e82cd710c818e55f7b468472b4908e4d14a25a79"
 subdirectory = "python/cloud-sql-connector"
 
 [[package]]

--- a/legal-api/src/legal_api/__init__.py
+++ b/legal-api/src/legal_api/__init__.py
@@ -35,14 +35,13 @@
 
 This module is the API for the Legal Entity system.
 """
-import logging
 import os
 from typing import Optional
 
+from cloud_sql_connector import setup_pg8000_close_event_listener
 from flask import Flask, jsonify
 from registry_schemas import __version__ as registry_schemas_version
 from registry_schemas.flask import SchemaServices
-from sqlalchemy import event
 
 from legal_api import config, models
 from legal_api.models import db
@@ -63,29 +62,6 @@ from legal_api.scripts.document_service_import import document_service_bp  # noq
 setup_logging(os.path.join(os.path.abspath(os.path.dirname(__file__)), "logging.conf"))  # important to do this first
 
 
-def _setup_pg8000_graceful_shutdown(engine) -> None:
-    """Suppress pg8000 InterfaceError on connection close during Cloud Run scale-down."""
-    try:
-        from pg8000.exceptions import InterfaceError as _interface_error  # noqa: N813
-    except ImportError:
-        _interface_error = None
-
-    @event.listens_for(engine, "connect")
-    def on_connect(dbapi_conn, _connection_record):
-        orig_close = dbapi_conn.close
-
-        def safe_close():
-            try:
-                orig_close()
-            except Exception as exc:
-                if _interface_error and isinstance(exc, _interface_error):
-                    logging.getLogger(__name__).debug("Suppressed pg8000 InterfaceError on teardown.")
-                else:
-                    raise
-
-        dbapi_conn.close = safe_close
-
-
 def create_app(run_mode: Optional[str] = None, **kwargs) -> Flask:
     """Return a configured Flask App using the Factory method."""
     run_mode = run_mode or os.getenv("RUN_MODE", "production")
@@ -96,18 +72,6 @@ def create_app(run_mode: Optional[str] = None, **kwargs) -> Flask:
         app.config.from_object(_config)
     else:
         app.config.from_object(config.CONFIGURATION[run_mode])
-
-    if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
-        from cloud_sql_connector import DBConfig
-        db_config = DBConfig(
-            instance_name=app.config["CLOUDSQL_INSTANCE_CONNECTION_NAME"],
-            database=app.config.get("DB_NAME", ""),
-            user=app.config.get("DB_USER", ""),
-            ip_type=app.config["DB_IP_TYPE"],
-            pool_recycle = 60,
-            schema="public",
-        )
-        app.config["SQLALCHEMY_ENGINE_OPTIONS"] = db_config.get_engine_options()
 
     app.logger = StructuredLogging(app).get_logger()
     init_db(app)
@@ -120,7 +84,7 @@ def create_app(run_mode: Optional[str] = None, **kwargs) -> Flask:
     with app.app_context():  # db require app context
         digital_credentials.init_app(app)
         if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
-            _setup_pg8000_graceful_shutdown(db.engine)
+            setup_pg8000_close_event_listener(db.engine)
 
     cache.init_app(app)
 

--- a/legal-api/src/legal_api/__init__.py
+++ b/legal-api/src/legal_api/__init__.py
@@ -73,7 +73,7 @@ def create_app(run_mode: Optional[str] = None, **kwargs) -> Flask:
         app.config.from_object(config.CONFIGURATION[run_mode])
 
     if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
-        from cloud_sql_connector import DBConfig
+        from cloud_sql_connector import DBConfig, setup_pg8000_close_event_listener
         db_config = DBConfig(
             instance_name=app.config["CLOUDSQL_INSTANCE_CONNECTION_NAME"],
             database=app.config.get("DB_NAME", ""),
@@ -94,6 +94,8 @@ def create_app(run_mode: Optional[str] = None, **kwargs) -> Flask:
 
     with app.app_context():  # db require app context
         digital_credentials.init_app(app)
+        if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
+            setup_pg8000_close_event_listener(db.engine)
 
     cache.init_app(app)
 

--- a/legal-api/src/legal_api/__init__.py
+++ b/legal-api/src/legal_api/__init__.py
@@ -35,12 +35,14 @@
 
 This module is the API for the Legal Entity system.
 """
+import logging
 import os
 from typing import Optional
 
 from flask import Flask, jsonify
 from registry_schemas import __version__ as registry_schemas_version
 from registry_schemas.flask import SchemaServices
+from sqlalchemy import event
 
 from legal_api import config, models
 from legal_api.models import db
@@ -63,12 +65,10 @@ setup_logging(os.path.join(os.path.abspath(os.path.dirname(__file__)), "logging.
 
 def _setup_pg8000_graceful_shutdown(engine) -> None:
     """Suppress pg8000 InterfaceError on connection close during Cloud Run scale-down."""
-    import logging
-    from sqlalchemy import event
     try:
-        from pg8000.exceptions import InterfaceError as _InterfaceError
+        from pg8000.exceptions import InterfaceError as _interface_error
     except ImportError:
-        _InterfaceError = None
+        _interface_error = None
 
     @event.listens_for(engine, "connect")
     def on_connect(dbapi_conn, _connection_record):
@@ -78,7 +78,7 @@ def _setup_pg8000_graceful_shutdown(engine) -> None:
             try:
                 orig_close()
             except Exception as exc:
-                if _InterfaceError and isinstance(exc, _InterfaceError):
+                if _interface_error and isinstance(exc, _interface_error):
                     logging.getLogger(__name__).debug("Suppressed pg8000 InterfaceError on teardown.")
                 else:
                     raise

--- a/legal-api/src/legal_api/__init__.py
+++ b/legal-api/src/legal_api/__init__.py
@@ -35,13 +35,14 @@
 
 This module is the API for the Legal Entity system.
 """
+import logging
 import os
 from typing import Optional
 
-from cloud_sql_connector import setup_pg8000_close_event_listener
 from flask import Flask, jsonify
 from registry_schemas import __version__ as registry_schemas_version
 from registry_schemas.flask import SchemaServices
+from sqlalchemy import event
 
 from legal_api import config, models
 from legal_api.models import db
@@ -61,6 +62,28 @@ from legal_api.scripts.document_service_import import document_service_bp  # noq
 
 setup_logging(os.path.join(os.path.abspath(os.path.dirname(__file__)), "logging.conf"))  # important to do this first
 
+
+def _setup_pg8000_graceful_shutdown(engine) -> None:
+    """Suppress pg8000 InterfaceError on connection close during Cloud Run scale-down."""
+    try:
+        from pg8000.exceptions import InterfaceError as _interface_error  # noqa: N813
+    except ImportError:
+        _interface_error = None
+
+    @event.listens_for(engine, "connect")
+    def on_connect(dbapi_conn, _connection_record):
+        orig_close = dbapi_conn.close
+
+        def safe_close():
+            try:
+                orig_close()
+            except Exception as exc:
+                if _interface_error and isinstance(exc, _interface_error):
+                    logging.getLogger(__name__).debug("Suppressed pg8000 InterfaceError on teardown.")
+                else:
+                    raise
+
+        dbapi_conn.close = safe_close
 
 
 def create_app(run_mode: Optional[str] = None, **kwargs) -> Flask:
@@ -85,7 +108,7 @@ def create_app(run_mode: Optional[str] = None, **kwargs) -> Flask:
     with app.app_context():  # db require app context
         digital_credentials.init_app(app)
         if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
-            setup_pg8000_close_event_listener(db.engine)
+            _setup_pg8000_graceful_shutdown(db.engine)
 
     cache.init_app(app)
 

--- a/legal-api/src/legal_api/__init__.py
+++ b/legal-api/src/legal_api/__init__.py
@@ -35,13 +35,14 @@
 
 This module is the API for the Legal Entity system.
 """
+import logging
 import os
 from typing import Optional
 
-from cloud_sql_connector import setup_pg8000_close_event_listener
 from flask import Flask, jsonify
 from registry_schemas import __version__ as registry_schemas_version
 from registry_schemas.flask import SchemaServices
+from sqlalchemy import event
 
 from legal_api import config, models
 from legal_api.models import db
@@ -60,6 +61,29 @@ from legal_api.scripts.document_service_import import document_service_bp  # noq
 
 
 setup_logging(os.path.join(os.path.abspath(os.path.dirname(__file__)), "logging.conf"))  # important to do this first
+
+
+def _setup_pg8000_graceful_shutdown(engine) -> None:
+    """Suppress pg8000 InterfaceError on connection close during Cloud Run scale-down."""
+    try:
+        from pg8000.exceptions import InterfaceError as _interface_error  # noqa: N813
+    except ImportError:
+        _interface_error = None
+
+    @event.listens_for(engine, "connect")
+    def on_connect(dbapi_conn, _connection_record):
+        orig_close = dbapi_conn.close
+
+        def safe_close():
+            try:
+                orig_close()
+            except Exception as exc:
+                if _interface_error and isinstance(exc, _interface_error):
+                    logging.getLogger(__name__).debug("Suppressed pg8000 InterfaceError on teardown.")
+                else:
+                    raise
+
+        dbapi_conn.close = safe_close
 
 
 def create_app(run_mode: Optional[str] = None, **kwargs) -> Flask:
@@ -84,7 +108,7 @@ def create_app(run_mode: Optional[str] = None, **kwargs) -> Flask:
     with app.app_context():  # db require app context
         digital_credentials.init_app(app)
         if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
-            setup_pg8000_close_event_listener(db.engine)
+            _setup_pg8000_graceful_shutdown(db.engine)
 
     cache.init_app(app)
 

--- a/legal-api/src/legal_api/__init__.py
+++ b/legal-api/src/legal_api/__init__.py
@@ -35,14 +35,13 @@
 
 This module is the API for the Legal Entity system.
 """
-import logging
 import os
 from typing import Optional
 
+from cloud_sql_connector import setup_pg8000_close_event_listener
 from flask import Flask, jsonify
 from registry_schemas import __version__ as registry_schemas_version
 from registry_schemas.flask import SchemaServices
-from sqlalchemy import event
 
 from legal_api import config, models
 from legal_api.models import db
@@ -62,28 +61,6 @@ from legal_api.scripts.document_service_import import document_service_bp  # noq
 
 setup_logging(os.path.join(os.path.abspath(os.path.dirname(__file__)), "logging.conf"))  # important to do this first
 
-
-def _setup_pg8000_graceful_shutdown(engine) -> None:
-    """Suppress pg8000 InterfaceError on connection close during Cloud Run scale-down."""
-    try:
-        from pg8000.exceptions import InterfaceError as _interface_error  # noqa: N813
-    except ImportError:
-        _interface_error = None
-
-    @event.listens_for(engine, "connect")
-    def on_connect(dbapi_conn, _connection_record):
-        orig_close = dbapi_conn.close
-
-        def safe_close():
-            try:
-                orig_close()
-            except Exception as exc:
-                if _interface_error and isinstance(exc, _interface_error):
-                    logging.getLogger(__name__).debug("Suppressed pg8000 InterfaceError on teardown.")
-                else:
-                    raise
-
-        dbapi_conn.close = safe_close
 
 
 def create_app(run_mode: Optional[str] = None, **kwargs) -> Flask:
@@ -108,7 +85,7 @@ def create_app(run_mode: Optional[str] = None, **kwargs) -> Flask:
     with app.app_context():  # db require app context
         digital_credentials.init_app(app)
         if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
-            _setup_pg8000_graceful_shutdown(db.engine)
+            setup_pg8000_close_event_listener(db.engine)
 
     cache.init_app(app)
 

--- a/legal-api/src/legal_api/__init__.py
+++ b/legal-api/src/legal_api/__init__.py
@@ -35,14 +35,13 @@
 
 This module is the API for the Legal Entity system.
 """
-import logging
 import os
 from typing import Optional
 
+from cloud_sql_connector import setup_pg8000_close_event_listener
 from flask import Flask, jsonify
 from registry_schemas import __version__ as registry_schemas_version
 from registry_schemas.flask import SchemaServices
-from sqlalchemy import event
 
 from legal_api import config, models
 from legal_api.models import db
@@ -61,29 +60,6 @@ from legal_api.scripts.document_service_import import document_service_bp  # noq
 
 
 setup_logging(os.path.join(os.path.abspath(os.path.dirname(__file__)), "logging.conf"))  # important to do this first
-
-
-def _setup_pg8000_graceful_shutdown(engine) -> None:
-    """Suppress pg8000 InterfaceError on connection close during Cloud Run scale-down."""
-    try:
-        from pg8000.exceptions import InterfaceError as _interface_error  # noqa: N813
-    except ImportError:
-        _interface_error = None
-
-    @event.listens_for(engine, "connect")
-    def on_connect(dbapi_conn, _connection_record):
-        orig_close = dbapi_conn.close
-
-        def safe_close():
-            try:
-                orig_close()
-            except Exception as exc:
-                if _interface_error and isinstance(exc, _interface_error):
-                    logging.getLogger(__name__).debug("Suppressed pg8000 InterfaceError on teardown.")
-                else:
-                    raise
-
-        dbapi_conn.close = safe_close
 
 
 def create_app(run_mode: Optional[str] = None, **kwargs) -> Flask:
@@ -108,7 +84,7 @@ def create_app(run_mode: Optional[str] = None, **kwargs) -> Flask:
     with app.app_context():  # db require app context
         digital_credentials.init_app(app)
         if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
-            _setup_pg8000_graceful_shutdown(db.engine)
+            setup_pg8000_close_event_listener(db.engine)
 
     cache.init_app(app)
 

--- a/legal-api/src/legal_api/__init__.py
+++ b/legal-api/src/legal_api/__init__.py
@@ -61,6 +61,31 @@ from legal_api.scripts.document_service_import import document_service_bp  # noq
 setup_logging(os.path.join(os.path.abspath(os.path.dirname(__file__)), "logging.conf"))  # important to do this first
 
 
+def _setup_pg8000_graceful_shutdown(engine) -> None:
+    """Suppress pg8000 InterfaceError on connection close during Cloud Run scale-down."""
+    import logging
+    from sqlalchemy import event
+    try:
+        from pg8000.exceptions import InterfaceError as _InterfaceError
+    except ImportError:
+        _InterfaceError = None
+
+    @event.listens_for(engine, "connect")
+    def on_connect(dbapi_conn, _connection_record):
+        orig_close = dbapi_conn.close
+
+        def safe_close():
+            try:
+                orig_close()
+            except Exception as exc:
+                if _InterfaceError and isinstance(exc, _InterfaceError):
+                    logging.getLogger(__name__).debug("Suppressed pg8000 InterfaceError on teardown.")
+                else:
+                    raise
+
+        dbapi_conn.close = safe_close
+
+
 def create_app(run_mode: Optional[str] = None, **kwargs) -> Flask:
     """Return a configured Flask App using the Factory method."""
     run_mode = run_mode or os.getenv("RUN_MODE", "production")
@@ -73,7 +98,7 @@ def create_app(run_mode: Optional[str] = None, **kwargs) -> Flask:
         app.config.from_object(config.CONFIGURATION[run_mode])
 
     if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
-        from cloud_sql_connector import DBConfig, setup_pg8000_close_event_listener
+        from cloud_sql_connector import DBConfig
         db_config = DBConfig(
             instance_name=app.config["CLOUDSQL_INSTANCE_CONNECTION_NAME"],
             database=app.config.get("DB_NAME", ""),
@@ -95,7 +120,7 @@ def create_app(run_mode: Optional[str] = None, **kwargs) -> Flask:
     with app.app_context():  # db require app context
         digital_credentials.init_app(app)
         if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
-            setup_pg8000_close_event_listener(db.engine)
+            _setup_pg8000_graceful_shutdown(db.engine)
 
     cache.init_app(app)
 

--- a/legal-api/src/legal_api/__init__.py
+++ b/legal-api/src/legal_api/__init__.py
@@ -66,7 +66,7 @@ setup_logging(os.path.join(os.path.abspath(os.path.dirname(__file__)), "logging.
 def _setup_pg8000_graceful_shutdown(engine) -> None:
     """Suppress pg8000 InterfaceError on connection close during Cloud Run scale-down."""
     try:
-        from pg8000.exceptions import InterfaceError as _interface_error
+        from pg8000.exceptions import InterfaceError as _interface_error  # noqa: N813
     except ImportError:
         _interface_error = None
 

--- a/legal-api/src/legal_api/config.py
+++ b/legal-api/src/legal_api/config.py
@@ -23,6 +23,7 @@ or by accessing this configuration directly.
 import os
 import sys
 
+from cloud_sql_connector import DBConfig
 from dotenv import find_dotenv, load_dotenv
 
 # this will load all the envars from a .env file located in the project root (api)
@@ -118,6 +119,15 @@ class _Config:  # pylint: disable=too-few-public-methods
         SQLALCHEMY_DATABASE_URI = f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
     elif CLOUDSQL_INSTANCE_CONNECTION_NAME:
         SQLALCHEMY_DATABASE_URI = "postgresql+pg8000://"
+        db_config = DBConfig(
+            instance_name=CLOUDSQL_INSTANCE_CONNECTION_NAME,
+            database=DB_NAME,
+            user=DB_USER,
+            ip_type=DB_IP_TYPE,
+            pool_recycle=60,
+            schema="public",
+        )
+        SQLALCHEMY_ENGINE_OPTIONS = db_config.get_engine_options()
 
     # JWT_OIDC Settings
     JWT_OIDC_WELL_KNOWN_CONFIG = os.getenv("JWT_OIDC_WELL_KNOWN_CONFIG")

--- a/queue_services/business-bn/poetry.lock
+++ b/queue_services/business-bn/poetry.lock
@@ -639,7 +639,7 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cloud-sql-connector"
-version = "0.2.1"
+version = "0.2.3"
 description = "Cloud SQL connection utilities for database connectivity with authentication and schema management"
 optional = false
 python-versions = "^3.12"
@@ -656,7 +656,7 @@ sqlalchemy = "^2.0.0"
 type = "git"
 url = "https://github.com/bcgov/sbc-connect-common.git"
 reference = "main"
-resolved_reference = "2a3d5a2d5b5ff3c905626f3193db5ed0af6d4952"
+resolved_reference = "b83281702031386f92a0f3d27577e15b842b769b"
 subdirectory = "python/cloud-sql-connector"
 
 [[package]]

--- a/queue_services/business-bn/poetry.lock
+++ b/queue_services/business-bn/poetry.lock
@@ -656,7 +656,7 @@ sqlalchemy = "^2.0.0"
 type = "git"
 url = "https://github.com/bcgov/sbc-connect-common.git"
 reference = "main"
-resolved_reference = "b83281702031386f92a0f3d27577e15b842b769b"
+resolved_reference = "9a760cf5ea31d3f95806c2dcac15ca9d9800df51"
 subdirectory = "python/cloud-sql-connector"
 
 [[package]]

--- a/queue_services/business-bn/src/business_bn/__init__.py
+++ b/queue_services/business-bn/src/business_bn/__init__.py
@@ -36,6 +36,7 @@ The Business BN service.
 """
 import os
 
+from cloud_sql_connector import setup_pg8000_close_event_listener
 from flask import Flask
 
 from business_model.models import db
@@ -57,23 +58,10 @@ def create_app(environment: str = os.getenv("DEPLOYMENT_ENV", "production"), **k
     app.logger = StructuredLogging(app).get_logger()
     app.config.from_object(CONFIGURATION[environment])
 
-    if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
-        from cloud_sql_connector import DBConfig, setup_pg8000_close_event_listener
-        db_config = DBConfig(
-            instance_name=app.config["CLOUDSQL_INSTANCE_CONNECTION_NAME"],
-            database=app.config.get("DB_NAME", ""),
-            user=app.config.get("DB_USER", ""),
-            ip_type=app.config["DB_IP_TYPE"],
-            pool_recycle=60,
-            schema="public",
-        )
-        app.config["SQLALCHEMY_ENGINE_OPTIONS"] = db_config.get_engine_options()
-
     db.init_app(app)
 
-    if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
-        with app.app_context():
-            setup_pg8000_close_event_listener(db.engine)
+    with app.app_context():
+        setup_pg8000_close_event_listener(db.engine)
     register_endpoints(app)
     gcp_queue.init_app(app)
 

--- a/queue_services/business-bn/src/business_bn/__init__.py
+++ b/queue_services/business-bn/src/business_bn/__init__.py
@@ -58,7 +58,7 @@ def create_app(environment: str = os.getenv("DEPLOYMENT_ENV", "production"), **k
     app.config.from_object(CONFIGURATION[environment])
 
     if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
-        from cloud_sql_connector import DBConfig
+        from cloud_sql_connector import DBConfig, setup_pg8000_close_event_listener
         db_config = DBConfig(
             instance_name=app.config["CLOUDSQL_INSTANCE_CONNECTION_NAME"],
             database=app.config.get("DB_NAME", ""),
@@ -70,6 +70,10 @@ def create_app(environment: str = os.getenv("DEPLOYMENT_ENV", "production"), **k
         app.config["SQLALCHEMY_ENGINE_OPTIONS"] = db_config.get_engine_options()
 
     db.init_app(app)
+
+    if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
+        with app.app_context():
+            setup_pg8000_close_event_listener(db.engine)
     register_endpoints(app)
     gcp_queue.init_app(app)
 

--- a/queue_services/business-bn/src/business_bn/config.py
+++ b/queue_services/business-bn/src/business_bn/config.py
@@ -42,6 +42,7 @@ or by accessing this configuration directly.
 
 import os
 
+from cloud_sql_connector import DBConfig
 from dotenv import find_dotenv, load_dotenv
 
 # this will load all the envars from a .env file located in the project root (api)
@@ -93,6 +94,15 @@ class Config:  # pylint: disable=too-few-public-methods
         SQLALCHEMY_DATABASE_URI = f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
     elif CLOUDSQL_INSTANCE_CONNECTION_NAME:
         SQLALCHEMY_DATABASE_URI = "postgresql+pg8000://"
+        db_config = DBConfig(
+            instance_name=CLOUDSQL_INSTANCE_CONNECTION_NAME,
+            database=DB_NAME,
+            user=DB_USER,
+            ip_type=DB_IP_TYPE,
+            pool_recycle=60,
+            schema="public",
+        )
+        SQLALCHEMY_ENGINE_OPTIONS = db_config.get_engine_options()
 
     # legislative timezone for future effective dating
     LEGISLATIVE_TIMEZONE = os.getenv("LEGISLATIVE_TIMEZONE", "America/Vancouver")

--- a/queue_services/business-digital-credentials/poetry.lock
+++ b/queue_services/business-digital-credentials/poetry.lock
@@ -649,7 +649,7 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cloud-sql-connector"
-version = "0.2.1"
+version = "0.2.3"
 description = "Cloud SQL connection utilities for database connectivity with authentication and schema management"
 optional = false
 python-versions = "^3.12"
@@ -666,7 +666,7 @@ sqlalchemy = "^2.0.0"
 type = "git"
 url = "https://github.com/bcgov/sbc-connect-common.git"
 reference = "main"
-resolved_reference = "2a3d5a2d5b5ff3c905626f3193db5ed0af6d4952"
+resolved_reference = "b83281702031386f92a0f3d27577e15b842b769b"
 subdirectory = "python/cloud-sql-connector"
 
 [[package]]

--- a/queue_services/business-digital-credentials/poetry.lock
+++ b/queue_services/business-digital-credentials/poetry.lock
@@ -666,7 +666,7 @@ sqlalchemy = "^2.0.0"
 type = "git"
 url = "https://github.com/bcgov/sbc-connect-common.git"
 reference = "main"
-resolved_reference = "b83281702031386f92a0f3d27577e15b842b769b"
+resolved_reference = "9a760cf5ea31d3f95806c2dcac15ca9d9800df51"
 subdirectory = "python/cloud-sql-connector"
 
 [[package]]

--- a/queue_services/business-digital-credentials/pyproject.toml
+++ b/queue_services/business-digital-credentials/pyproject.toml
@@ -133,7 +133,49 @@ docstring-quotes = "double"
 "**/__init__.py" = ["F401"] # used for imports
 
 [tool.pytest.ini_options]
-addopts = "--cov=src"
+minversion = "2.0"
+testpaths = [
+   "tests",
+]
+addopts = "--verbose --strict -p no:warnings --cov=src --cov-report html:htmlcov --cov-report xml:coverage.xml"
+python_files = [
+   "test*.py"
+]
+norecursedirs = [
+   ".git", ".tox", "venv*", "requirements*", "build",
+]
+log_cli = true
+log_cli_level = "1"
+filterwarnings = [
+   "ignore::UserWarning"
+]
+markers = [
+   "slow",
+   "serial",
+]
+
+[tool.coverage.run]
+branch = true
+source = [
+   "src/business_digital_credentials",
+]
+omit = [
+    "wsgi.py",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+   "pragma: no cover",
+   "from",
+   "import",
+   "def __repr__",
+   "if self.debug:",
+   "if settings.DEBUG",
+   "raise AssertionError",
+   "raise NotImplementedError",
+   "if 0:",
+   'if __name__ == "__main__":',
+]
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]

--- a/queue_services/business-digital-credentials/src/business_digital_credentials/__init__.py
+++ b/queue_services/business-digital-credentials/src/business_digital_credentials/__init__.py
@@ -18,7 +18,7 @@ This module is the service worker for handling events that deal with Digital Bus
 import os
 
 from business_registry_digital_credentials import digital_credentials
-from cloud_sql_connector import DBConfig, setup_pg8000_close_event_listener
+from cloud_sql_connector import setup_pg8000_close_event_listener
 from flask import Flask
 
 from business_model.models.db import db
@@ -50,24 +50,12 @@ def create_app(
     if app.config.get("LD_SDK_KEY", None):
         flags.init_app(app)
 
-    if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
-        db_config = DBConfig(
-            instance_name=app.config["CLOUDSQL_INSTANCE_CONNECTION_NAME"],
-            database=app.config.get("DB_NAME", ""),
-            user=app.config.get("DB_USER", ""),
-            ip_type=app.config["DB_IP_TYPE"],
-            pool_recycle=60,
-            schema="public",
-        )
-        app.config["SQLALCHEMY_ENGINE_OPTIONS"] = db_config.get_engine_options()
-
     db.init_app(app)
     register_endpoints(app)
     gcp_queue.init_app(app)
 
     with app.app_context():
         digital_credentials.init_app(app)
-        if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
-            setup_pg8000_close_event_listener(db.engine)
+        setup_pg8000_close_event_listener(db.engine)
 
     return app

--- a/queue_services/business-digital-credentials/src/business_digital_credentials/__init__.py
+++ b/queue_services/business-digital-credentials/src/business_digital_credentials/__init__.py
@@ -18,7 +18,7 @@ This module is the service worker for handling events that deal with Digital Bus
 import os
 
 from business_registry_digital_credentials import digital_credentials
-from cloud_sql_connector import DBConfig
+from cloud_sql_connector import DBConfig, setup_pg8000_close_event_listener
 from flask import Flask
 
 from business_model.models.db import db
@@ -67,5 +67,7 @@ def create_app(
 
     with app.app_context():
         digital_credentials.init_app(app)
+        if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
+            setup_pg8000_close_event_listener(db.engine)
 
     return app

--- a/queue_services/business-digital-credentials/src/business_digital_credentials/config.py
+++ b/queue_services/business-digital-credentials/src/business_digital_credentials/config.py
@@ -22,6 +22,7 @@ or by accessing this configuration directly.
 
 import os
 
+from cloud_sql_connector import DBConfig
 from dotenv import find_dotenv, load_dotenv
 
 # this will load all the envars from a .env file located in the project root (api)
@@ -80,6 +81,15 @@ class Config:  # pylint: disable=too-few-public-methods
         SQLALCHEMY_DATABASE_URI = f"postgresql+pg8000://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
     elif CLOUDSQL_INSTANCE_CONNECTION_NAME:
         SQLALCHEMY_DATABASE_URI = "postgresql+pg8000://"
+        db_config = DBConfig(
+            instance_name=CLOUDSQL_INSTANCE_CONNECTION_NAME,
+            database=DB_NAME,
+            user=DB_USER,
+            ip_type=DB_IP_TYPE,
+            pool_recycle=60,
+            schema="public",
+        )
+        SQLALCHEMY_ENGINE_OPTIONS = db_config.get_engine_options()
 
     # Traction ACA-Py tenant settings to issue credentials from
     TRACTION_API_URL = os.getenv("TRACTION_API_URL")

--- a/queue_services/business-emailer/poetry.lock
+++ b/queue_services/business-emailer/poetry.lock
@@ -691,7 +691,7 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cloud-sql-connector"
-version = "0.2.1"
+version = "0.2.3"
 description = "Cloud SQL connection utilities for database connectivity with authentication and schema management"
 optional = false
 python-versions = "^3.12"
@@ -708,7 +708,7 @@ sqlalchemy = "^2.0.0"
 type = "git"
 url = "https://github.com/bcgov/sbc-connect-common.git"
 reference = "main"
-resolved_reference = "2a3d5a2d5b5ff3c905626f3193db5ed0af6d4952"
+resolved_reference = "b83281702031386f92a0f3d27577e15b842b769b"
 subdirectory = "python/cloud-sql-connector"
 
 [[package]]

--- a/queue_services/business-emailer/poetry.lock
+++ b/queue_services/business-emailer/poetry.lock
@@ -708,7 +708,7 @@ sqlalchemy = "^2.0.0"
 type = "git"
 url = "https://github.com/bcgov/sbc-connect-common.git"
 reference = "main"
-resolved_reference = "b83281702031386f92a0f3d27577e15b842b769b"
+resolved_reference = "9a760cf5ea31d3f95806c2dcac15ca9d9800df51"
 subdirectory = "python/cloud-sql-connector"
 
 [[package]]

--- a/queue_services/business-emailer/pyproject.toml
+++ b/queue_services/business-emailer/pyproject.toml
@@ -200,7 +200,49 @@ docstring-quotes = "double"
 "src/business_emailer/services/namex.py" = ["I001"]  # ignoring 'unordered' imports
 
 [tool.pytest.ini_options]
-addopts = "--cov=src"
+minversion = "2.0"
+testpaths = [
+   "tests",
+]
+addopts = "--verbose --strict -p no:warnings --cov=src --cov-report html:htmlcov --cov-report xml:coverage.xml"
+python_files = [
+   "test*.py"
+]
+norecursedirs = [
+   ".git", ".tox", "venv*", "requirements*", "build",
+]
+log_cli = true
+log_cli_level = "1"
+filterwarnings = [
+   "ignore::UserWarning"
+]
+markers = [
+   "slow",
+   "serial",
+]
+
+[tool.coverage.run]
+branch = true
+source = [
+   "src/business_emailer",
+]
+omit = [
+    "wsgi.py",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+   "pragma: no cover",
+   "from",
+   "import",
+   "def __repr__",
+   "if self.debug:",
+   "if settings.DEBUG",
+   "raise AssertionError",
+   "raise NotImplementedError",
+   "if 0:",
+   'if __name__ == "__main__":',
+]
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]

--- a/queue_services/business-emailer/src/business_emailer/__init__.py
+++ b/queue_services/business-emailer/src/business_emailer/__init__.py
@@ -15,6 +15,7 @@
 
 This module is the service worker for sending emails about entity related events.
 """
+from cloud_sql_connector import setup_pg8000_close_event_listener
 from flask import Flask
 
 from business_model.models.db import db
@@ -35,23 +36,10 @@ def create_app(environment: Config = ProdConfig, **kwargs) -> Flask:
     if app.config.get("LD_SDK_KEY", None):
         flags.init_app(app)
 
-    if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
-        from cloud_sql_connector import DBConfig, setup_pg8000_close_event_listener
-        db_config = DBConfig(
-            instance_name=app.config["CLOUDSQL_INSTANCE_CONNECTION_NAME"],
-            database=app.config.get("DB_NAME", ""),
-            user=app.config.get("DB_USER", ""),
-            ip_type=app.config["DB_IP_TYPE"],
-            pool_recycle=60,
-            schema="public",
-        )
-        app.config["SQLALCHEMY_ENGINE_OPTIONS"] = db_config.get_engine_options()
-
     db.init_app(app)
 
-    if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
-        with app.app_context():
-            setup_pg8000_close_event_listener(db.engine)
+    with app.app_context():
+        setup_pg8000_close_event_listener(db.engine)
     register_endpoints(app)
     gcp_queue.init_app(app)
 

--- a/queue_services/business-emailer/src/business_emailer/__init__.py
+++ b/queue_services/business-emailer/src/business_emailer/__init__.py
@@ -36,7 +36,7 @@ def create_app(environment: Config = ProdConfig, **kwargs) -> Flask:
         flags.init_app(app)
 
     if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
-        from cloud_sql_connector import DBConfig
+        from cloud_sql_connector import DBConfig, setup_pg8000_close_event_listener
         db_config = DBConfig(
             instance_name=app.config["CLOUDSQL_INSTANCE_CONNECTION_NAME"],
             database=app.config.get("DB_NAME", ""),
@@ -48,6 +48,10 @@ def create_app(environment: Config = ProdConfig, **kwargs) -> Flask:
         app.config["SQLALCHEMY_ENGINE_OPTIONS"] = db_config.get_engine_options()
 
     db.init_app(app)
+
+    if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
+        with app.app_context():
+            setup_pg8000_close_event_listener(db.engine)
     register_endpoints(app)
     gcp_queue.init_app(app)
 

--- a/queue_services/business-emailer/src/business_emailer/config.py
+++ b/queue_services/business-emailer/src/business_emailer/config.py
@@ -22,6 +22,7 @@ or by accessing this configuration directly.
 
 import os
 
+from cloud_sql_connector import DBConfig
 from dotenv import find_dotenv, load_dotenv
 
 # this will load all the envars from a .env file located in the project root (api)
@@ -113,6 +114,15 @@ class Config:  # pylint: disable=too-few-public-methods
         SQLALCHEMY_DATABASE_URI = f"postgresql+pg8000://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{int(DB_PORT)}/{DB_NAME}"    
     elif CLOUDSQL_INSTANCE_CONNECTION_NAME:
         SQLALCHEMY_DATABASE_URI = "postgresql+pg8000://"
+        db_config = DBConfig(
+            instance_name=CLOUDSQL_INSTANCE_CONNECTION_NAME,
+            database=DB_NAME,
+            user=DB_USER,
+            ip_type=DB_IP_TYPE,
+            pool_recycle=60,
+            schema="public",
+        )
+        SQLALCHEMY_ENGINE_OPTIONS = db_config.get_engine_options()
 
 
 

--- a/queue_services/business-filer/poetry.lock
+++ b/queue_services/business-filer/poetry.lock
@@ -602,7 +602,7 @@ sqlalchemy = "^2.0.0"
 type = "git"
 url = "https://github.com/bcgov/sbc-connect-common.git"
 reference = "main"
-resolved_reference = "b83281702031386f92a0f3d27577e15b842b769b"
+resolved_reference = "9a760cf5ea31d3f95806c2dcac15ca9d9800df51"
 subdirectory = "python/cloud-sql-connector"
 
 [[package]]

--- a/queue_services/business-filer/poetry.lock
+++ b/queue_services/business-filer/poetry.lock
@@ -585,7 +585,7 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cloud-sql-connector"
-version = "0.2.1"
+version = "0.2.3"
 description = "Cloud SQL connection utilities for database connectivity with authentication and schema management"
 optional = false
 python-versions = "^3.12"
@@ -602,7 +602,7 @@ sqlalchemy = "^2.0.0"
 type = "git"
 url = "https://github.com/bcgov/sbc-connect-common.git"
 reference = "main"
-resolved_reference = "2a3d5a2d5b5ff3c905626f3193db5ed0af6d4952"
+resolved_reference = "b83281702031386f92a0f3d27577e15b842b769b"
 subdirectory = "python/cloud-sql-connector"
 
 [[package]]

--- a/queue_services/business-filer/src/business_filer/__init__.py
+++ b/queue_services/business-filer/src/business_filer/__init__.py
@@ -35,6 +35,7 @@
 import os
 
 from business_model.models import db
+from cloud_sql_connector import setup_pg8000_close_event_listener
 from flask import Flask
 
 from business_filer.config import DevConfig, ProdConfig, TestConfig
@@ -60,23 +61,10 @@ def create_app(environment: str = os.getenv("DEPLOYMENT_ENV", "production"), **k
     app.logger = StructuredLogging(app).get_logger()
     flags.init_app(app, kwargs.get("ld_test_data"))
 
-    if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
-        from cloud_sql_connector import DBConfig, setup_pg8000_close_event_listener
-        db_config = DBConfig(
-            instance_name=app.config["CLOUDSQL_INSTANCE_CONNECTION_NAME"],
-            database=app.config.get("DB_NAME", ""),
-            user=app.config.get("DB_USER", ""),
-            ip_type=app.config["DB_IP_TYPE"],
-            pool_recycle=60,
-            schema="public",
-        )
-        app.config["SQLALCHEMY_ENGINE_OPTIONS"] = db_config.get_engine_options()
-
     db.init_app(app)
 
-    if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
-        with app.app_context():
-            setup_pg8000_close_event_listener(db.engine)
+    with app.app_context():
+        setup_pg8000_close_event_listener(db.engine)
     gcp_queue.init_app(app)
 
     register_endpoints(app)

--- a/queue_services/business-filer/src/business_filer/__init__.py
+++ b/queue_services/business-filer/src/business_filer/__init__.py
@@ -61,7 +61,7 @@ def create_app(environment: str = os.getenv("DEPLOYMENT_ENV", "production"), **k
     flags.init_app(app, kwargs.get("ld_test_data"))
 
     if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
-        from cloud_sql_connector import DBConfig
+        from cloud_sql_connector import DBConfig, setup_pg8000_close_event_listener
         db_config = DBConfig(
             instance_name=app.config["CLOUDSQL_INSTANCE_CONNECTION_NAME"],
             database=app.config.get("DB_NAME", ""),
@@ -73,6 +73,10 @@ def create_app(environment: str = os.getenv("DEPLOYMENT_ENV", "production"), **k
         app.config["SQLALCHEMY_ENGINE_OPTIONS"] = db_config.get_engine_options()
 
     db.init_app(app)
+
+    if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
+        with app.app_context():
+            setup_pg8000_close_event_listener(db.engine)
     gcp_queue.init_app(app)
 
     register_endpoints(app)

--- a/queue_services/business-filer/src/business_filer/config.py
+++ b/queue_services/business-filer/src/business_filer/config.py
@@ -22,6 +22,7 @@ or by accessing this configuration directly.
 
 import os
 
+from cloud_sql_connector import DBConfig
 from dotenv import find_dotenv, load_dotenv
 
 # this will load all the envars from a .env file located in the project root (api)
@@ -54,6 +55,15 @@ class _Config:  # pylint: disable=too-few-public-methods
         SQLALCHEMY_DATABASE_URI = f"postgresql+pg8000://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
     elif CLOUDSQL_INSTANCE_CONNECTION_NAME:
         SQLALCHEMY_DATABASE_URI = "postgresql+pg8000://"
+        db_config = DBConfig(
+            instance_name=CLOUDSQL_INSTANCE_CONNECTION_NAME,
+            database=DB_NAME,
+            user=DB_USER,
+            ip_type=DB_IP_TYPE,
+            pool_recycle=60,
+            schema="public",
+        )
+        SQLALCHEMY_ENGINE_OPTIONS = db_config.get_engine_options()
 
     COLIN_API = os.getenv("COLIN_API_URL", "") + os.getenv("COLIN_API_VERSION", "")
 

--- a/queue_services/business-pay/poetry.lock
+++ b/queue_services/business-pay/poetry.lock
@@ -545,7 +545,7 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cloud-sql-connector"
-version = "0.2.1"
+version = "0.2.3"
 description = "Cloud SQL connection utilities for database connectivity with authentication and schema management"
 optional = false
 python-versions = "^3.12"
@@ -562,7 +562,7 @@ sqlalchemy = "^2.0.0"
 type = "git"
 url = "https://github.com/bcgov/sbc-connect-common.git"
 reference = "main"
-resolved_reference = "2a3d5a2d5b5ff3c905626f3193db5ed0af6d4952"
+resolved_reference = "b83281702031386f92a0f3d27577e15b842b769b"
 subdirectory = "python/cloud-sql-connector"
 
 [[package]]

--- a/queue_services/business-pay/poetry.lock
+++ b/queue_services/business-pay/poetry.lock
@@ -562,7 +562,7 @@ sqlalchemy = "^2.0.0"
 type = "git"
 url = "https://github.com/bcgov/sbc-connect-common.git"
 reference = "main"
-resolved_reference = "b83281702031386f92a0f3d27577e15b842b769b"
+resolved_reference = "9a760cf5ea31d3f95806c2dcac15ca9d9800df51"
 subdirectory = "python/cloud-sql-connector"
 
 [[package]]

--- a/queue_services/business-pay/pyproject.toml
+++ b/queue_services/business-pay/pyproject.toml
@@ -34,6 +34,51 @@ zimports = "^0.6.1"
 lovely-pytest-docker = "^0.3.1"
 pytest-cov = "^6.1.1"
 
+[tool.pytest.ini_options]
+minversion = "2.0"
+testpaths = [
+   "tests",
+]
+addopts = "--verbose --strict -p no:warnings --cov=src --cov-report html:htmlcov --cov-report xml:coverage.xml"
+python_files = [
+   "test*.py"
+]
+norecursedirs = [
+   ".git", ".tox", "venv*", "requirements*", "build",
+]
+log_cli = true
+log_cli_level = "1"
+filterwarnings = [
+   "ignore::UserWarning"
+]
+markers = [
+   "slow",
+   "serial",
+]
+
+[tool.coverage.run]
+branch = true
+source = [
+   "src/business_pay",
+]
+omit = [
+    "wsgi.py",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+   "pragma: no cover",
+   "from",
+   "import",
+   "def __repr__",
+   "if self.debug:",
+   "if settings.DEBUG",
+   "raise AssertionError",
+   "raise NotImplementedError",
+   "if 0:",
+   'if __name__ == "__main__":',
+]
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/queue_services/business-pay/src/business_pay/__init__.py
+++ b/queue_services/business-pay/src/business_pay/__init__.py
@@ -38,6 +38,7 @@ puts a message onto the Filers queue to process the file.
 """
 from __future__ import annotations
 
+from cloud_sql_connector import setup_pg8000_close_event_listener
 from flask import Flask
 
 from .config import Config, ProdConfig
@@ -55,24 +56,10 @@ def create_app(environment: Config = ProdConfig, **kwargs) -> Flask:
     if app.config.get("LD_SDK_KEY", None):
         flags.init_app(app)
 
-    if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
-        from cloud_sql_connector import DBConfig, setup_pg8000_close_event_listener
-
-        db_config = DBConfig(
-            instance_name=app.config["CLOUDSQL_INSTANCE_CONNECTION_NAME"],
-            database=app.config.get("DB_NAME", ""),
-            user=app.config.get("DB_USER", ""),
-            ip_type=app.config["DB_IP_TYPE"],
-            pool_recycle=60,
-            schema="public",
-        )
-        app.config["SQLALCHEMY_ENGINE_OPTIONS"] = db_config.get_engine_options()
-
     db.init_app(app)
 
-    if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
-        with app.app_context():
-            setup_pg8000_close_event_listener(db.engine)
+    with app.app_context():
+        setup_pg8000_close_event_listener(db.engine)
     register_endpoints(app)
     gcp_queue.init_app(app)
 

--- a/queue_services/business-pay/src/business_pay/__init__.py
+++ b/queue_services/business-pay/src/business_pay/__init__.py
@@ -56,7 +56,7 @@ def create_app(environment: Config = ProdConfig, **kwargs) -> Flask:
         flags.init_app(app)
 
     if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
-        from cloud_sql_connector import DBConfig
+        from cloud_sql_connector import DBConfig, setup_pg8000_close_event_listener
 
         db_config = DBConfig(
             instance_name=app.config["CLOUDSQL_INSTANCE_CONNECTION_NAME"],
@@ -69,6 +69,10 @@ def create_app(environment: Config = ProdConfig, **kwargs) -> Flask:
         app.config["SQLALCHEMY_ENGINE_OPTIONS"] = db_config.get_engine_options()
 
     db.init_app(app)
+
+    if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
+        with app.app_context():
+            setup_pg8000_close_event_listener(db.engine)
     register_endpoints(app)
     gcp_queue.init_app(app)
 

--- a/queue_services/business-pay/src/business_pay/config.py
+++ b/queue_services/business-pay/src/business_pay/config.py
@@ -43,6 +43,7 @@ or by accessing this configuration directly.
 import os
 import random
 
+from cloud_sql_connector import DBConfig
 from dotenv import find_dotenv, load_dotenv
 
 # this will load all the envars from a .env file located in the project root (api)
@@ -102,6 +103,15 @@ class Config:  # pylint: disable=too-few-public-methods
         )
     elif CLOUDSQL_INSTANCE_CONNECTION_NAME:
         SQLALCHEMY_DATABASE_URI = "postgresql+pg8000://"
+        db_config = DBConfig(
+            instance_name=CLOUDSQL_INSTANCE_CONNECTION_NAME,
+            database=DB_NAME,
+            user=DB_USER,
+            ip_type=DB_IP_TYPE,
+            pool_recycle=60,
+            schema="public",
+        )
+        SQLALCHEMY_ENGINE_OPTIONS = db_config.get_engine_options()
 
     ENVIRONMENT = os.getenv("DEPLOYMENT_ENV", "production")
 


### PR DESCRIPTION
## Summary

- Registers a SQLAlchemy `connect` event listener on app startup that wraps each pg8000 connection's `close()` to suppress `pg8000.exceptions.InterfaceError` during Cloud Run scale-down
- Fixes intermittent `pg8000.exceptions.InterfaceError: network error` logged when Cloud Run terminates idle instances and SQLAlchemy's connection pool teardown tries to close already-severed sockets
- Calls `setup_pg8000_close_event_listener(engine)` (from `sbc-connect-common/cloud-sql-connector`) in all affected long-running services
- GCP Cloud Run Jobs (furnishings, email-reminder, bn-retry, involuntary-dissolutions) were confirmed to have zero InterfaceError occurrences in logs and are excluded

## Services fixed

- `legal-api/src/legal_api/__init__.py`
- `queue_services/business-filer/src/business_filer/__init__.py`
- `queue_services/business-emailer/src/business_emailer/__init__.py`
- `queue_services/business-pay/src/business_pay/__init__.py`
- `queue_services/business-bn/src/business_bn/__init__.py`
- `queue_services/business-digital-credentials/src/business_digital_credentials/__init__.py`

## Test plan

- [ ] Confirm no new `pg8000.exceptions.InterfaceError` entries in GCP Log Explorer for `a083gt-prod` project after deployment
- [ ] Existing unit and integration test suites pass