### PR TITLE
32928 - Enforce deterministic name option validation

### DIFF
--- a/legal-api/src/legal_api/services/filings/validations/amalgamation_application.py
+++ b/legal-api/src/legal_api/services/filings/validations/amalgamation_application.py
@@ -59,9 +59,11 @@ def validate(amalgamation_json: dict, account_id) -> Optional[Error]:
 
     amalgamation_type = get_str(amalgamation_json, f"/filing/{filing_type}/type")
 
-    if amalgamation_json.get("filing", {}).get(filing_type, {}).get("nameRequest", {}).get("nrNumber", None):
-        # Adopt from one of the amalgamating businesses contains name not nrNumber
-        msg.extend(validate_name_request(amalgamation_json, legal_type, filing_type))
+    name_option, name_option_errors = _derive_and_validate_name_option(amalgamation_json, legal_type, filing_type)
+    msg.extend(name_option_errors)
+    if name_option == "new_nr":
+        msg.extend(validate_name_request(amalgamation_json, legal_type, filing_type,
+                                         require_legal_name=False))
     
     if flags.is_on("enabled-deeper-permission-action"):
         err = validate_permission_and_completing_party(
@@ -357,6 +359,33 @@ def _validate_foreign_identifier(amalgamating_business, amalgamating_business_pa
             })
 
     return msg
+
+
+def _derive_and_validate_name_option(filing_json, legal_type, filing_type):
+    nr_path = f"/filing/{filing_type}/nameRequest"
+    name_request = filing_json.get("filing", {}).get(filing_type, {}).get("nameRequest", {})
+    nr_number = name_request.get("nrNumber")
+    legal_name = name_request.get("legalName")
+
+    if nr_number and legal_name:
+        return None, [{
+            "error": "nameRequest must include either legalName (adopted name) or nrNumber (new NR), not both.",
+            "path": nr_path,
+        }]
+
+    if nr_number:
+        return "new_nr", []
+
+    if legal_name:
+        return "adopted_name", []
+
+    if legal_type not in Business.CORPS:
+        return None, [{
+            "error": f"{legal_type} cannot be a numbered company; nameRequest must include legalName or nrNumber.",
+            "path": nr_path,
+        }]
+
+    return "numbered_company", []
 
 
 def _check_aml_permission_or_default_error(msg: list, message: str, default_error: dict) -> bool:

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -884,7 +884,8 @@ def validate_relationship_roles(roles: list[dict[str, str]],
 def validate_name_request(filing_json: dict,  # pylint: disable=too-many-locals
                           legal_type: str,
                           filing_type: str,
-                          accepted_request_types: Optional[list] = None) -> list:
+                          accepted_request_types: Optional[list] = None,
+                          require_legal_name: bool = True) -> list:
     """Validate name request section."""
     nr_path = f"/filing/{filing_type}/nameRequest"
     nr_number_path = f"{nr_path}/nrNumber"
@@ -901,7 +902,8 @@ def validate_name_request(filing_json: dict,  # pylint: disable=too-many-locals
             # CP, SP, GP doesn't support numbered company
             return [{"error": _("Legal name and nrNumber is missing in nameRequest."), "path": nr_path}]
     elif nr_number and not legal_name:
-        return [{"error": _("Legal name is missing in nameRequest."), "path": legal_name_path}]
+        if require_legal_name:
+            return [{"error": _("Legal name is missing in nameRequest."), "path": legal_name_path}]
     elif not nr_number and legal_name:
         # expecting nrNumber when legalName provided
         return [{
@@ -928,11 +930,12 @@ def validate_name_request(filing_json: dict,  # pylint: disable=too-many-locals
         msg.append({"error": _("Name Request legal type is not same as the business legal type."),
                     "path": legal_type_path})
 
-    # ensure NR request has the same legal name
-    nr_name = namex.get_approved_name(nr_response_json)
-    if nr_name != legal_name:
-        msg.append({"error": _("Name Request legal name is not same as the business legal name."),
-                    "path": legal_name_path})
+    # ensure NR request has the same legal name (only when caller provided one)
+    if legal_name:
+        nr_name = namex.get_approved_name(nr_response_json)
+        if nr_name != legal_name:
+            msg.append({"error": _("Name Request legal name is not same as the business legal name."),
+                        "path": legal_name_path})
 
     return msg
 

--- a/legal-api/tests/unit/services/filings/validations/test_amalgamation_application.py
+++ b/legal-api/tests/unit/services/filings/validations/test_amalgamation_application.py
@@ -26,7 +26,10 @@ from registry_schemas.example_data import AMALGAMATION_APPLICATION
 
 from legal_api.models import AmalgamatingBusiness, Amalgamation, Business, Filing
 from legal_api.services import NameXService, STAFF_ROLE, BASIC_USER, flags
-from legal_api.services.filings.validations.amalgamation_application import _validate_foreign_identifier
+from legal_api.services.filings.validations.amalgamation_application import (
+    _derive_and_validate_name_option,
+    _validate_foreign_identifier,
+)
 from legal_api.services.filings.validations.validation import validate
 from legal_api.services.filings.validations.amalgamation_application import _validate_foreign_businesses
 
@@ -66,6 +69,7 @@ def test_invalid_nr_amalgamation(mocker, app, session):
                                   'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
+    filing['filing']['amalgamationApplication']['nameRequest'].pop('legalName', None)
 
     invalid_nr_response = {
         'state': 'INPROGRESS',
@@ -101,6 +105,7 @@ def test_amalgamation_parties_missing_role(mocker, app, session, amalgamation_ty
                                   'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
+    filing['filing']['amalgamationApplication']['nameRequest'].pop('legalName', None)
 
     filing['filing']['amalgamationApplication']['type'] = amalgamation_type
     filing['filing']['amalgamationApplication']['parties'] = []
@@ -143,6 +148,7 @@ def test_amalgamation_parties_invalid_role(mocker, app, session, parties, expect
     }
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
+    filing['filing']['amalgamationApplication']['nameRequest'].pop('legalName', None)
     filing['filing']['amalgamationApplication']['type'] = Amalgamation.AmalgamationTypes.regular.name
 
     base_mailing_address = filing['filing']['amalgamationApplication']['parties'][0]['mailingAddress']
@@ -350,6 +356,7 @@ def test_validate_amalgamation_office(session, mocker, test_name, legal_type, de
 
     filing['filing']['amalgamationApplication']['nameRequest'] = {}
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
+    filing['filing']['amalgamationApplication']['nameRequest'].pop('legalName', None)
     filing['filing']['amalgamationApplication']['nameRequest']['legalType'] = legal_type
     filing['filing']['amalgamationApplication']['contactPoint']['email'] = 'no_one@never.get'
     filing['filing']['amalgamationApplication']['contactPoint']['phone'] = '(123) 456-7890'
@@ -664,6 +671,7 @@ def test_validate_incorporation_share_classes(session, mocker, test_name, legal_
 
     filing['filing']['amalgamationApplication']['nameRequest'] = {}
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
+    filing['filing']['amalgamationApplication']['nameRequest'].pop('legalName', None)
     filing['filing']['amalgamationApplication']['nameRequest']['legalType'] = legal_type
 
     share_structure = filing['filing']['amalgamationApplication']['shareStructure']
@@ -719,6 +727,7 @@ def test_validate_amalgamation_office_or_share_required(session, mocker, amalgam
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['type'] = amalgamation_type
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
+    filing['filing']['amalgamationApplication']['nameRequest'].pop('legalName', None)
 
     del filing['filing']['amalgamationApplication']['offices']
     del filing['filing']['amalgamationApplication']['shareStructure']
@@ -753,6 +762,7 @@ def test_amalgamation_court_orders(mocker, app, session,
                                   'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
+    filing['filing']['amalgamationApplication']['nameRequest'].pop('legalName', None)
 
     court_order = {'effectOfOrder': effect_of_order}
     if file_number:
@@ -789,6 +799,7 @@ def test_is_business_historical(mocker, app, session, jwt, test_status, expected
                                   'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
+    filing['filing']['amalgamationApplication']['nameRequest'].pop('legalName', None)
 
     def mock_find_by_identifier(identifier):
         return Business(identifier=identifier,
@@ -830,6 +841,7 @@ def test_has_pending_filing(mocker, app, session, jwt, test_status, expected_cod
                                   'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
+    filing['filing']['amalgamationApplication']['nameRequest'].pop('legalName', None)
 
     mocker.patch('legal_api.services.filings.validations.amalgamation_application.validate_name_request',
                  return_value=[])
@@ -867,6 +879,7 @@ def test_in_future_effective_amalgamation_filing(mocker, app, session, jwt,
                                   'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
+    filing['filing']['amalgamationApplication']['nameRequest'].pop('legalName', None)
 
     mocker.patch('legal_api.services.filings.validations.amalgamation_application.validate_name_request',
                  return_value=[])
@@ -906,6 +919,7 @@ def test_is_business_affliated(mocker, app, session, jwt, test_status, flag_enab
                                   'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
+    filing['filing']['amalgamationApplication']['nameRequest'].pop('legalName', None)
     filing['filing']['amalgamationApplication']['amalgamatingBusinesses'] = [
         {
             'role': AmalgamatingBusiness.Role.amalgamating.name,
@@ -977,6 +991,7 @@ def test_is_business_in_good_standing(mocker, app, session, jwt, test_status, fl
                                   'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
+    filing['filing']['amalgamationApplication']['nameRequest'].pop('legalName', None)
     filing['filing']['amalgamationApplication']['amalgamatingBusinesses'] = [
         {
             'role': AmalgamatingBusiness.Role.amalgamating.name,
@@ -1048,6 +1063,7 @@ def test_is_business_not_found(mocker, app, session, jwt, test_status, expected_
                                   'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
+    filing['filing']['amalgamationApplication']['nameRequest'].pop('legalName', None)
     filing['filing']['amalgamationApplication']['amalgamatingBusinesses'] = [
         {
             'role': AmalgamatingBusiness.Role.amalgamating.name,
@@ -1107,6 +1123,7 @@ def test_amalgamating_foreign_business(mocker, app, session, jwt, test_status, r
                                   'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
+    filing['filing']['amalgamationApplication']['nameRequest'].pop('legalName', None)
 
     def mock_find_by_identifier(identifier):
         return Business(identifier=identifier,
@@ -1194,6 +1211,7 @@ def test_amalgamating_foreign_business_with_bc_company_to_ulc(mocker, app, sessi
                                   'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
+    filing['filing']['amalgamationApplication']['nameRequest'].pop('legalName', None)
     if test_status == 'FAIL':
         filing['filing']['amalgamationApplication']['nameRequest']['legalType'] = 'ULC'
 
@@ -1243,6 +1261,7 @@ def test_amalgamating_foreign_business_with_ulc_company(mocker, app, session, jw
                                   'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
+    filing['filing']['amalgamationApplication']['nameRequest'].pop('legalName', None)
 
     def mock_find_by_identifier(identifier):
         return Business(identifier=identifier,
@@ -1292,6 +1311,7 @@ def test_amalgamating_cc_to_cc(mocker, app, session, jwt,
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['legalType'] = 'CC'
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
+    filing['filing']['amalgamationApplication']['nameRequest'].pop('legalName', None)
 
     def mock_find_by_identifier(identifier):
         return Business(identifier=identifier,
@@ -1337,6 +1357,7 @@ def test_amalgamating_expro_to_cc_or_ulc(mocker, app, session, jwt, test_status,
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['legalType'] = legal_type
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
+    filing['filing']['amalgamationApplication']['nameRequest'].pop('legalName', None)
     filing['filing']['amalgamationApplication']['amalgamatingBusinesses'] = [
         {
             'role': AmalgamatingBusiness.Role.amalgamating.name,
@@ -1467,6 +1488,7 @@ def test_duplicate_amalgamating_businesses(mocker, app, session, jwt, test_statu
                                   'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
+    filing['filing']['amalgamationApplication']['nameRequest'].pop('legalName', None)
     filing['filing']['amalgamationApplication']['amalgamatingBusinesses'] = amalgamating_businesses
 
     def mock_find_by_identifier(identifier):
@@ -1554,6 +1576,7 @@ def test_amalgamating_business_roles(mocker, app, session, jwt, amalgamation_typ
                                   'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
+    filing['filing']['amalgamationApplication']['nameRequest'].pop('legalName', None)
     filing['filing']['amalgamationApplication']['type'] = amalgamation_type
     filing['filing']['amalgamationApplication']['amalgamatingBusinesses'] = amalgamating_businesses
 
@@ -1608,6 +1631,7 @@ def test_amalgamation_legal_type_mismatch(mocker, app, session, jwt, legal_type,
                                   'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
+    filing['filing']['amalgamationApplication']['nameRequest'].pop('legalName', None)
     filing['filing']['amalgamationApplication']['nameRequest']['legalType'] = legal_type
     filing['filing']['amalgamationApplication']['type'] = amalgamation_type
     filing['filing']['amalgamationApplication']['amalgamatingBusinesses'] = [
@@ -1834,6 +1858,7 @@ def test_amalgamation_permission_and_completing_party_flag(mocker, app, session,
 
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
+    filing['filing']['amalgamationApplication']['nameRequest'].pop('legalName', None)
     filing['filing']['amalgamationApplication']['nameRequest']['legalType'] = Business.LegalTypes.BCOMP.value
     filing['filing']['amalgamationApplication']['type'] = Amalgamation.AmalgamationTypes.regular.name
 
@@ -1925,5 +1950,37 @@ def test_validate_foreign_identifier(test_name, amalgamating_business, expected_
     """Assert _validate_foreign_identifier mirrors the frontend MRAS + format rules."""
     path = '/filing/amalgamationApplication/amalgamatingBusinesses/1'
     errors = _validate_foreign_identifier(amalgamating_business, path)
+    assert errors == expected_errors
+
+
+@pytest.mark.parametrize(
+    'test_name, name_request, legal_type, expected_option, expected_errors',
+    [
+        ('adopted_name', {'legalName': 'Foo Ltd.'}, 'BC', 'adopted_name', []),
+        ('new_nr', {'nrNumber': 'NR 1234567'}, 'BC', 'new_nr', []),
+        ('numbered_company', {}, 'BC', 'numbered_company', []),
+        (
+            'both_present_rejected',
+            {'legalName': 'Foo Ltd.', 'nrNumber': 'NR 1234567'},
+            'BC',
+            None,
+            [{'error': 'nameRequest must include either legalName (adopted name) or nrNumber (new NR), not both.',
+              'path': '/filing/amalgamationApplication/nameRequest'}],
+        ),
+        (
+            'numbered_not_allowed_for_non_corps',
+            {},
+            'SP',
+            None,
+            [{'error': 'SP cannot be a numbered company; nameRequest must include legalName or nrNumber.',
+              'path': '/filing/amalgamationApplication/nameRequest'}],
+        ),
+    ]
+)
+def test_derive_and_validate_name_option(test_name, name_request, legal_type, expected_option, expected_errors):
+    """Assert deterministic name-option derivation from nameRequest field combinations."""
+    filing_json = {'filing': {'amalgamationApplication': {'nameRequest': name_request}}}
+    option, errors = _derive_and_validate_name_option(filing_json, legal_type, 'amalgamationApplication')
+    assert option == expected_option
     assert errors == expected_errors
  


### PR DESCRIPTION
*Issue #:* /bcgov/entity#32928 

*Description of changes:*

The backend previously inferred the name processing path (Adopted Name, Numbered Company, or New NR) based on the presence or absence of legalName and nrNumber. This implicit and permissive logic allowed malformed or ambiguous payloads to pass validation and be misinterpreted.
The updated implementation now deterministically derives a single name option from the (legalName, nrNumber) combination. It rejects ambiguous payloads (where both fields are present) at the outset and dispatches to the correct downstream validator based on the derived option.

`amalgamation_application.py`
  Replaced the permissive if nrNumber: validate_name_request(...) in validate() with a dispatcher that derives one of three name options (Adopted Name, New NR, Numbered Company) from (legalName, nrNumber) and routes to the right downstream check.
  Added a private _derive_and_validate_name_option helper that rejects both-present payloads and enforces Numbered Company only for Business.CORPS types.

`common_validations.py`
  Added an optional require_legal_name=True param to validate_name_request so the amalgamation New NR path can skip the "legalName required" check (legalName is now forbidden for that option).
  Default preserves existing behaviour for incorporation, alteration, and continuation.

`test_amalgamation_application.py`
  Added a parameterized test_derive_and_validate_name_option covering the three valid combos plus the two rejection cases. Updated 22 existing fixtures that intended "New NR" to drop the template's inherited legalName so they conform to the new strict combos.
 POST http://127.0.0.1:5000/api/v2/businesses/T0nRimgoiH/filings?only_validate=true against various payloads:
  <table>
    <thead>
      <tr>
        <th>Case</th>
        <th>Payload change to <code>nameRequest</code></th>
        <th>Result</th>
      </tr>
    </thead>
    <tbody>
      <tr>
        <td>A — Sends only legalName (matching one of the amalgamating businesses) to confirm the request is routed to the Adopted-Name path and passes. </td>
        <td><code>"legalType": "BC", "legalName": "PRYASK TRADING LTD. - SAF_1.1_IMPORT_TEST"</code></td>
        <td>200</td>
      </tr>
      <tr>
        <td>B — Sends only nrNumber to confirm the request is routed to the New-NR path (NameX validation).</td>
        <td><code>"legalType": "BC", "nrNumber": "NR 1234567"</code></td>
        <td>400 — "A required field state was missing or invalid."</td>
      </tr>
      <tr>
        <td>C — Sends neither legalName nor nrNumber with a CORPS legalType (BC) to confirm the request is routed to the Numbered Company path and passes.</td>
        <td><code>"legalType": "BC"</code> (neither field)</td>
        <td>200</td>
      </tr>
      <tr>
        <td>D — Sends both legalName and nrNumber to confirm the validator rejects ambiguous payloads outright.</td>
        <td><code>"legalType": "BC", "legalName": "PRYASK TRADING LTD. - SAF_1.1_IMPORT_TEST", "nrNumber": "NR 1234567"</code></td>
        <td>400 — "nameRequest must include either legalName (adopted name) or nrNumber (new NR), not both."</td>
      </tr>
      <tr>
        <td>E — Sends no name fields with a non-CORPS legalType (SP) to confirm the validator blocks Numbered Company for entity types that don't support it.</td>
        <td><code>"legalType": "SP"</code> (neither field)</td>
        <td>403 — "Not Allowed - You are not allowed to submit this type of filing for T0nRimgoiH."</td>
      </tr>
    </tbody>
  </table>
<i><b>Case E is accounted for regardless of the 403 from the upstream authorization layer.</b><i>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
