### PR TITLE
32928 add validation to short form amalgamations to reject nr name when supplied

### DIFF
--- a/legal-api/src/legal_api/services/filings/validations/amalgamation_application.py
+++ b/legal-api/src/legal_api/services/filings/validations/amalgamation_application.py
@@ -60,8 +60,16 @@ def validate(amalgamation_json: dict, account_id) -> Optional[Error]:
     amalgamation_type = get_str(amalgamation_json, f"/filing/{filing_type}/type")
 
     if amalgamation_json.get("filing", {}).get(filing_type, {}).get("nameRequest", {}).get("nrNumber", None):
-        # Adopt from one of the amalgamating businesses contains name not nrNumber
-        msg.extend(validate_name_request(amalgamation_json, legal_type, filing_type))
+        if amalgamation_type in [Amalgamation.AmalgamationTypes.horizontal.name,
+                                 Amalgamation.AmalgamationTypes.vertical.name]:
+            # Short-form amalgamations adopt the primary/holding business name; an NR is not allowed.
+            msg.append({
+                "error": "Short-form amalgamations cannot have a Name Request.",
+                "path": f"/filing/{filing_type}/nameRequest/nrNumber"
+            })
+        else:
+            # Adopt from one of the amalgamating businesses contains name not nrNumber
+            msg.extend(validate_name_request(amalgamation_json, legal_type, filing_type))
     
     if flags.is_on("enabled-deeper-permission-action"):
         err = validate_permission_and_completing_party(

--- a/legal-api/src/legal_api/services/filings/validations/amalgamation_application.py
+++ b/legal-api/src/legal_api/services/filings/validations/amalgamation_application.py
@@ -59,18 +59,8 @@ def validate(amalgamation_json: dict, account_id) -> Optional[Error]:
 
     amalgamation_type = get_str(amalgamation_json, f"/filing/{filing_type}/type")
 
-    if amalgamation_json.get("filing", {}).get(filing_type, {}).get("nameRequest", {}).get("nrNumber", None):
-        if amalgamation_type in [Amalgamation.AmalgamationTypes.horizontal.name,
-                                 Amalgamation.AmalgamationTypes.vertical.name]:
-            # Short-form amalgamations adopt the primary/holding business name; an NR is not allowed.
-            msg.append({
-                "error": "Short-form amalgamations cannot have a Name Request.",
-                "path": f"/filing/{filing_type}/nameRequest/nrNumber"
-            })
-        else:
-            # Adopt from one of the amalgamating businesses contains name not nrNumber
-            msg.extend(validate_name_request(amalgamation_json, legal_type, filing_type))
-    
+    msg.extend(_validate_name_request_section(amalgamation_json, amalgamation_type, legal_type, filing_type))
+
     if flags.is_on("enabled-deeper-permission-action"):
         err = validate_permission_and_completing_party(
             None,
@@ -118,6 +108,22 @@ def validate(amalgamation_json: dict, account_id) -> Optional[Error]:
     if msg:
         return Error(HTTPStatus.BAD_REQUEST, msg)
     return None
+
+
+def _validate_name_request_section(amalgamation_json, amalgamation_type, legal_type, filing_type) -> list:
+    name_request = amalgamation_json.get("filing", {}).get(filing_type, {}).get("nameRequest", {})
+    if not name_request.get("nrNumber"):
+        return []
+
+    if amalgamation_type in [Amalgamation.AmalgamationTypes.horizontal.name,
+                             Amalgamation.AmalgamationTypes.vertical.name]:
+        # Short-form amalgamations adopt the primary/holding business name; an NR is not allowed.
+        return [{
+            "error": "Short-form amalgamations cannot have a Name Request.",
+            "path": f"/filing/{filing_type}/nameRequest/nrNumber"
+        }]
+
+    return validate_name_request(amalgamation_json, legal_type, filing_type)
 
 
 def validate_amalgamating_businesses(  # noqa: PLR0912, PLR0915

--- a/legal-api/tests/unit/services/filings/validations/test_amalgamation_application.py
+++ b/legal-api/tests/unit/services/filings/validations/test_amalgamation_application.py
@@ -93,7 +93,7 @@ def test_invalid_nr_amalgamation(mocker, app, session):
     ]
 )
 def test_short_form_amalgamation_rejects_nr(mocker, app, session, amalgamation_type):
-    """Assert short-form amalgamations reject an nrNumber without calling NameX."""
+    """Assert short-form amalgamations reject an nrNumber."""
     filing = {'filing': {}}
     filing['filing']['header'] = {'name': 'amalgamationApplication', 'date': '2019-04-08',
                                   'certifiedBy': 'full name', 'authorizationReceived': True,

--- a/legal-api/tests/unit/services/filings/validations/test_amalgamation_application.py
+++ b/legal-api/tests/unit/services/filings/validations/test_amalgamation_application.py
@@ -86,6 +86,33 @@ def test_invalid_nr_amalgamation(mocker, app, session):
 
 
 @pytest.mark.parametrize(
+    'amalgamation_type',
+    [
+        Amalgamation.AmalgamationTypes.horizontal.name,
+        Amalgamation.AmalgamationTypes.vertical.name,
+    ]
+)
+def test_short_form_amalgamation_rejects_nr(mocker, app, session, amalgamation_type):
+    """Assert short-form amalgamations reject an nrNumber without calling NameX."""
+    filing = {'filing': {}}
+    filing['filing']['header'] = {'name': 'amalgamationApplication', 'date': '2019-04-08',
+                                  'certifiedBy': 'full name', 'authorizationReceived': True,
+                                  'email': 'no_one@never.get', 'filingId': 1}
+    filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
+    filing['filing']['amalgamationApplication']['type'] = amalgamation_type
+    filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
+
+    mocker.patch('legal_api.services.filings.validations.amalgamation_application.validate_amalgamating_businesses',
+                 return_value=[])
+    with patch.object(NameXService, 'query_nr_number') as mock_query:
+        err = validate(None, filing)
+
+    assert err
+    assert any(m['error'] == 'Short-form amalgamations cannot have a Name Request.' for m in err.msg)
+    mock_query.assert_not_called()
+
+
+@pytest.mark.parametrize(
     'amalgamation_type, expected_msg',
     [
         (Amalgamation.AmalgamationTypes.regular.name, 'At least one Director and a Completing Party is required.'),
@@ -100,8 +127,6 @@ def test_amalgamation_parties_missing_role(mocker, app, session, amalgamation_ty
                                   'certifiedBy': 'full name', 'authorizationReceived': True,
                                   'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
-    filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
-
     filing['filing']['amalgamationApplication']['type'] = amalgamation_type
     filing['filing']['amalgamationApplication']['parties'] = []
     mocker.patch('legal_api.services.filings.validations.amalgamation_application.validate_name_request',
@@ -718,7 +743,6 @@ def test_validate_amalgamation_office_or_share_required(session, mocker, amalgam
                                   'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
     filing['filing']['amalgamationApplication']['type'] = amalgamation_type
-    filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
 
     del filing['filing']['amalgamationApplication']['offices']
     del filing['filing']['amalgamationApplication']['shareStructure']
@@ -1553,8 +1577,9 @@ def test_amalgamating_business_roles(mocker, app, session, jwt, amalgamation_typ
                                   'certifiedBy': 'full name', 'authorizationReceived': True,
                                   'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
-    filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
     filing['filing']['amalgamationApplication']['type'] = amalgamation_type
+    if amalgamation_type == Amalgamation.AmalgamationTypes.regular.name:
+        filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
     filing['filing']['amalgamationApplication']['amalgamatingBusinesses'] = amalgamating_businesses
 
     def mock_find_by_identifier(identifier):
@@ -1607,7 +1632,6 @@ def test_amalgamation_legal_type_mismatch(mocker, app, session, jwt, legal_type,
                                   'certifiedBy': 'full name', 'authorizationReceived': True,
                                   'email': 'no_one@never.get', 'filingId': 1}
     filing['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
-    filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
     filing['filing']['amalgamationApplication']['nameRequest']['legalType'] = legal_type
     filing['filing']['amalgamationApplication']['type'] = amalgamation_type
     filing['filing']['amalgamationApplication']['amalgamatingBusinesses'] = [


### PR DESCRIPTION
*Issue #:* /bcgov/entity#32928

*Description of changes:*
Backend now rejects nrNumber on short-form (horizontal/vertical) amalgamations

<table border="1">
    <thead>
      <tr>
        <th>Payload</th>
        <th>Type</th>
        <th>HTTP</th>
        <th>Result</th>
      </tr>
    </thead>
    <tbody>
      <tr>
        <td>horizontal_with_nr.json</td>
        <td>horizontal + nrNumber</td>
        <td>400</td>
        <td>"Short-form amalgamations cannot have a Name Request." (rejected)</td>
      </tr>
      <tr>
        <td>vertical_with_nr.json</td>
        <td>vertical + nrNumber</td>
        <td>400</td>
        <td>"Short-form amalgamations cannot have a Name Request." (rejected)</td>
      </tr>
    </tbody>
  </table>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
