### PR TITLE
33365 Business Filer - use same colin sequence for 'C's and 'BC's

### DIFF
--- a/queue_services/business-filer/pyproject.toml
+++ b/queue_services/business-filer/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "business-filer"
-version = "3.0.17"
+version = "3.0.18"
 description = "Business Registry Filer Service"
 authors = [
     {name = "thor",email = "1042854+thorwolpert@users.noreply.github.com"}

--- a/queue_services/business-filer/src/business_filer/filing_processors/filing_components/business_info.py
+++ b/queue_services/business-filer/src/business_filer/filing_processors/filing_components/business_info.py
@@ -116,16 +116,21 @@ def update_naics_info(business: Business, naics: dict):
 def get_next_corp_num(legal_type: str):
     """Retrieve the next available sequential corp-num from Lear or fallback to COLIN."""
     # this gets called if the new services are generating the Business.identifier.
+    colin_sequence_type = legal_type
     if legal_type in (Business.LegalTypes.BCOMP.value,
                       Business.LegalTypes.BC_ULC_COMPANY.value,
                       Business.LegalTypes.BC_CCC.value,
                       Business.LegalTypes.COMP.value):
         legal_type = "BC"
+        colin_sequence_type = "BC"
     elif legal_type in (Business.LegalTypes.BCOMP_CONTINUE_IN.value,
                         Business.LegalTypes.ULC_CONTINUE_IN.value,
                         Business.LegalTypes.CCC_CONTINUE_IN.value,
                         Business.LegalTypes.CONTINUE_IN.value):
         legal_type = "C"
+        # 'C' types share the same colin sequence as 'BC'
+        colin_sequence_type = "BC"
+        
 
     # when lear generating the identifier
     if (
@@ -141,7 +146,7 @@ def get_next_corp_num(legal_type: str):
     try:
         token = AccountService.get_bearer_token()
         resp = requests.post(
-            f'{current_app.config["COLIN_API"]}/businesses/{legal_type}',
+            f'{current_app.config["COLIN_API"]}/businesses/{colin_sequence_type}',
             headers={"Accept": "application/json",
                      "Authorization": f"Bearer {token}"}
         )

--- a/queue_services/business-filer/tests/unit/filing_processors/test_continuation_in.py
+++ b/queue_services/business-filer/tests/unit/filing_processors/test_continuation_in.py
@@ -1,0 +1,81 @@
+# Copyright © 2026 Province of British Columbia
+#
+# Licensed under the BSD 3 Clause License, (the "License");
+# you may not use this file except in compliance with the License.
+# The template for the license can be found here
+#    https://opensource.org/license/bsd-3-clause/
+#
+# Redistribution and use in source and binary forms,
+# with or without modification, are permitted provided that the
+# following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""The Unit Tests for the Incorporation filing."""
+
+import copy
+import random
+from datetime import datetime, timezone, timezone
+from unittest.mock import patch
+
+import pytest
+from business_model.models import Business, Filing
+from business_model.models.colin_event_id import ColinEventId
+from business_model.models.document import DocumentType
+from registry_schemas.example_data import CONTINUATION_IN_FILING_TEMPLATE
+
+from business_filer.filing_meta import FilingMeta
+from business_filer.filing_processors import continuation_in
+from business_filer.filing_processors.filing_components import business_info
+from tests.unit import create_filing
+
+
+CONTINUATION_IN_FILING_TEMPLATE = copy.deepcopy(CONTINUATION_IN_FILING_TEMPLATE)
+
+
+@pytest.mark.parametrize('legal_type, filing, next_corp_num ', [
+    ('C', copy.deepcopy(CONTINUATION_IN_FILING_TEMPLATE), 'C0001095')
+])
+def test_continuation_in_filing_process(app, session, requests_mock, legal_type, filing, next_corp_num):
+    """Assert that the incorporation object is correctly populated to model objects."""
+    # setup
+    mock_bearer_token = requests_mock.post(f'{app.config["ACCOUNT_SVC_AUTH_URL"]}', json={'access_token': 'fake-token'})
+    mock_get_next_corp_num = requests_mock.post(f'{app.config["COLIN_API"]}/businesses/BC', json={'corpNum': int(next_corp_num[1:])})
+
+    create_filing('123', filing)
+
+    effective_date = datetime.now(timezone.utc)
+    filing_rec = Filing(effective_date=effective_date, filing_json=filing)
+    filing_meta = FilingMeta(application_date=effective_date)
+
+    # test
+    business, filing_rec, filing_meta = continuation_in.process(None, filing, filing_rec, filing_meta)
+
+    # Assertions
+    assert business.identifier == next_corp_num
+    assert business.founding_date == effective_date
+    assert business.state == Business.State.ACTIVE
+    assert mock_bearer_token.called
+    assert mock_bearer_token.call_count == 1
+    assert mock_get_next_corp_num.called
+    assert mock_get_next_corp_num.call_count == 1


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33365

*Description of changes:*
- get the new corp num from the same colin sequence for 'C' companies as 'BC' companies
- added test for continuation in to verify number

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
