### PR TITLE
33656 Add exclude business filter to mv_legacy_corps_data

### DIFF
--- a/data-tool/backup_extract_tables.sh
+++ b/data-tool/backup_extract_tables.sh
@@ -19,7 +19,7 @@ PGDATABASE="${PGDATABASE:-colin-mig-corps-test}"     # or ‑‑dbname
 ##############################################################################
 
 # -- Tables to keep ------------------------------------------------------------
-KEEP=(corp_processing colin_tracking mig_group mig_batch mig_corp_batch mig_corp_account corps_with_third_party email_domain_groups bar_corps bad_emails)
+KEEP=(corp_processing colin_tracking mig_group mig_batch mig_corp_batch mig_corp_account corps_with_third_party email_domain_groups bar_corps bad_emails exclude_corps)
 
 # -- Runtime options -----------------------------------------------------------
 BACKUP_DIR="${BACKUP_DIR:-/backups}"

--- a/data-tool/flows/common/query_utils.py
+++ b/data-tool/flows/common/query_utils.py
@@ -78,6 +78,7 @@ def get_candidates_not_matching_saf_criteria_query(updated_corp_nums: list) -> s
     AND has_bar_filing = false
     AND directors_within_bc = true
     AND is_bad_email = false
+    AND is_migration_excluded = false
     )
 """
 

--- a/data-tool/restore_extract.sh
+++ b/data-tool/restore_extract.sh
@@ -20,7 +20,7 @@ PGDATABASE="${PGDATABASE:-colin-mig-corps-test}"     # or ‑‑dbname
 ##############################################################################
 
 # -- Tables to restore ------------------------------------------------------------
-RESTORE=(corp_processing colin_tracking mig_group mig_batch mig_corp_batch mig_corp_account corps_with_third_party email_domain_groups bar_corps bad_emails)
+RESTORE=(corp_processing colin_tracking mig_group mig_batch mig_corp_batch mig_corp_account corps_with_third_party email_domain_groups bar_corps bad_emails exclude_corps)
 
 # -- Runtime options -----------------------------------------------------------
 DUMP="${DUMP}"

--- a/data-tool/scripts/colin_corps_extract_postgres_ddl
+++ b/data-tool/scripts/colin_corps_extract_postgres_ddl
@@ -1141,6 +1141,15 @@ CREATE TABLE IF NOT EXISTS bad_emails (
 alter table bad_emails
     owner to postgres;
 
+CREATE TABLE IF NOT EXISTS exclude_corps (
+    corp_num varchar(10) NOT NULL
+        CONSTRAINT pk_exclude_corps PRIMARY KEY,
+    notes text
+);
+
+alter table exclude_corps
+    owner to postgres;
+
 CREATE INDEX if not exists ix_conv_event_event_id ON conv_event (event_id);
 
 CREATE INDEX if not exists ix_conv_ledger_event_id ON conv_ledger (event_id);

--- a/data-tool/scripts/colin_corps_extract_postgres_views_ddl
+++ b/data-tool/scripts/colin_corps_extract_postgres_views_ddl
@@ -870,6 +870,11 @@ SELECT COALESCE(edg.group_name, NULL) AS group_name,
         mb.display_name as mig_batch_display_name,
         mb.migrated_date as mig_date,
         COALESCE(ms.migrated, 'N') AS migrated,
+        CAST(EXISTS (
+          SELECT 1
+          FROM exclude_corps ec
+          WHERE ec.corp_num = tblFe.corp_num
+        ) AS boolean) AS is_migration_excluded,
         CAST(has_password as boolean) as has_password,
         CAST(COALESCE(sif.has_other_currency, false) as boolean) as has_other_share_currency,
         CAST(COALESCE(sif.has_par_value_lt1_gt6dp, false) as boolean) as has_share_par_value_lt1_gt6dp,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33656

*Description of changes:*
- Add `exclude_corps` table to COLIN extract to manage list of busineses excluded from migration along with note field
- Add `is_migration_excluded` column to `mv_legacy_corps_data`
- Update pruning query to include `is_migration_excluded` filter

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
