### PR TITLE
33657 separate auth flow updates

### DIFF
--- a/data-tool/.corps.env.sample
+++ b/data-tool/.corps.env.sample
@@ -12,7 +12,7 @@ APP_SETTINGS=dev
 ## LOCAL_MIGR_TEST
 ## ------------------------------------------------------------------------------------------------------------
 DATA_LOAD_ENV=local_migr_test
-TARGET_CONNECTION= 
+TARGET_CONNECTION=
 SKIP_IF_RUNNING_HANDLER_ENABLED=False
 
 # Source database
@@ -73,6 +73,56 @@ DATABASE_PASSWORD_AUTH=
 DATABASE_NAME_AUTH=
 DATABASE_HOST_AUTH=
 DATABASE_PORT_AUTH=
+
+# ------------------------------------------------------------------------------------------
+# Auth-only flows (auth_processing tracking)
+# ------------------------------------------------------------------------------------------
+
+# Targeting:
+# - MANUAL uses AUTH_CORP_NUMS as the source list.
+# - MIGRATION_FILTER requires AUTH_MIG_GROUP_IDS and/or AUTH_MIG_BATCH_IDS.
+# - In MIGRATION_FILTER, AUTH_CORP_NUMS only narrows the migration cohort; it does not replace AUTH_MIG_GROUP_IDS/AUTH_MIG_BATCH_IDS.
+# - Auth flows do not use global MIG_GROUP_IDS/MIG_BATCH_IDS.
+# Clear AUTH_CORP_NUMS when running the full MIGRATION_FILTER cohort; stale values will narrow create/delete/repeatable runs.
+AUTH_SELECTION_MODE=MIGRATION_FILTER
+AUTH_MIG_GROUP_IDS=
+AUTH_MIG_BATCH_IDS=
+AUTH_CORP_NUMS=
+
+# Repeatable contact/invite/affiliation-create/affiliation-only-delete real runs require a cycle key.
+AUTH_REPEATABLE_CYCLE_KEY=
+# Blank AUTH_REPEATABLE_CAMPAIGN_SCOPE is valid/recommended for normal runs.
+# When blank, scope is derived from selection mode + AUTH_MIG_* IDs + optional AUTH_CORP_NUMS subset hash.
+# Set it only to intentionally share progress across otherwise distinct derived selections; it does not bypass MIGRATION_FILTER validation.
+AUTH_REPEATABLE_CAMPAIGN_SCOPE=
+
+# Throughput. Must be positive before running Auth flows; 0 keeps sample fail-fast.
+AUTH_BATCHES=0
+AUTH_BATCH_SIZE=0
+AUTH_MAX_WORKERS=50
+
+# Create/contact/affiliation/invite controls.
+AUTH_CREATE_ENTITY=True
+AUTH_UPSERT_CONTACT=False
+AUTH_CREATE_AFFILIATIONS=False
+AUTH_SEND_UNAFFILIATED_EMAIL=False
+AUTH_FAIL_IF_MISSING_EMAIL=False
+AUTH_DRY_RUN=False
+
+# Auth-only fallback account IDs for affiliation create/delete/reset.
+# Separate from AFFILIATE_ENTITY_ACCOUNT_ID.
+AUTH_AFFILIATION_ACCOUNT_IDS=
+
+# Delete/reset controls.
+AUTH_DELETE_AFFILIATIONS=False
+AUTH_DELETE_ENTITY=False
+
+# Cleanup-only mode for auth-delete-flow tracking rows: OFF|PREVIEW|EXECUTE.
+# PREVIEW/EXECUTE use the targeting block above and do not call Auth APIs.
+AUTH_DELETE_TRACKING_CLEANUP_MODE=OFF
+
+# Component-operation audit logging. Default is off; set True for explicit opt-in tracing.
+AUTH_LOG_COMPONENT_OPERATIONS=False
 
 ## batch configs, must be positive integer
 TOMBSTONE_BATCHES=1

--- a/data-tool/Makefile
+++ b/data-tool/Makefile
@@ -14,6 +14,7 @@ VENV_DIR=venv
 PREFECT_VENV_DIR=venv-prefect
 SQLALCHEMY_VENV_DIR=venv-sqlalchemy
 PYTHON_VERSION=python3.11
+AUTH_MODULE_RUNNER=PYTHONPATH="$(CURRENT_ABS_DIR)/flows:$$PYTHONPATH" python -m
 
 #################################################################################
 # COMMANDS -- Setup                                                             #
@@ -129,6 +130,27 @@ run-update-colin-ar-ind: ## Run update COLIN AR indicator flow
 run-verify-colin-updates: ## Run verify COLIN updates flow
 	. $(VENV_DIR)/bin/activate && \
 	python flows/verify_colin_updates_flow.py
+
+run-auth-create: ## Run auth create flow
+	. $(VENV_DIR)/bin/activate && \
+	$(AUTH_MODULE_RUNNER) auth.auth_create_flow
+
+run-auth-contact: ## Run auth contact flow
+	. $(VENV_DIR)/bin/activate && \
+	$(AUTH_MODULE_RUNNER) auth.auth_contact_flow
+
+run-auth-affiliation: ## Run auth affiliation flow
+	. $(VENV_DIR)/bin/activate && \
+	$(AUTH_MODULE_RUNNER) auth.auth_affiliation_flow
+
+run-auth-invite: ## Run auth invitation flow
+	. $(VENV_DIR)/bin/activate && \
+	$(AUTH_MODULE_RUNNER) auth.auth_invite_flow
+
+run-auth-delete: ## Run auth delete flow
+	. $(VENV_DIR)/bin/activate && \
+	$(AUTH_MODULE_RUNNER) auth.auth_delete_flow
+
 
 #################################################################################
 # Self Documenting Commands                                                     #

--- a/data-tool/backup_extract_tables.sh
+++ b/data-tool/backup_extract_tables.sh
@@ -19,7 +19,7 @@ PGDATABASE="${PGDATABASE:-colin-mig-corps-test}"     # or ‑‑dbname
 ##############################################################################
 
 # -- Tables to keep ------------------------------------------------------------
-KEEP=(corp_processing colin_tracking mig_group mig_batch mig_corp_batch mig_corp_account corps_with_third_party email_domain_groups bar_corps bad_emails exclude_corps)
+KEEP=(corp_processing auth_processing auth_component_operation colin_tracking mig_group mig_batch mig_corp_batch mig_corp_account corps_with_third_party email_domain_groups bar_corps bad_emails exclude_corps)
 
 # -- Runtime options -----------------------------------------------------------
 BACKUP_DIR="${BACKUP_DIR:-/backups}"

--- a/data-tool/flows/auth/auth_affiliation_flow.py
+++ b/data-tool/flows/auth/auth_affiliation_flow.py
@@ -1,281 +1,267 @@
-import math
-import os
-from typing import Dict, List
-
 from prefect import flow
 from prefect.context import get_run_context
-from prefect.futures import wait
 from prefect.states import Failed
 from prefect.task_runners import ConcurrentTaskRunner
-from sqlalchemy import text
 
-from common.extract_tracking_service import ExtractTrackingService, ProcessingStatuses
+from common.extract_tracking_service import ProcessingStatuses
 from common.init_utils import colin_extract_init, get_config
-from common.query_utils import convert_result_set_to_dict
 
-from .auth_models import AuthCreatePlan, AuthDeletePlan, AuthSelectionMode
-from .auth_queries import (
-    get_auth_business_profiles_query,
-    get_auth_reservable_corps_query,
-    get_auth_reservable_count_query,
+from .auth_flow_utils import auth_affiliation_identity
+from .auth_models import AuthCreatePlan
+from .auth_orchestration import (
+    AUTH_ALL_ACTION_FIELDS,
+    AuthReservationOptions,
+    AuthSubmittedTask,
+    build_auth_repeatable_campaign,
+    build_auth_tracking_services,
+    calculate_max_corps,
+    claim_auth_batch,
+    count_auth_reservable,
+    describe_auth_effective_selection,
+    fetch_auth_profiles,
+    finalize_auth_task_results,
+    get_auth_max_workers,
+    get_batch_token_or_mark_failed,
+    insert_component_operations_or_failed,
+    log_auth_config_preflight,
+    parse_auth_selection_mode,
+    planned_failure_actions,
+    reserve_auth_candidates,
+    validate_auth_throughput,
 )
-from .auth_tasks import get_auth_token, parse_accounts_csv, perform_auth_create_for_corp, perform_auth_delete_for_corp
-
-FLOW_NAME = 'auth-affiliation-flow'
-
-
-def _get_max_workers() -> int:
-    try:
-        v = int(os.getenv('AUTH_MAX_WORKERS', '50'))
-        return v if v > 0 else 50
-    except Exception:
-        return 50
-
-
-def _parse_selection_mode(config) -> AuthSelectionMode:
-    raw = (getattr(config, 'AUTH_SELECTION_MODE', 'MIGRATION_FILTER') or 'MIGRATION_FILTER').strip().upper()
-    try:
-        return AuthSelectionMode(raw)
-    except Exception as e:
-        raise ValueError(f'Unknown AUTH_SELECTION_MODE: {raw}') from e
-
-
-def _fetch_profiles(colin_engine, corp_nums: List[str], suffix: str) -> Dict[str, dict]:
-    if not corp_nums:
-        return {}
-    sql = get_auth_business_profiles_query(corp_nums, suffix or '')
-    with colin_engine.connect() as conn:
-        rs = conn.execute(text(sql))
-        rows = convert_result_set_to_dict(rs)
-        return {r['identifier']: r for r in rows}
+from .auth_tasks import parse_accounts_csv, perform_auth_create_for_corp
 
 
 @flow(
     name='Auth-Affiliation-Flow',
     log_prints=True,
     persist_result=False,
-    task_runner=ConcurrentTaskRunner(max_workers=_get_max_workers())
+    task_runner=ConcurrentTaskRunner(max_workers=get_auth_max_workers())
 )
 def auth_affiliation_flow():
     """
-    Create OR delete affiliations (mutually exclusive for this run).
+    Create account affiliations only.
 
-    - Create mode: uses AuthCreatePlan(create_affiliations=True)
-    - Delete mode: uses AuthDeletePlan(delete_affiliations=True)
-
-    Selection excludes any corp already tracked in auth_processing for (corp_num, FLOW_NAME, environment).
+    Running this component flow creates affiliations. Affiliation-only deletes are
+    handled by auth_delete_flow with AUTH_DELETE_AFFILIATIONS=True.
     """
     config = get_config()
+    selection_mode = parse_auth_selection_mode(config)
+
+    create_plan = AuthCreatePlan(
+        create_entity=False,
+        upsert_contact=False,
+        create_affiliations=True,
+        send_unaffiliated_invite=False,
+        fail_if_missing_email=False,
+        dry_run=bool(getattr(config, 'AUTH_DRY_RUN', False)),
+        allow_entity_creation_for_affiliations=False,
+    )
+
+    log_auth_config_preflight(
+        config,
+        selection_mode,
+        flow_label='affiliation',
+        dry_run=create_plan.dry_run,
+        campaign_scope_applies=True,
+    )
+
+    flow_run_id = get_run_context().flow_run.id
+    campaign = build_auth_repeatable_campaign(
+        config,
+        selection_mode,
+        dry_run=create_plan.dry_run,
+        flow_label='affiliation',
+    )
+    identity = auth_affiliation_identity(
+        flow_run_id,
+        dry_run=create_plan.dry_run,
+        campaign=campaign,
+    )
+    print(f'👷 {describe_auth_effective_selection(config, selection_mode, dry_run=create_plan.dry_run, campaign=campaign)}')
     colin_engine = colin_extract_init(config)
-    selection_mode = _parse_selection_mode(config)
-
-    do_create = bool(getattr(config, 'AUTH_CREATE_AFFILIATIONS', False))
-    do_delete = bool(getattr(config, 'AUTH_DELETE_AFFILIATIONS', False))
-
-    if do_create and do_delete:
-        raise ValueError('Invalid config: cannot both AUTH_CREATE_AFFILIATIONS and AUTH_DELETE_AFFILIATIONS in one run')
-    if not do_create and not do_delete:
-        raise ValueError('Nothing to do: set either AUTH_CREATE_AFFILIATIONS or AUTH_DELETE_AFFILIATIONS')
-
-    create_plan = None
-    delete_plan = None
-    if do_create:
-        create_plan = AuthCreatePlan(
-            create_entity=bool(getattr(config, 'AUTH_CREATE_ENTITY', True)),
-            upsert_contact=False,
-            create_affiliations=True,
-            send_unaffiliated_invite=False,
-            fail_if_missing_email=False,
-            dry_run=bool(getattr(config, 'AUTH_DRY_RUN', False)),
-        )
-        plan_desc = create_plan
-    else:
-        delete_plan = AuthDeletePlan(
-            delete_affiliations=True,
-            delete_entity=False,
-            delete_invites=False,
-            dry_run=bool(getattr(config, 'AUTH_DRY_RUN', False)),
-        )
-        plan_desc = delete_plan
 
     # Count reservable
-    count_sql = get_auth_reservable_count_query(
-        flow_name=FLOW_NAME,
+    total_reservable = count_auth_reservable(
+        colin_engine=colin_engine,
         config=config,
-        selection_mode=selection_mode
+        selection_mode=selection_mode,
+        identity=identity,
     )
-    with colin_engine.connect() as conn:
-        total_reservable = int(conn.execute(text(count_sql)).scalar() or 0)
-
     if total_reservable <= 0:
         print('No reservable corps found for this run.')
         return
 
-    if getattr(config, 'AUTH_BATCHES', 0) <= 0:
-        raise ValueError('AUTH_BATCHES must be explicitly set to a positive integer')
-    if getattr(config, 'AUTH_BATCH_SIZE', 0) <= 0:
-        raise ValueError('AUTH_BATCH_SIZE must be explicitly set to a positive integer')
-
+    validate_auth_throughput(config)
     batch_size = config.AUTH_BATCH_SIZE
-    max_corps = min(total_reservable, config.AUTH_BATCHES * config.AUTH_BATCH_SIZE)
+    max_corps = calculate_max_corps(config, total_reservable)
 
-    flow_run_id = get_run_context().flow_run.id
-
-    tracking = ExtractTrackingService(
-        config.DATA_LOAD_ENV,
-        colin_engine,
-        FLOW_NAME,
-        table_name='auth_processing',
-        statement_timeout_ms=getattr(config, 'RESERVE_STATEMENT_TIMEOUT_MS', None)
-    )
-
-    extra_insert_cols = ['account_ids']
-
-    base_query = get_auth_reservable_corps_query(
-        flow_name=FLOW_NAME,
+    tracking, auth_tracking, log_component_operations = build_auth_tracking_services(config, colin_engine, identity)
+    reservation = reserve_auth_candidates(
         config=config,
-        batch_size=max_corps,
-        selection_mode=selection_mode,
-        include_account_ids=True,
-        include_contact_email=False
-    )
-
-    reserved = tracking.reserve_for_flow(
-        base_query=base_query,
+        tracking=tracking,
+        identity=identity,
         flow_run_id=flow_run_id,
-        extra_insert_cols=extra_insert_cols,
-        fallback_account_ids=config.AFFILIATE_ENTITY_ACCOUNT_IDS_CSV
+        selection_mode=selection_mode,
+        batch_size=batch_size,
+        max_corps=max_corps,
+        options=AuthReservationOptions(include_account_ids=True),
     )
 
-    if reserved <= 0:
+    if reservation.reserved <= 0:
         print('No corps reserved (cohort may be exhausted or already reserved).')
         return
 
-    batches = min(math.ceil(reserved / batch_size), config.AUTH_BATCHES)
-
-    print(f'👷 Auth affiliation mode: {"CREATE" if do_create else "DELETE"}')
-    print(f'👷 Plan: {plan_desc}')
-    print(f'👷 Reservable={total_reservable}, Reserved={reserved}, Batches={batches}, BatchSize={batch_size}')
-    print(f'👷 SelectionMode={selection_mode.value}')
+    print('👷 Auth affiliation mode: CREATE')
+    print(f'👷 Plan: {create_plan}')
+    print(
+        f'👷 Reservable={total_reservable}, Reserved={reservation.reserved}, '
+        f'Batches={reservation.batches}, BatchSize={batch_size}'
+    )
+    print(f'👷 TrackingFlow={identity.flow_name}')
 
     cnt = 0
     total_failed = 0
     total_completed = 0
 
-    while cnt < batches:
-        claimed = tracking.claim_batch(
-            flow_run_id,
-            batch_size,
-            extra_return_cols=extra_insert_cols,
-            as_dict=True
+    token_failure_actions = planned_failure_actions(
+        entity=create_plan.create_entity,
+        contact=False,
+        affiliation=True,
+        invite=False,
+        action_detail='token_error',
+    )
+    profile_failure_actions = planned_failure_actions(
+        entity=create_plan.create_entity,
+        contact=False,
+        affiliation=True,
+        invite=False,
+        action_detail='profile_missing',
+    )
+    create_task_failure_actions = planned_failure_actions(
+        entity=create_plan.create_entity,
+        contact=False,
+        affiliation=True,
+        invite=False,
+        action_detail='task_result_error',
+    )
+    missing_accounts_actions = {
+        'entity_action': 'NOT_RUN',
+        'contact_action': 'NOT_RUN',
+        'affiliation_action': 'FAILED',
+        'invite_action': 'NOT_RUN',
+        'action_detail': 'affiliation_missing_accounts',
+    }
+
+    while cnt < reservation.batches:
+        claimed = claim_auth_batch(
+            tracking=tracking,
+            flow_run_id=flow_run_id,
+            batch_size=batch_size,
+            extra_insert_cols=reservation.extra_insert_cols,
         )
         if not claimed:
             print('No more corps available to claim')
             break
 
         corp_nums = [r['corp_num'] for r in claimed]
+        claimed_by_corp = {r['corp_num']: r for r in claimed}
         corp_accounts = {r['corp_num']: (r.get('account_ids') or None) for r in claimed}
+        parsed_accounts_by_corp = {
+            corp_num: parse_accounts_csv(corp_accounts.get(corp_num))
+            for corp_num in corp_nums
+        }
 
-        profiles = _fetch_profiles(colin_engine, corp_nums, getattr(config, 'CORP_NAME_SUFFIX', '') or '') if do_create else {}
+        processable_corp_nums = []
+        for corp_num in corp_nums:
+            if parsed_accounts_by_corp.get(corp_num):
+                processable_corp_nums.append(corp_num)
+                continue
+            tracking.update_corp_status(
+                flow_run_id,
+                corp_num,
+                ProcessingStatuses.FAILED,
+                error='Affiliation create requires account_ids; no account_ids resolved for corp.',
+                **missing_accounts_actions,
+            )
+            total_failed += 1
 
-        try:
-            token = get_auth_token(config)
-        except Exception as e:
-            err = f'Failed to obtain auth token: {repr(e)}'
-            print(f'❌ {err}')
-            for corp_num in corp_nums:
+        if not processable_corp_nums:
+            cnt += 1
+            print(
+                f'🌟 Complete round {cnt}/{reservation.batches}. '
+                f'Completed={total_completed}, Failed={total_failed}'
+            )
+            continue
+
+        profiles = fetch_auth_profiles(
+            colin_engine,
+            processable_corp_nums,
+            getattr(config, 'CORP_NAME_SUFFIX', '') or '',
+        )
+
+        token, failed_state = get_batch_token_or_mark_failed(
+            config=config,
+            tracking=tracking,
+            flow_run_id=flow_run_id,
+            corp_nums=processable_corp_nums,
+            failure_actions=token_failure_actions,
+        )
+        if failed_state:
+            return failed_state
+
+        submitted: list[AuthSubmittedTask] = []
+        for corp_num in processable_corp_nums:
+            accounts = parsed_accounts_by_corp.get(corp_num, [])
+            profile = profiles.get(corp_num)
+            if not profile:
+                total_failed += 1
                 tracking.update_corp_status(
                     flow_run_id,
                     corp_num,
                     ProcessingStatuses.FAILED,
-                    error=err,
-                    entity_action='FAILED' if (do_create and create_plan and create_plan.create_entity) else 'NOT_RUN',
-                    contact_action='NOT_RUN',
-                    affiliation_action='FAILED',
-                    invite_action='NOT_RUN',
-                    action_detail='token_error'
+                    error='Missing business profile for corp in COLIN extract',
+                    **profile_failure_actions,
                 )
-            return Failed(message=err)
+                continue
 
-        futures = []
-        for corp_num in corp_nums:
-            accounts = parse_accounts_csv(corp_accounts.get(corp_num))
-
-            if do_create:
-                profile = profiles.get(corp_num)
-                if not profile:
-                    total_failed += 1
-                    tracking.update_corp_status(
-                        flow_run_id,
-                        corp_num,
-                        ProcessingStatuses.FAILED,
-                        error='Missing business profile for corp in COLIN extract',
-                        entity_action='FAILED' if (create_plan and create_plan.create_entity) else 'NOT_RUN',
-                        contact_action='NOT_RUN',
-                        affiliation_action='FAILED',
-                        invite_action='NOT_RUN',
-                        action_detail='profile_missing'
-                    )
-                    continue
-
-                futures.append(
-                    perform_auth_create_for_corp.submit(
-                        config,
-                        corp_num,
-                        profile,
-                        accounts,
-                        create_plan,
-                        token
-                    )
-                )
-            else:
-                futures.append(
-                    perform_auth_delete_for_corp.submit(
-                        config,
-                        corp_num,
-                        accounts,
-                        delete_plan,
-                        token
-                    )
-                )
-
-        wait(futures)
-
-        for f in futures:
-            res = f.result()
-            actions = [
-                res.get('entity_action'),
-                res.get('contact_action'),
-                res.get('affiliation_action'),
-                res.get('invite_action'),
-            ]
-            failed = any(a == 'FAILED' for a in actions if a)
-            status = ProcessingStatuses.FAILED if failed else ProcessingStatuses.COMPLETED
-
-            tracking.update_corp_status(
-                flow_run_id,
-                res['corp_num'],
-                status,
-                error=res.get('error'),
-                entity_action=res.get('entity_action'),
-                contact_action=res.get('contact_action'),
-                affiliation_action=res.get('affiliation_action'),
-                invite_action=res.get('invite_action'),
-                action_detail=res.get('action_detail')
+            future = perform_auth_create_for_corp.submit(
+                config,
+                corp_num,
+                profile,
+                accounts,
+                create_plan,
+                token,
+                auth_processing_id=claimed_by_corp[corp_num]['id'],
+                identity=identity,
+                flow_run_id=flow_run_id,
+                log_component_operations=log_component_operations,
             )
+            submitted.append(AuthSubmittedTask(future, corp_num, create_task_failure_actions))
 
-            if status == ProcessingStatuses.FAILED:
-                total_failed += 1
-            else:
-                total_completed += 1
+        finalization = finalize_auth_task_results(
+            tracking=tracking,
+            flow_run_id=flow_run_id,
+            submitted=submitted,
+            status_action_fields=AUTH_ALL_ACTION_FIELDS,
+        )
+        total_failed += finalization.failed
+        total_completed += finalization.completed
+
+        insert_failed_state = insert_component_operations_or_failed(
+            auth_tracking,
+            finalization.component_operations,
+        )
+        if insert_failed_state:
+            return insert_failed_state
 
         cnt += 1
-        print(f'🌟 Complete round {cnt}/{batches}. Completed={total_completed}, Failed={total_failed}')
+        print(f'🌟 Complete round {cnt}/{reservation.batches}. Completed={total_completed}, Failed={total_failed}')
 
     if total_failed > 0:
-        return Failed(message=f'{total_failed} corps failed in {FLOW_NAME}.')
+        return Failed(message=f'{total_failed} corps failed in {identity.flow_name}.')
 
-    print(f'🌰 {FLOW_NAME} complete. Completed={total_completed}, Failed={total_failed}')
+    print(f'🌰 {identity.flow_name} complete. Completed={total_completed}, Failed={total_failed}')
 
 
 if __name__ == '__main__':

--- a/data-tool/flows/auth/auth_contact_flow.py
+++ b/data-tool/flows/auth/auth_contact_flow.py
@@ -1,70 +1,51 @@
-import math
-import os
-from typing import Dict, List
-
 from prefect import flow
 from prefect.context import get_run_context
-from prefect.futures import wait
 from prefect.states import Failed
 from prefect.task_runners import ConcurrentTaskRunner
-from sqlalchemy import text
 
-from common.extract_tracking_service import ExtractTrackingService, ProcessingStatuses
+from common.extract_tracking_service import ProcessingStatuses
 from common.init_utils import colin_extract_init, get_config
-from common.query_utils import convert_result_set_to_dict
 
-from .auth_models import AuthCreatePlan, AuthSelectionMode
-from .auth_queries import (
-    get_auth_business_profiles_query,
-    get_auth_reservable_corps_query,
-    get_auth_reservable_count_query,
+from .auth_flow_utils import auth_contact_identity
+from .auth_models import AuthCreatePlan
+from .auth_orchestration import (
+    AUTH_CONTACT_ACTION_FIELDS,
+    AuthReservationOptions,
+    AuthSubmittedTask,
+    build_auth_repeatable_campaign,
+    build_auth_tracking_services,
+    calculate_max_corps,
+    claim_auth_batch,
+    count_auth_reservable,
+    describe_auth_effective_selection,
+    fetch_auth_profiles,
+    finalize_auth_task_results,
+    get_auth_max_workers,
+    get_batch_token_or_mark_failed,
+    insert_component_operations_or_failed,
+    log_auth_config_preflight,
+    parse_auth_selection_mode,
+    planned_failure_actions,
+    reserve_auth_candidates,
+    validate_auth_throughput,
 )
-from .auth_tasks import get_auth_token, perform_auth_create_for_corp
-
-FLOW_NAME = 'auth-contact-flow'
-
-
-def _get_max_workers() -> int:
-    try:
-        v = int(os.getenv('AUTH_MAX_WORKERS', '50'))
-        return v if v > 0 else 50
-    except Exception:
-        return 50
-
-
-def _parse_selection_mode(config) -> AuthSelectionMode:
-    raw = (getattr(config, 'AUTH_SELECTION_MODE', 'MIGRATION_FILTER') or 'MIGRATION_FILTER').strip().upper()
-    try:
-        return AuthSelectionMode(raw)
-    except Exception as e:
-        raise ValueError(f'Unknown AUTH_SELECTION_MODE: {raw}') from e
-
-
-def _fetch_profiles(colin_engine, corp_nums: List[str], suffix: str) -> Dict[str, dict]:
-    if not corp_nums:
-        return {}
-    sql = get_auth_business_profiles_query(corp_nums, suffix or '')
-    with colin_engine.connect() as conn:
-        rs = conn.execute(text(sql))
-        rows = convert_result_set_to_dict(rs)
-        return {r['identifier']: r for r in rows}
+from .auth_tasks import perform_auth_create_for_corp
 
 
 @flow(
     name='Auth-Contact-Flow',
     log_prints=True,
     persist_result=False,
-    task_runner=ConcurrentTaskRunner(max_workers=_get_max_workers())
+    task_runner=ConcurrentTaskRunner(max_workers=get_auth_max_workers())
 )
 def auth_contact_flow():
     """
     Upsert entity contact email (no entity creation, no affiliations, no invite).
 
-    Selection excludes any corp already tracked in auth_processing for (corp_num, FLOW_NAME, environment).
+    Repeatable by Auth identity; each real run creates a new auth_processing attempt row.
     """
     config = get_config()
-    colin_engine = colin_extract_init(config)
-    selection_mode = _parse_selection_mode(config)
+    selection_mode = parse_auth_selection_mode(config)
 
     plan = AuthCreatePlan(
         create_entity=False,
@@ -75,101 +56,113 @@ def auth_contact_flow():
         dry_run=bool(getattr(config, 'AUTH_DRY_RUN', False)),
     )
 
-    count_sql = get_auth_reservable_count_query(
-        flow_name=FLOW_NAME,
-        config=config,
-        selection_mode=selection_mode
+    log_auth_config_preflight(
+        config,
+        selection_mode,
+        flow_label='contact',
+        dry_run=plan.dry_run,
+        campaign_scope_applies=True,
     )
-    with colin_engine.connect() as conn:
-        total_reservable = int(conn.execute(text(count_sql)).scalar() or 0)
 
+    flow_run_id = get_run_context().flow_run.id
+    campaign = build_auth_repeatable_campaign(
+        config,
+        selection_mode,
+        dry_run=plan.dry_run,
+        flow_label='contact',
+    )
+    identity = auth_contact_identity(flow_run_id, dry_run=plan.dry_run, campaign=campaign)
+    print(f'👷 {describe_auth_effective_selection(config, selection_mode, dry_run=plan.dry_run, campaign=campaign)}')
+    colin_engine = colin_extract_init(config)
+
+    total_reservable = count_auth_reservable(
+        colin_engine=colin_engine,
+        config=config,
+        selection_mode=selection_mode,
+        identity=identity,
+    )
     if total_reservable <= 0:
         print('No reservable corps found for this run.')
         return
 
-    if getattr(config, 'AUTH_BATCHES', 0) <= 0:
-        raise ValueError('AUTH_BATCHES must be explicitly set to a positive integer')
-    if getattr(config, 'AUTH_BATCH_SIZE', 0) <= 0:
-        raise ValueError('AUTH_BATCH_SIZE must be explicitly set to a positive integer')
-
+    validate_auth_throughput(config)
     batch_size = config.AUTH_BATCH_SIZE
-    max_corps = min(total_reservable, config.AUTH_BATCHES * config.AUTH_BATCH_SIZE)
+    max_corps = calculate_max_corps(config, total_reservable)
 
-    flow_run_id = get_run_context().flow_run.id
-
-    tracking = ExtractTrackingService(
-        config.DATA_LOAD_ENV,
-        colin_engine,
-        FLOW_NAME,
-        table_name='auth_processing',
-        statement_timeout_ms=getattr(config, 'RESERVE_STATEMENT_TIMEOUT_MS', None)
-    )
-
-    extra_insert_cols = ['contact_email']
-
-    base_query = get_auth_reservable_corps_query(
-        flow_name=FLOW_NAME,
+    tracking, auth_tracking, log_component_operations = build_auth_tracking_services(config, colin_engine, identity)
+    reservation = reserve_auth_candidates(
         config=config,
-        batch_size=max_corps,
-        selection_mode=selection_mode,
-        include_account_ids=False,
-        include_contact_email=True
-    )
-
-    reserved = tracking.reserve_for_flow(
-        base_query=base_query,
+        tracking=tracking,
+        identity=identity,
         flow_run_id=flow_run_id,
-        extra_insert_cols=extra_insert_cols
+        selection_mode=selection_mode,
+        batch_size=batch_size,
+        max_corps=max_corps,
+        options=AuthReservationOptions(include_contact_email=True),
     )
 
-    if reserved <= 0:
+    if reservation.reserved <= 0:
         print('No corps reserved (cohort may be exhausted or already reserved).')
         return
 
-    batches = min(math.ceil(reserved / batch_size), config.AUTH_BATCHES)
-
     print(f'👷 Auth contact plan: {plan}')
-    print(f'👷 Reservable={total_reservable}, Reserved={reserved}, Batches={batches}, BatchSize={batch_size}')
-    print(f'👷 SelectionMode={selection_mode.value}, DryRun={plan.dry_run}')
+    print(
+        f'👷 Reservable={total_reservable}, Reserved={reservation.reserved}, '
+        f'Batches={reservation.batches}, BatchSize={batch_size}'
+    )
 
     cnt = 0
     total_failed = 0
     total_completed = 0
 
-    while cnt < batches:
-        claimed = tracking.claim_batch(
-            flow_run_id,
-            batch_size,
-            extra_return_cols=extra_insert_cols,
-            as_dict=True
+    token_failure_actions = planned_failure_actions(
+        entity=False,
+        contact=True,
+        affiliation=False,
+        invite=False,
+        action_detail='token_error',
+    )
+    profile_failure_actions = planned_failure_actions(
+        entity=False,
+        contact=True,
+        affiliation=False,
+        invite=False,
+        action_detail='profile_missing',
+    )
+    task_failure_actions = planned_failure_actions(
+        entity=False,
+        contact=True,
+        affiliation=False,
+        invite=False,
+        action_detail='task_result_error',
+    )
+
+    while cnt < reservation.batches:
+        claimed = claim_auth_batch(
+            tracking=tracking,
+            flow_run_id=flow_run_id,
+            batch_size=batch_size,
+            extra_insert_cols=reservation.extra_insert_cols,
         )
         if not claimed:
             print('No more corps available to claim')
             break
 
         corp_nums = [r['corp_num'] for r in claimed]
-        profiles = _fetch_profiles(colin_engine, corp_nums, getattr(config, 'CORP_NAME_SUFFIX', '') or '')
+        claimed_by_corp = {r['corp_num']: r for r in claimed}
+        profiles = fetch_auth_profiles(colin_engine, corp_nums, getattr(config, 'CORP_NAME_SUFFIX', '') or '')
 
-        try:
-            token = get_auth_token(config)
-        except Exception as e:
-            err = f'Failed to obtain auth token: {repr(e)}'
-            print(f'❌ {err}')
-            for corp_num in corp_nums:
-                tracking.update_corp_status(
-                    flow_run_id,
-                    corp_num,
-                    ProcessingStatuses.FAILED,
-                    error=err,
-                    entity_action='NOT_RUN',
-                    contact_action='FAILED',
-                    affiliation_action='NOT_RUN',
-                    invite_action='NOT_RUN',
-                    action_detail='token_error'
-                )
-            return Failed(message=err)
+        token, failed_state = get_batch_token_or_mark_failed(
+            config=config,
+            tracking=tracking,
+            flow_run_id=flow_run_id,
+            corp_nums=corp_nums,
+            failure_actions=token_failure_actions,
+        )
+        if failed_state:
+            return failed_state
 
-        futures = []
+        submitted: list[AuthSubmittedTask] = []
         for corp_num in corp_nums:
             profile = profiles.get(corp_num)
             if not profile:
@@ -179,56 +172,47 @@ def auth_contact_flow():
                     corp_num,
                     ProcessingStatuses.FAILED,
                     error='Missing business profile for corp in COLIN extract',
-                    entity_action='NOT_RUN',
-                    contact_action='FAILED',
-                    affiliation_action='NOT_RUN',
-                    invite_action='NOT_RUN',
-                    action_detail='profile_missing'
+                    **profile_failure_actions,
                 )
                 continue
 
-            futures.append(
-                perform_auth_create_for_corp.submit(
-                    config,
-                    corp_num,
-                    profile,
-                    [],
-                    plan,
-                    token
-                )
+            future = perform_auth_create_for_corp.submit(
+                config,
+                corp_num,
+                profile,
+                [],
+                plan,
+                token,
+                auth_processing_id=claimed_by_corp[corp_num]['id'],
+                identity=identity,
+                flow_run_id=flow_run_id,
+                log_component_operations=log_component_operations,
             )
+            submitted.append(AuthSubmittedTask(future, corp_num, task_failure_actions))
 
-        wait(futures)
+        finalization = finalize_auth_task_results(
+            tracking=tracking,
+            flow_run_id=flow_run_id,
+            submitted=submitted,
+            status_action_fields=AUTH_CONTACT_ACTION_FIELDS,
+        )
+        total_failed += finalization.failed
+        total_completed += finalization.completed
 
-        for f in futures:
-            res = f.result()
-            failed = res.get('contact_action') == 'FAILED'
-            status = ProcessingStatuses.FAILED if failed else ProcessingStatuses.COMPLETED
-
-            tracking.update_corp_status(
-                flow_run_id,
-                res['corp_num'],
-                status,
-                error=res.get('error'),
-                entity_action=res.get('entity_action'),
-                contact_action=res.get('contact_action'),
-                affiliation_action=res.get('affiliation_action'),
-                invite_action=res.get('invite_action'),
-                action_detail=res.get('action_detail')
-            )
-
-            if status == ProcessingStatuses.FAILED:
-                total_failed += 1
-            else:
-                total_completed += 1
+        insert_failed_state = insert_component_operations_or_failed(
+            auth_tracking,
+            finalization.component_operations,
+        )
+        if insert_failed_state:
+            return insert_failed_state
 
         cnt += 1
-        print(f'🌟 Complete round {cnt}/{batches}. Completed={total_completed}, Failed={total_failed}')
+        print(f'🌟 Complete round {cnt}/{reservation.batches}. Completed={total_completed}, Failed={total_failed}')
 
     if total_failed > 0:
-        return Failed(message=f'{total_failed} corps failed in {FLOW_NAME}.')
+        return Failed(message=f'{total_failed} corps failed in {identity.flow_name}.')
 
-    print(f'🌰 {FLOW_NAME} complete. Completed={total_completed}, Failed={total_failed}')
+    print(f'🌰 {identity.flow_name} complete. Completed={total_completed}, Failed={total_failed}')
 
 
 if __name__ == '__main__':

--- a/data-tool/flows/auth/auth_create_flow.py
+++ b/data-tool/flows/auth/auth_create_flow.py
@@ -1,72 +1,52 @@
-import math
-import os
-from typing import Dict, List
-
 from prefect import flow
 from prefect.context import get_run_context
-from prefect.futures import wait
 from prefect.states import Failed
 from prefect.task_runners import ConcurrentTaskRunner
-from sqlalchemy import text
 
-from common.extract_tracking_service import ExtractTrackingService, ProcessingStatuses
+from common.extract_tracking_service import ProcessingStatuses
 from common.init_utils import colin_extract_init, get_config
-from common.query_utils import convert_result_set_to_dict
 
-from .auth_models import AuthCreatePlan, AuthSelectionMode
-from .auth_queries import (
-    get_auth_business_profiles_query,
-    get_auth_reservable_corps_query,
-    get_auth_reservable_count_query,
+from .auth_flow_utils import auth_create_identity
+from .auth_models import AuthCreatePlan
+from .auth_orchestration import (
+    AUTH_ALL_ACTION_FIELDS,
+    AuthReservationOptions,
+    AuthSubmittedTask,
+    build_auth_tracking_services,
+    calculate_max_corps,
+    claim_auth_batch,
+    count_auth_reservable,
+    describe_auth_effective_selection,
+    fetch_auth_profiles,
+    finalize_auth_task_results,
+    get_auth_max_workers,
+    get_batch_token_or_mark_failed,
+    insert_component_operations_or_failed,
+    log_auth_config_preflight,
+    parse_auth_selection_mode,
+    planned_failure_actions,
+    reserve_auth_candidates,
+    validate_auth_create_flow_plan,
+    validate_auth_cycle_key_for_flow,
+    validate_auth_throughput,
 )
-from .auth_tasks import get_auth_token, parse_accounts_csv, perform_auth_create_for_corp
-
-FLOW_NAME = 'auth-create-flow'
-
-
-def _get_max_workers() -> int:
-    try:
-        v = int(os.getenv('AUTH_MAX_WORKERS', '50'))
-        return v if v > 0 else 50
-    except Exception:
-        return 50
-
-
-def _parse_selection_mode(config) -> AuthSelectionMode:
-    raw = (getattr(config, 'AUTH_SELECTION_MODE', 'MIGRATION_FILTER') or 'MIGRATION_FILTER').strip().upper()
-    try:
-        return AuthSelectionMode(raw)
-    except Exception as e:
-        raise ValueError(f'Unknown AUTH_SELECTION_MODE: {raw}') from e
-
-
-def _fetch_profiles(colin_engine, corp_nums: List[str], suffix: str) -> Dict[str, dict]:
-    if not corp_nums:
-        return {}
-    sql = get_auth_business_profiles_query(corp_nums, suffix or '')
-    with colin_engine.connect() as conn:
-        rs = conn.execute(text(sql))
-        rows = convert_result_set_to_dict(rs)
-        return {r['identifier']: r for r in rows}
+from .auth_tasks import parse_accounts_csv, perform_auth_create_for_corp
 
 
 @flow(
     name='Auth-Create-Flow',
     log_prints=True,
     persist_result=False,
-    task_runner=ConcurrentTaskRunner(max_workers=_get_max_workers())
+    task_runner=ConcurrentTaskRunner(max_workers=get_auth_max_workers())
 )
 def auth_create_flow():
     """
     Create/ensure entities, optionally upsert contact, optionally create affiliations,
     optionally send unaffiliated invite (mutually exclusive with affiliations).
 
-    Selection excludes any corp already tracked in auth_processing for (corp_num, FLOW_NAME, environment).
+    Real runs remain one-shot by Auth identity; dry-run rows do not block real runs.
     """
     config = get_config()
-    colin_engine = colin_extract_init(config)
-
-    selection_mode = _parse_selection_mode(config)
 
     plan = AuthCreatePlan(
         create_entity=bool(getattr(config, 'AUTH_CREATE_ENTITY', True)),
@@ -77,117 +57,127 @@ def auth_create_flow():
         dry_run=bool(getattr(config, 'AUTH_DRY_RUN', False)),
     )
 
-    if plan.create_affiliations and plan.send_unaffiliated_invite:
-        raise ValueError('Invalid plan: cannot both create affiliations and send unaffiliated invite')
+    validate_auth_create_flow_plan(plan)
+
+    selection_mode = parse_auth_selection_mode(config)
+    log_auth_config_preflight(
+        config,
+        selection_mode,
+        flow_label='create',
+        dry_run=plan.dry_run,
+        campaign_scope_applies=False,
+    )
+    validate_auth_cycle_key_for_flow(
+        config,
+        flow_label='create',
+        dry_run=plan.dry_run,
+        log_context='operator context only; create attempt key is hash-only from ONE_SHOT context',
+    )
+
+    flow_run_id = get_run_context().flow_run.id
+    identity = auth_create_identity(flow_run_id, dry_run=plan.dry_run)
+    print(f'👷 {describe_auth_effective_selection(config, selection_mode, dry_run=plan.dry_run)}')
+    colin_engine = colin_extract_init(config)
 
     # Count reservable
-    count_sql = get_auth_reservable_count_query(
-        flow_name=FLOW_NAME,
+    total_reservable = count_auth_reservable(
+        colin_engine=colin_engine,
         config=config,
-        selection_mode=selection_mode
+        selection_mode=selection_mode,
+        identity=identity,
     )
-    with colin_engine.connect() as conn:
-        total_reservable = int(conn.execute(text(count_sql)).scalar() or 0)
-
     if total_reservable <= 0:
         print('No reservable corps found for this run.')
         return
 
     # Throughput config
-    if getattr(config, 'AUTH_BATCHES', 0) <= 0:
-        raise ValueError('AUTH_BATCHES must be explicitly set to a positive integer')
-    if getattr(config, 'AUTH_BATCH_SIZE', 0) <= 0:
-        raise ValueError('AUTH_BATCH_SIZE must be explicitly set to a positive integer')
-
+    validate_auth_throughput(config)
     batch_size = config.AUTH_BATCH_SIZE
-    max_corps = min(total_reservable, config.AUTH_BATCHES * config.AUTH_BATCH_SIZE)
+    max_corps = calculate_max_corps(config, total_reservable)
 
-    flow_run_id = get_run_context().flow_run.id
-
-    tracking = ExtractTrackingService(
-        config.DATA_LOAD_ENV,
-        colin_engine,
-        FLOW_NAME,
-        table_name='auth_processing',
-        statement_timeout_ms=getattr(config, 'RESERVE_STATEMENT_TIMEOUT_MS', None)
-    )
+    tracking, auth_tracking, log_component_operations = build_auth_tracking_services(config, colin_engine, identity)
 
     include_account_ids = bool(plan.create_affiliations)
     include_contact_email = bool(plan.upsert_contact or plan.send_unaffiliated_invite or plan.fail_if_missing_email)
 
-    extra_insert_cols: List[str] = []
-    if include_account_ids:
-        extra_insert_cols.append('account_ids')
-    if include_contact_email:
-        extra_insert_cols.append('contact_email')
-
-    base_query = get_auth_reservable_corps_query(
-        flow_name=FLOW_NAME,
+    reservation = reserve_auth_candidates(
         config=config,
-        batch_size=max_corps,
-        selection_mode=selection_mode,
-        include_account_ids=include_account_ids,
-        include_contact_email=include_contact_email
-    )
-
-    fallback_accounts = config.AFFILIATE_ENTITY_ACCOUNT_IDS_CSV if include_account_ids else None
-    reserved = tracking.reserve_for_flow(
-        base_query=base_query,
+        tracking=tracking,
+        identity=identity,
         flow_run_id=flow_run_id,
-        extra_insert_cols=extra_insert_cols or None,
-        fallback_account_ids=fallback_accounts
+        selection_mode=selection_mode,
+        batch_size=batch_size,
+        max_corps=max_corps,
+        options=AuthReservationOptions(
+            include_account_ids=include_account_ids,
+            include_contact_email=include_contact_email,
+        ),
     )
 
-    if reserved <= 0:
+    if reservation.reserved <= 0:
         print('No corps reserved (cohort may be exhausted or already reserved).')
         return
 
-    batches = min(math.ceil(reserved / batch_size), config.AUTH_BATCHES)
-
     print(f'👷 Auth create plan: {plan}')
-    print(f'👷 Reservable={total_reservable}, Reserved={reserved}, Batches={batches}, BatchSize={batch_size}')
-    print(f'👷 SelectionMode={selection_mode.value}, DryRun={plan.dry_run}')
+    print(
+        f'👷 Reservable={total_reservable}, Reserved={reservation.reserved}, '
+        f'Batches={reservation.batches}, BatchSize={batch_size}'
+    )
 
     cnt = 0
     total_failed = 0
     total_completed = 0
 
-    while cnt < batches:
-        claimed = tracking.claim_batch(
-            flow_run_id,
-            batch_size,
-            extra_return_cols=extra_insert_cols or None,
-            as_dict=True
+    token_failure_actions = planned_failure_actions(
+        entity=plan.create_entity,
+        contact=plan.upsert_contact,
+        affiliation=plan.create_affiliations,
+        invite=plan.send_unaffiliated_invite,
+        action_detail='token_error',
+    )
+    profile_failure_actions = planned_failure_actions(
+        entity=plan.create_entity,
+        contact=plan.upsert_contact,
+        affiliation=plan.create_affiliations,
+        invite=plan.send_unaffiliated_invite,
+        action_detail='profile_missing',
+    )
+    task_failure_actions = planned_failure_actions(
+        entity=plan.create_entity,
+        contact=plan.upsert_contact,
+        affiliation=plan.create_affiliations,
+        invite=plan.send_unaffiliated_invite,
+        action_detail='task_result_error',
+    )
+
+    while cnt < reservation.batches:
+        claimed = claim_auth_batch(
+            tracking=tracking,
+            flow_run_id=flow_run_id,
+            batch_size=batch_size,
+            extra_insert_cols=reservation.extra_insert_cols,
         )
         if not claimed:
             print('No more corps available to claim')
             break
 
         corp_nums = [r['corp_num'] for r in claimed]
+        claimed_by_corp = {r['corp_num']: r for r in claimed}
         corp_accounts = {r['corp_num']: (r.get('account_ids') or None) for r in claimed} if include_account_ids else {}
 
-        profiles = _fetch_profiles(colin_engine, corp_nums, getattr(config, 'CORP_NAME_SUFFIX', '') or '')
+        profiles = fetch_auth_profiles(colin_engine, corp_nums, getattr(config, 'CORP_NAME_SUFFIX', '') or '')
 
-        try:
-            token = get_auth_token(config)
-        except Exception as e:
-            err = f'Failed to obtain auth token: {repr(e)}'
-            print(f'❌ {err}')
-            for corp_num in corp_nums:
-                tracking.update_corp_status(
-                    flow_run_id,
-                    corp_num,
-                    ProcessingStatuses.FAILED,
-                    error=err,
-                    entity_action='FAILED' if plan.create_entity else 'NOT_RUN',
-                    contact_action='FAILED' if plan.upsert_contact else 'NOT_RUN',
-                    affiliation_action='FAILED' if plan.create_affiliations else 'NOT_RUN',
-                    invite_action='FAILED' if plan.send_unaffiliated_invite else 'NOT_RUN',
-                    action_detail='token_error'
-                )
-            return Failed(message=err)
+        token, failed_state = get_batch_token_or_mark_failed(
+            config=config,
+            tracking=tracking,
+            flow_run_id=flow_run_id,
+            corp_nums=corp_nums,
+            failure_actions=token_failure_actions,
+        )
+        if failed_state:
+            return failed_state
 
-        futures = []
+        submitted: list[AuthSubmittedTask] = []
         for corp_num in corp_nums:
             profile = profiles.get(corp_num)
             if not profile:
@@ -197,63 +187,48 @@ def auth_create_flow():
                     corp_num,
                     ProcessingStatuses.FAILED,
                     error='Missing business profile for corp in COLIN extract',
-                    entity_action='FAILED' if plan.create_entity else 'NOT_RUN',
-                    contact_action='FAILED' if plan.upsert_contact else 'NOT_RUN',
-                    affiliation_action='FAILED' if plan.create_affiliations else 'NOT_RUN',
-                    invite_action='FAILED' if plan.send_unaffiliated_invite else 'NOT_RUN',
-                    action_detail='profile_missing'
+                    **profile_failure_actions,
                 )
                 continue
 
             accounts = parse_accounts_csv(corp_accounts.get(corp_num)) if include_account_ids else []
-            futures.append(
-                perform_auth_create_for_corp.submit(
-                    config,
-                    corp_num,
-                    profile,
-                    accounts,
-                    plan,
-                    token
-                )
+            future = perform_auth_create_for_corp.submit(
+                config,
+                corp_num,
+                profile,
+                accounts,
+                plan,
+                token,
+                auth_processing_id=claimed_by_corp[corp_num]['id'],
+                identity=identity,
+                flow_run_id=flow_run_id,
+                log_component_operations=log_component_operations,
             )
+            submitted.append(AuthSubmittedTask(future, corp_num, task_failure_actions))
 
-        wait(futures)
+        finalization = finalize_auth_task_results(
+            tracking=tracking,
+            flow_run_id=flow_run_id,
+            submitted=submitted,
+            status_action_fields=AUTH_ALL_ACTION_FIELDS,
+        )
+        total_failed += finalization.failed
+        total_completed += finalization.completed
 
-        for f in futures:
-            res = f.result()
-            actions = [
-                res.get('entity_action'),
-                res.get('contact_action'),
-                res.get('affiliation_action'),
-                res.get('invite_action'),
-            ]
-            failed = any(a == 'FAILED' for a in actions if a)
-            status = ProcessingStatuses.FAILED if failed else ProcessingStatuses.COMPLETED
-
-            tracking.update_corp_status(
-                flow_run_id,
-                res['corp_num'],
-                status,
-                error=res.get('error'),
-                entity_action=res.get('entity_action'),
-                contact_action=res.get('contact_action'),
-                affiliation_action=res.get('affiliation_action'),
-                invite_action=res.get('invite_action'),
-                action_detail=res.get('action_detail')
-            )
-
-            if status == ProcessingStatuses.FAILED:
-                total_failed += 1
-            else:
-                total_completed += 1
+        insert_failed_state = insert_component_operations_or_failed(
+            auth_tracking,
+            finalization.component_operations,
+        )
+        if insert_failed_state:
+            return insert_failed_state
 
         cnt += 1
-        print(f'🌟 Complete round {cnt}/{batches}. Completed={total_completed}, Failed={total_failed}')
+        print(f'🌟 Complete round {cnt}/{reservation.batches}. Completed={total_completed}, Failed={total_failed}')
 
     if total_failed > 0:
-        return Failed(message=f'{total_failed} corps failed in {FLOW_NAME}.')
+        return Failed(message=f'{total_failed} corps failed in {identity.flow_name}.')
 
-    print(f'🌰 {FLOW_NAME} complete. Completed={total_completed}, Failed={total_failed}')
+    print(f'🌰 {identity.flow_name} complete. Completed={total_completed}, Failed={total_failed}')
 
 
 if __name__ == '__main__':

--- a/data-tool/flows/auth/auth_delete_flow.py
+++ b/data-tool/flows/auth/auth_delete_flow.py
@@ -1,228 +1,417 @@
-import math
-import os
-from typing import List
-
 from prefect import flow
 from prefect.context import get_run_context
 from prefect.futures import wait
 from prefect.states import Failed
 from prefect.task_runners import ConcurrentTaskRunner
-from sqlalchemy import text
 
-from common.extract_tracking_service import ExtractTrackingService, ProcessingStatuses
+from common.extract_tracking_service import ProcessingStatuses
 from common.init_utils import colin_extract_init, get_config
 
-from .auth_models import AuthDeletePlan, AuthSelectionMode
-from .auth_queries import (
-    get_auth_reservable_corps_query,
-    get_auth_reservable_count_query,
+from .auth_flow_utils import AUTH_DELETE_FLOW_NAME, auth_delete_identity
+from .auth_models import AuthDeletePlan, AuthDeleteTrackingCleanupMode, AuthOperationScope
+from .auth_orchestration import (
+    AUTH_ALL_ACTION_FIELDS,
+    AuthReservationOptions,
+    AuthSubmittedTask,
+    build_auth_repeatable_campaign,
+    build_auth_tracking_services,
+    calculate_max_corps,
+    claim_auth_batch,
+    count_auth_reservable,
+    describe_auth_effective_selection,
+    finalize_auth_task_results,
+    format_auth_delete_tracking_cleanup_summary,
+    get_auth_max_workers,
+    get_batch_token_or_mark_failed,
+    has_failed_action,
+    insert_component_operations_or_failed,
+    log_auth_config_preflight,
+    parse_auth_delete_tracking_cleanup_mode,
+    parse_auth_selection_mode,
+    planned_failure_actions,
+    reserve_auth_candidates,
+    task_result_error,
+    update_auth_processing_from_task_result,
+    validate_auth_delete_flow_plan,
+    validate_auth_throughput,
 )
-from .auth_tasks import get_auth_token, parse_accounts_csv, perform_auth_delete_for_corp
-
-FLOW_NAME = 'auth-delete-flow'
-
-
-def _get_max_workers() -> int:
-    try:
-        v = int(os.getenv('AUTH_MAX_WORKERS', '50'))
-        return v if v > 0 else 50
-    except Exception:
-        return 50
-
-
-def _parse_selection_mode(config) -> AuthSelectionMode:
-    raw = (getattr(config, 'AUTH_SELECTION_MODE', 'MIGRATION_FILTER') or 'MIGRATION_FILTER').strip().upper()
-    try:
-        return AuthSelectionMode(raw)
-    except Exception as e:
-        raise ValueError(f'Unknown AUTH_SELECTION_MODE: {raw}') from e
+from .auth_queries import get_auth_selected_corp_nums_query
+from .auth_tasks import parse_accounts_csv, perform_auth_delete_for_corp
+from .auth_tracking import AuthComponentOperationRecord, AuthTrackingService
 
 
 @flow(
     name='Auth-Delete-Flow',
     log_prints=True,
     persist_result=False,
-    task_runner=ConcurrentTaskRunner(max_workers=_get_max_workers())
+    task_runner=ConcurrentTaskRunner(max_workers=get_auth_max_workers())
 )
 def auth_delete_flow():
     """
-    Delete affiliations (optional) and delete entity (optional).
+    Delete Auth components (repeatable) or fully reset Auth entities (reset semantics).
 
-    SAFETY: If AUTH_REQUIRE_CONFIRMATION is True, AUTH_CONFIRMATION_TOKEN must be set (non-empty),
-    or the flow will fail fast before reserving/claiming.
-
-    Selection excludes any corp already tracked in auth_processing for (corp_num, FLOW_NAME, environment).
+    Failed or interrupted non-dry-run RESET/FULL_ENTITY rows intentionally block future reset
+    selection until manually deleted.
     """
     config = get_config()
-    colin_engine = colin_extract_init(config)
 
-    # Safety gate
-    if bool(getattr(config, 'AUTH_REQUIRE_CONFIRMATION', False)):
-        if not (getattr(config, 'AUTH_CONFIRMATION_TOKEN', '') or '').strip():
-            raise ValueError('AUTH_REQUIRE_CONFIRMATION is True but AUTH_CONFIRMATION_TOKEN is not set.')
-        print('🛑 Delete confirmation token is present (value not displayed). Proceeding.')
+    cleanup_mode = parse_auth_delete_tracking_cleanup_mode(config)
+    if cleanup_mode != AuthDeleteTrackingCleanupMode.OFF:
+        selection_mode = parse_auth_selection_mode(config)
+        log_auth_config_preflight(
+            config,
+            selection_mode,
+            flow_label='delete cleanup',
+            dry_run=False,
+            campaign_scope_applies=False,
+        )
+        if bool(getattr(config, 'AUTH_DELETE_AFFILIATIONS', False)) or bool(getattr(config, 'AUTH_DELETE_ENTITY', False)):
+            print('👷 AUTH_DELETE_TRACKING_CLEANUP_MODE is set; ignoring Auth API delete flags.')
+        selected_corp_nums_sql = get_auth_selected_corp_nums_query(config, selection_mode)
+        colin_engine = colin_extract_init(config)
+        auth_tracking = AuthTrackingService.from_config(config, colin_engine)
+        summary = auth_tracking.preview_delete_tracking_cleanup(
+            selected_corp_nums_sql,
+            flow_name=AUTH_DELETE_FLOW_NAME,
+        )
+        for line in format_auth_delete_tracking_cleanup_summary(summary):
+            print(f'👷 {line}')
+        if cleanup_mode == AuthDeleteTrackingCleanupMode.PREVIEW:
+            print('👷 Auth delete tracking cleanup PREVIEW complete; no rows deleted.')
+            return
 
-    selection_mode = _parse_selection_mode(config)
+        deleted = auth_tracking.execute_delete_tracking_cleanup(
+            selected_corp_nums_sql,
+            flow_name=AUTH_DELETE_FLOW_NAME,
+        )
+        print(f'👷 Auth delete tracking cleanup EXECUTE deleted auth_processing rows: {deleted}')
+        if deleted != summary.total_auth_processing_rows:
+            print(
+                '⚠️ Auth delete tracking cleanup deleted rowcount differs from preview: '
+                f'preview={summary.total_auth_processing_rows}, deleted={deleted}'
+            )
+        return
 
     plan = AuthDeletePlan(
         delete_affiliations=bool(getattr(config, 'AUTH_DELETE_AFFILIATIONS', False)),
         delete_entity=bool(getattr(config, 'AUTH_DELETE_ENTITY', False)),
-        delete_invites=bool(getattr(config, 'AUTH_DELETE_INVITES', False)),
         dry_run=bool(getattr(config, 'AUTH_DRY_RUN', False)),
     )
+    validate_auth_delete_flow_plan(plan)
 
-    # Count reservable
-    count_sql = get_auth_reservable_count_query(
-        flow_name=FLOW_NAME,
-        config=config,
-        selection_mode=selection_mode
+    selection_mode = parse_auth_selection_mode(config)
+    log_auth_config_preflight(
+        config,
+        selection_mode,
+        flow_label='delete',
+        dry_run=plan.dry_run,
+        campaign_scope_applies=bool(plan.delete_entity or plan.delete_affiliations),
     )
-    with colin_engine.connect() as conn:
-        total_reservable = int(conn.execute(text(count_sql)).scalar() or 0)
 
+    flow_run_id = get_run_context().flow_run.id
+    full_reset_sweep = plan.delete_entity and not plan.dry_run
+    campaign = None
+    if full_reset_sweep:
+        print(
+            '👷 Auth delete mode: full reset sweep '
+            '(AUTH_DELETE_ENTITY=True, AUTH_DRY_RUN=False); '
+            'AUTH_REPEATABLE_CYCLE_KEY is required because sweep tracking uses a campaign identity.'
+        )
+        campaign = build_auth_repeatable_campaign(
+            config,
+            selection_mode,
+            dry_run=plan.dry_run,
+            missing_cycle_key_message=(
+                'AUTH_REPEATABLE_CYCLE_KEY is required for non-dry-run auth delete full reset '
+                '(AUTH_DELETE_ENTITY=True, AUTH_DRY_RUN=False) because full reset uses sweep tracking'
+            ),
+            flow_label='delete full reset',
+        )
+    elif plan.delete_affiliations and not plan.delete_entity:
+        print('👷 Auth delete mode: affiliation-only repeatable delete')
+        campaign = build_auth_repeatable_campaign(
+            config,
+            selection_mode,
+            dry_run=plan.dry_run,
+            flow_label='delete',
+        )
+    elif plan.delete_entity:
+        print('👷 Auth delete mode: dry-run full reset (no sweep tracking campaign required)')
+    identity = auth_delete_identity(plan, flow_run_id, campaign=campaign)
+    print(f'👷 {describe_auth_effective_selection(config, selection_mode, dry_run=plan.dry_run, campaign=campaign)}')
+    colin_engine = colin_extract_init(config)
+
+    tracking, auth_tracking, log_component_operations = build_auth_tracking_services(config, colin_engine, identity)
+
+    # Count reservable with reset blockers left in place until manual cleanup.
+    total_reservable = count_auth_reservable(
+        colin_engine=colin_engine,
+        config=config,
+        selection_mode=selection_mode,
+        identity=identity,
+    )
     if total_reservable <= 0:
         print('No reservable corps found for this run.')
         return
 
-    # Throughput config
-    if getattr(config, 'AUTH_BATCHES', 0) <= 0:
-        raise ValueError('AUTH_BATCHES must be explicitly set to a positive integer')
-    if getattr(config, 'AUTH_BATCH_SIZE', 0) <= 0:
-        raise ValueError('AUTH_BATCH_SIZE must be explicitly set to a positive integer')
-
+    # Throughput config is validated before reservation.
+    validate_auth_throughput(config)
     batch_size = config.AUTH_BATCH_SIZE
-    max_corps = min(total_reservable, config.AUTH_BATCHES * config.AUTH_BATCH_SIZE)
-
-    flow_run_id = get_run_context().flow_run.id
-
-    tracking = ExtractTrackingService(
-        config.DATA_LOAD_ENV,
-        colin_engine,
-        FLOW_NAME,
-        table_name='auth_processing',
-        statement_timeout_ms=getattr(config, 'RESERVE_STATEMENT_TIMEOUT_MS', None)
-    )
-
+    max_corps = calculate_max_corps(config, total_reservable)
     include_account_ids = bool(plan.delete_affiliations)
 
-    extra_insert_cols: List[str] = []
-    if include_account_ids:
-        extra_insert_cols.append('account_ids')
-
-    base_query = get_auth_reservable_corps_query(
-        flow_name=FLOW_NAME,
+    reservation = reserve_auth_candidates(
         config=config,
-        batch_size=max_corps,
-        selection_mode=selection_mode,
-        include_account_ids=include_account_ids,
-        include_contact_email=False
-    )
-
-    fallback_accounts = config.AFFILIATE_ENTITY_ACCOUNT_IDS_CSV if include_account_ids else None
-    reserved = tracking.reserve_for_flow(
-        base_query=base_query,
+        tracking=tracking,
+        identity=identity,
         flow_run_id=flow_run_id,
-        extra_insert_cols=extra_insert_cols or None,
-        fallback_account_ids=fallback_accounts
+        selection_mode=selection_mode,
+        batch_size=batch_size,
+        max_corps=max_corps,
+        options=AuthReservationOptions(include_account_ids=include_account_ids),
     )
 
-    if reserved <= 0:
+    if reservation.reserved <= 0:
         print('No corps reserved (cohort may be exhausted or already reserved).')
         return
 
-    batches = min(math.ceil(reserved / batch_size), config.AUTH_BATCHES)
-
     print(f'👷 Auth delete plan: {plan}')
-    print(f'👷 Reservable={total_reservable}, Reserved={reserved}, Batches={batches}, BatchSize={batch_size}')
-    print(f'👷 SelectionMode={selection_mode.value}, DryRun={plan.dry_run}')
+    print(
+        f'👷 Reservable={total_reservable}, Reserved={reservation.reserved}, '
+        f'Batches={reservation.batches}, BatchSize={batch_size}'
+    )
+    print(
+        f'👷 TrackingFlow={identity.flow_name}, '
+        f'Identity={identity.operation.value}/{identity.operation_scope.value}'
+    )
 
     cnt = 0
     total_failed = 0
     total_completed = 0
 
-    while cnt < batches:
-        claimed = tracking.claim_batch(
-            flow_run_id,
-            batch_size,
-            extra_return_cols=extra_insert_cols or None,
-            as_dict=True
+    token_failure_actions = planned_failure_actions(
+        entity=plan.delete_entity,
+        contact=False,
+        affiliation=plan.delete_affiliations,
+        invite=False,
+        action_detail='token_error',
+    )
+    task_failure_actions = planned_failure_actions(
+        entity=plan.delete_entity,
+        contact=False,
+        affiliation=plan.delete_affiliations,
+        invite=False,
+        action_detail='task_result_error',
+    )
+    is_affiliation_only_delete = plan.delete_affiliations and not plan.delete_entity
+    missing_accounts_actions = {
+        'entity_action': 'NOT_RUN',
+        'contact_action': 'NOT_RUN',
+        'affiliation_action': 'FAILED',
+        'invite_action': 'NOT_RUN',
+        'action_detail': 'delete_affiliations_missing_accounts',
+    }
+    missing_accounts_error = 'Delete affiliations requires account coverage; no account_ids resolved for corp.'
+    is_non_dry_run_full_reset = plan.delete_entity and not plan.dry_run
+
+    while cnt < reservation.batches:
+        claimed = claim_auth_batch(
+            tracking=tracking,
+            flow_run_id=flow_run_id,
+            batch_size=batch_size,
+            extra_insert_cols=reservation.extra_insert_cols,
         )
         if not claimed:
             print('No more corps available to claim')
             break
 
         corp_nums = [r['corp_num'] for r in claimed]
+        claimed_by_corp = {r['corp_num']: r for r in claimed}
         corp_accounts = {r['corp_num']: (r.get('account_ids') or None) for r in claimed} if include_account_ids else {}
+        parsed_accounts_by_corp = {
+            corp_num: parse_accounts_csv(corp_accounts.get(corp_num)) if include_account_ids else []
+            for corp_num in corp_nums
+        }
 
-        try:
-            token = get_auth_token(config)
-        except Exception as e:
-            err = f'Failed to obtain auth token: {repr(e)}'
-            print(f'❌ {err}')
+        processable_corp_nums = corp_nums
+        if is_affiliation_only_delete:
+            processable_corp_nums = []
             for corp_num in corp_nums:
+                if parsed_accounts_by_corp.get(corp_num):
+                    processable_corp_nums.append(corp_num)
+                    continue
                 tracking.update_corp_status(
                     flow_run_id,
                     corp_num,
                     ProcessingStatuses.FAILED,
-                    error=err,
-                    entity_action='FAILED' if plan.delete_entity else 'NOT_RUN',
-                    contact_action='NOT_RUN',
-                    affiliation_action='FAILED' if plan.delete_affiliations else 'NOT_RUN',
-                    invite_action='FAILED' if plan.delete_invites else 'NOT_RUN',
-                    action_detail='token_error'
+                    error=missing_accounts_error,
+                    **missing_accounts_actions,
                 )
-            return Failed(message=err)
-
-        futures = []
-        for corp_num in corp_nums:
-            accounts = parse_accounts_csv(corp_accounts.get(corp_num)) if include_account_ids else []
-            futures.append(
-                perform_auth_delete_for_corp.submit(
-                    config,
-                    corp_num,
-                    accounts,
-                    plan,
-                    token
-                )
-            )
-
-        wait(futures)
-
-        for f in futures:
-            res = f.result()
-            actions = [
-                res.get('entity_action'),
-                res.get('contact_action'),
-                res.get('affiliation_action'),
-                res.get('invite_action'),
-            ]
-            failed = any(a == 'FAILED' for a in actions if a)
-            status = ProcessingStatuses.FAILED if failed else ProcessingStatuses.COMPLETED
-
-            tracking.update_corp_status(
-                flow_run_id,
-                res['corp_num'],
-                status,
-                error=res.get('error'),
-                entity_action=res.get('entity_action'),
-                contact_action=res.get('contact_action'),
-                affiliation_action=res.get('affiliation_action'),
-                invite_action=res.get('invite_action'),
-                action_detail=res.get('action_detail')
-            )
-
-            if status == ProcessingStatuses.FAILED:
                 total_failed += 1
-            else:
+
+        if not processable_corp_nums:
+            cnt += 1
+            print(
+                f'🌟 Complete round {cnt}/{reservation.batches}. '
+                f'Completed={total_completed}, Failed={total_failed}'
+            )
+            continue
+
+        token, failed_state = get_batch_token_or_mark_failed(
+            config=config,
+            tracking=tracking,
+            flow_run_id=flow_run_id,
+            corp_nums=processable_corp_nums,
+            failure_actions=token_failure_actions,
+        )
+        if failed_state:
+            return failed_state
+
+        submitted: list[AuthSubmittedTask] = []
+        for corp_num in processable_corp_nums:
+            accounts = parsed_accounts_by_corp.get(corp_num, [])
+            future = perform_auth_delete_for_corp.submit(
+                config,
+                corp_num,
+                accounts,
+                plan,
+                token,
+                auth_processing_id=claimed_by_corp[corp_num]['id'],
+                identity=identity,
+                flow_run_id=flow_run_id,
+                log_component_operations=log_component_operations,
+            )
+            submitted.append(AuthSubmittedTask(future, corp_num, task_failure_actions))
+
+        if not is_non_dry_run_full_reset:
+            finalization = finalize_auth_task_results(
+                tracking=tracking,
+                flow_run_id=flow_run_id,
+                submitted=submitted,
+                status_action_fields=AUTH_ALL_ACTION_FIELDS,
+            )
+            total_failed += finalization.failed
+            total_completed += finalization.completed
+            insert_failed_state = insert_component_operations_or_failed(
+                auth_tracking,
+                finalization.component_operations,
+            )
+            if insert_failed_state:
+                return insert_failed_state
+
+            cnt += 1
+            print(f'🌟 Complete round {cnt}/{reservation.batches}. Completed={total_completed}, Failed={total_failed}')
+            continue
+
+        if submitted:
+            wait([item.future for item in submitted])
+
+        component_operations = []
+        cleanup_errors = []
+        for item in submitted:
+            try:
+                res = item.future.result()
+            except Exception as e:
+                err = task_result_error(e)
+                tracking.update_corp_status(
+                    flow_run_id,
+                    item.corp_num,
+                    ProcessingStatuses.FAILED,
+                    error=err,
+                    **item.failure_actions,
+                )
+                total_failed += 1
+                continue
+
+            failed = has_failed_action(res, AUTH_ALL_ACTION_FIELDS)
+
+            if not failed:
+                try:
+                    preserve_auth_processing_id = (
+                        claimed_by_corp[res['corp_num']]['id']
+                        if full_reset_sweep
+                        else None
+                    )
+                    auth_tracking.cleanup_full_reset_tracking(
+                        res['corp_num'],
+                        preserve_auth_processing_id=preserve_auth_processing_id,
+                    )
+                except Exception as e:
+                    err = f'Full reset tracking cleanup failed: {repr(e)}'
+                    detail = 'reset_cleanup_error'
+                    if res.get('action_detail'):
+                        detail = f"{res.get('action_detail')}; {detail}"
+                    print(f'❌ {err}')
+                    tracking.update_corp_status(
+                        flow_run_id,
+                        res['corp_num'],
+                        ProcessingStatuses.FAILED,
+                        error=err,
+                        entity_action=res.get('entity_action'),
+                        contact_action=res.get('contact_action'),
+                        affiliation_action=res.get('affiliation_action'),
+                        invite_action=res.get('invite_action'),
+                        action_detail=detail,
+                    )
+                    component_operations.extend(res.get('component_operations') or [])
+                    if log_component_operations:
+                        component_operations.append(
+                            AuthComponentOperationRecord(
+                                auth_processing_id=claimed_by_corp[res['corp_num']]['id'],
+                                corp_num=res['corp_num'],
+                                flow_name=identity.flow_name,
+                                environment=config.DATA_LOAD_ENV,
+                                flow_run_id=flow_run_id,
+                                operation=identity.operation,
+                                operation_scope=identity.operation_scope,
+                                component=AuthOperationScope.FULL_ENTITY,
+                                target_type='tracking',
+                                target_value=res['corp_num'],
+                                action='CLEANUP_FULL_RESET_TRACKING',
+                                error=err,
+                                detail='result:FAILED; reset_cleanup_error',
+                                dry_run=plan.dry_run,
+                            )
+                        )
+                    total_failed += 1
+                    cleanup_errors.append(err)
+                    continue
+
+                if full_reset_sweep:
+                    update_auth_processing_from_task_result(
+                        tracking=tracking,
+                        flow_run_id=flow_run_id,
+                        result=res,
+                        status=ProcessingStatuses.COMPLETED,
+                    )
+                    component_operations.extend(res.get('component_operations') or [])
+
                 total_completed += 1
+                continue
+
+            update_auth_processing_from_task_result(
+                tracking=tracking,
+                flow_run_id=flow_run_id,
+                result=res,
+                status=ProcessingStatuses.FAILED,
+            )
+            component_operations.extend(res.get('component_operations') or [])
+            total_failed += 1
+
+        insert_failed_state = insert_component_operations_or_failed(auth_tracking, component_operations)
+        if insert_failed_state:
+            return insert_failed_state
+
+        if cleanup_errors:
+            return Failed(message='; '.join(cleanup_errors[:3]))
 
         cnt += 1
-        print(f'🌟 Complete round {cnt}/{batches}. Completed={total_completed}, Failed={total_failed}')
+        print(f'🌟 Complete round {cnt}/{reservation.batches}. Completed={total_completed}, Failed={total_failed}')
 
     if total_failed > 0:
-        return Failed(message=f'{total_failed} corps failed in {FLOW_NAME}.')
+        return Failed(message=f'{total_failed} corps failed in {identity.flow_name}.')
 
-    print(f'🌰 {FLOW_NAME} complete. Completed={total_completed}, Failed={total_failed}')
+    print(f'🌰 {identity.flow_name} complete. Completed={total_completed}, Failed={total_failed}')
 
 
 if __name__ == '__main__':

--- a/data-tool/flows/auth/auth_flow_utils.py
+++ b/data-tool/flows/auth/auth_flow_utils.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Optional, Sequence
+
+from .auth_models import (
+    AuthDeletePlan,
+    AuthOperation,
+    AuthOperationScope,
+    AuthProcessingIdentity,
+    AuthRepeatability,
+    AuthRepeatableCampaign,
+)
+
+AUTH_CREATE_FLOW_NAME = 'auth-create-flow'
+AUTH_CONTACT_FLOW_NAME = 'auth-contact-flow'
+AUTH_AFFILIATION_CREATE_FLOW_NAME = 'auth-affiliation-create-flow'
+AUTH_INVITE_FLOW_NAME = 'auth-invite-flow'
+AUTH_DELETE_FLOW_NAME = 'auth-delete-flow'
+
+AUTH_PROCESSING_IDENTITY_CONFLICT_COLUMNS: Sequence[str] = (
+    'corp_num',
+    'flow_name',
+    'environment',
+    'operation',
+    'operation_scope',
+    'attempt_key',
+)
+
+
+def _flow_run_id_text(flow_run_id) -> str:
+    """Return flow_run_id text, raising when an attempt-specific key needs one."""
+    value = str(flow_run_id or '').strip()
+    if not value:
+        raise ValueError('flow_run_id is required to build auth attempt identity')
+    return value
+
+
+def build_auth_attempt_key_from_context(attempt_key_context: str) -> str:
+    """Build the hash-only auth_processing attempt_key from its canonical text context."""
+    if not isinstance(attempt_key_context, str) or not attempt_key_context:
+        raise ValueError('attempt_key_context is required to build auth attempt identity')
+    digest = hashlib.sha256(attempt_key_context.encode('utf-8')).hexdigest()
+    return f'ATTEMPT:v1:{digest}'
+
+
+def build_auth_attempt_key_context(
+    *,
+    flow_name: str,
+    operation: AuthOperation,
+    operation_scope: AuthOperationScope,
+    repeatability: AuthRepeatability,
+    flow_run_id,
+    dry_run: bool = False,
+    campaign: Optional[AuthRepeatableCampaign] = None,
+) -> str:
+    """Build the canonical readable preimage for auth_processing attempt identity."""
+    operation_value = AuthOperation(operation).value
+    scope_value = AuthOperationScope(operation_scope).value
+
+    if dry_run:
+        return f'DRY_RUN:v1:{flow_name}:{operation_value}:{scope_value}:{_flow_run_id_text(flow_run_id)}'
+    if repeatability == AuthRepeatability.ONE_SHOT:
+        return f'ONE_SHOT:v1:{flow_name}:{operation_value}:{scope_value}'
+    if repeatability == AuthRepeatability.REPEATABLE:
+        if campaign is None:
+            raise ValueError('campaign is required for non-dry-run repeatable auth identity')
+        return campaign.attempt_key_context
+    if repeatability == AuthRepeatability.RESET:
+        if campaign is not None:
+            return campaign.attempt_key_context
+        return f'RESET:v1:{flow_name}:{operation_value}:{scope_value}'
+    raise ValueError(f'Unsupported auth repeatability: {repeatability}')
+
+
+def build_auth_processing_identity(
+    *,
+    flow_name: str,
+    operation: AuthOperation,
+    operation_scope: AuthOperationScope,
+    repeatability: AuthRepeatability,
+    flow_run_id,
+    dry_run: bool = False,
+    campaign: Optional[AuthRepeatableCampaign] = None,
+    operation_target: Optional[str] = None,
+    full_reset_sweep: bool = False,
+) -> AuthProcessingIdentity:
+    """Create an AuthProcessingIdentity with the correct attempt key."""
+    if (
+        repeatability in (AuthRepeatability.REPEATABLE, AuthRepeatability.RESET)
+        and not dry_run
+        and campaign is not None
+        and operation_target is None
+    ):
+        operation_target = campaign.operation_target
+
+    attempt_key_context = build_auth_attempt_key_context(
+        flow_name=flow_name,
+        operation=operation,
+        operation_scope=operation_scope,
+        repeatability=repeatability,
+        flow_run_id=flow_run_id,
+        dry_run=dry_run,
+        campaign=campaign,
+    )
+
+    return AuthProcessingIdentity(
+        flow_name=flow_name,
+        operation=operation,
+        operation_scope=operation_scope,
+        repeatability=repeatability,
+        attempt_key_context=attempt_key_context,
+        attempt_key=build_auth_attempt_key_from_context(attempt_key_context),
+        dry_run=dry_run,
+        operation_target=operation_target,
+        full_reset_sweep=full_reset_sweep,
+    )
+
+
+def auth_create_identity(flow_run_id, *, dry_run: bool = False) -> AuthProcessingIdentity:
+    """Identity for the one-shot Auth entity create flow."""
+    return build_auth_processing_identity(
+        flow_name=AUTH_CREATE_FLOW_NAME,
+        operation=AuthOperation.CREATE,
+        operation_scope=AuthOperationScope.ENTITY,
+        repeatability=AuthRepeatability.ONE_SHOT,
+        flow_run_id=flow_run_id,
+        dry_run=dry_run,
+    )
+
+
+def auth_contact_identity(
+    flow_run_id,
+    *,
+    dry_run: bool = False,
+    campaign: Optional[AuthRepeatableCampaign] = None,
+    operation_target: Optional[str] = None,
+) -> AuthProcessingIdentity:
+    """Identity for repeatable Auth contact upsert runs."""
+    return build_auth_processing_identity(
+        flow_name=AUTH_CONTACT_FLOW_NAME,
+        operation=AuthOperation.UPSERT,
+        operation_scope=AuthOperationScope.CONTACT,
+        repeatability=AuthRepeatability.REPEATABLE,
+        flow_run_id=flow_run_id,
+        dry_run=dry_run,
+        campaign=campaign,
+        operation_target=operation_target,
+    )
+
+
+def auth_affiliation_identity(
+    flow_run_id,
+    *,
+    dry_run: bool = False,
+    campaign: Optional[AuthRepeatableCampaign] = None,
+    operation_target: Optional[str] = None,
+) -> AuthProcessingIdentity:
+    """Identity for repeatable affiliation create runs."""
+    return build_auth_processing_identity(
+        flow_name=AUTH_AFFILIATION_CREATE_FLOW_NAME,
+        operation=AuthOperation.CREATE,
+        operation_scope=AuthOperationScope.AFFILIATION,
+        repeatability=AuthRepeatability.REPEATABLE,
+        flow_run_id=flow_run_id,
+        dry_run=dry_run,
+        campaign=campaign,
+        operation_target=operation_target,
+    )
+
+
+def auth_invite_identity(
+    flow_run_id,
+    *,
+    dry_run: bool = False,
+    campaign: Optional[AuthRepeatableCampaign] = None,
+    operation_target: Optional[str] = None,
+) -> AuthProcessingIdentity:
+    """Identity for repeatable unaffiliated invite sends."""
+    return build_auth_processing_identity(
+        flow_name=AUTH_INVITE_FLOW_NAME,
+        operation=AuthOperation.SEND,
+        operation_scope=AuthOperationScope.INVITE,
+        repeatability=AuthRepeatability.REPEATABLE,
+        flow_run_id=flow_run_id,
+        dry_run=dry_run,
+        campaign=campaign,
+        operation_target=operation_target,
+    )
+
+
+def auth_delete_identity(
+    plan: AuthDeletePlan,
+    flow_run_id,
+    *,
+    campaign: Optional[AuthRepeatableCampaign] = None,
+    operation_target: Optional[str] = None,
+) -> AuthProcessingIdentity:
+    """Identity for supported Auth delete flow modes.
+
+    Full entity delete uses RESET/FULL_ENTITY. Affiliation-only delete remains repeatable.
+    """
+    if not (plan.delete_entity or plan.delete_affiliations):
+        raise ValueError('At least one auth delete operation must be selected')
+
+    if plan.delete_entity:
+        return build_auth_processing_identity(
+            flow_name=AUTH_DELETE_FLOW_NAME,
+            operation=AuthOperation.RESET,
+            operation_scope=AuthOperationScope.FULL_ENTITY,
+            repeatability=AuthRepeatability.RESET,
+            flow_run_id=flow_run_id,
+            dry_run=plan.dry_run,
+            campaign=campaign,
+            operation_target=operation_target,
+            full_reset_sweep=bool(campaign is not None and not plan.dry_run),
+        )
+
+    return build_auth_processing_identity(
+        flow_name=AUTH_DELETE_FLOW_NAME,
+        operation=AuthOperation.DELETE,
+        operation_scope=AuthOperationScope.AFFILIATION,
+        repeatability=AuthRepeatability.REPEATABLE,
+        flow_run_id=flow_run_id,
+        dry_run=plan.dry_run,
+        campaign=campaign,
+        operation_target=operation_target,
+    )
+
+
+def _config_bool(config, attr: str, default: bool) -> bool:
+    """Return a bool config value, accepting real bools and env-style strings."""
+    value = getattr(config, attr, default)
+    if isinstance(value, str):
+        return value.strip().lower() == 'true'
+    if value is None:
+        return default
+    return bool(value)
+
+
+def auth_component_operation_logging_enabled(config) -> bool:
+    """Return whether component-operation logging is enabled; defaults to false."""
+    return _config_bool(config, 'AUTH_LOG_COMPONENT_OPERATIONS', False)

--- a/data-tool/flows/auth/auth_invite_flow.py
+++ b/data-tool/flows/auth/auth_invite_flow.py
@@ -1,178 +1,171 @@
-import math
-import os
-from typing import Dict, List
-
 from prefect import flow
 from prefect.context import get_run_context
-from prefect.futures import wait
 from prefect.states import Failed
 from prefect.task_runners import ConcurrentTaskRunner
-from sqlalchemy import text
 
-from common.extract_tracking_service import ExtractTrackingService, ProcessingStatuses
+from common.extract_tracking_service import ProcessingStatuses
 from common.init_utils import colin_extract_init, get_config
-from common.query_utils import convert_result_set_to_dict
 
-from .auth_models import AuthCreatePlan, AuthSelectionMode
-from .auth_queries import (
-    get_auth_business_profiles_query,
-    get_auth_reservable_corps_query,
-    get_auth_reservable_count_query,
+from .auth_flow_utils import auth_invite_identity
+from .auth_models import AuthCreatePlan
+from .auth_orchestration import (
+    AUTH_INVITE_ACTION_FIELDS,
+    AuthReservationOptions,
+    AuthSubmittedTask,
+    build_auth_repeatable_campaign,
+    build_auth_tracking_services,
+    calculate_max_corps,
+    claim_auth_batch,
+    count_auth_reservable,
+    describe_auth_effective_selection,
+    fetch_auth_profiles,
+    finalize_auth_task_results,
+    get_auth_max_workers,
+    get_batch_token_or_mark_failed,
+    insert_component_operations_or_failed,
+    log_auth_config_preflight,
+    parse_auth_selection_mode,
+    planned_failure_actions,
+    reserve_auth_candidates,
+    validate_auth_throughput,
 )
-from .auth_tasks import get_auth_token, perform_auth_create_for_corp
-
-FLOW_NAME = 'auth-invite-flow'
-
-
-def _get_max_workers() -> int:
-    try:
-        v = int(os.getenv('AUTH_MAX_WORKERS', '50'))
-        return v if v > 0 else 50
-    except Exception:
-        return 50
-
-
-def _parse_selection_mode(config) -> AuthSelectionMode:
-    raw = (getattr(config, 'AUTH_SELECTION_MODE', 'MIGRATION_FILTER') or 'MIGRATION_FILTER').strip().upper()
-    try:
-        return AuthSelectionMode(raw)
-    except Exception as e:
-        raise ValueError(f'Unknown AUTH_SELECTION_MODE: {raw}') from e
-
-
-def _fetch_profiles(colin_engine, corp_nums: List[str], suffix: str) -> Dict[str, dict]:
-    if not corp_nums:
-        return {}
-    sql = get_auth_business_profiles_query(corp_nums, suffix or '')
-    with colin_engine.connect() as conn:
-        rs = conn.execute(text(sql))
-        rows = convert_result_set_to_dict(rs)
-        return {r['identifier']: r for r in rows}
+from .auth_tasks import perform_auth_create_for_corp
 
 
 @flow(
     name='Auth-Invite-Flow',
     log_prints=True,
     persist_result=False,
-    task_runner=ConcurrentTaskRunner(max_workers=_get_max_workers())
+    task_runner=ConcurrentTaskRunner(max_workers=get_auth_max_workers())
 )
 def auth_invite_flow():
     """
     Send unaffiliated invite for an entity.
 
-    Optionally upserts contact email first (AUTH_UPSERT_CONTACT).
+    This flow is invite-only. Run auth_contact_flow first if contact repair is needed.
     (Affiliations are mutually exclusive with invites; this flow does invites only.)
 
-    Selection excludes any corp already tracked in auth_processing for (corp_num, FLOW_NAME, environment).
+    Repeatable by Auth identity; each real run creates a new auth_processing attempt row.
     """
     config = get_config()
-    colin_engine = colin_extract_init(config)
-    selection_mode = _parse_selection_mode(config)
+    selection_mode = parse_auth_selection_mode(config)
 
     plan = AuthCreatePlan(
         create_entity=False,
-        upsert_contact=bool(getattr(config, 'AUTH_UPSERT_CONTACT', False)),
+        upsert_contact=False,
         create_affiliations=False,
         send_unaffiliated_invite=True,
         fail_if_missing_email=bool(getattr(config, 'AUTH_FAIL_IF_MISSING_EMAIL', False)),
         dry_run=bool(getattr(config, 'AUTH_DRY_RUN', False)),
     )
 
-    count_sql = get_auth_reservable_count_query(
-        flow_name=FLOW_NAME,
-        config=config,
-        selection_mode=selection_mode
+    log_auth_config_preflight(
+        config,
+        selection_mode,
+        flow_label='invite',
+        dry_run=plan.dry_run,
+        campaign_scope_applies=True,
     )
-    with colin_engine.connect() as conn:
-        total_reservable = int(conn.execute(text(count_sql)).scalar() or 0)
 
+    flow_run_id = get_run_context().flow_run.id
+    campaign = build_auth_repeatable_campaign(
+        config,
+        selection_mode,
+        dry_run=plan.dry_run,
+        flow_label='invite',
+    )
+    identity = auth_invite_identity(flow_run_id, dry_run=plan.dry_run, campaign=campaign)
+    print(f'👷 {describe_auth_effective_selection(config, selection_mode, dry_run=plan.dry_run, campaign=campaign)}')
+    colin_engine = colin_extract_init(config)
+
+    total_reservable = count_auth_reservable(
+        colin_engine=colin_engine,
+        config=config,
+        selection_mode=selection_mode,
+        identity=identity,
+    )
     if total_reservable <= 0:
         print('No reservable corps found for this run.')
         return
 
-    if getattr(config, 'AUTH_BATCHES', 0) <= 0:
-        raise ValueError('AUTH_BATCHES must be explicitly set to a positive integer')
-    if getattr(config, 'AUTH_BATCH_SIZE', 0) <= 0:
-        raise ValueError('AUTH_BATCH_SIZE must be explicitly set to a positive integer')
-
+    validate_auth_throughput(config)
     batch_size = config.AUTH_BATCH_SIZE
-    max_corps = min(total_reservable, config.AUTH_BATCHES * config.AUTH_BATCH_SIZE)
+    max_corps = calculate_max_corps(config, total_reservable)
 
-    flow_run_id = get_run_context().flow_run.id
-
-    tracking = ExtractTrackingService(
-        config.DATA_LOAD_ENV,
-        colin_engine,
-        FLOW_NAME,
-        table_name='auth_processing',
-        statement_timeout_ms=getattr(config, 'RESERVE_STATEMENT_TIMEOUT_MS', None)
-    )
-
-    extra_insert_cols = ['contact_email']
-
-    base_query = get_auth_reservable_corps_query(
-        flow_name=FLOW_NAME,
+    tracking, auth_tracking, log_component_operations = build_auth_tracking_services(config, colin_engine, identity)
+    reservation = reserve_auth_candidates(
         config=config,
-        batch_size=max_corps,
-        selection_mode=selection_mode,
-        include_account_ids=False,
-        include_contact_email=True
-    )
-
-    reserved = tracking.reserve_for_flow(
-        base_query=base_query,
+        tracking=tracking,
+        identity=identity,
         flow_run_id=flow_run_id,
-        extra_insert_cols=extra_insert_cols
+        selection_mode=selection_mode,
+        batch_size=batch_size,
+        max_corps=max_corps,
+        options=AuthReservationOptions(include_contact_email=True),
     )
 
-    if reserved <= 0:
+    if reservation.reserved <= 0:
         print('No corps reserved (cohort may be exhausted or already reserved).')
         return
 
-    batches = min(math.ceil(reserved / batch_size), config.AUTH_BATCHES)
-
     print(f'👷 Auth invite plan: {plan}')
-    print(f'👷 Reservable={total_reservable}, Reserved={reserved}, Batches={batches}, BatchSize={batch_size}')
-    print(f'👷 SelectionMode={selection_mode.value}, DryRun={plan.dry_run}')
+    print(
+        f'👷 Reservable={total_reservable}, Reserved={reservation.reserved}, '
+        f'Batches={reservation.batches}, BatchSize={batch_size}'
+    )
 
     cnt = 0
     total_failed = 0
     total_completed = 0
 
-    while cnt < batches:
-        claimed = tracking.claim_batch(
-            flow_run_id,
-            batch_size,
-            extra_return_cols=extra_insert_cols,
-            as_dict=True
+    token_failure_actions = planned_failure_actions(
+        entity=False,
+        contact=False,
+        affiliation=False,
+        invite=True,
+        action_detail='token_error',
+    )
+    profile_failure_actions = planned_failure_actions(
+        entity=False,
+        contact=False,
+        affiliation=False,
+        invite=True,
+        action_detail='profile_missing',
+    )
+    task_failure_actions = planned_failure_actions(
+        entity=False,
+        contact=False,
+        affiliation=False,
+        invite=True,
+        action_detail='task_result_error',
+    )
+
+    while cnt < reservation.batches:
+        claimed = claim_auth_batch(
+            tracking=tracking,
+            flow_run_id=flow_run_id,
+            batch_size=batch_size,
+            extra_insert_cols=reservation.extra_insert_cols,
         )
         if not claimed:
             print('No more corps available to claim')
             break
 
         corp_nums = [r['corp_num'] for r in claimed]
-        profiles = _fetch_profiles(colin_engine, corp_nums, getattr(config, 'CORP_NAME_SUFFIX', '') or '')
+        claimed_by_corp = {r['corp_num']: r for r in claimed}
+        profiles = fetch_auth_profiles(colin_engine, corp_nums, getattr(config, 'CORP_NAME_SUFFIX', '') or '')
 
-        try:
-            token = get_auth_token(config)
-        except Exception as e:
-            err = f'Failed to obtain auth token: {repr(e)}'
-            print(f'❌ {err}')
-            for corp_num in corp_nums:
-                tracking.update_corp_status(
-                    flow_run_id,
-                    corp_num,
-                    ProcessingStatuses.FAILED,
-                    error=err,
-                    entity_action='NOT_RUN',
-                    contact_action='FAILED' if plan.upsert_contact else 'NOT_RUN',
-                    affiliation_action='NOT_RUN',
-                    invite_action='FAILED',
-                    action_detail='token_error'
-                )
-            return Failed(message=err)
+        token, failed_state = get_batch_token_or_mark_failed(
+            config=config,
+            tracking=tracking,
+            flow_run_id=flow_run_id,
+            corp_nums=corp_nums,
+            failure_actions=token_failure_actions,
+        )
+        if failed_state:
+            return failed_state
 
-        futures = []
+        submitted: list[AuthSubmittedTask] = []
         for corp_num in corp_nums:
             profile = profiles.get(corp_num)
             if not profile:
@@ -182,60 +175,47 @@ def auth_invite_flow():
                     corp_num,
                     ProcessingStatuses.FAILED,
                     error='Missing business profile for corp in COLIN extract',
-                    entity_action='NOT_RUN',
-                    contact_action='FAILED' if plan.upsert_contact else 'NOT_RUN',
-                    affiliation_action='NOT_RUN',
-                    invite_action='FAILED',
-                    action_detail='profile_missing'
+                    **profile_failure_actions,
                 )
                 continue
 
-            futures.append(
-                perform_auth_create_for_corp.submit(
-                    config,
-                    corp_num,
-                    profile,
-                    [],
-                    plan,
-                    token
-                )
+            future = perform_auth_create_for_corp.submit(
+                config,
+                corp_num,
+                profile,
+                [],
+                plan,
+                token,
+                auth_processing_id=claimed_by_corp[corp_num]['id'],
+                identity=identity,
+                flow_run_id=flow_run_id,
+                log_component_operations=log_component_operations,
             )
+            submitted.append(AuthSubmittedTask(future, corp_num, task_failure_actions))
 
-        wait(futures)
+        finalization = finalize_auth_task_results(
+            tracking=tracking,
+            flow_run_id=flow_run_id,
+            submitted=submitted,
+            status_action_fields=AUTH_INVITE_ACTION_FIELDS,
+        )
+        total_failed += finalization.failed
+        total_completed += finalization.completed
 
-        for f in futures:
-            res = f.result()
-            actions = [
-                res.get('contact_action'),
-                res.get('invite_action'),
-            ]
-            failed = any(a == 'FAILED' for a in actions if a)
-            status = ProcessingStatuses.FAILED if failed else ProcessingStatuses.COMPLETED
-
-            tracking.update_corp_status(
-                flow_run_id,
-                res['corp_num'],
-                status,
-                error=res.get('error'),
-                entity_action=res.get('entity_action'),
-                contact_action=res.get('contact_action'),
-                affiliation_action=res.get('affiliation_action'),
-                invite_action=res.get('invite_action'),
-                action_detail=res.get('action_detail')
-            )
-
-            if status == ProcessingStatuses.FAILED:
-                total_failed += 1
-            else:
-                total_completed += 1
+        insert_failed_state = insert_component_operations_or_failed(
+            auth_tracking,
+            finalization.component_operations,
+        )
+        if insert_failed_state:
+            return insert_failed_state
 
         cnt += 1
-        print(f'🌟 Complete round {cnt}/{batches}. Completed={total_completed}, Failed={total_failed}')
+        print(f'🌟 Complete round {cnt}/{reservation.batches}. Completed={total_completed}, Failed={total_failed}')
 
     if total_failed > 0:
-        return Failed(message=f'{total_failed} corps failed in {FLOW_NAME}.')
+        return Failed(message=f'{total_failed} corps failed in {identity.flow_name}.')
 
-    print(f'🌰 {FLOW_NAME} complete. Completed={total_completed}, Failed={total_failed}')
+    print(f'🌰 {identity.flow_name} complete. Completed={total_completed}, Failed={total_failed}')
 
 
 if __name__ == '__main__':

--- a/data-tool/flows/auth/auth_models.py
+++ b/data-tool/flows/auth/auth_models.py
@@ -1,12 +1,19 @@
 from dataclasses import dataclass
 from enum import Enum
+from typing import Dict, Optional
 
 
 class AuthSelectionMode(str, Enum):
     """How an auth flow selects candidate corps to process."""
     MANUAL = "MANUAL"
     MIGRATION_FILTER = "MIGRATION_FILTER"
-    CORP_PROCESSING = "CORP_PROCESSING"
+
+
+class AuthDeleteTrackingCleanupMode(str, Enum):
+    """Cleanup-only behavior for auth-delete-flow tracking rows."""
+    OFF = "OFF"
+    PREVIEW = "PREVIEW"
+    EXECUTE = "EXECUTE"
 
 
 class AuthComponentStatus(str, Enum):
@@ -15,6 +22,69 @@ class AuthComponentStatus(str, Enum):
     SKIPPED = "SKIPPED"
     FAILED = "FAILED"
     NOT_RUN = "NOT_RUN"
+
+
+class AuthOperation(str, Enum):
+    """High-level Auth operation identity stored in auth_processing."""
+    CREATE = "CREATE"
+    UPSERT = "UPSERT"
+    DELETE = "DELETE"
+    SEND = "SEND"
+    RESET = "RESET"
+
+
+class AuthOperationScope(str, Enum):
+    """Auth operation scope stored in auth_processing."""
+    ENTITY = "ENTITY"
+    CONTACT = "CONTACT"
+    AFFILIATION = "AFFILIATION"
+    INVITE = "INVITE"
+    FULL_ENTITY = "FULL_ENTITY"
+
+
+class AuthRepeatability(str, Enum):
+    """Reservation/attempt policy for auth_processing identity."""
+    ONE_SHOT = "ONE_SHOT"
+    REPEATABLE = "REPEATABLE"
+    RESET = "RESET"
+
+
+@dataclass(frozen=True)
+class AuthRepeatableCampaign:
+    """Stable campaign identity for real repeatable auth flows."""
+    cycle_key: str
+    campaign_scope: str
+    attempt_key_context: str
+    attempt_key: str
+    operation_target: str
+
+
+@dataclass(frozen=True)
+class AuthProcessingIdentity:
+    """Complete auth_processing operation identity for one reservation attempt."""
+    flow_name: str
+    operation: AuthOperation
+    operation_scope: AuthOperationScope
+    repeatability: AuthRepeatability
+    attempt_key_context: str
+    attempt_key: str
+    dry_run: bool = False
+    operation_target: Optional[str] = None
+    full_reset_sweep: bool = False
+
+    def as_insert_values(self) -> Dict[str, object]:
+        """Return static insert values for auth_processing rows."""
+        values: Dict[str, object] = {
+            'operation': self.operation.value,
+            'operation_scope': self.operation_scope.value,
+            'repeatability': self.repeatability.value,
+            'attempt_key': self.attempt_key,
+            'attempt_key_context': self.attempt_key_context,
+            'dry_run': self.dry_run,
+        }
+        if self.operation_target is not None:
+            values['operation_target'] = self.operation_target
+        return values
 
 
 @dataclass(frozen=True)
@@ -26,6 +96,7 @@ class AuthCreatePlan:
     send_unaffiliated_invite: bool = False
     fail_if_missing_email: bool = False
     dry_run: bool = False
+    allow_entity_creation_for_affiliations: bool = True
 
 
 @dataclass(frozen=True)
@@ -33,5 +104,4 @@ class AuthDeletePlan:
     """Immutable plan for delete-like auth flows."""
     delete_affiliations: bool = False
     delete_entity: bool = False
-    delete_invites: bool = False  # only if supported by API
     dry_run: bool = False

--- a/data-tool/flows/auth/auth_orchestration.py
+++ b/data-tool/flows/auth/auth_orchestration.py
@@ -1,0 +1,675 @@
+from __future__ import annotations
+
+import hashlib
+import math
+import os
+import re
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from prefect.futures import wait
+from prefect.states import Failed
+from sqlalchemy import text
+
+from common.extract_tracking_service import ExtractTrackingService, ProcessingStatuses
+from common.query_utils import convert_result_set_to_dict
+
+from .auth_flow_utils import AUTH_PROCESSING_IDENTITY_CONFLICT_COLUMNS, build_auth_attempt_key_from_context
+from .auth_models import (
+    AuthCreatePlan,
+    AuthDeletePlan,
+    AuthDeleteTrackingCleanupMode,
+    AuthProcessingIdentity,
+    AuthRepeatableCampaign,
+    AuthSelectionMode,
+)
+from .auth_queries import (
+    get_auth_business_profiles_query,
+    get_auth_query_params,
+    get_auth_reservable_corps_query,
+    get_auth_reservable_count_query,
+)
+from .auth_selection import (
+    auth_migration_filter_ids,
+    corp_nums_scope_hash,
+    corp_nums_subset_scope,
+    parse_auth_corp_nums_csv,
+    parse_positive_int_csv,
+    positive_int_csv_for_scope,
+)
+from .auth_tasks import get_auth_token
+from .auth_tracking import AuthComponentOperationRecord, AuthTrackingService
+
+
+AUTH_ALL_ACTION_FIELDS = (
+    'entity_action',
+    'contact_action',
+    'affiliation_action',
+    'invite_action',
+)
+AUTH_CONTACT_ACTION_FIELDS = ('contact_action',)
+AUTH_INVITE_ACTION_FIELDS = ('invite_action',)
+
+
+@dataclass(frozen=True)
+class AuthReservationOptions:
+    include_account_ids: bool = False
+    include_contact_email: bool = False
+
+
+@dataclass(frozen=True)
+class AuthReservationResult:
+    reserved: int
+    batches: int
+    extra_insert_cols: list[str]
+
+
+@dataclass(frozen=True)
+class AuthSubmittedTask:
+    future: Any
+    corp_num: str
+    failure_actions: dict[str, str]
+
+
+@dataclass(frozen=True)
+class AuthBatchFinalizationResult:
+    completed: int
+    failed: int
+    component_operations: list[AuthComponentOperationRecord]
+
+
+def get_auth_max_workers() -> int:
+    try:
+        v = int(os.getenv('AUTH_MAX_WORKERS', '50'))
+        return v if v > 0 else 50
+    except Exception:
+        return 50
+
+
+def parse_auth_selection_mode(config) -> AuthSelectionMode:
+    raw = (getattr(config, 'AUTH_SELECTION_MODE', 'MIGRATION_FILTER') or 'MIGRATION_FILTER').strip().upper()
+    try:
+        return AuthSelectionMode(raw)
+    except Exception as e:
+        raise ValueError(f'Unknown AUTH_SELECTION_MODE: {raw}') from e
+
+
+def parse_auth_delete_tracking_cleanup_mode(config) -> AuthDeleteTrackingCleanupMode:
+    """Return normalized auth delete tracking cleanup mode."""
+    raw = (getattr(config, 'AUTH_DELETE_TRACKING_CLEANUP_MODE', 'OFF') or 'OFF').strip().upper()
+    try:
+        return AuthDeleteTrackingCleanupMode(raw)
+    except Exception as e:
+        allowed = ', '.join(mode.value for mode in AuthDeleteTrackingCleanupMode)
+        raise ValueError(f'Unknown AUTH_DELETE_TRACKING_CLEANUP_MODE: {raw}; expected one of {allowed}') from e
+
+
+_CYCLE_KEY_RE = re.compile(r'^[A-Za-z0-9_.:-]+$')
+_CAMPAIGN_SCOPE_RE = re.compile(r'^[A-Za-z0-9_.:/=-]+$')
+_MAX_CYCLE_KEY_LEN = 80
+_MAX_EXPLICIT_SCOPE_LEN = 240
+_MAX_OPERATION_TARGET_LEN = 500
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode('utf-8')).hexdigest()
+
+
+def _preview_text(value: str, max_len: int) -> str:
+    if max_len <= 0:
+        return ''
+    if len(value) <= max_len:
+        return value
+    if max_len == 1:
+        return value[:1]
+    return f'{value[:max_len - 1]}~'
+
+
+def normalize_auth_repeatable_cycle_key(config, *, missing_message: str | None = None) -> str:
+    """Return normalized AUTH_REPEATABLE_CYCLE_KEY or raise for real auth flows."""
+    cycle_key = str(getattr(config, 'AUTH_REPEATABLE_CYCLE_KEY', '') or '').strip()
+    if not cycle_key:
+        raise ValueError(missing_message or 'AUTH_REPEATABLE_CYCLE_KEY is required for non-dry-run repeatable auth flows')
+    if len(cycle_key) > _MAX_CYCLE_KEY_LEN:
+        raise ValueError(f'AUTH_REPEATABLE_CYCLE_KEY must be {_MAX_CYCLE_KEY_LEN} characters or fewer')
+    if not _CYCLE_KEY_RE.fullmatch(cycle_key):
+        raise ValueError('AUTH_REPEATABLE_CYCLE_KEY may contain only letters, digits, underscore, dash, dot, and colon')
+    return cycle_key
+
+
+def validate_auth_cycle_key_for_flow(
+    config,
+    *,
+    flow_label: str,
+    dry_run: bool,
+    missing_message: str | None = None,
+    log_context: str | None = None,
+) -> str | None:
+    """Validate/log the normalized auth cycle key for non-dry-run flow entrypoints."""
+    if dry_run:
+        return None
+
+    label = str(flow_label or '').strip() or 'flow'
+    cycle_key = normalize_auth_repeatable_cycle_key(
+        config,
+        missing_message=missing_message or f'AUTH_REPEATABLE_CYCLE_KEY is required for non-dry-run auth {label} runs',
+    )
+    context = f' ({log_context})' if log_context else ''
+    print(f'👷 Auth {label} cycle key: {cycle_key}{context}')
+    return cycle_key
+
+
+def _safe_positive_int_scope(config, attr: str, name: str) -> str:
+    """Return normalized CSV/ALL for preflight logs without raising on malformed config."""
+    try:
+        return positive_int_csv_for_scope(getattr(config, attr, None), name=name)
+    except ValueError as err:
+        return f'INVALID({err})'
+
+
+def auth_config_preflight_lines(
+    config,
+    selection_mode: AuthSelectionMode,
+    *,
+    flow_label: str,
+    dry_run: bool,
+    campaign_scope_applies: bool,
+) -> list[str]:
+    """Return safe operator-facing Auth config context before fail-fast validation.
+
+    This intentionally does not enforce required Auth migration IDs so operators can
+    see the selected mode, subset, and campaign-scope behavior before the later
+    validation raises the authoritative error.
+    """
+    label = str(flow_label or '').strip() or 'flow'
+    selection_mode = AuthSelectionMode(selection_mode)
+    lines: list[str] = []
+
+    if selection_mode == AuthSelectionMode.MIGRATION_FILTER:
+        group_scope = _safe_positive_int_scope(config, 'AUTH_MIG_GROUP_IDS', 'AUTH_MIG_GROUP_IDS')
+        batch_scope = _safe_positive_int_scope(config, 'AUTH_MIG_BATCH_IDS', 'AUTH_MIG_BATCH_IDS')
+        subset_scope = corp_nums_subset_scope(getattr(config, 'AUTH_CORP_NUMS', ''), all_label='ALL')
+        lines.append(
+            f'Auth {label} selection preflight: SelectionMode=MIGRATION_FILTER, '
+            f'AuthMigGroups={group_scope}, AuthMigBatches={batch_scope}, Subset={subset_scope}'
+        )
+        lines.append(
+            'Auth MIGRATION_FILTER note: AUTH_CORP_NUMS only narrows the migration-filter cohort '
+            'and does not replace AUTH_MIG_GROUP_IDS/AUTH_MIG_BATCH_IDS; Auth flows do not fall back '
+            'to global MIG_GROUP_IDS/MIG_BATCH_IDS.'
+        )
+    else:
+        corp_nums = parse_auth_corp_nums_csv(getattr(config, 'AUTH_CORP_NUMS', ''))
+        canonical_corp_nums = sorted(corp_nums)
+        subset_scope = f'count={len(canonical_corp_nums)};sha256={corp_nums_scope_hash(canonical_corp_nums)}'
+        lines.append(
+            f'Auth {label} selection preflight: SelectionMode=MANUAL, '
+            f'AuthCorpNums=count={len(corp_nums)}, Subset={subset_scope}'
+        )
+        lines.append(
+            'Auth MANUAL note: AUTH_CORP_NUMS is the source list; blank AUTH_CORP_NUMS means no '
+            'candidates; AUTH_MIG_GROUP_IDS/AUTH_MIG_BATCH_IDS are ignored.'
+        )
+
+    if not campaign_scope_applies:
+        return lines
+
+    if dry_run:
+        lines.append(
+            'Auth campaign preflight: dry-runs do not require AUTH_REPEATABLE_CAMPAIGN_SCOPE and use '
+            'a flow-run-specific dry-run attempt identity.'
+        )
+        return lines
+
+    explicit_scope = str(getattr(config, 'AUTH_REPEATABLE_CAMPAIGN_SCOPE', '') or '').strip()
+    if explicit_scope:
+        explicit_preview = _preview_text(explicit_scope, 80)
+        if selection_mode == AuthSelectionMode.MIGRATION_FILTER:
+            lines.append(
+                f'Auth campaign preflight: AUTH_REPEATABLE_CAMPAIGN_SCOPE is explicit ({explicit_preview}); '
+                'it overrides derived scope but does not bypass MIGRATION_FILTER Auth migration ID validation.'
+            )
+        else:
+            lines.append(
+                f'Auth campaign preflight: AUTH_REPEATABLE_CAMPAIGN_SCOPE is explicit ({explicit_preview}); '
+                'it overrides the derived selection scope.'
+            )
+    else:
+        lines.append(
+            'Auth campaign preflight: blank AUTH_REPEATABLE_CAMPAIGN_SCOPE is valid; real-run scope '
+            'will be derived from selection mode + Auth migration IDs + optional AUTH_CORP_NUMS subset hash.'
+        )
+    return lines
+
+
+def log_auth_config_preflight(
+    config,
+    selection_mode: AuthSelectionMode,
+    *,
+    flow_label: str,
+    dry_run: bool,
+    campaign_scope_applies: bool,
+) -> None:
+    """Print safe Auth selection/campaign-scope context for flow entrypoints."""
+    for line in auth_config_preflight_lines(
+        config,
+        selection_mode,
+        flow_label=flow_label,
+        dry_run=dry_run,
+        campaign_scope_applies=campaign_scope_applies,
+    ):
+        print(f'👷 {line}')
+
+
+def _normalize_explicit_campaign_scope(raw_scope: str) -> str:
+    campaign_scope = str(raw_scope or '').strip()
+    if not campaign_scope:
+        return ''
+    if len(campaign_scope) > _MAX_EXPLICIT_SCOPE_LEN:
+        raise ValueError(f'AUTH_REPEATABLE_CAMPAIGN_SCOPE must be {_MAX_EXPLICIT_SCOPE_LEN} characters or fewer')
+    if not _CAMPAIGN_SCOPE_RE.fullmatch(campaign_scope):
+        raise ValueError('AUTH_REPEATABLE_CAMPAIGN_SCOPE may contain only letters, digits, underscore, dash, dot, colon, slash, and equals')
+    return campaign_scope
+
+
+def _normalized_int_scope(config, attr: str, name: str) -> str:
+    values = parse_positive_int_csv(getattr(config, attr, None), name=name)
+    return ','.join(values) if values else 'ALL'
+
+
+def derive_auth_campaign_scope(config, selection_mode: AuthSelectionMode) -> str:
+    """Derive campaign scope from selection config unless an explicit override is set."""
+    selection_mode = AuthSelectionMode(selection_mode)
+    if selection_mode == AuthSelectionMode.MIGRATION_FILTER:
+        # Validation intentionally uses auth-specific IDs only; global MIG IDs are ignored.
+        auth_migration_filter_ids(config, require_any=True)
+
+    explicit_scope = _normalize_explicit_campaign_scope(
+        getattr(config, 'AUTH_REPEATABLE_CAMPAIGN_SCOPE', '')
+    )
+    if explicit_scope:
+        return explicit_scope
+
+    if selection_mode == AuthSelectionMode.MIGRATION_FILTER:
+        group_scope = _normalized_int_scope(config, 'AUTH_MIG_GROUP_IDS', 'AUTH_MIG_GROUP_IDS')
+        batch_scope = _normalized_int_scope(config, 'AUTH_MIG_BATCH_IDS', 'AUTH_MIG_BATCH_IDS')
+        subset_scope = corp_nums_subset_scope(getattr(config, 'AUTH_CORP_NUMS', ''), all_label='ALL')
+        return f'MIGRATION_FILTER:groups={group_scope};batches={batch_scope};subset={subset_scope}'
+
+    corp_nums = sorted(parse_auth_corp_nums_csv(getattr(config, 'AUTH_CORP_NUMS', '')))
+    return f'MANUAL:count={len(corp_nums)};sha256={corp_nums_scope_hash(corp_nums)}'
+
+
+def _build_repeatable_attempt_key_context(
+    *,
+    selection_mode: AuthSelectionMode,
+    cycle_key: str,
+    campaign_scope: str,
+) -> str:
+    """Build the readable canonical context for repeatable auth campaign identity."""
+    mode = AuthSelectionMode(selection_mode).value
+    return f'CYCLE:v1:{mode}:{cycle_key}:{campaign_scope}'
+
+
+def _build_operation_target(cycle_key: str, campaign_scope: str) -> str:
+    scope_hash = _sha256_text(campaign_scope)
+    prefix = f'cycle={cycle_key};scope='
+    suffix = f';scope_hash={scope_hash}'
+    if len(prefix) + len(campaign_scope) + len(suffix) <= _MAX_OPERATION_TARGET_LEN:
+        return f'{prefix}{campaign_scope}{suffix}'
+
+    max_scope_len = max(0, _MAX_OPERATION_TARGET_LEN - len(prefix) - len(suffix) - 3)
+    return f'{prefix}{campaign_scope[:max_scope_len]}...{suffix}'
+
+
+def build_auth_repeatable_campaign(
+    config,
+    selection_mode: AuthSelectionMode,
+    *,
+    dry_run: bool = False,
+    missing_cycle_key_message: str | None = None,
+    flow_label: str | None = None,
+) -> AuthRepeatableCampaign | None:
+    """Build stable campaign identity for real repeatable flows; dry-runs do not need one."""
+    if dry_run:
+        return None
+
+    if flow_label:
+        cycle_key = validate_auth_cycle_key_for_flow(
+            config,
+            flow_label=flow_label,
+            dry_run=dry_run,
+            missing_message=missing_cycle_key_message,
+        )
+    else:
+        cycle_key = normalize_auth_repeatable_cycle_key(config, missing_message=missing_cycle_key_message)
+    campaign_scope = derive_auth_campaign_scope(config, selection_mode)
+    attempt_key_context = _build_repeatable_attempt_key_context(
+        selection_mode=selection_mode,
+        cycle_key=cycle_key,
+        campaign_scope=campaign_scope,
+    )
+    return AuthRepeatableCampaign(
+        cycle_key=cycle_key,
+        campaign_scope=campaign_scope,
+        attempt_key_context=attempt_key_context,
+        attempt_key=build_auth_attempt_key_from_context(attempt_key_context),
+        operation_target=_build_operation_target(cycle_key, campaign_scope),
+    )
+
+
+def describe_auth_effective_selection(
+    config,
+    selection_mode: AuthSelectionMode,
+    *,
+    dry_run: bool,
+    campaign: AuthRepeatableCampaign | None = None,
+) -> str:
+    """Return a concise operator-facing summary of effective auth targeting."""
+    selection_mode = AuthSelectionMode(selection_mode)
+    if selection_mode == AuthSelectionMode.MIGRATION_FILTER:
+        auth_migration_filter_ids(config, require_any=True)
+        group_scope = _normalized_int_scope(config, 'AUTH_MIG_GROUP_IDS', 'AUTH_MIG_GROUP_IDS')
+        batch_scope = _normalized_int_scope(config, 'AUTH_MIG_BATCH_IDS', 'AUTH_MIG_BATCH_IDS')
+        subset_scope = corp_nums_subset_scope(getattr(config, 'AUTH_CORP_NUMS', ''), all_label='ALL')
+        target = f'SelectionMode=MIGRATION_FILTER, AuthMigGroups={group_scope}, AuthMigBatches={batch_scope}, Subset={subset_scope}'
+    else:
+        corp_nums = parse_auth_corp_nums_csv(getattr(config, 'AUTH_CORP_NUMS', ''))
+        canonical_corp_nums = sorted(corp_nums)
+        subset_scope = f'count={len(canonical_corp_nums)};sha256={corp_nums_scope_hash(canonical_corp_nums)}'
+        target = f'SelectionMode=MANUAL, AuthCorpNums=count={len(corp_nums)}, Subset={subset_scope}'
+
+    campaign_text = ''
+    if campaign is not None:
+        campaign_text = (
+            f', CycleKey={campaign.cycle_key}, CampaignScope={campaign.campaign_scope}, '
+            f'AttemptKey={campaign.attempt_key}, AttemptKeyContext={campaign.attempt_key_context}'
+        )
+    return f'{target}, DryRun={dry_run}{campaign_text}'
+
+
+def validate_auth_create_flow_plan(plan: AuthCreatePlan) -> None:
+    """Validate create-flow plan shape before one-shot CREATE/ENTITY reservation."""
+    has_any_action = any((
+        plan.create_entity,
+        plan.upsert_contact,
+        plan.create_affiliations,
+        plan.send_unaffiliated_invite,
+    ))
+    if not has_any_action:
+        raise ValueError('Invalid auth_create_flow plan: at least one create action must be enabled')
+    if not plan.create_entity:
+        raise ValueError(
+            'Invalid auth_create_flow plan: AUTH_CREATE_ENTITY must be True; '
+            'use dedicated contact, affiliation, or invite flows for component-only work'
+        )
+    if plan.create_affiliations and plan.send_unaffiliated_invite:
+        raise ValueError('Invalid auth_create_flow plan: cannot both create affiliations and send unaffiliated invite')
+
+
+def validate_auth_delete_flow_plan(plan: AuthDeletePlan) -> None:
+    """Validate delete-flow plan shape before delete/reset reservation."""
+    if not (plan.delete_affiliations or plan.delete_entity):
+        raise ValueError('Invalid auth_delete_flow plan: set at least one of AUTH_DELETE_AFFILIATIONS or AUTH_DELETE_ENTITY')
+
+
+def format_auth_delete_tracking_cleanup_summary(summary) -> list[str]:
+    """Return compact operator-facing cleanup summary lines."""
+    status_counts = ', '.join(
+        f'{status}={count}' for status, count in sorted((summary.status_counts or {}).items())
+    ) or 'none'
+    corp_sample = ', '.join(summary.corp_sample or []) or 'none'
+    return [
+        f'Auth delete tracking cleanup summary ({summary.flow_name}/{summary.environment})',
+        f'auth_processing rows: {summary.total_auth_processing_rows}',
+        f'distinct corps: {summary.distinct_corp_count}; sample: {corp_sample}',
+        f'processed_status counts: {status_counts}',
+        f'estimated auth_component_operation cascade rows: {summary.estimated_component_operation_rows}',
+    ]
+
+
+def fetch_auth_profiles(colin_engine, corp_nums: list[str], suffix: str) -> dict[str, dict]:
+    if not corp_nums:
+        return {}
+    sql = get_auth_business_profiles_query(corp_nums, suffix or '')
+    with colin_engine.connect() as conn:
+        rs = conn.execute(text(sql))
+        rows = convert_result_set_to_dict(rs)
+        return {r['identifier']: r for r in rows}
+
+
+def task_result_error(e: Exception) -> str:
+    return f'Task result error: {repr(e)}'[:1000]
+
+
+def count_auth_reservable(
+    *,
+    colin_engine,
+    config,
+    selection_mode: AuthSelectionMode,
+    identity: AuthProcessingIdentity,
+) -> int:
+    count_sql = get_auth_reservable_count_query(
+        flow_name=identity.flow_name,
+        config=config,
+        selection_mode=selection_mode,
+        identity=identity,
+    )
+    query_params = get_auth_query_params(identity)
+    with colin_engine.connect() as conn:
+        return int(conn.execute(text(count_sql), query_params).scalar() or 0)
+
+
+def validate_auth_throughput(config) -> None:
+    if getattr(config, 'AUTH_BATCHES', 0) <= 0:
+        raise ValueError('AUTH_BATCHES must be explicitly set to a positive integer')
+    if getattr(config, 'AUTH_BATCH_SIZE', 0) <= 0:
+        raise ValueError('AUTH_BATCH_SIZE must be explicitly set to a positive integer')
+
+
+def calculate_max_corps(config, total_reservable: int) -> int:
+    return min(total_reservable, config.AUTH_BATCHES * config.AUTH_BATCH_SIZE)
+
+
+def build_auth_tracking_services(config, colin_engine, identity: AuthProcessingIdentity):
+    tracking = ExtractTrackingService(
+        config.DATA_LOAD_ENV,
+        colin_engine,
+        identity.flow_name,
+        table_name='auth_processing',
+        statement_timeout_ms=getattr(config, 'RESERVE_STATEMENT_TIMEOUT_MS', None),
+    )
+    auth_tracking = AuthTrackingService.from_config(config, colin_engine)
+    return tracking, auth_tracking, auth_tracking.component_logging_enabled
+
+
+def reserve_auth_candidates(
+    *,
+    config,
+    tracking: ExtractTrackingService,
+    identity: AuthProcessingIdentity,
+    flow_run_id,
+    selection_mode: AuthSelectionMode,
+    batch_size: int,
+    max_corps: int,
+    options: AuthReservationOptions,
+) -> AuthReservationResult:
+    extra_insert_cols: list[str] = []
+    if options.include_account_ids:
+        extra_insert_cols.append('account_ids')
+    if options.include_contact_email:
+        extra_insert_cols.append('contact_email')
+
+    base_query = get_auth_reservable_corps_query(
+        flow_name=identity.flow_name,
+        config=config,
+        batch_size=max_corps,
+        selection_mode=selection_mode,
+        include_account_ids=options.include_account_ids,
+        include_contact_email=options.include_contact_email,
+        identity=identity,
+    )
+
+    reserved = tracking.reserve_for_flow(
+        base_query=base_query,
+        flow_run_id=flow_run_id,
+        extra_insert_cols=extra_insert_cols or None,
+        fallback_account_ids=(
+            getattr(config, 'AUTH_AFFILIATION_ACCOUNT_IDS_CSV', None)
+            if options.include_account_ids else None
+        ),
+        base_query_params=get_auth_query_params(identity),
+        static_insert_values=identity.as_insert_values(),
+        conflict_columns=AUTH_PROCESSING_IDENTITY_CONFLICT_COLUMNS,
+    )
+    batches = min(math.ceil(reserved / batch_size), config.AUTH_BATCHES) if reserved > 0 else 0
+    return AuthReservationResult(
+        reserved=reserved,
+        batches=batches,
+        extra_insert_cols=extra_insert_cols,
+    )
+
+
+def claim_auth_batch(
+    *,
+    tracking: ExtractTrackingService,
+    flow_run_id,
+    batch_size: int,
+    extra_insert_cols: list[str],
+) -> list[dict]:
+    return tracking.claim_batch(
+        flow_run_id,
+        batch_size,
+        extra_return_cols=['id'] + extra_insert_cols,
+        as_dict=True,
+    )
+
+
+def planned_failure_actions(
+    *,
+    entity: bool,
+    contact: bool,
+    affiliation: bool,
+    invite: bool,
+    action_detail: str,
+) -> dict[str, str]:
+    return {
+        'entity_action': 'FAILED' if entity else 'NOT_RUN',
+        'contact_action': 'FAILED' if contact else 'NOT_RUN',
+        'affiliation_action': 'FAILED' if affiliation else 'NOT_RUN',
+        'invite_action': 'FAILED' if invite else 'NOT_RUN',
+        'action_detail': action_detail,
+    }
+
+
+def get_batch_token_or_mark_failed(
+    *,
+    config,
+    tracking: ExtractTrackingService,
+    flow_run_id,
+    corp_nums: list[str],
+    failure_actions: dict[str, str],
+) -> tuple[Optional[str], Optional[Failed]]:
+    try:
+        return get_auth_token(config), None
+    except Exception as e:
+        err = f'Failed to obtain auth token: {repr(e)}'
+        print(f'❌ {err}')
+        for corp_num in corp_nums:
+            tracking.update_corp_status(
+                flow_run_id,
+                corp_num,
+                ProcessingStatuses.FAILED,
+                error=err,
+                **failure_actions,
+            )
+        return None, Failed(message=err)
+
+
+def has_failed_action(result: dict, action_fields: tuple[str, ...]) -> bool:
+    return any(result.get(field) == 'FAILED' for field in action_fields)
+
+
+def update_auth_processing_from_task_result(
+    *,
+    tracking: ExtractTrackingService,
+    flow_run_id,
+    result: dict,
+    status: ProcessingStatuses,
+) -> None:
+    tracking.update_corp_status(
+        flow_run_id,
+        result['corp_num'],
+        status,
+        error=result.get('error'),
+        entity_action=result.get('entity_action'),
+        contact_action=result.get('contact_action'),
+        affiliation_action=result.get('affiliation_action'),
+        invite_action=result.get('invite_action'),
+        action_detail=result.get('action_detail'),
+    )
+
+
+def finalize_auth_task_results(
+    *,
+    tracking: ExtractTrackingService,
+    flow_run_id,
+    submitted: list[AuthSubmittedTask],
+    status_action_fields: tuple[str, ...],
+) -> AuthBatchFinalizationResult:
+    if submitted:
+        wait([item.future for item in submitted])
+
+    component_operations: list[AuthComponentOperationRecord] = []
+    failed_count = 0
+    completed_count = 0
+
+    for item in submitted:
+        try:
+            result = item.future.result()
+        except Exception as e:
+            err = task_result_error(e)
+            tracking.update_corp_status(
+                flow_run_id,
+                item.corp_num,
+                ProcessingStatuses.FAILED,
+                error=err,
+                **item.failure_actions,
+            )
+            failed_count += 1
+            continue
+
+        component_operations.extend(result.get('component_operations') or [])
+        status = (
+            ProcessingStatuses.FAILED
+            if has_failed_action(result, status_action_fields)
+            else ProcessingStatuses.COMPLETED
+        )
+        update_auth_processing_from_task_result(
+            tracking=tracking,
+            flow_run_id=flow_run_id,
+            result=result,
+            status=status,
+        )
+
+        if status == ProcessingStatuses.FAILED:
+            failed_count += 1
+        else:
+            completed_count += 1
+
+    return AuthBatchFinalizationResult(
+        completed=completed_count,
+        failed=failed_count,
+        component_operations=component_operations,
+    )
+
+
+def insert_component_operations_or_failed(
+    auth_tracking: AuthTrackingService,
+    records: list[AuthComponentOperationRecord],
+) -> Optional[Failed]:
+    try:
+        auth_tracking.insert_component_operations_required(records)
+    except Exception as e:
+        return Failed(message=f'Auth component-operation logging failed: {repr(e)}')
+    return None

--- a/data-tool/flows/auth/auth_queries.py
+++ b/data-tool/flows/auth/auth_queries.py
@@ -1,8 +1,17 @@
 from __future__ import annotations
 
-from typing import List, Sequence
+from typing import Dict, List, Optional, Sequence
 
-from .auth_models import AuthSelectionMode
+from .auth_models import (
+    AuthProcessingIdentity,
+    AuthRepeatability,
+    AuthSelectionMode,
+)
+from .auth_selection import (
+    auth_migration_filter_ids,
+    parse_auth_corp_nums_csv,
+    positive_int_csv_for_sql,
+)
 
 # Match the existing tombstone corp type cohort by default.
 CORP_TYPE_FILTER = "('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')"
@@ -18,22 +27,241 @@ def _quote_list(values: Sequence[str]) -> str:
     return ", ".join([f"'{_escape_sql_literal(v)}'" for v in values])
 
 
+def get_auth_query_params(identity: Optional[AuthProcessingIdentity]) -> Dict[str, object]:
+    """Return bind parameters required by identity-aware auth query predicates."""
+    if identity is None or identity.dry_run:
+        return {}
+    if identity.repeatability == AuthRepeatability.REPEATABLE:
+        return {'auth_attempt_key': identity.attempt_key}
+    if identity.repeatability == AuthRepeatability.RESET and identity.full_reset_sweep:
+        return {'auth_attempt_key': identity.attempt_key}
+    return {}
+
+
+def _auth_processing_exclusion_sql(
+    *,
+    flow_name: str,
+    environment: str,
+    identity: Optional[AuthProcessingIdentity],
+) -> tuple[str, str]:
+    """Return auth_processing join/predicate SQL for the selection policy.
+
+    Legacy callers that have not yet been updated to pass an AuthProcessingIdentity retain
+    the old one-row-per-(corp, flow, environment) anti-join behavior. Identity-aware callers
+    get policy-driven blocking:
+      - active non-dry-run rows for the same corp/environment block all auth flows, including dry-runs;
+      - ONE_SHOT and RESET real runs also exclude historical non-dry-run rows for the same operation/scope;
+      - real REPEATABLE rows exclude same-cycle attempts by attempt_key, regardless of status;
+      - older-cycle REPEATABLE history only contributes to priority ordering.
+    """
+    flow_sql = _escape_sql_literal(flow_name)
+    env_sql = _escape_sql_literal(environment)
+
+    if identity is None:
+        legacy_join = f"""
+    LEFT JOIN auth_processing ap
+        ON ap.corp_num = c.corp_num
+       AND ap.flow_name = '{flow_sql}'
+       AND ap.environment = '{env_sql}'
+    """
+        return legacy_join, "AND ap.corp_num IS NULL"
+
+    if identity.flow_name != flow_name:
+        raise ValueError(
+            f'flow_name ({flow_name}) must match identity.flow_name ({identity.flow_name})'
+        )
+
+    if identity.repeatability not in (
+        AuthRepeatability.ONE_SHOT,
+        AuthRepeatability.RESET,
+        AuthRepeatability.REPEATABLE,
+    ):
+        raise ValueError(f'Unsupported auth repeatability: {identity.repeatability}')
+
+    operation_sql = _escape_sql_literal(identity.operation.value)
+    scope_sql = _escape_sql_literal(identity.operation_scope.value)
+
+    exclusion = f"""
+        AND NOT EXISTS (
+            SELECT 1
+            FROM auth_processing ap_active
+            WHERE ap_active.corp_num = c.corp_num
+              AND ap_active.environment = '{env_sql}'
+              AND COALESCE(ap_active.dry_run, false) = false
+              AND ap_active.processed_status IN ('PENDING', 'PROCESSING')
+        )
+    """
+
+    if identity.dry_run:
+        return "", exclusion
+
+    if identity.repeatability == AuthRepeatability.RESET and identity.full_reset_sweep:
+        exclusion += f"""
+        AND NOT EXISTS (
+            SELECT 1
+            FROM auth_processing ap_reset_sweep
+            WHERE ap_reset_sweep.corp_num = c.corp_num
+              AND ap_reset_sweep.flow_name = '{flow_sql}'
+              AND ap_reset_sweep.environment = '{env_sql}'
+              AND ap_reset_sweep.operation = '{operation_sql}'
+              AND ap_reset_sweep.operation_scope = '{scope_sql}'
+              AND ap_reset_sweep.attempt_key = :auth_attempt_key
+              AND COALESCE(ap_reset_sweep.dry_run, false) = false
+        )
+        AND NOT EXISTS (
+            SELECT 1
+            FROM auth_processing ap_reset_failed
+            WHERE ap_reset_failed.corp_num = c.corp_num
+              AND ap_reset_failed.flow_name = '{flow_sql}'
+              AND ap_reset_failed.environment = '{env_sql}'
+              AND ap_reset_failed.operation = '{operation_sql}'
+              AND ap_reset_failed.operation_scope = '{scope_sql}'
+              AND ap_reset_failed.processed_status = 'FAILED'
+              AND COALESCE(ap_reset_failed.dry_run, false) = false
+        )
+        """
+
+    if identity.repeatability in (AuthRepeatability.ONE_SHOT, AuthRepeatability.RESET) and not identity.full_reset_sweep:
+        exclusion += f"""
+        AND NOT EXISTS (
+            SELECT 1
+            FROM auth_processing ap_history
+            WHERE ap_history.corp_num = c.corp_num
+              AND ap_history.flow_name = '{flow_sql}'
+              AND ap_history.environment = '{env_sql}'
+              AND ap_history.operation = '{operation_sql}'
+              AND ap_history.operation_scope = '{scope_sql}'
+              AND COALESCE(ap_history.dry_run, false) = false
+        )
+        """
+
+    if identity.repeatability == AuthRepeatability.REPEATABLE:
+        exclusion += f"""
+        AND NOT EXISTS (
+            SELECT 1
+            FROM auth_processing ap_cycle
+            WHERE ap_cycle.corp_num = c.corp_num
+              AND ap_cycle.flow_name = '{flow_sql}'
+              AND ap_cycle.environment = '{env_sql}'
+              AND ap_cycle.operation = '{operation_sql}'
+              AND ap_cycle.operation_scope = '{scope_sql}'
+              AND ap_cycle.attempt_key = :auth_attempt_key
+              AND COALESCE(ap_cycle.dry_run, false) = false
+        )
+        """
+
+    return "", exclusion
+
+
+def _auth_repeatable_real_history_priority_sql(
+    *,
+    flow_name: str,
+    environment: str,
+    identity: Optional[AuthProcessingIdentity],
+) -> str:
+    """Return ORDER BY expression that ranks never-run repeatable real corps first.
+
+    Repeatable flows remain rerunnable across cycles: prior real history outside the current
+    attempt_key is not excluded here, it only sorts after corps with no prior real attempt for
+    the same flow/operation/scope identity.
+    Dry-run history is ignored for real-run priority, and dry-runs do not apply this
+    priority because they should not be treated as durable progress.
+    """
+    if (
+        identity is None
+        or identity.dry_run
+        or identity.repeatability != AuthRepeatability.REPEATABLE
+    ):
+        return ""
+
+    flow_sql = _escape_sql_literal(flow_name)
+    env_sql = _escape_sql_literal(environment)
+    operation_sql = _escape_sql_literal(identity.operation.value)
+    scope_sql = _escape_sql_literal(identity.operation_scope.value)
+
+    return f"""
+        CASE
+            WHEN EXISTS (
+                SELECT 1
+                FROM auth_processing ap_repeatable_history
+                WHERE ap_repeatable_history.corp_num = c.corp_num
+                  AND ap_repeatable_history.flow_name = '{flow_sql}'
+                  AND ap_repeatable_history.environment = '{env_sql}'
+                  AND ap_repeatable_history.operation = '{operation_sql}'
+                  AND ap_repeatable_history.operation_scope = '{scope_sql}'
+                  AND COALESCE(ap_repeatable_history.dry_run, false) = false
+            ) THEN 1
+            ELSE 0
+        END
+    """
+
+
+def _order_by_sql(*terms: str) -> str:
+    """Return an ORDER BY clause from non-empty terms."""
+    cleaned = [term.strip() for term in terms if term and term.strip()]
+    return f"ORDER BY\n            {', '.join(cleaned)}" if cleaned else ""
+
+
+
+def _positive_int_csv(csv_val: str | None, *, name: str) -> Optional[str]:
+    """Return safe positive integer CSV for SQL interpolation, or None when unset."""
+    return positive_int_csv_for_sql(csv_val, name=name)
+
+
+def _auth_migration_filter_ids(config) -> tuple[Optional[str], Optional[str]]:
+    """Return Auth-only migration group/batch ID filters, without global fallback."""
+    return auth_migration_filter_ids(config, require_any=True)
+
+
 def _parse_corp_nums_csv(csv_val: str | None) -> List[str]:
-    if not csv_val:
-        return []
-    parts: List[str] = []
-    for tok in str(csv_val).split(','):
-        t = tok.strip().upper()
-        if t:
-            parts.append(t)
-    # Deduplicate while preserving order
-    seen = set()
-    out: List[str] = []
-    for t in parts:
-        if t not in seen:
-            seen.add(t)
-            out.append(t)
-    return out
+    return parse_auth_corp_nums_csv(csv_val)
+
+
+def get_auth_selected_corp_nums_query(config, selection_mode: AuthSelectionMode) -> str:
+    """Build SQL for the currently configured auth selection, returning one corp_num column.
+
+    This cleanup/preview helper intentionally does not join auth_processing, does not apply
+    reservation exclusions, and does not limit rows.
+    """
+    selection_mode = AuthSelectionMode(selection_mode)
+
+    if selection_mode == AuthSelectionMode.MIGRATION_FILTER:
+        mig_group_ids, mig_batch_ids = _auth_migration_filter_ids(config)
+        auth_corp_nums = _parse_corp_nums_csv(getattr(config, 'AUTH_CORP_NUMS', ''))
+        mig_extra_where = ""
+        if mig_batch_ids:
+            mig_extra_where += f" AND b.id IN ({mig_batch_ids})"
+        if mig_group_ids:
+            mig_extra_where += f" AND g.id IN ({mig_group_ids})"
+        if auth_corp_nums:
+            mig_extra_where += f" AND c.corp_num IN ({_quote_list(auth_corp_nums)})"
+
+        return f"""
+        SELECT DISTINCT c.corp_num
+        FROM mig_corp_batch mcb
+        JOIN mig_batch b ON b.id = mcb.mig_batch_id
+        JOIN mig_group g ON g.id = b.mig_group_id
+        JOIN corporation c ON c.corp_num = mcb.corp_num
+        JOIN corp_state cs
+            ON cs.corp_num = c.corp_num
+           AND cs.end_event_id IS NULL
+        WHERE 1=1
+        {mig_extra_where}
+        AND c.corp_type_cd IN {CORP_TYPE_FILTER}
+        """
+
+    corp_nums = _parse_corp_nums_csv(getattr(config, 'AUTH_CORP_NUMS', ''))
+    corp_filter = f"AND c.corp_num IN ({_quote_list(corp_nums)})" if corp_nums else "AND 1=0"
+    return f"""
+    SELECT c.corp_num
+    FROM corporation c
+    JOIN corp_state cs
+        ON cs.corp_num = c.corp_num
+       AND cs.end_event_id IS NULL
+    WHERE 1=1
+      {corp_filter}
+      AND c.corp_type_cd IN {CORP_TYPE_FILTER}
+    """
 
 
 def get_auth_reservable_corps_query(
@@ -44,6 +272,7 @@ def get_auth_reservable_corps_query(
     selection_mode: AuthSelectionMode,
     include_account_ids: bool = False,
     include_contact_email: bool = False,
+    identity: Optional[AuthProcessingIdentity] = None,
 ) -> str:
     """
     Build SQL to select corps eligible to be reserved for an auth flow.
@@ -57,13 +286,24 @@ def get_auth_reservable_corps_query(
         - account_ids (CSV string)
         - contact_email
 
-    IMPORTANT: Always excludes corps already present in auth_processing for the same
+    Identity-aware selection policy:
+        - ONE_SHOT excludes existing non-dry-run rows by operation/scope.
+        - REPEATABLE excludes active non-dry-run rows for the same corp/environment, but not historic rows.
+        - RESET excludes existing non-dry-run reset rows by operation/scope.
+        - Dry-runs ignore historical durable rows but still exclude active non-dry-run rows.
+
+    Legacy callers that do not pass identity keep the prior anti-join by
     (corp_num, flow_name, environment).
     """
+    selection_mode = AuthSelectionMode(selection_mode)
+
     environment = getattr(config, 'DATA_LOAD_ENV', '')
-    mig_group_ids = getattr(config, 'MIG_GROUP_IDS', None)
-    mig_batch_ids = getattr(config, 'MIG_BATCH_IDS', None)
-    source_flow = getattr(config, 'AUTH_SOURCE_FLOW_NAME', 'tombstone-flow')
+    mig_group_ids = None
+    mig_batch_ids = None
+    auth_corp_nums = []
+    if selection_mode == AuthSelectionMode.MIGRATION_FILTER:
+        mig_group_ids, mig_batch_ids = _auth_migration_filter_ids(config)
+        auth_corp_nums = _parse_corp_nums_csv(getattr(config, 'AUTH_CORP_NUMS', ''))
 
     # Optional select columns
     account_map_cte = ""
@@ -81,25 +321,28 @@ def get_auth_reservable_corps_query(
                 WHERE mca.target_environment = '{_escape_sql_literal(environment)}'
                 {f" AND b2.id IN ({mig_batch_ids})" if mig_batch_ids else ""}
                 {f" AND b2.mig_group_id IN ({mig_group_ids})" if mig_group_ids else ""}
+                {f" AND mca.corp_num IN ({_quote_list(auth_corp_nums)})" if auth_corp_nums else ""}
                 GROUP BY mca.corp_num
             )
             """
             account_join = "LEFT JOIN account_map am ON am.corp_num = c.corp_num"
             account_select = ", COALESCE(am.account_ids, NULL::varchar(100)) AS account_ids"
-        elif selection_mode == AuthSelectionMode.CORP_PROCESSING:
-            account_select = ", cp.account_ids AS account_ids"
         else:
             # MANUAL
             account_select = ", NULL::varchar(100) AS account_ids"
 
     contact_select = ", c.admin_email AS contact_email" if include_contact_email else ""
 
-    ap_join = f"""
-    LEFT JOIN auth_processing ap
-        ON ap.corp_num = c.corp_num
-       AND ap.flow_name = '{_escape_sql_literal(flow_name)}'
-       AND ap.environment = '{_escape_sql_literal(environment)}'
-    """
+    ap_join, ap_exclusion_where = _auth_processing_exclusion_sql(
+        flow_name=flow_name,
+        environment=environment,
+        identity=identity,
+    )
+    repeatable_priority_order = _auth_repeatable_real_history_priority_sql(
+        flow_name=flow_name,
+        environment=environment,
+        identity=identity,
+    )
 
     # MIG filters for MIGRATION_FILTER mode
     mig_extra_where = ""
@@ -108,8 +351,15 @@ def get_auth_reservable_corps_query(
             mig_extra_where += f" AND b.id IN ({mig_batch_ids})"
         if mig_group_ids:
             mig_extra_where += f" AND g.id IN ({mig_group_ids})"
+        if auth_corp_nums:
+            mig_extra_where += f" AND c.corp_num IN ({_quote_list(auth_corp_nums)})"
 
     if selection_mode == AuthSelectionMode.MIGRATION_FILTER:
+        order_by = _order_by_sql(
+            f"{repeatable_priority_order} ASC" if repeatable_priority_order else "",
+            "b.id ASC",
+            "c.corp_num ASC",
+        )
         query = f"""
         {account_map_cte}
         SELECT
@@ -130,31 +380,8 @@ def get_auth_reservable_corps_query(
         WHERE 1=1
         {mig_extra_where}
         AND c.corp_type_cd IN {CORP_TYPE_FILTER}
-        AND ap.corp_num IS NULL
-        LIMIT {int(batch_size)}
-        """
-        return query
-
-    if selection_mode == AuthSelectionMode.CORP_PROCESSING:
-        query = f"""
-        SELECT
-            cp.corp_num,
-            c.corp_type_cd,
-            cp.mig_batch_id AS mig_batch_id
-            {account_select}
-            {contact_select}
-        FROM corp_processing cp
-        JOIN corporation c ON c.corp_num = cp.corp_num
-        JOIN corp_state cs
-            ON cs.corp_num = c.corp_num
-           AND cs.end_event_id IS NULL
-        {ap_join}
-        WHERE 1=1
-          AND cp.flow_name = '{_escape_sql_literal(source_flow)}'
-          AND cp.environment = '{_escape_sql_literal(environment)}'
-          AND cp.processed_status IN ('COMPLETED', 'PARTIAL')
-          AND c.corp_type_cd IN {CORP_TYPE_FILTER}
-          AND ap.corp_num IS NULL
+        {ap_exclusion_where}
+        {order_by}
         LIMIT {int(batch_size)}
         """
         return query
@@ -162,6 +389,16 @@ def get_auth_reservable_corps_query(
     # MANUAL
     corp_nums = _parse_corp_nums_csv(getattr(config, 'AUTH_CORP_NUMS', ''))
     corp_filter = f"AND c.corp_num IN ({_quote_list(corp_nums)})" if corp_nums else "AND 1=0"
+    manual_input_order = (
+        f"array_position(ARRAY[{_quote_list(corp_nums)}]::text[], c.corp_num::text) ASC"
+        if corp_nums
+        else ""
+    )
+    order_by = _order_by_sql(
+        f"{repeatable_priority_order} ASC" if repeatable_priority_order else "",
+        manual_input_order,
+        "c.corp_num ASC",
+    )
 
     query = f"""
     SELECT
@@ -178,7 +415,8 @@ def get_auth_reservable_corps_query(
     WHERE 1=1
       {corp_filter}
       AND c.corp_type_cd IN {CORP_TYPE_FILTER}
-      AND ap.corp_num IS NULL
+      {ap_exclusion_where}
+    {order_by}
     LIMIT {int(batch_size)}
     """
     return query
@@ -189,6 +427,7 @@ def get_auth_reservable_count_query(
     flow_name: str,
     config,
     selection_mode: AuthSelectionMode,
+    identity: Optional[AuthProcessingIdentity] = None,
 ) -> str:
     """
     Count corps eligible to be reserved for this auth flow.
@@ -198,19 +437,23 @@ def get_auth_reservable_count_query(
       - MIG filters (when enabled)
       - corp type filter
       - corp_state current row (end_event_id IS NULL)
-      - exclusion of existing auth_processing rows for (corp_num, flow_name, environment)
+      - identity-aware auth_processing exclusion policy, or legacy exclusion when identity is omitted
     """
-    environment = getattr(config, 'DATA_LOAD_ENV', '')
-    mig_group_ids = getattr(config, 'MIG_GROUP_IDS', None)
-    mig_batch_ids = getattr(config, 'MIG_BATCH_IDS', None)
-    source_flow = getattr(config, 'AUTH_SOURCE_FLOW_NAME', 'tombstone-flow')
+    selection_mode = AuthSelectionMode(selection_mode)
 
-    ap_join = f"""
-    LEFT JOIN auth_processing ap
-        ON ap.corp_num = c.corp_num
-       AND ap.flow_name = '{_escape_sql_literal(flow_name)}'
-       AND ap.environment = '{_escape_sql_literal(environment)}'
-    """
+    environment = getattr(config, 'DATA_LOAD_ENV', '')
+    mig_group_ids = None
+    mig_batch_ids = None
+    auth_corp_nums = []
+    if selection_mode == AuthSelectionMode.MIGRATION_FILTER:
+        mig_group_ids, mig_batch_ids = _auth_migration_filter_ids(config)
+        auth_corp_nums = _parse_corp_nums_csv(getattr(config, 'AUTH_CORP_NUMS', ''))
+
+    ap_join, ap_exclusion_where = _auth_processing_exclusion_sql(
+        flow_name=flow_name,
+        environment=environment,
+        identity=identity,
+    )
 
     mig_extra_where = ""
     if selection_mode == AuthSelectionMode.MIGRATION_FILTER:
@@ -218,6 +461,8 @@ def get_auth_reservable_count_query(
             mig_extra_where += f" AND b.id IN ({mig_batch_ids})"
         if mig_group_ids:
             mig_extra_where += f" AND g.id IN ({mig_group_ids})"
+        if auth_corp_nums:
+            mig_extra_where += f" AND c.corp_num IN ({_quote_list(auth_corp_nums)})"
 
     if selection_mode == AuthSelectionMode.MIGRATION_FILTER:
         return f"""
@@ -233,24 +478,7 @@ def get_auth_reservable_count_query(
         WHERE 1=1
         {mig_extra_where}
         AND c.corp_type_cd IN {CORP_TYPE_FILTER}
-        AND ap.corp_num IS NULL
-        """
-
-    if selection_mode == AuthSelectionMode.CORP_PROCESSING:
-        return f"""
-        SELECT count(*)
-        FROM corp_processing cp
-        JOIN corporation c ON c.corp_num = cp.corp_num
-        JOIN corp_state cs
-            ON cs.corp_num = c.corp_num
-           AND cs.end_event_id IS NULL
-        {ap_join}
-        WHERE 1=1
-          AND cp.flow_name = '{_escape_sql_literal(source_flow)}'
-          AND cp.environment = '{_escape_sql_literal(environment)}'
-          AND cp.processed_status IN ('COMPLETED', 'PARTIAL')
-          AND c.corp_type_cd IN {CORP_TYPE_FILTER}
-          AND ap.corp_num IS NULL
+        {ap_exclusion_where}
         """
 
     corp_nums = _parse_corp_nums_csv(getattr(config, 'AUTH_CORP_NUMS', ''))
@@ -265,7 +493,7 @@ def get_auth_reservable_count_query(
     WHERE 1=1
       {corp_filter}
       AND c.corp_type_cd IN {CORP_TYPE_FILTER}
-      AND ap.corp_num IS NULL
+      {ap_exclusion_where}
     """
 
 

--- a/data-tool/flows/auth/auth_selection.py
+++ b/data-tool/flows/auth/auth_selection.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import hashlib
+from typing import List, Optional, Sequence
+
+
+def parse_auth_corp_nums_csv(csv_val: str | None) -> List[str]:
+    """Parse AUTH_CORP_NUMS permissively: trim, uppercase, drop blanks, dedupe in input order."""
+    if not csv_val:
+        return []
+
+    parts: List[str] = []
+    for tok in str(csv_val).split(','):
+        t = tok.strip().upper()
+        if t:
+            parts.append(t)
+
+    seen = set()
+    out: List[str] = []
+    for t in parts:
+        if t not in seen:
+            seen.add(t)
+            out.append(t)
+    return out
+
+
+def canonical_auth_corp_nums_for_scope(csv_val: str | None) -> List[str]:
+    """Return parsed AUTH_CORP_NUMS sorted for order-insensitive campaign identity."""
+    return sorted(parse_auth_corp_nums_csv(csv_val))
+
+
+def corp_nums_scope_hash(corp_nums: Sequence[str]) -> str:
+    """Hash a canonical corp-num sequence for compact campaign scope identity."""
+    return hashlib.sha256(','.join(corp_nums).encode('utf-8')).hexdigest()
+
+
+def corp_nums_subset_scope(csv_val: str | None, *, all_label: str = 'ALL') -> str:
+    """Return subset=... value for campaign/logging from AUTH_CORP_NUMS."""
+    corp_nums = canonical_auth_corp_nums_for_scope(csv_val)
+    if not corp_nums:
+        return all_label
+    return f"count={len(corp_nums)};sha256={corp_nums_scope_hash(corp_nums)}"
+
+
+def parse_positive_int_csv(csv_val: str | None, *, name: str) -> List[str]:
+    """Return normalized positive integer tokens, deduped in input order."""
+    if csv_val is None:
+        return []
+
+    csv_text = str(csv_val).strip()
+    if not csv_text:
+        return []
+
+    values: List[str] = []
+    seen = set()
+    for tok in csv_text.split(','):
+        t = tok.strip()
+        if not t:
+            continue
+        if not t.isdigit():
+            raise ValueError(f'{name} must be a CSV of positive integers: {csv_val}')
+        val = int(t)
+        if val <= 0:
+            raise ValueError(f'{name} must contain only positive integers: {csv_val}')
+        normalized = str(val)
+        if normalized not in seen:
+            seen.add(normalized)
+            values.append(normalized)
+    return values
+
+
+def positive_int_csv_for_sql(csv_val: str | None, *, name: str) -> Optional[str]:
+    """Return normalized positive integer CSV for SQL interpolation, or None when unset."""
+    values = parse_positive_int_csv(csv_val, name=name)
+    return ', '.join(values) if values else None
+
+
+def positive_int_csv_for_scope(csv_val: str | None, *, name: str) -> str:
+    """Return normalized positive integer CSV for campaign scope, or ALL when unset."""
+    values = parse_positive_int_csv(csv_val, name=name)
+    return ','.join(values) if values else 'ALL'
+
+
+def auth_migration_filter_ids(config, *, require_any: bool = False) -> tuple[Optional[str], Optional[str]]:
+    """Return Auth-only migration group/batch ID SQL filters, without global fallback."""
+    mig_group_ids = positive_int_csv_for_sql(
+        getattr(config, 'AUTH_MIG_GROUP_IDS', None),
+        name='AUTH_MIG_GROUP_IDS',
+    )
+    mig_batch_ids = positive_int_csv_for_sql(
+        getattr(config, 'AUTH_MIG_BATCH_IDS', None),
+        name='AUTH_MIG_BATCH_IDS',
+    )
+    if require_any and not (mig_group_ids or mig_batch_ids):
+        raise ValueError(
+            'AUTH_SELECTION_MODE=MIGRATION_FILTER requires AUTH_MIG_GROUP_IDS and/or AUTH_MIG_BATCH_IDS; '
+            'AUTH_CORP_NUMS only narrows the migration-filter cohort and does not replace '
+            'AUTH_MIG_GROUP_IDS/AUTH_MIG_BATCH_IDS; Auth flows do not fall back to global '
+            'MIG_GROUP_IDS/MIG_BATCH_IDS'
+        )
+    return mig_group_ids, mig_batch_ids

--- a/data-tool/flows/auth/auth_tasks.py
+++ b/data-tool/flows/auth/auth_tasks.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 from http import HTTPStatus
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from prefect import task
 from prefect.cache_policies import NO_CACHE
 
 from common.auth_service import AuthService
-from .auth_models import AuthComponentStatus, AuthCreatePlan, AuthDeletePlan
+from .auth_flow_utils import auth_component_operation_logging_enabled
+from .auth_models import AuthComponentStatus, AuthCreatePlan, AuthDeletePlan, AuthOperationScope, AuthProcessingIdentity
+from .auth_tracking import AuthComponentOperationRecord
 
 
 def parse_accounts_csv(csv_val: str | None) -> List[int]:
@@ -55,6 +57,96 @@ def _truncate(val: str, max_len: int) -> str:
     return val[: max_len - 3] + '...'
 
 
+def _component_record_logging_enabled(
+    config,
+    *,
+    auth_processing_id: Optional[int],
+    identity: Optional[AuthProcessingIdentity],
+    log_component_operations: Optional[bool],
+) -> bool:
+    """Return true only when task callers supplied enough identity to build records."""
+    if auth_processing_id is None or identity is None:
+        return False
+    if log_component_operations is None:
+        return auth_component_operation_logging_enabled(config)
+    return bool(log_component_operations)
+
+
+def _operation_detail(status: AuthComponentStatus, detail: str | None = None) -> str:
+    parts = [f'result:{status.value}']
+    if detail:
+        parts.append(detail)
+    return '; '.join(parts)
+
+
+def _append_component_operation(
+    records: Optional[List[AuthComponentOperationRecord]],
+    *,
+    auth_processing_id: int,
+    corp_num: str,
+    identity: AuthProcessingIdentity,
+    flow_run_id,
+    component: AuthOperationScope,
+    target_type: str | None,
+    target_value: Any = None,
+    action: str,
+    status: AuthComponentStatus,
+    status_code: int | None = None,
+    error: str | None = None,
+    detail: str | None = None,
+) -> None:
+    """Append one safe component-operation record when logging is enabled.
+
+    Do not pass passcodes, bearer tokens, or raw request/response payloads into this helper.
+    """
+    if records is None:
+        return
+
+    records.append(
+        AuthComponentOperationRecord(
+            auth_processing_id=auth_processing_id,
+            corp_num=corp_num,
+            flow_name=identity.flow_name,
+            flow_run_id=flow_run_id,
+            operation=identity.operation,
+            operation_scope=identity.operation_scope,
+            component=component,
+            dry_run=identity.dry_run,
+            target_type=target_type,
+            target_value=str(target_value) if target_value is not None else None,
+            action=action,
+            status_code=status_code,
+            error=error,
+            detail=_operation_detail(status, detail),
+        )
+    )
+
+
+def _auth_task_result(
+    *,
+    corp_num: str,
+    entity_action: AuthComponentStatus,
+    contact_action: AuthComponentStatus,
+    affiliation_action: AuthComponentStatus,
+    invite_action: AuthComponentStatus,
+    action_detail: str,
+    error: str | None,
+    component_operations: Optional[List[AuthComponentOperationRecord]],
+) -> Dict[str, Any]:
+    result: Dict[str, Any] = {
+        'corp_num': corp_num,
+        'entity_action': entity_action.value,
+        'contact_action': contact_action.value,
+        'affiliation_action': affiliation_action.value,
+        'invite_action': invite_action.value,
+        'action_detail': action_detail,
+        'error': error,
+    }
+    if component_operations is not None:
+        result['component_operations'] = component_operations
+    return result
+
+
 @task(cache_policy=NO_CACHE)
 def get_auth_token(config) -> str:
     """Get one bearer token to reuse for an entire claimed batch."""
@@ -71,7 +163,12 @@ def perform_auth_create_for_corp(
     profile: Dict[str, Any],
     account_ids: List[int],
     plan: AuthCreatePlan,
-    token: str
+    token: str,
+    *,
+    auth_processing_id: int | None = None,
+    identity: AuthProcessingIdentity | None = None,
+    flow_run_id=None,
+    log_component_operations: bool | None = None,
 ) -> Dict[str, Any]:
     """
     Execute auth create-like operations for a single corp based on plan.
@@ -80,6 +177,7 @@ def perform_auth_create_for_corp(
       - entity_action/contact_action/affiliation_action/invite_action
       - action_detail (short)
       - error (short, safe)
+      - component_operations (optional, only when component logging inputs are supplied and enabled)
     """
     entity_action = AuthComponentStatus.NOT_RUN
     contact_action = AuthComponentStatus.NOT_RUN
@@ -88,6 +186,16 @@ def perform_auth_create_for_corp(
 
     detail_parts: List[str] = []
     errors: List[str] = []
+    current_operation: Optional[Dict[str, Any]] = None
+
+    component_operations: Optional[List[AuthComponentOperationRecord]] = None
+    if _component_record_logging_enabled(
+        config,
+        auth_processing_id=auth_processing_id,
+        identity=identity,
+        log_component_operations=log_component_operations,
+    ):
+        component_operations = []
 
     try:
         identifier = (profile or {}).get('identifier') or corp_num
@@ -110,22 +218,72 @@ def perform_auth_create_for_corp(
             invite_action = AuthComponentStatus.FAILED
             errors.append('plan_conflict_affiliations_vs_invite')
             detail_parts.append('plan:invalid(affiliations+invite)')
-            return {
-                'corp_num': corp_num,
-                'entity_action': entity_action.value,
-                'contact_action': contact_action.value,
-                'affiliation_action': affiliation_action.value,
-                'invite_action': invite_action.value,
-                'action_detail': _truncate('; '.join(detail_parts), 2000),
-                'error': _truncate('; '.join(errors), 1000) or None
-            }
+            if auth_processing_id is not None and identity is not None:
+                _append_component_operation(
+                    component_operations,
+                    auth_processing_id=auth_processing_id,
+                    corp_num=corp_num,
+                    identity=identity,
+                    flow_run_id=flow_run_id,
+                    component=AuthOperationScope.AFFILIATION,
+                    target_type='account',
+                    action='CREATE_AFFILIATION',
+                    status=AuthComponentStatus.FAILED,
+                    error='plan_conflict_affiliations_vs_invite',
+                    detail='plan_conflict',
+                )
+                _append_component_operation(
+                    component_operations,
+                    auth_processing_id=auth_processing_id,
+                    corp_num=corp_num,
+                    identity=identity,
+                    flow_run_id=flow_run_id,
+                    component=AuthOperationScope.INVITE,
+                    target_type='email',
+                    target_value=email or None,
+                    action='SEND_INVITE',
+                    status=AuthComponentStatus.FAILED,
+                    error='plan_conflict_affiliations_vs_invite',
+                    detail='plan_conflict',
+                )
+            return _auth_task_result(
+                corp_num=corp_num,
+                entity_action=entity_action,
+                contact_action=contact_action,
+                affiliation_action=affiliation_action,
+                invite_action=invite_action,
+                action_detail=_truncate('; '.join(detail_parts), 2000),
+                error=_truncate('; '.join(errors), 1000) or None,
+                component_operations=component_operations,
+            )
 
         # 1) Create entity
+        explicit_entity_create_succeeded = False
         if plan.create_entity:
             if plan.dry_run:
                 entity_action = AuthComponentStatus.SKIPPED
                 detail_parts.append('entity:DRY_RUN')
+                if auth_processing_id is not None and identity is not None:
+                    _append_component_operation(
+                        component_operations,
+                        auth_processing_id=auth_processing_id,
+                        corp_num=corp_num,
+                        identity=identity,
+                        flow_run_id=flow_run_id,
+                        component=AuthOperationScope.ENTITY,
+                        target_type='entity',
+                        target_value=identifier,
+                        action='CREATE_ENTITY',
+                        status=AuthComponentStatus.SKIPPED,
+                        detail='DRY_RUN',
+                    )
             else:
+                current_operation = {
+                    'component': AuthOperationScope.ENTITY,
+                    'target_type': 'entity',
+                    'target_value': identifier,
+                    'action': 'CREATE_ENTITY',
+                }
                 status = AuthService.create_entity(
                     config=config,
                     business_registration=identifier,
@@ -134,13 +292,47 @@ def perform_auth_create_for_corp(
                     pass_code=pass_code,
                     token=token
                 )
+                current_operation = None
                 code = _status_code(status)
                 detail_parts.append(f'entity:{code}')
                 if code == int(HTTPStatus.OK):
                     entity_action = AuthComponentStatus.SUCCESS
+                    explicit_entity_create_succeeded = True
                 else:
                     entity_action = AuthComponentStatus.FAILED
                     errors.append(f'create_entity:{code}')
+                if auth_processing_id is not None and identity is not None:
+                    _append_component_operation(
+                        component_operations,
+                        auth_processing_id=auth_processing_id,
+                        corp_num=corp_num,
+                        identity=identity,
+                        flow_run_id=flow_run_id,
+                        component=AuthOperationScope.ENTITY,
+                        target_type='entity',
+                        target_value=identifier,
+                        action='CREATE_ENTITY',
+                        status=entity_action,
+                        status_code=code,
+                        error=None if entity_action == AuthComponentStatus.SUCCESS else f'create_entity:{code}',
+                    )
+                if entity_action == AuthComponentStatus.FAILED:
+                    # Dependent create-side actions assume the explicit entity create succeeded.
+                    # Do not call contact/affiliation/invite APIs after that failure; in
+                    # particular avoid legacy create_affiliation(), which may create Auth side
+                    # effects even though entity_action is already FAILED.
+                    if plan.upsert_contact or plan.create_affiliations or plan.send_unaffiliated_invite:
+                        detail_parts.append('dependent_actions:not_run_entity_failed')
+                    return _auth_task_result(
+                        corp_num=corp_num,
+                        entity_action=entity_action,
+                        contact_action=contact_action,
+                        affiliation_action=affiliation_action,
+                        invite_action=invite_action,
+                        action_detail=_truncate('; '.join(detail_parts), 2000),
+                        error=_truncate('; '.join(errors), 1000) or None,
+                        component_operations=component_operations,
+                    )
 
         # 2) Upsert contact
         if plan.upsert_contact:
@@ -149,18 +341,55 @@ def perform_auth_create_for_corp(
                 if plan.fail_if_missing_email:
                     contact_action = AuthComponentStatus.FAILED
                     errors.append('missing_email_for_contact')
+                    contact_error = 'missing_email_for_contact'
                 else:
                     contact_action = AuthComponentStatus.SKIPPED
+                    contact_error = None
+                if auth_processing_id is not None and identity is not None:
+                    _append_component_operation(
+                        component_operations,
+                        auth_processing_id=auth_processing_id,
+                        corp_num=corp_num,
+                        identity=identity,
+                        flow_run_id=flow_run_id,
+                        component=AuthOperationScope.CONTACT,
+                        target_type='email',
+                        action='UPSERT_CONTACT',
+                        status=contact_action,
+                        error=contact_error,
+                        detail='missing_email',
+                    )
             elif plan.dry_run:
                 contact_action = AuthComponentStatus.SKIPPED
                 detail_parts.append('contact:DRY_RUN')
+                if auth_processing_id is not None and identity is not None:
+                    _append_component_operation(
+                        component_operations,
+                        auth_processing_id=auth_processing_id,
+                        corp_num=corp_num,
+                        identity=identity,
+                        flow_run_id=flow_run_id,
+                        component=AuthOperationScope.CONTACT,
+                        target_type='email',
+                        target_value=email,
+                        action='UPSERT_CONTACT',
+                        status=AuthComponentStatus.SKIPPED,
+                        detail='DRY_RUN',
+                    )
             else:
+                current_operation = {
+                    'component': AuthOperationScope.CONTACT,
+                    'target_type': 'email',
+                    'target_value': email,
+                    'action': 'UPSERT_CONTACT',
+                }
                 status = AuthService.update_contact_email(
                     config=config,
                     identifier=identifier,
                     email=email,
                     token=token
                 )
+                current_operation = None
                 code = _status_code(status)
                 detail_parts.append(f'contact:{code}')
                 if code == int(HTTPStatus.OK):
@@ -168,34 +397,115 @@ def perform_auth_create_for_corp(
                 else:
                     contact_action = AuthComponentStatus.FAILED
                     errors.append(f'upsert_contact:{code}')
+                if auth_processing_id is not None and identity is not None:
+                    _append_component_operation(
+                        component_operations,
+                        auth_processing_id=auth_processing_id,
+                        corp_num=corp_num,
+                        identity=identity,
+                        flow_run_id=flow_run_id,
+                        component=AuthOperationScope.CONTACT,
+                        target_type='email',
+                        target_value=email,
+                        action='UPSERT_CONTACT',
+                        status=contact_action,
+                        status_code=code,
+                        error=None if contact_action == AuthComponentStatus.SUCCESS else f'upsert_contact:{code}',
+                    )
 
         # 3) Create affiliations
         if plan.create_affiliations:
-            if not account_ids:
+            unique_accounts = sorted(set(account_ids))
+            if not unique_accounts:
                 affiliation_action = AuthComponentStatus.SKIPPED
                 detail_parts.append('affiliations:no_accounts')
+                if auth_processing_id is not None and identity is not None:
+                    _append_component_operation(
+                        component_operations,
+                        auth_processing_id=auth_processing_id,
+                        corp_num=corp_num,
+                        identity=identity,
+                        flow_run_id=flow_run_id,
+                        component=AuthOperationScope.AFFILIATION,
+                        target_type='account',
+                        action='CREATE_AFFILIATION',
+                        status=AuthComponentStatus.SKIPPED,
+                        detail='no_accounts',
+                    )
             elif plan.dry_run:
                 affiliation_action = AuthComponentStatus.SKIPPED
-                detail_parts.append(f'affiliations:DRY_RUN({len(account_ids)})')
+                detail_parts.append(f'affiliations:DRY_RUN({len(unique_accounts)})')
+                if auth_processing_id is not None and identity is not None:
+                    for acct in unique_accounts:
+                        _append_component_operation(
+                            component_operations,
+                            auth_processing_id=auth_processing_id,
+                            corp_num=corp_num,
+                            identity=identity,
+                            flow_run_id=flow_run_id,
+                            component=AuthOperationScope.AFFILIATION,
+                            target_type='account',
+                            target_value=acct,
+                            action='CREATE_AFFILIATION',
+                            status=AuthComponentStatus.SKIPPED,
+                            detail='DRY_RUN',
+                        )
             else:
                 ok = 0
                 fail = 0
-                for acct in sorted(set(account_ids)):
-                    status = AuthService.create_affiliation(
-                        config=config,
-                        account=acct,
-                        business_registration=identifier,
-                        business_name=legal_name,
-                        corp_type_code=legal_type,
-                        pass_code=pass_code,
-                        details={'identifier': identifier},
-                        token=token
-                    )
+                for acct in unique_accounts:
+                    current_operation = {
+                        'component': AuthOperationScope.AFFILIATION,
+                        'target_type': 'account',
+                        'target_value': acct,
+                        'action': 'CREATE_AFFILIATION',
+                    }
+                    use_affiliation_only = explicit_entity_create_succeeded or not plan.allow_entity_creation_for_affiliations
+                    if use_affiliation_only:
+                        status = AuthService.create_affiliation_only(
+                            config=config,
+                            account=acct,
+                            business_registration=identifier,
+                            pass_code=pass_code,
+                            details={'identifier': identifier},
+                            token=token
+                        )
+                    else:
+                        # Preserve legacy idempotent fallback when entity creation is allowed by the caller.
+                        status = AuthService.create_affiliation(
+                            config=config,
+                            account=acct,
+                            business_registration=identifier,
+                            business_name=legal_name,
+                            corp_type_code=legal_type,
+                            pass_code=pass_code,
+                            details={'identifier': identifier},
+                            token=token
+                        )
+                    current_operation = None
                     code = _status_code(status)
                     if code == int(HTTPStatus.OK):
                         ok += 1
+                        affiliation_status = AuthComponentStatus.SUCCESS
                     else:
                         fail += 1
+                        affiliation_status = AuthComponentStatus.FAILED
+                    if auth_processing_id is not None and identity is not None:
+                        _append_component_operation(
+                            component_operations,
+                            auth_processing_id=auth_processing_id,
+                            corp_num=corp_num,
+                            identity=identity,
+                            flow_run_id=flow_run_id,
+                            component=AuthOperationScope.AFFILIATION,
+                            target_type='account',
+                            target_value=acct,
+                            action='CREATE_AFFILIATION',
+                            status=affiliation_status,
+                            status_code=code,
+                            error=None if affiliation_status == AuthComponentStatus.SUCCESS else f'create_affiliation:{code}',
+                            detail='affiliation_only' if use_affiliation_only else 'legacy_create_affiliation',
+                        )
                 detail_parts.append(f'affiliations:ok{ok} fail{fail}')
                 if fail > 0:
                     affiliation_action = AuthComponentStatus.FAILED
@@ -210,18 +520,55 @@ def perform_auth_create_for_corp(
                 if plan.fail_if_missing_email:
                     invite_action = AuthComponentStatus.FAILED
                     errors.append('missing_email_for_invite')
+                    invite_error = 'missing_email_for_invite'
                 else:
                     invite_action = AuthComponentStatus.SKIPPED
+                    invite_error = None
+                if auth_processing_id is not None and identity is not None:
+                    _append_component_operation(
+                        component_operations,
+                        auth_processing_id=auth_processing_id,
+                        corp_num=corp_num,
+                        identity=identity,
+                        flow_run_id=flow_run_id,
+                        component=AuthOperationScope.INVITE,
+                        target_type='email',
+                        action='SEND_INVITE',
+                        status=invite_action,
+                        error=invite_error,
+                        detail='missing_email',
+                    )
             elif plan.dry_run:
                 invite_action = AuthComponentStatus.SKIPPED
                 detail_parts.append('invite:DRY_RUN')
+                if auth_processing_id is not None and identity is not None:
+                    _append_component_operation(
+                        component_operations,
+                        auth_processing_id=auth_processing_id,
+                        corp_num=corp_num,
+                        identity=identity,
+                        flow_run_id=flow_run_id,
+                        component=AuthOperationScope.INVITE,
+                        target_type='email',
+                        target_value=email,
+                        action='SEND_INVITE',
+                        status=AuthComponentStatus.SKIPPED,
+                        detail='DRY_RUN',
+                    )
             else:
+                current_operation = {
+                    'component': AuthOperationScope.INVITE,
+                    'target_type': 'email',
+                    'target_value': email,
+                    'action': 'SEND_INVITE',
+                }
                 status = AuthService.send_unaffiliated_email(
                     config=config,
                     identifier=identifier,
                     email=email,
                     token=token
                 )
+                current_operation = None
                 code = _status_code(status)
                 detail_parts.append(f'invite:{code}')
                 if code == int(HTTPStatus.OK):
@@ -229,10 +576,38 @@ def perform_auth_create_for_corp(
                 else:
                     invite_action = AuthComponentStatus.FAILED
                     errors.append(f'send_invite:{code}')
+                if auth_processing_id is not None and identity is not None:
+                    _append_component_operation(
+                        component_operations,
+                        auth_processing_id=auth_processing_id,
+                        corp_num=corp_num,
+                        identity=identity,
+                        flow_run_id=flow_run_id,
+                        component=AuthOperationScope.INVITE,
+                        target_type='email',
+                        target_value=email,
+                        action='SEND_INVITE',
+                        status=invite_action,
+                        status_code=code,
+                        error=None if invite_action == AuthComponentStatus.SUCCESS else f'send_invite:{code}',
+                    )
 
     except Exception as e:
         detail_parts.append('exception')
-        errors.append(_truncate(repr(e), 900))
+        exception_error = _truncate(repr(e), 900)
+        errors.append(exception_error)
+        if current_operation and auth_processing_id is not None and identity is not None:
+            _append_component_operation(
+                component_operations,
+                auth_processing_id=auth_processing_id,
+                corp_num=corp_num,
+                identity=identity,
+                flow_run_id=flow_run_id,
+                status=AuthComponentStatus.FAILED,
+                error=exception_error,
+                detail='exception',
+                **current_operation,
+            )
         if plan.create_entity and entity_action == AuthComponentStatus.NOT_RUN:
             entity_action = AuthComponentStatus.FAILED
         if plan.upsert_contact and contact_action == AuthComponentStatus.NOT_RUN:
@@ -245,15 +620,16 @@ def perform_auth_create_for_corp(
     action_detail = _truncate('; '.join(detail_parts), 2000)
     error = _truncate('; '.join(errors), 1000) if errors else None
 
-    return {
-        'corp_num': corp_num,
-        'entity_action': entity_action.value,
-        'contact_action': contact_action.value,
-        'affiliation_action': affiliation_action.value,
-        'invite_action': invite_action.value,
-        'action_detail': action_detail,
-        'error': error
-    }
+    return _auth_task_result(
+        corp_num=corp_num,
+        entity_action=entity_action,
+        contact_action=contact_action,
+        affiliation_action=affiliation_action,
+        invite_action=invite_action,
+        action_detail=action_detail,
+        error=error,
+        component_operations=component_operations,
+    )
 
 
 @task(cache_policy=NO_CACHE)
@@ -262,7 +638,12 @@ def perform_auth_delete_for_corp(
     corp_num: str,
     account_ids: List[int],
     plan: AuthDeletePlan,
-    token: str
+    token: str,
+    *,
+    auth_processing_id: int | None = None,
+    identity: AuthProcessingIdentity | None = None,
+    flow_run_id=None,
+    log_component_operations: bool | None = None,
 ) -> Dict[str, Any]:
     """
     Execute auth delete-like operations for a single corp based on plan.
@@ -280,34 +661,98 @@ def perform_auth_delete_for_corp(
 
     detail_parts: List[str] = []
     errors: List[str] = []
+    current_operation: Optional[Dict[str, Any]] = None
+
+    component_operations: Optional[List[AuthComponentOperationRecord]] = None
+    if _component_record_logging_enabled(
+        config,
+        auth_processing_id=auth_processing_id,
+        identity=identity,
+        log_component_operations=log_component_operations,
+    ):
+        component_operations = []
 
     try:
         # 1) Delete affiliations (best-effort across accounts)
         if plan.delete_affiliations:
-            if not account_ids:
+            unique_accounts = sorted(set(account_ids))
+            if not unique_accounts:
                 affiliation_action = AuthComponentStatus.SKIPPED
                 detail_parts.append('del_affiliations:no_accounts')
+                if auth_processing_id is not None and identity is not None:
+                    _append_component_operation(
+                        component_operations,
+                        auth_processing_id=auth_processing_id,
+                        corp_num=corp_num,
+                        identity=identity,
+                        flow_run_id=flow_run_id,
+                        component=AuthOperationScope.AFFILIATION,
+                        target_type='account',
+                        action='DELETE_AFFILIATION',
+                        status=AuthComponentStatus.SKIPPED,
+                        detail='no_accounts',
+                    )
             elif plan.dry_run:
                 affiliation_action = AuthComponentStatus.SKIPPED
-                detail_parts.append(f'del_affiliations:DRY_RUN({len(account_ids)})')
+                detail_parts.append(f'del_affiliations:DRY_RUN({len(unique_accounts)})')
+                if auth_processing_id is not None and identity is not None:
+                    for acct in unique_accounts:
+                        _append_component_operation(
+                            component_operations,
+                            auth_processing_id=auth_processing_id,
+                            corp_num=corp_num,
+                            identity=identity,
+                            flow_run_id=flow_run_id,
+                            component=AuthOperationScope.AFFILIATION,
+                            target_type='account',
+                            target_value=acct,
+                            action='DELETE_AFFILIATION',
+                            status=AuthComponentStatus.SKIPPED,
+                            detail='DRY_RUN',
+                        )
             else:
                 ok = 0
                 not_found = 0
                 fail = 0
-                for acct in sorted(set(account_ids)):
+                for acct in unique_accounts:
+                    current_operation = {
+                        'component': AuthOperationScope.AFFILIATION,
+                        'target_type': 'account',
+                        'target_value': acct,
+                        'action': 'DELETE_AFFILIATION',
+                    }
                     status = AuthService.delete_affiliation_only(
                         config=config,
                         account=acct,
                         identifier=identifier,
                         token=token
                     )
+                    current_operation = None
                     code = _status_code(status)
                     if code in (int(HTTPStatus.OK), int(HTTPStatus.NO_CONTENT)):
                         ok += 1
+                        affiliation_status = AuthComponentStatus.SUCCESS
                     elif code == int(HTTPStatus.NOT_FOUND):
                         not_found += 1
+                        affiliation_status = AuthComponentStatus.SKIPPED
                     else:
                         fail += 1
+                        affiliation_status = AuthComponentStatus.FAILED
+                    if auth_processing_id is not None and identity is not None:
+                        _append_component_operation(
+                            component_operations,
+                            auth_processing_id=auth_processing_id,
+                            corp_num=corp_num,
+                            identity=identity,
+                            flow_run_id=flow_run_id,
+                            component=AuthOperationScope.AFFILIATION,
+                            target_type='account',
+                            target_value=acct,
+                            action='DELETE_AFFILIATION',
+                            status=affiliation_status,
+                            status_code=code,
+                            error=None if affiliation_status != AuthComponentStatus.FAILED else f'delete_affiliation:{code}',
+                        )
 
                 detail_parts.append(f'del_affiliations:ok{ok} nf{not_found} fail{fail}')
                 if fail > 0:
@@ -318,23 +763,38 @@ def perform_auth_delete_for_corp(
                 else:
                     affiliation_action = AuthComponentStatus.SKIPPED
 
-        # 2) Delete invites (NOT supported by current client/API)
-        if plan.delete_invites:
-            invite_action = AuthComponentStatus.FAILED
-            detail_parts.append('del_invites:UNSUPPORTED')
-            errors.append('delete_invites_not_supported')
-
-        # 3) Delete entity (after affiliations)
+        # 2) Delete entity (after affiliations)
         if plan.delete_entity:
             if plan.dry_run:
                 entity_action = AuthComponentStatus.SKIPPED
                 detail_parts.append('del_entity:DRY_RUN')
+                if auth_processing_id is not None and identity is not None:
+                    _append_component_operation(
+                        component_operations,
+                        auth_processing_id=auth_processing_id,
+                        corp_num=corp_num,
+                        identity=identity,
+                        flow_run_id=flow_run_id,
+                        component=AuthOperationScope.ENTITY,
+                        target_type='entity',
+                        target_value=identifier,
+                        action='DELETE_ENTITY',
+                        status=AuthComponentStatus.SKIPPED,
+                        detail='DRY_RUN',
+                    )
             else:
+                current_operation = {
+                    'component': AuthOperationScope.ENTITY,
+                    'target_type': 'entity',
+                    'target_value': identifier,
+                    'action': 'DELETE_ENTITY',
+                }
                 status = AuthService.delete_entity(
                     config=config,
                     identifier=identifier,
                     token=token
                 )
+                current_operation = None
                 code = _status_code(status)
                 detail_parts.append(f'del_entity:{code}')
                 if code in (int(HTTPStatus.OK), int(HTTPStatus.NO_CONTENT)):
@@ -344,26 +804,53 @@ def perform_auth_delete_for_corp(
                 else:
                     entity_action = AuthComponentStatus.FAILED
                     errors.append(f'delete_entity:{code}')
+                if auth_processing_id is not None and identity is not None:
+                    _append_component_operation(
+                        component_operations,
+                        auth_processing_id=auth_processing_id,
+                        corp_num=corp_num,
+                        identity=identity,
+                        flow_run_id=flow_run_id,
+                        component=AuthOperationScope.ENTITY,
+                        target_type='entity',
+                        target_value=identifier,
+                        action='DELETE_ENTITY',
+                        status=entity_action,
+                        status_code=code,
+                        error=None if entity_action != AuthComponentStatus.FAILED else f'delete_entity:{code}',
+                    )
 
     except Exception as e:
         detail_parts.append('exception')
-        errors.append(_truncate(repr(e), 900))
+        exception_error = _truncate(repr(e), 900)
+        errors.append(exception_error)
+        if current_operation and auth_processing_id is not None and identity is not None:
+            _append_component_operation(
+                component_operations,
+                auth_processing_id=auth_processing_id,
+                corp_num=corp_num,
+                identity=identity,
+                flow_run_id=flow_run_id,
+                status=AuthComponentStatus.FAILED,
+                error=exception_error,
+                detail='exception',
+                **current_operation,
+            )
         if plan.delete_affiliations and affiliation_action == AuthComponentStatus.NOT_RUN:
             affiliation_action = AuthComponentStatus.FAILED
-        if plan.delete_invites and invite_action == AuthComponentStatus.NOT_RUN:
-            invite_action = AuthComponentStatus.FAILED
         if plan.delete_entity and entity_action == AuthComponentStatus.NOT_RUN:
             entity_action = AuthComponentStatus.FAILED
 
     action_detail = _truncate('; '.join(detail_parts), 2000)
     error = _truncate('; '.join(errors), 1000) if errors else None
 
-    return {
-        'corp_num': corp_num,
-        'entity_action': entity_action.value,
-        'contact_action': contact_action.value,
-        'affiliation_action': affiliation_action.value,
-        'invite_action': invite_action.value,
-        'action_detail': action_detail,
-        'error': error
-    }
+    return _auth_task_result(
+        corp_num=corp_num,
+        entity_action=entity_action,
+        contact_action=contact_action,
+        affiliation_action=affiliation_action,
+        invite_action=invite_action,
+        action_detail=action_detail,
+        error=error,
+        component_operations=component_operations,
+    )

--- a/data-tool/flows/auth/auth_tracking.py
+++ b/data-tool/flows/auth/auth_tracking.py
@@ -1,0 +1,487 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional, Sequence
+
+from sqlalchemy import Engine, bindparam, text
+
+from .auth_flow_utils import AUTH_DELETE_FLOW_NAME, auth_component_operation_logging_enabled
+
+
+def _enum_value(value: Any) -> Any:
+    """Return enum.value when present, otherwise the original value."""
+    return value.value if hasattr(value, 'value') else value
+
+
+def _truncate(value: Any, max_len: int) -> Optional[str]:
+    """Normalize optional strings to fit auth tracking columns."""
+    if value is None:
+        return None
+    text_value = str(value)
+    if len(text_value) <= max_len:
+        return text_value
+    return text_value[: max_len - 3] + '...'
+
+
+@dataclass(frozen=True)
+class AuthDeleteTrackingCleanupSummary:
+    """Compact summary of auth-delete-flow tracking rows selected for cleanup."""
+    environment: str
+    flow_name: str
+    total_auth_processing_rows: int
+    distinct_corp_count: int
+    corp_sample: list[str]
+    status_counts: dict[str, int]
+    estimated_component_operation_rows: int
+
+
+@dataclass(frozen=True)
+class AuthComponentOperationRecord:
+    """One auth_component_operation row.
+
+    Values must be safe for persistence: no passcodes, bearer tokens, or raw unsafe payloads.
+    """
+    auth_processing_id: int
+    corp_num: str
+    flow_name: str
+    flow_run_id: Any
+    operation: Any
+    operation_scope: Any
+    component: Any
+    dry_run: bool = False
+    environment: Optional[str] = None
+    target_type: Optional[str] = None
+    target_value: Optional[str] = None
+    action: Optional[str] = None
+    status_code: Optional[int] = None
+    error: Optional[str] = None
+    detail: Optional[str] = None
+
+    def as_insert_values(self, default_environment: str) -> dict:
+        """Return normalized bind values for insertion."""
+        return {
+            'auth_processing_id': self.auth_processing_id,
+            'corp_num': self.corp_num,
+            'flow_name': self.flow_name,
+            'environment': self.environment or default_environment,
+            'flow_run_id': self.flow_run_id,
+            'operation': _truncate(_enum_value(self.operation), 25),
+            'operation_scope': _truncate(_enum_value(self.operation_scope), 25),
+            'component': _truncate(_enum_value(self.component), 25),
+            'target_type': _truncate(self.target_type, 50),
+            'target_value': _truncate(self.target_value, 500),
+            'action': _truncate(self.action, 50),
+            'status_code': self.status_code,
+            'error': _truncate(self.error, 1000),
+            'detail': _truncate(self.detail, 2000),
+            'dry_run': bool(self.dry_run),
+        }
+
+
+class AuthTrackingService:
+    """Auth tracking helpers for component logs and tracking cleanup."""
+
+    def __init__(
+        self,
+        environment: str,
+        db_engine: Engine,
+        *,
+        log_component_operations: bool = False,
+    ):
+        self.environment = environment
+        self.db_engine = db_engine
+        self.log_component_operations = bool(log_component_operations)
+        self.logger = logging.getLogger(__name__)
+
+    @classmethod
+    def from_config(cls, config, db_engine: Engine) -> 'AuthTrackingService':
+        """Build a service using config defaults.
+
+        AUTH_LOG_COMPONENT_OPERATIONS defaults to false via auth_component_operation_logging_enabled().
+        """
+        return cls(
+            getattr(config, 'DATA_LOAD_ENV', ''),
+            db_engine,
+            log_component_operations=auth_component_operation_logging_enabled(config),
+        )
+
+    @property
+    def component_logging_enabled(self) -> bool:
+        """Whether callers should build and insert component-operation rows."""
+        return self.log_component_operations
+
+    def build_component_operation(
+        self,
+        *,
+        auth_processing_id: int,
+        corp_num: str,
+        flow_name: str,
+        flow_run_id,
+        operation,
+        operation_scope,
+        component,
+        dry_run: bool = False,
+        target_type: Optional[str] = None,
+        target_value: Optional[str] = None,
+        action: Optional[str] = None,
+        status_code: Optional[int] = None,
+        error: Optional[str] = None,
+        detail: Optional[str] = None,
+    ) -> Optional[AuthComponentOperationRecord]:
+        """Build a component-operation record, or None when logging is disabled.
+
+        Future task integrations can call this helper to avoid constructing row payloads when
+        AUTH_LOG_COMPONENT_OPERATIONS is false.
+        """
+        if not self.log_component_operations:
+            return None
+        return AuthComponentOperationRecord(
+            auth_processing_id=auth_processing_id,
+            corp_num=corp_num,
+            flow_name=flow_name,
+            environment=self.environment,
+            flow_run_id=flow_run_id,
+            operation=operation,
+            operation_scope=operation_scope,
+            component=component,
+            target_type=target_type,
+            target_value=target_value,
+            action=action,
+            status_code=status_code,
+            error=error,
+            detail=detail,
+            dry_run=dry_run,
+        )
+
+    def insert_component_operations(
+        self,
+        records: Sequence[AuthComponentOperationRecord | Mapping[str, Any]],
+    ) -> int:
+        """Bulk insert component-operation rows in one transaction per batch.
+
+        When component logging is disabled this intentionally performs no DB work.
+        """
+        if not self.log_component_operations or not records:
+            return 0
+
+        rows = [self._normalize_component_record(record) for record in records if record]
+        if not rows:
+            return 0
+
+        return self._insert_component_operation_rows(rows)
+
+    def insert_component_operations_required(
+        self,
+        records: Sequence[AuthComponentOperationRecord | Mapping[str, Any]],
+    ) -> int:
+        """Insert component-operation rows, reconciling affected auth rows on failure.
+
+        Logging disabled or empty records remain a no-op. When logging is enabled,
+        normalization/insert failures mark affected auth_processing rows FAILED where
+        auth_processing_id can be recovered, then re-raise the original exception.
+        """
+        if not self.log_component_operations or not records:
+            return 0
+
+        rows = None
+        try:
+            rows = [self._normalize_component_record(record) for record in records if record]
+            if not rows:
+                return 0
+            return self._insert_component_operation_rows(rows)
+        except Exception as err:
+            affected_records = rows if rows is not None else records
+            auth_processing_ids = self._extract_auth_processing_ids(affected_records)
+            if auth_processing_ids:
+                try:
+                    marked = self._mark_component_log_insert_failed(auth_processing_ids, err)
+                    self.logger.error(
+                        'Marked %s auth_processing rows FAILED after component-operation insert failure',
+                        marked,
+                    )
+                except Exception:
+                    self.logger.exception(
+                        'Failed to reconcile auth_processing rows after component-operation insert failure'
+                    )
+            else:
+                self.logger.error(
+                    'Component-operation insert failed and no auth_processing_id values were available for reconciliation'
+                )
+            raise
+
+    def _insert_component_operation_rows(self, rows: Sequence[Mapping[str, Any]]) -> int:
+        query = """
+        INSERT INTO auth_component_operation (
+            auth_processing_id,
+            corp_num,
+            flow_name,
+            environment,
+            flow_run_id,
+            operation,
+            operation_scope,
+            component,
+            target_type,
+            target_value,
+            action,
+            status_code,
+            error,
+            detail,
+            dry_run,
+            create_date
+        ) VALUES (
+            :auth_processing_id,
+            :corp_num,
+            :flow_name,
+            :environment,
+            :flow_run_id,
+            :operation,
+            :operation_scope,
+            :component,
+            :target_type,
+            :target_value,
+            :action,
+            :status_code,
+            :error,
+            :detail,
+            :dry_run,
+            NOW()
+        )
+        """
+
+        with self.db_engine.connect() as conn:
+            with conn.begin():
+                result = conn.execute(text(query), list(rows))
+                inserted = result.rowcount if result.rowcount and result.rowcount > 0 else len(rows)
+
+        self.logger.info('Inserted %s auth component operation rows', inserted)
+        return inserted
+
+    def _extract_auth_processing_ids(
+        self,
+        records: Sequence[AuthComponentOperationRecord | Mapping[str, Any]],
+    ) -> list[int]:
+        ids: list[int] = []
+        seen = set()
+        for record in records or []:
+            if not record:
+                continue
+            value = (
+                record.auth_processing_id
+                if isinstance(record, AuthComponentOperationRecord)
+                else record.get('auth_processing_id')
+            )
+            try:
+                auth_processing_id = int(value)
+            except Exception:
+                continue
+            if auth_processing_id not in seen:
+                seen.add(auth_processing_id)
+                ids.append(auth_processing_id)
+        return ids
+
+    def _mark_component_log_insert_failed(self, auth_processing_ids: Sequence[int], error: Exception) -> int:
+        safe_error = _truncate(f'component_log_insert_error:{type(error).__name__}', 1000)
+        safe_detail = _truncate('component_log_insert_error', 2000)
+        query = text("""
+        UPDATE auth_processing
+        SET processed_status = 'FAILED',
+            last_modified = NOW(),
+            last_error = LEFT(
+                CASE
+                    WHEN last_error IS NULL OR last_error = '' THEN :error
+                    ELSE last_error || '; ' || :error
+                END,
+                1000
+            ),
+            action_detail = LEFT(
+                CASE
+                    WHEN action_detail IS NULL OR action_detail = '' THEN :detail
+                    ELSE action_detail || '; ' || :detail
+                END,
+                2000
+            )
+        WHERE id IN :auth_processing_ids
+        """).bindparams(bindparam('auth_processing_ids', expanding=True))
+
+        with self.db_engine.connect() as conn:
+            with conn.begin():
+                result = conn.execute(
+                    query,
+                    {
+                        'auth_processing_ids': list(auth_processing_ids),
+                        'error': safe_error,
+                        'detail': safe_detail,
+                    },
+                )
+                return result.rowcount or 0
+
+    def _auth_delete_cleanup_target_cte(self, selected_corp_nums_sql: str) -> str:
+        """Return shared target CTE for auth-delete-flow tracking cleanup."""
+        return f"""
+        WITH selected_corps AS (
+            {selected_corp_nums_sql}
+        ),
+        target_auth_processing AS (
+            SELECT ap.id, ap.corp_num, ap.processed_status
+            FROM auth_processing ap
+            JOIN selected_corps sc ON sc.corp_num = ap.corp_num
+            WHERE ap.flow_name = :flow_name
+              AND ap.environment = :environment
+        )
+        """
+
+    def preview_delete_tracking_cleanup(
+        self,
+        selected_corp_nums_sql: str,
+        *,
+        flow_name: str = AUTH_DELETE_FLOW_NAME,
+        sample_size: int = 10,
+    ) -> AuthDeleteTrackingCleanupSummary:
+        """Summarize auth-delete-flow tracking rows that would be deleted."""
+        target_cte = self._auth_delete_cleanup_target_cte(selected_corp_nums_sql)
+        params = {
+            'environment': self.environment,
+            'flow_name': flow_name,
+            'sample_size': int(sample_size),
+        }
+        totals_sql = text(target_cte + """
+        SELECT count(*) AS total_rows,
+               count(DISTINCT corp_num) AS distinct_corp_count
+        FROM target_auth_processing
+        """)
+        statuses_sql = text(target_cte + """
+        SELECT COALESCE(processed_status, 'NULL') AS processed_status,
+               count(*) AS row_count
+        FROM target_auth_processing
+        GROUP BY COALESCE(processed_status, 'NULL')
+        ORDER BY processed_status
+        """)
+        component_count_sql = text(target_cte + """
+        SELECT count(*)
+        FROM auth_component_operation aco
+        JOIN target_auth_processing target ON target.id = aco.auth_processing_id
+        """)
+        sample_sql = text(target_cte + """
+        SELECT DISTINCT corp_num
+        FROM target_auth_processing
+        ORDER BY corp_num
+        LIMIT :sample_size
+        """)
+
+        with self.db_engine.connect() as conn:
+            totals = conn.execute(totals_sql, params).mappings().first() or {}
+            status_rows = conn.execute(statuses_sql, params).mappings().all()
+            component_rows = int(conn.execute(component_count_sql, params).scalar() or 0)
+            corp_sample = [row['corp_num'] for row in conn.execute(sample_sql, params).mappings().all()]
+
+        return AuthDeleteTrackingCleanupSummary(
+            environment=self.environment,
+            flow_name=flow_name,
+            total_auth_processing_rows=int(totals.get('total_rows') or 0),
+            distinct_corp_count=int(totals.get('distinct_corp_count') or 0),
+            corp_sample=corp_sample,
+            status_counts={row['processed_status']: int(row['row_count'] or 0) for row in status_rows},
+            estimated_component_operation_rows=component_rows,
+        )
+
+    def execute_delete_tracking_cleanup(
+        self,
+        selected_corp_nums_sql: str,
+        *,
+        flow_name: str = AUTH_DELETE_FLOW_NAME,
+    ) -> int:
+        """Delete matching auth-delete-flow auth_processing rows; FK cascade removes components."""
+        target_cte = self._auth_delete_cleanup_target_cte(selected_corp_nums_sql)
+        delete_sql = text(target_cte + """
+        DELETE FROM auth_processing ap
+        USING target_auth_processing target
+        WHERE ap.id = target.id
+        """)
+        with self.db_engine.connect() as conn:
+            with conn.begin():
+                result = conn.execute(
+                    delete_sql,
+                    {
+                        'environment': self.environment,
+                        'flow_name': flow_name,
+                    },
+                )
+                deleted = result.rowcount or 0
+        self.logger.info(
+            'Deleted %s auth_processing rows for %s/%s cleanup',
+            deleted,
+            flow_name,
+            self.environment,
+        )
+        return deleted
+
+    def cleanup_full_reset_tracking(
+        self,
+        corp_num: str,
+        *,
+        environment: Optional[str] = None,
+        preserve_auth_processing_id: Optional[int] = None,
+    ) -> int:
+        """Delete auth tracking for a corp/environment after a successful full reset.
+
+        When preserve_auth_processing_id is provided, that exact current auth_processing row
+        is retained as the durable full-reset sweep marker. auth_component_operation rows for
+        deleted auth_processing rows are removed by the FK ON DELETE CASCADE.
+        """
+        env = environment or self.environment
+        query = """
+        DELETE FROM auth_processing
+        WHERE corp_num = :corp_num
+          AND environment = :environment
+          AND (:preserve_auth_processing_id IS NULL OR id <> :preserve_auth_processing_id)
+        """
+        with self.db_engine.connect() as conn:
+            with conn.begin():
+                result = conn.execute(
+                    text(query),
+                    {
+                        'corp_num': corp_num,
+                        'environment': env,
+                        'preserve_auth_processing_id': preserve_auth_processing_id,
+                    },
+                )
+                deleted = result.rowcount or 0
+        self.logger.info(
+            'Deleted %s auth_processing rows for full reset cleanup of %s/%s (preserved id=%s)',
+            deleted,
+            corp_num,
+            env,
+            preserve_auth_processing_id,
+        )
+        return deleted
+
+    def _normalize_component_record(
+        self,
+        record: AuthComponentOperationRecord | Mapping[str, Any],
+    ) -> dict:
+        if isinstance(record, AuthComponentOperationRecord):
+            return record.as_insert_values(self.environment)
+
+        values = dict(record)
+        normalized = {
+            'auth_processing_id': values.get('auth_processing_id'),
+            'corp_num': values.get('corp_num'),
+            'flow_name': values.get('flow_name'),
+            'environment': values.get('environment') or self.environment,
+            'flow_run_id': values.get('flow_run_id'),
+            'operation': _truncate(_enum_value(values.get('operation')), 25),
+            'operation_scope': _truncate(_enum_value(values.get('operation_scope')), 25),
+            'component': _truncate(_enum_value(values.get('component')), 25),
+            'target_type': _truncate(values.get('target_type'), 50),
+            'target_value': _truncate(values.get('target_value'), 500),
+            'action': _truncate(values.get('action'), 50),
+            'status_code': values.get('status_code'),
+            'error': _truncate(values.get('error'), 1000),
+            'detail': _truncate(values.get('detail'), 2000),
+            'dry_run': bool(values.get('dry_run', False)),
+        }
+        missing = [k for k in ('auth_processing_id', 'corp_num', 'flow_name', 'operation', 'operation_scope', 'component') if not normalized.get(k)]
+        if missing:
+            raise ValueError(f'Missing required auth component operation fields: {missing}')
+        return normalized

--- a/data-tool/flows/common/auth_service.py
+++ b/data-tool/flows/common/auth_service.py
@@ -129,6 +129,57 @@ class AuthService:
         return HTTPStatus.OK
 
     @classmethod
+    def create_affiliation_only(
+        cls,
+        config,
+        account: int,
+        business_registration: str,
+        pass_code: str = '',
+        details: dict = None,
+        *,
+        token: str | None = None
+    ) -> HTTPStatus:
+        """Create an account:business affiliation ONLY (does not create the entity)."""
+        auth_url = config.AUTH_SVC_URL
+        account_svc_affiliate_url = f'{auth_url}/orgs/{account}/affiliations'
+
+        token = cls._resolve_token(config, token)
+        if not token:
+            return HTTPStatus.UNAUTHORIZED
+
+        affiliate_data = {
+            'businessIdentifier': business_registration,
+        }
+        if pass_code:
+            affiliate_data['passCode'] = pass_code
+        if details:
+            affiliate_data['entityDetails'] = details
+
+        affiliate = requests.post(
+            url=account_svc_affiliate_url,
+            headers={**cls.CONTENT_TYPE_JSON,
+                     'Authorization': cls.BEARER + token},
+            data=json.dumps(affiliate_data),
+            timeout=cls.get_time_out(config)
+        )
+
+        affiliate_ok = affiliate.status_code in (
+            HTTPStatus.CREATED,
+            HTTPStatus.OK,
+            HTTPStatus.CONFLICT
+        )
+        if affiliate.status_code == HTTPStatus.BAD_REQUEST and 'DATA_ALREADY_EXISTS' in affiliate.text:
+            affiliate_ok = True
+
+        if not affiliate_ok:
+            try:
+                return HTTPStatus(affiliate.status_code)
+            except Exception:
+                return HTTPStatus.BAD_REQUEST
+
+        return HTTPStatus.OK
+
+    @classmethod
     def create_entity(
         cls,
         config,

--- a/data-tool/flows/common/extract_tracking_service.py
+++ b/data-tool/flows/common/extract_tracking_service.py
@@ -1,8 +1,29 @@
 from enum import Enum
-from typing import List, Optional
+from typing import Any, List, Mapping, Optional, Sequence
 from sqlalchemy import Engine, text
 import logging
+import re
 import time
+
+
+_SQL_IDENTIFIER_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
+_UPDATE_STATUS_RESERVED_IDENTIFIERS = {
+    'status',
+    'error',
+    'corp_num',
+    'flow_run_id',
+    'environment',
+    'flow_name',
+    'processed_status',
+    'last_modified',
+    'last_error',
+}
+
+
+def _validate_sql_identifier(identifier: str, *, context: str) -> None:
+    """Validate an interpolated SQL identifier."""
+    if not _SQL_IDENTIFIER_RE.match(str(identifier or '')):
+        raise ValueError(f'Unsafe SQL identifier for {context}: {identifier}')
 
 
 class ProcessingStatuses(str, Enum):
@@ -30,6 +51,7 @@ class ExtractTrackingService:
         *,
         statement_timeout_ms: Optional[int] = None
     ):
+        _validate_sql_identifier(table_name, context='ExtractTrackingService.table_name')
         self.data_load_env = environment
         self.db_engine = db_engine
         self.flow_name = flow_name
@@ -40,7 +62,10 @@ class ExtractTrackingService:
     def reserve_for_flow(self, base_query: str, flow_run_id: str,
                     extra_insert_cols: Optional[List[str]] = None,
                     *,
-                    fallback_account_ids: Optional[str] = None) -> int:
+                    fallback_account_ids: Optional[str] = None,
+                    base_query_params: Optional[Mapping[str, Any]] = None,
+                    static_insert_values: Optional[Mapping[str, Any]] = None,
+                    conflict_columns: Optional[Sequence[str]] = None) -> int:
         """Reserve corporations for processing in a specific flow run.
 
         Args:
@@ -48,12 +73,59 @@ class ExtractTrackingService:
             flow_run_id: Unique identifier for this flow run
             fallback_account_ids: Optional CSV string of account IDs to use when candidate_corps does not
                                   provide account_ids.
+            base_query_params: Optional bind parameters required by base_query.
+            static_insert_values: Optional static column values to insert for every reserved row.
+                                  Auth flows use this for operation identity columns.
+            conflict_columns: Optional ON CONFLICT column list. Defaults to the legacy
+                              (corp_num, flow_name, environment) conflict key used by non-auth callers.
 
         Returns:
             Number of corporations successfully reserved for this flow
         """
         # Columns from candidate_corps we also want to persist (e.g., 'account_ids')
         extra_cols: List[str] = extra_insert_cols or []
+        static_values = dict(static_insert_values or {})
+        base_params = dict(base_query_params or {})
+        conflict_cols = list(conflict_columns or ('corp_num', 'flow_name', 'environment'))
+        if not conflict_cols:
+            raise ValueError('conflict_columns must contain at least one column')
+
+        for col in [*extra_cols, *static_values.keys(), *conflict_cols]:
+            _validate_sql_identifier(col, context='reserve_for_flow')
+        for param_name in base_params.keys():
+            _validate_sql_identifier(param_name, context='reserve_for_flow.base_query_params')
+        reserved_param_names = {
+            'flow_name',
+            'status',
+            'environment',
+            'flow_run_id',
+            'fallback_account_ids',
+            *(f'static_{col}' for col in static_values.keys()),
+        }
+        conflicting_base_params = set(base_params).intersection(reserved_param_names)
+        if conflicting_base_params:
+            raise ValueError(
+                f'base_query_params conflicts with reserve_for_flow parameters: '
+                f'{sorted(conflicting_base_params)}'
+            )
+
+        base_insert_cols = {
+            'corp_num',
+            'corp_type_cd',
+            'mig_batch_id',
+            'flow_name',
+            'processed_status',
+            'environment',
+            'flow_run_id',
+            'create_date',
+            'last_modified',
+            'claimed_at',
+        }
+        duplicate_static_cols = base_insert_cols.intersection(static_values.keys())
+        if duplicate_static_cols:
+            raise ValueError(
+                f'static_insert_values cannot override reserved tracking columns: {sorted(duplicate_static_cols)}'
+            )
         # We may need to ensure 'account_ids' is present even when the base query doesn't return it
         include_account_ids = ('account_ids' in extra_cols) or (fallback_account_ids is not None)
 
@@ -72,7 +144,7 @@ class ExtractTrackingService:
                 if fallback_account_ids is not None:
                     # base query yields account_ids; prefer it, but allow fallback when NULL
                     select_extras_parts.append(
-                        ", COALESCE(candidate_corps.account_ids, CAST(:fallback_account_ids AS varchar(100))) AS account_ids"
+                        ", COALESCE(candidate_corps.account_ids, CAST(:fallback_account_ids AS text)) AS account_ids"
                     )
                     uses_fallback_bind = True
                 else:
@@ -80,7 +152,7 @@ class ExtractTrackingService:
                     select_extras_parts.append(", candidate_corps.account_ids AS account_ids")
             else:
                 # base query does NOT yield account_ids; inject constant fallback
-                select_extras_parts.append(", CAST(:fallback_account_ids AS varchar(100)) AS account_ids")
+                select_extras_parts.append(", CAST(:fallback_account_ids AS text) AS account_ids")
                 uses_fallback_bind = True
 
         available_select_extras = ''.join(select_extras_parts)
@@ -90,8 +162,25 @@ class ExtractTrackingService:
         if include_account_ids and 'account_ids' not in insert_extra_cols:
             insert_extra_cols.append('account_ids')
 
-        # This must include a leading comma when used in the SELECT list
+        duplicate_extra_static_cols = set(insert_extra_cols).intersection(static_values.keys())
+        if duplicate_extra_static_cols:
+            raise ValueError(
+                f'static_insert_values duplicates candidate insert columns: {sorted(duplicate_extra_static_cols)}'
+            )
+
+        insert_identity_cols = list(static_values.keys())
+        insert_optional_cols = insert_extra_cols + insert_identity_cols
+
+        # These must include a leading comma when used in the SELECT list
         insert_extra_cols_csv = (', ' + ', '.join(insert_extra_cols)) if insert_extra_cols else ''
+        insert_identity_cols_csv = ''.join(
+            f', :static_{col} AS {col}' for col in insert_identity_cols
+        )
+
+        insert_optional_cols_sql = (
+            ', '.join(insert_optional_cols) + ',' if insert_optional_cols else ''
+        )
+        conflict_cols_sql = ', '.join(conflict_cols)
 
         init_query = f"""
         WITH candidate_corps AS ({base_query}),
@@ -104,7 +193,7 @@ class ExtractTrackingService:
             corp_num,
             corp_type_cd,
             mig_batch_id,
-            {', '.join(insert_extra_cols) + ',' if insert_extra_cols else ''}
+            {insert_optional_cols_sql}
             flow_name,
             processed_status,
             environment,
@@ -116,7 +205,7 @@ class ExtractTrackingService:
         SELECT 
             corp_num,
             corp_type_cd,
-            mig_batch_id{insert_extra_cols_csv},
+            mig_batch_id{insert_extra_cols_csv}{insert_identity_cols_csv},
             :flow_name,
             :status,
             :environment,
@@ -125,7 +214,7 @@ class ExtractTrackingService:
             NOW(),
             NULL
         FROM available_corps
-        ON CONFLICT (corp_num, flow_name, environment) 
+        ON CONFLICT ({conflict_cols_sql}) 
         DO NOTHING
         RETURNING corp_num
         """
@@ -144,9 +233,13 @@ class ExtractTrackingService:
                     'environment': self.data_load_env,
                     'flow_run_id': flow_run_id
                 }
+                for col, value in static_values.items():
+                    params[f'static_{col}'] = value.value if hasattr(value, 'value') else value
                 # Only add the fallback bind if the SQL references it
                 if uses_fallback_bind:
                     params['fallback_account_ids'] = fallback_account_ids
+
+                params.update(base_params)
 
                 start = time.monotonic()
                 result = conn.execute(text(init_query), params)
@@ -176,6 +269,8 @@ class ExtractTrackingService:
             List of corporation numbers that were successfully claimed for processing
         """
         extra_cols = extra_return_cols or []
+        for col in extra_cols:
+            _validate_sql_identifier(col, context='claim_batch.extra_return_cols')
         ret_cols = ['tbl.corp_num', 'tbl.claimed_at'] + [f'tbl.{c}' for c in extra_cols]
         returning_sql = ', '.join(ret_cols)
 
@@ -242,6 +337,11 @@ class ExtractTrackingService:
         **extra_params
     ) -> bool:
         """Update status for a corp."""
+        for key in extra_params.keys():
+            _validate_sql_identifier(key, context='update_corp_status')
+            if key in _UPDATE_STATUS_RESERVED_IDENTIFIERS:
+                raise ValueError(f'extra_params cannot override update_corp_status column/bind: {key}')
+
         set_clauses = [
             'processed_status = :status',
             'last_modified = NOW()',

--- a/data-tool/flows/config.py
+++ b/data-tool/flows/config.py
@@ -54,6 +54,19 @@ def _get_bool(name: str, default: bool = False) -> bool:
     return val.strip().lower() == 'true'
 
 
+def _parse_int_csv(raw_value: str) -> list[int]:
+    """Parse a comma-separated list into ints, ignoring blanks and non-numeric tokens."""
+    return [
+        int(x.strip()) for x in (raw_value or '').split(',')
+        if x and x.strip().isdigit()
+    ]
+
+
+def _normalized_csv(values: list[int]):
+    """Return a normalized comma-separated string for integer values."""
+    return ','.join(str(x) for x in values) if values else None
+
+
 def get_named_config(config_name: str = 'production'):
     """Return the configuration object based on the name.
 
@@ -83,15 +96,9 @@ class _Config():  # pylint: disable=too-few-public-methods
     AFFILIATE_ENTITY = os.getenv('AFFILIATE_ENTITY', 'False') == 'True'
     AFFILIATE_ENTITY_ACCOUNT_ID = os.getenv('AFFILIATE_ENTITY_ACCOUNT_ID', '')
     # Normalized parsed list of ints (preferred for program logic)
-    AFFILIATE_ENTITY_ACCOUNT_IDS = [
-        int(x.strip()) for x in AFFILIATE_ENTITY_ACCOUNT_ID.split(',')
-        if x and x.strip().isdigit()
-    ]
+    AFFILIATE_ENTITY_ACCOUNT_IDS = _parse_int_csv(AFFILIATE_ENTITY_ACCOUNT_ID)
     # Normalized CSV string (useful when passing into SQL as a single value)
-    AFFILIATE_ENTITY_ACCOUNT_IDS_CSV = (
-        ','.join(str(x) for x in AFFILIATE_ENTITY_ACCOUNT_IDS)
-        if AFFILIATE_ENTITY_ACCOUNT_IDS else None
-    )
+    AFFILIATE_ENTITY_ACCOUNT_IDS_CSV = _normalized_csv(AFFILIATE_ENTITY_ACCOUNT_IDS)
 
     USE_CUSTOM_CONTACT_EMAIL = os.getenv('USE_CUSTOM_CONTACT_EMAIL', 'False') == 'True'
     CUSTOM_CONTACT_EMAIL = os.getenv('CUSTOM_CONTACT_EMAIL', '')
@@ -227,7 +234,10 @@ class _Config():  # pylint: disable=too-few-public-methods
     # Selection
     AUTH_SELECTION_MODE = os.getenv('AUTH_SELECTION_MODE', 'MIGRATION_FILTER')
     AUTH_CORP_NUMS = os.getenv('AUTH_CORP_NUMS', '')
-    AUTH_SOURCE_FLOW_NAME = os.getenv('AUTH_SOURCE_FLOW_NAME', 'tombstone-flow')
+    AUTH_MIG_GROUP_IDS = os.getenv('AUTH_MIG_GROUP_IDS')
+    AUTH_MIG_BATCH_IDS = os.getenv('AUTH_MIG_BATCH_IDS')
+    AUTH_REPEATABLE_CYCLE_KEY = os.getenv('AUTH_REPEATABLE_CYCLE_KEY', '')
+    AUTH_REPEATABLE_CAMPAIGN_SCOPE = os.getenv('AUTH_REPEATABLE_CAMPAIGN_SCOPE', '')
 
     # Throughput
     AUTH_BATCHES = _get_int('AUTH_BATCHES', 0)
@@ -242,12 +252,19 @@ class _Config():  # pylint: disable=too-few-public-methods
     AUTH_FAIL_IF_MISSING_EMAIL = _get_bool('AUTH_FAIL_IF_MISSING_EMAIL', False)
     AUTH_DRY_RUN = _get_bool('AUTH_DRY_RUN', False)
 
+    # Auth-only affiliation fallback accounts. Separate Auth flows intentionally do not
+    # alias/fallback from tombstone AFFILIATE_ENTITY_ACCOUNT_ID(S).
+    AUTH_AFFILIATION_ACCOUNT_IDS_RAW = os.getenv('AUTH_AFFILIATION_ACCOUNT_IDS', '')
+    AUTH_AFFILIATION_ACCOUNT_IDS = _parse_int_csv(AUTH_AFFILIATION_ACCOUNT_IDS_RAW)
+    AUTH_AFFILIATION_ACCOUNT_IDS_CSV = _normalized_csv(AUTH_AFFILIATION_ACCOUNT_IDS)
+
     # Delete plan
     AUTH_DELETE_AFFILIATIONS = _get_bool('AUTH_DELETE_AFFILIATIONS', False)
     AUTH_DELETE_ENTITY = _get_bool('AUTH_DELETE_ENTITY', False)
-    AUTH_DELETE_INVITES = _get_bool('AUTH_DELETE_INVITES', False)  # unsupported unless API confirmed
-    AUTH_REQUIRE_CONFIRMATION = _get_bool('AUTH_REQUIRE_CONFIRMATION', False)
-    AUTH_CONFIRMATION_TOKEN = os.getenv('AUTH_CONFIRMATION_TOKEN', '')
+    AUTH_DELETE_TRACKING_CLEANUP_MODE = os.getenv('AUTH_DELETE_TRACKING_CLEANUP_MODE', 'OFF')
+
+    # Tracking
+    AUTH_LOG_COMPONENT_OPERATIONS = _get_bool('AUTH_LOG_COMPONENT_OPERATIONS', False)
 
     TESTING = False
     DEBUG = False

--- a/data-tool/restore_extract.sh
+++ b/data-tool/restore_extract.sh
@@ -20,7 +20,7 @@ PGDATABASE="${PGDATABASE:-colin-mig-corps-test}"     # or ‑‑dbname
 ##############################################################################
 
 # -- Tables to restore ------------------------------------------------------------
-RESTORE=(corp_processing colin_tracking mig_group mig_batch mig_corp_batch mig_corp_account corps_with_third_party email_domain_groups bar_corps bad_emails exclude_corps)
+RESTORE=(corp_processing auth_processing auth_component_operation colin_tracking mig_group mig_batch mig_corp_batch mig_corp_account corps_with_third_party email_domain_groups bar_corps bad_emails exclude_corps)
 
 # -- Runtime options -----------------------------------------------------------
 DUMP="${DUMP}"
@@ -67,7 +67,8 @@ fi
 # ── RESTORE DATA FOR THE PRESERVED TABLES                                   #
 ##############################################################################
 if [ "$DELTA_MODE" = "true" ]; then
-  printf "⚠️  DELTA_MODE is true: skipping restore of preserved tables, processing table only "corp_processing".\n"
+  printf "⚠️  DELTA_MODE is true: skipping restore of preserved tables, processing table only \"corp_processing\".\n"
+  printf "⚠️  Auth tables auth_processing and auth_component_operation are not restored or merged in delta mode.\n"
   psql $(pg_conn_opts) -v ON_ERROR_STOP=1 <<  SQL
   ALTER TABLE IF EXISTS corp_processing RENAME TO corp_processing_old;
   CREATE TABLE corp_processing (LIKE corp_processing_old INCLUDING ALL);

--- a/data-tool/scripts/colin_corps_extract_generate_view_drop.sql
+++ b/data-tool/scripts/colin_corps_extract_generate_view_drop.sql
@@ -32,6 +32,7 @@ INSERT INTO colin_extract_reset_allowlist (obj_name, expected_relkind)
 VALUES
   ('v_addr_links', 'v'),
   ('v_addr_issues', 'v'),
+  ('v_auth_component_operation_audit', 'v'),
   ('v_business_state', 'v'),
   ('v_corp_issue_flags_long', 'v'),
   ('mv_corps_with_officers', 'm'),

--- a/data-tool/scripts/colin_corps_extract_postgres_ddl
+++ b/data-tool/scripts/colin_corps_extract_postgres_ddl
@@ -6,6 +6,10 @@ create sequence if not exists auth_processing_id_seq;
 
 alter sequence auth_processing_id_seq owner to postgres;
 
+create sequence if not exists auth_component_operation_id_seq;
+
+alter sequence auth_component_operation_id_seq owner to postgres;
+
 create sequence corp_processing_id_seq;
 
 alter sequence corp_processing_id_seq owner to postgres;
@@ -861,6 +865,15 @@ create table if not exists auth_processing
 	flow_run_id      uuid,
 	processed_status varchar(25)  not null,
 
+	-- auth operation identity. Defaults preserve legacy insert behavior until flows pass explicit values.
+	operation        varchar(25) default 'CREATE' not null,
+	operation_scope  varchar(25) default 'ENTITY' not null,
+	operation_target varchar(500),
+	repeatability    varchar(25) default 'ONE_SHOT' not null,
+	attempt_key      varchar(100) default 'ONE_SHOT' not null,
+	-- auth attempt identity audit context only; not part of uniqueness.
+	attempt_key_context text,
+	dry_run          boolean default false not null,
 	create_date      timestamp with time zone default current_timestamp not null,
 	last_modified    timestamp with time zone default current_timestamp not null,
 	claimed_at       timestamp with time zone,
@@ -879,7 +892,14 @@ create table if not exists auth_processing
 	-- short structured summary, never secrets
 	action_detail        varchar(2000),
 
-	constraint unq_auth_processing unique (corp_num, flow_name, environment)
+	constraint unq_auth_processing unique (
+		corp_num,
+		flow_name,
+		environment,
+		operation,
+		operation_scope,
+		attempt_key
+	)
 );
 
 alter table auth_processing owner to postgres;
@@ -889,6 +909,46 @@ create index if not exists idx_auth_processing_claim_batch
 
 create index if not exists idx_auth_processing_flow_env_status
 	on auth_processing (flow_name, environment, processed_status, corp_num);
+
+create index if not exists idx_auth_processing_identity
+	on auth_processing (corp_num, flow_name, environment, operation, operation_scope, attempt_key);
+
+create index if not exists idx_auth_processing_reset_guard
+	on auth_processing (corp_num, environment, flow_name, operation, operation_scope, dry_run, processed_status);
+
+create table if not exists auth_component_operation
+(
+	id                  integer default nextval('auth_component_operation_id_seq'::regclass) not null
+		constraint pk_auth_component_operation primary key,
+	auth_processing_id  integer not null
+		constraint fk_auth_component_operation_auth_processing
+			references auth_processing (id) on delete cascade,
+
+	corp_num            varchar(10) not null,
+	flow_name           varchar(100) not null,
+	environment         varchar(25) not null,
+	flow_run_id         uuid,
+
+	operation           varchar(25) not null,
+	operation_scope     varchar(25) not null,
+	component           varchar(25) not null,
+	target_type         varchar(50),
+	target_value        varchar(500),
+	action              varchar(50),
+	status_code         integer,
+	error               varchar(1000),
+	detail              varchar(2000),
+	dry_run             boolean default false not null,
+	create_date         timestamp with time zone default current_timestamp not null
+);
+
+alter table auth_component_operation owner to postgres;
+
+create index if not exists idx_auth_component_operation_auth_processing_id
+	on auth_component_operation (auth_processing_id);
+
+create index if not exists idx_auth_component_operation_lookup
+	on auth_component_operation (corp_num, environment, flow_name, create_date);
 
 create table if not exists corp_restriction
 (

--- a/data-tool/scripts/colin_corps_extract_postgres_views_ddl
+++ b/data-tool/scripts/colin_corps_extract_postgres_views_ddl
@@ -1054,6 +1054,56 @@ WHERE cs.end_event_id IS NULL;
 ALTER VIEW v_business_state
     owner to postgres;
 
+CREATE OR REPLACE VIEW v_auth_component_operation_audit AS
+SELECT
+    aco.id AS component_operation_id,
+    aco.auth_processing_id,
+    aco.corp_num,
+    aco.environment,
+    aco.flow_name,
+    aco.flow_run_id,
+    c.corp_type_cd,
+    c.recognition_dts,
+    ap.processed_status AS auth_processing_status,
+    ap.operation AS processing_operation,
+    ap.operation_scope AS processing_operation_scope,
+    ap.operation_target AS processing_operation_target,
+    ap.repeatability,
+    ap.attempt_key,
+    ap.dry_run AS processing_dry_run,
+    ap.attempt_key_context AS processing_attempt_key_context,
+    ap.mig_batch_id,
+    ap.claimed_at,
+    ap.create_date AS processing_create_date,
+    ap.last_modified AS processing_last_modified,
+    ap.last_error AS processing_last_error,
+    ap.entity_action,
+    ap.contact_action,
+    ap.affiliation_action,
+    ap.invite_action,
+    ap.action_detail AS processing_action_detail,
+    aco.operation AS component_operation,
+    aco.operation_scope AS component_operation_scope,
+    aco.component,
+    aco.target_type,
+    aco.target_value,
+    aco.action,
+    aco.status_code,
+    aco.error AS component_error,
+    aco.detail AS component_detail,
+    aco.dry_run AS component_dry_run,
+    aco.create_date AS component_create_date,
+    aco.corp_num = ap.corp_num AS corp_num_matches_parent,
+    aco.environment = ap.environment AS environment_matches_parent,
+    aco.flow_name = ap.flow_name AS flow_name_matches_parent,
+    aco.flow_run_id IS NOT DISTINCT FROM ap.flow_run_id AS flow_run_id_matches_parent
+FROM auth_component_operation aco
+JOIN auth_processing ap ON ap.id = aco.auth_processing_id
+LEFT JOIN corporation c ON c.corp_num = aco.corp_num;
+
+ALTER VIEW v_auth_component_operation_audit
+    owner to postgres;
+
 CREATE MATERIALIZED VIEW mv_corp_issue_flags AS
 SELECT
   co.corp_num,

--- a/data-tool/scripts/data-fixes/auth_tracking_identity_migration_2026_06_03.sql
+++ b/data-tool/scripts/data-fixes/auth_tracking_identity_migration_2026_06_03.sql
@@ -1,0 +1,193 @@
+-- Description:
+-- Extend COLIN extract auth tracking for repeatable auth operations.
+--
+-- This migration aligns existing databases with the source DDL changes in
+-- data-tool/scripts/colin_corps_extract_postgres_ddl:
+--   - adds operation identity columns to auth_processing;
+--   - adds auth attempt identity audit context to auth_processing (not part of uniqueness);
+--   - replaces the legacy unique constraint on (corp_num, flow_name, environment);
+--   - creates auth_component_operation with ON DELETE CASCADE to auth_processing;
+--   - backfills legacy auth_processing rows using the explicit mapping below.
+--
+-- Dry-run assumption:
+--   Legacy dry-run rows are identified only when action_detail contains the token
+--   'DRY_RUN'. Rows without that reliable marker are treated as real rows.
+
+BEGIN;
+
+CREATE SEQUENCE IF NOT EXISTS auth_component_operation_id_seq;
+ALTER SEQUENCE auth_component_operation_id_seq OWNER TO postgres;
+
+ALTER TABLE auth_processing
+    ADD COLUMN IF NOT EXISTS operation varchar(25) DEFAULT 'CREATE' NOT NULL,
+    ADD COLUMN IF NOT EXISTS operation_scope varchar(25) DEFAULT 'ENTITY' NOT NULL,
+    ADD COLUMN IF NOT EXISTS operation_target varchar(500),
+    ADD COLUMN IF NOT EXISTS repeatability varchar(25) DEFAULT 'ONE_SHOT' NOT NULL,
+    ADD COLUMN IF NOT EXISTS attempt_key varchar(100) DEFAULT 'ONE_SHOT' NOT NULL,
+    -- Auth attempt identity audit context only; not part of uniqueness.
+    ADD COLUMN IF NOT EXISTS attempt_key_context text,
+    ADD COLUMN IF NOT EXISTS dry_run boolean DEFAULT false NOT NULL;
+
+-- Explicit legacy-row mapping table required by the implementation plan.
+-- Inference notes:
+--   * auth-affiliation-flow action_detail containing 'del_affiliations' maps to DELETE/AFFILIATION.
+--   * auth-delete-flow with entity_action set maps to RESET/FULL_ENTITY.
+--   * auth-delete-flow without entity_action maps to DELETE/INVITE when invite_action is set;
+--     otherwise it maps to DELETE/AFFILIATION.
+CREATE TEMP TABLE auth_processing_legacy_identity_map (
+    legacy_flow_name varchar(100) PRIMARY KEY,
+    default_operation varchar(25) NOT NULL,
+    default_operation_scope varchar(25) NOT NULL,
+    default_repeatability varchar(25) NOT NULL,
+    notes text
+) ON COMMIT DROP;
+
+INSERT INTO auth_processing_legacy_identity_map (
+    legacy_flow_name,
+    default_operation,
+    default_operation_scope,
+    default_repeatability,
+    notes
+)
+VALUES
+    ('auth-create-flow', 'CREATE', 'ENTITY', 'ONE_SHOT',
+     'One-shot entity create rows keep ONE_SHOT attempt identity.'),
+    ('auth-contact-flow', 'UPSERT', 'CONTACT', 'REPEATABLE',
+     'Repeatable contact upsert rows use flow_run_id, else LEGACY:<id>.'),
+    ('auth-affiliation-flow', 'CREATE', 'AFFILIATION', 'REPEATABLE',
+     'Infer DELETE from action_detail containing del_affiliations; default CREATE.'),
+    ('auth-invite-flow', 'SEND', 'INVITE', 'REPEATABLE',
+     'Repeatable invite send rows use flow_run_id, else LEGACY:<id>.'),
+    ('auth-delete-flow', 'DELETE', 'AFFILIATION', 'REPEATABLE',
+     'Infer RESET/FULL_ENTITY when entity_action is set; infer INVITE when invite_action is set; default AFFILIATION.');
+
+WITH mapped AS (
+    SELECT
+        ap.id,
+        CASE
+            WHEN ap.flow_name = 'auth-affiliation-flow'
+                 AND COALESCE(ap.action_detail, '') ILIKE '%del_affiliations%'
+                THEN 'DELETE'
+            WHEN ap.flow_name = 'auth-delete-flow'
+                 AND ap.entity_action IS NOT NULL
+                 AND ap.entity_action <> 'NOT_RUN'
+                THEN 'RESET'
+            WHEN ap.flow_name = 'auth-delete-flow'
+                THEN 'DELETE'
+            ELSE m.default_operation
+        END AS operation,
+        CASE
+            WHEN ap.flow_name = 'auth-delete-flow'
+                 AND ap.entity_action IS NOT NULL
+                 AND ap.entity_action <> 'NOT_RUN'
+                THEN 'FULL_ENTITY'
+            WHEN ap.flow_name = 'auth-delete-flow'
+                 AND ap.invite_action IS NOT NULL
+                 AND ap.invite_action <> 'NOT_RUN'
+                THEN 'INVITE'
+            ELSE m.default_operation_scope
+        END AS operation_scope,
+        CASE
+            WHEN ap.flow_name = 'auth-delete-flow'
+                 AND ap.entity_action IS NOT NULL
+                 AND ap.entity_action <> 'NOT_RUN'
+                THEN 'RESET'
+            ELSE m.default_repeatability
+        END AS repeatability,
+        (COALESCE(ap.action_detail, '') ILIKE '%DRY_RUN%') AS dry_run,
+        CASE
+            WHEN COALESCE(ap.action_detail, '') ILIKE '%DRY_RUN%'
+                THEN 'DRY_RUN:' || COALESCE(ap.flow_run_id::text, ap.id::text)
+            WHEN ap.flow_name = 'auth-create-flow'
+                THEN 'ONE_SHOT'
+            WHEN ap.flow_name = 'auth-delete-flow'
+                 AND ap.entity_action IS NOT NULL
+                 AND ap.entity_action <> 'NOT_RUN'
+                THEN 'RESET'
+            ELSE COALESCE(ap.flow_run_id::text, 'LEGACY:' || ap.id::text)
+        END AS attempt_key
+    FROM auth_processing ap
+    JOIN auth_processing_legacy_identity_map m
+      ON m.legacy_flow_name = ap.flow_name
+)
+UPDATE auth_processing ap
+   SET operation = mapped.operation,
+       operation_scope = mapped.operation_scope,
+       repeatability = mapped.repeatability,
+       dry_run = mapped.dry_run,
+       attempt_key = mapped.attempt_key
+  FROM mapped
+ WHERE ap.id = mapped.id;
+
+-- Replace the legacy uniqueness with operation/attempt identity.
+ALTER TABLE auth_processing
+    DROP CONSTRAINT IF EXISTS unq_auth_processing;
+
+ALTER TABLE auth_processing
+    ADD CONSTRAINT unq_auth_processing UNIQUE (
+        corp_num,
+        flow_name,
+        environment,
+        operation,
+        operation_scope,
+        attempt_key
+    );
+
+CREATE INDEX IF NOT EXISTS idx_auth_processing_claim_batch
+    ON auth_processing (environment, flow_name, flow_run_id, processed_status, claimed_at);
+
+CREATE INDEX IF NOT EXISTS idx_auth_processing_flow_env_status
+    ON auth_processing (flow_name, environment, processed_status, corp_num);
+
+CREATE INDEX IF NOT EXISTS idx_auth_processing_identity
+    ON auth_processing (corp_num, flow_name, environment, operation, operation_scope, attempt_key);
+
+CREATE INDEX IF NOT EXISTS idx_auth_processing_reset_guard
+    ON auth_processing (corp_num, environment, flow_name, operation, operation_scope, dry_run, processed_status);
+
+CREATE TABLE IF NOT EXISTS auth_component_operation
+(
+    id                  integer DEFAULT nextval('auth_component_operation_id_seq'::regclass) NOT NULL
+        CONSTRAINT pk_auth_component_operation PRIMARY KEY,
+    auth_processing_id  integer NOT NULL
+        CONSTRAINT fk_auth_component_operation_auth_processing
+            REFERENCES auth_processing (id) ON DELETE CASCADE,
+
+    corp_num            varchar(10) NOT NULL,
+    flow_name           varchar(100) NOT NULL,
+    environment         varchar(25) NOT NULL,
+    flow_run_id         uuid,
+
+    operation           varchar(25) NOT NULL,
+    operation_scope     varchar(25) NOT NULL,
+    component           varchar(25) NOT NULL,
+    target_type         varchar(50),
+    target_value        varchar(500),
+    action              varchar(50),
+    status_code         integer,
+    error               varchar(1000),
+    detail              varchar(2000),
+    dry_run             boolean DEFAULT false NOT NULL,
+    create_date         timestamp with time zone DEFAULT current_timestamp NOT NULL
+);
+
+ALTER TABLE auth_component_operation OWNER TO postgres;
+
+CREATE INDEX IF NOT EXISTS idx_auth_component_operation_auth_processing_id
+    ON auth_component_operation (auth_processing_id);
+
+CREATE INDEX IF NOT EXISTS idx_auth_component_operation_lookup
+    ON auth_component_operation (corp_num, environment, flow_name, create_date);
+
+COMMIT;
+
+-- Verification helpers (run manually after migration):
+-- SELECT flow_name, operation, operation_scope, repeatability, dry_run, count(*)
+--   FROM auth_processing
+--  GROUP BY flow_name, operation, operation_scope, repeatability, dry_run
+--  ORDER BY flow_name, operation, operation_scope, repeatability, dry_run;
+--
+-- SELECT conname, pg_get_constraintdef(oid)
+--   FROM pg_constraint
+--  WHERE conrelid = 'auth_processing'::regclass
+--    AND conname = 'unq_auth_processing';


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33657

## Summary

Separate Auth migration work into explicit create/contact/affiliation/invite/delete Prefect flows with identity-aware tracking, safer repeatable reruns, hash-only attempt identities, and opt-in per-component operation logging.

## What changed

- Split Auth work into explicit component flows with clear ownership boundaries.
- Added Auth tracking identity fields on `auth_processing`: `operation`, `operation_scope`, `operation_target`, `repeatability`, `attempt_key`, `attempt_key_context`, and `dry_run`.
- Auth attempt identity now uses hash-only keys for new rows:
  - `attempt_key = ATTEMPT:v1:<sha256(attempt_key_context)>`
  - `attempt_key_context text` stores the readable audit/debug preimage.
- Separated standalone Auth-flow config from tombstone inline Auth config:
  - standalone flows use `AUTH_*` flags and `AUTH_AFFILIATION_ACCOUNT_IDS`
  - tombstone inline Auth remains controlled by `UPDATE_ENTITY`, `AFFILIATE_ENTITY`, `AFFILIATE_ENTITY_ACCOUNT_ID`, and `SEND_UNAFFILIATED_EMAIL`
- Added explicit auth selection modes:
  - `AUTH_SELECTION_MODE=MANUAL`: `AUTH_CORP_NUMS` is the source list
  - `AUTH_SELECTION_MODE=MIGRATION_FILTER`: `AUTH_MIG_GROUP_IDS` / `AUTH_MIG_BATCH_IDS` define the cohort, and `AUTH_CORP_NUMS` only narrows it
- Added repeatable cycle semantics:
  - real auth runs require `AUTH_REPEATABLE_CYCLE_KEY`
  - blank `AUTH_REPEATABLE_CAMPAIGN_SCOPE` is valid and derives from selection config
  - dry-runs remain flow-run scoped
- Added opt-in component-operation logging via `AUTH_LOG_COMPONENT_OPERATIONS=True`; default is off.
- Added `auth_component_operation` schema/audit view support with FK cascade from `auth_processing`.
- Added auth-delete tracking cleanup mode:
  - `AUTH_DELETE_TRACKING_CLEANUP_MODE=PREVIEW|EXECUTE`
  - cleanup mode makes no Auth API calls and removes selected `auth-delete-flow` tracking rows
- Updated full-reset cleanup semantics:
  - successful real full reset removes older Auth tracking rows for the corp/environment
  - preserves the current campaign-backed reset marker row as the durable sweep marker
- Updated extract backup/restore preservation so full restores include `auth_processing` and `auth_component_operation`; delta restore remains `corp_processing`-only and warns that Auth tracking rows are not merged there.

## Flow responsibilities

| Flow | Scope | Entity | Contact | Affiliation | Invite | Repeatability |
|---|---|---:|---:|---:|---:|---|
| `auth_create_flow.py` | Entity-create anchored create flow | ✅ | Optional | Optional | Optional | One-shot real run |
| `auth_contact_flow.py` | Contact email upsert only | ❌ | ✅ | ❌ | ❌ | Repeatable |
| `auth_affiliation_flow.py` | Affiliation create only | ❌ | ❌ | ✅ | ❌ | Repeatable |
| `auth_invite_flow.py` | Unaffiliated invite only | ❌ | ❌ | ❌ | ✅ | Repeatable |
| `auth_delete_flow.py` | Affiliation delete or full entity reset | ✅ full reset only | ❌ direct | ✅ delete | ❌ direct | Repeatable / reset |

```text
auth_delete_flow has no direct contact-delete or invite-delete path.
Full reset deletes the Auth entity, so contact/invite-related data may only disappear indirectly if Auth entity deletion cascades externally.
```

## Tracking identity notes

- New rows use hash-only `attempt_key` values, e.g. `ATTEMPT:v1:<sha256>`.
- The readable preimage is stored in `attempt_key_context`, e.g.:

```text
CYCLE:v1:MIGRATION_FILTER:saf_1_5_1:MIGRATION_FILTER:groups=30;batches=142;subset=count=1
```

- `attempt_key_context` is audit/readability only; uniqueness and same-cycle exclusion use `attempt_key`.
- Existing legacy rows may still have older readable/sentinel attempt keys.

## Direct delete semantics

- Affiliation delete directly calls `delete_affiliation_only()`.
- Full reset deletes affiliations first, then directly calls `delete_entity()`.
- Entity-only delete is invalid; full reset requires `AUTH_DELETE_AFFILIATIONS=True` and `AUTH_DELETE_ENTITY=True`.
- There is no direct contact-delete or invite-delete component/config/API path in this branch.

## Config / behavior notes

- `AUTH_SELECTION_MODE=MANUAL`: `AUTH_CORP_NUMS` is the source list.
- `AUTH_SELECTION_MODE=MIGRATION_FILTER`: `AUTH_MIG_GROUP_IDS` / `AUTH_MIG_BATCH_IDS` define the cohort; `AUTH_CORP_NUMS` is optional and only narrows that cohort.
- Auth flows do not fall back to global `MIG_GROUP_IDS` / `MIG_BATCH_IDS`.
- Real auth runs require `AUTH_REPEATABLE_CYCLE_KEY`; dry-runs do not.
- Blank `AUTH_REPEATABLE_CAMPAIGN_SCOPE` is valid; scope is derived from selection mode and filters.
- `AUTH_LOG_COMPONENT_OPERATIONS=True` enables per-component audit rows; default is off.
- `AUTH_DELETE_TRACKING_CLEANUP_MODE=PREVIEW|EXECUTE` is cleanup-only: no Auth API calls, normal delete flags ignored, child component rows removed by FK cascade.
- Successful full reset preserves the current `auth-delete-flow` reset marker row while removing older Auth tracking rows for the corp/environment.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
