### PR TITLE
33690 - return staff-uploaded Continuation Out documents in filing documents

### DIFF
--- a/legal-api/src/legal_api/core/meta/filing.py
+++ b/legal-api/src/legal_api/core/meta/filing.py
@@ -1079,6 +1079,14 @@ class FilingMeta:  # pylint: disable=too-few-public-methods
                         "name": file.get("fileName"),
                         "url": f"{url_prefix}/{file_key}"
                     })
+        elif filing.filing_type == "continuationOut":
+            continuation_out = filing.meta_data.get("continuationOut", {})
+            for file in continuation_out.get("uploadedDocuments", []):
+                if file_key := file.get("fileKey"):
+                    outputs.append({
+                        "name": file.get("fileName"),
+                        "url": f"{url_prefix}/{file_key}"
+                    })
         return outputs
 
     @staticmethod

--- a/legal-api/src/legal_api/models/document.py
+++ b/legal-api/src/legal_api/models/document.py
@@ -31,6 +31,7 @@ class DocumentType(Enum):
 
     AFFIDAVIT = "affidavit"
     AUTHORIZATION_FILE = "authorization_file"
+    CONTINUATION_OUT = "continuation_out"
     COOP_RULES = "coop_rules"
     COOP_MEMORANDUM = "coop_memorandum"
     COURT_ORDER = "court_order"

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
@@ -1577,6 +1577,68 @@ def filer_action(filing_name, filing_json, meta_data, business):
     return meta_data
 
 
+def test_continuation_out_uploaded_documents(app, session, client, jwt, monkeypatch, mock_drs_service):
+    """Assert that uploaded continuation out documents are returned as staff-only static documents."""
+    identifier = 'BC7654321'
+    entity_type = Business.LegalTypes.COMP.value
+    business = factory_business(identifier, entity_type=entity_type)
+
+    uploaded_documents = [
+        {'fileKey': 'aaaaaaaa-1111-2222-3333-444444444444', 'fileName': 'supporting-document-1.pdf'},
+        {'fileKey': 'bbbbbbbb-5555-6666-7777-888888888888', 'fileName': 'supporting-document-2.pdf'}
+    ]
+
+    filing_json = copy.deepcopy(FILING_HEADER)
+    filing_json['filing']['header']['name'] = 'continuationOut'
+    filing_json['filing']['business']['legalType'] = entity_type
+    filing_json['filing']['continuationOut'] = copy.deepcopy(CONTINUATION_OUT)
+    filing_json['filing']['continuationOut']['documents'] = uploaded_documents
+
+    filing = factory_filing(business, filing_json)
+    filing.skip_status_listener = True
+    filing._status = Filing.Status.COMPLETED.value
+    filing._payment_completion_date = '2017-10-01'
+    filing.save()
+
+    # set the meta data the filer would have written for a completed filing
+    filing._meta_data = {
+        'legalFilings': ['continuationOut'],
+        'continuationOut': {'uploadedDocuments': uploaded_documents}
+    }
+    filing.save()
+
+    expected_msg = {'documents': {
+        'receipt': f'{base_url}/api/v2/businesses/{identifier}/filings/1/documents/receipt',
+        'staticDocuments': [
+            {
+                'name': file.get('fileName'),
+                'url': f'{base_url}/api/v2/businesses/{identifier}/filings/1/documents/static/{file.get("fileKey")}'
+            }
+            for file in uploaded_documents
+        ]
+    }}
+
+    account_id = '1'
+    headers = create_header(jwt, [STAFF_ROLE], identifier, account_id=account_id)
+
+    def mock_auth(one, two):  # pylint: disable=unused-argument; mocks of library methods
+        return headers[one]
+
+    with app.test_request_context():
+        monkeypatch.setattr('flask.request.headers.get', mock_auth)
+        with requests_mock.Mocker() as m:
+            mock_url = f"{app.config['AUTH_SVC_URL']}/orgs/{account_id}/products?include_hidden=true"
+            m.get(mock_url, json=[], status_code=HTTPStatus.OK)
+            rv = client.get(f'/api/v2/businesses/{business.identifier}/filings/{filing.id}/documents',
+                            headers=headers)
+
+    rv_data = json.loads(re.sub(r"/\d+/", "/", rv.data.decode("utf-8")).replace("\n", ""))
+    expected = json.loads(re.sub(r"/\d+/", "/", json.dumps(expected_msg)))
+
+    assert rv.status_code == HTTPStatus.OK
+    assert rv_data == expected
+
+
 @pytest.mark.parametrize('test_name, temp_identifier, identifier, entity_type, filing_name, legal_filing, status, expected_msg, expected_http_code', [
     ('ben_ia_paid', 'Tb31yQIuBw', None, Business.LegalTypes.BCOMP.value,
      'incorporationApplication', INCORPORATION, Filing.Status.PAID,

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
@@ -53,7 +53,7 @@ from registry_schemas.example_data.schema_data import ALTERATION, INCORPORATION,
 
 from legal_api.core import Filing
 from legal_api.models import Business, RegistrationBootstrap
-from legal_api.services.authz import STAFF_ROLE
+from legal_api.services.authz import BASIC_USER, PUBLIC_USER, STAFF_ROLE
 from tests.unit.models import (  # noqa:E501,I001
     factory_business,
     factory_completed_filing,
@@ -1636,6 +1636,65 @@ def test_continuation_out_uploaded_documents(app, session, client, jwt, monkeypa
     expected = json.loads(re.sub(r"/\d+/", "/", json.dumps(expected_msg)))
 
     assert rv.status_code == HTTPStatus.OK
+    assert rv_data == expected
+
+
+@pytest.mark.parametrize('non_staff_role', [BASIC_USER, PUBLIC_USER])
+def test_continuation_out_uploaded_documents_not_returned_for_non_staff(non_staff_role, app, session, client, jwt,
+                                                                        monkeypatch, mock_drs_service):
+    """Assert that uploaded continuation out documents are returned to staff only, not other roles."""
+    identifier = 'BC7654321'
+    entity_type = Business.LegalTypes.COMP.value
+    business = factory_business(identifier, entity_type=entity_type)
+
+    uploaded_documents = [
+        {'fileKey': 'aaaaaaaa-1111-2222-3333-444444444444', 'fileName': 'supporting-document-1.pdf'},
+        {'fileKey': 'bbbbbbbb-5555-6666-7777-888888888888', 'fileName': 'supporting-document-2.pdf'}
+    ]
+
+    filing_json = copy.deepcopy(FILING_HEADER)
+    filing_json['filing']['header']['name'] = 'continuationOut'
+    filing_json['filing']['business']['legalType'] = entity_type
+    filing_json['filing']['continuationOut'] = copy.deepcopy(CONTINUATION_OUT)
+    filing_json['filing']['continuationOut']['documents'] = uploaded_documents
+
+    filing = factory_filing(business, filing_json)
+    filing.skip_status_listener = True
+    filing._status = Filing.Status.COMPLETED.value
+    filing._payment_completion_date = '2017-10-01'
+    filing.save()
+
+    # set the meta data the filer would have written for a completed filing
+    filing._meta_data = {
+        'legalFilings': ['continuationOut'],
+        'continuationOut': {'uploadedDocuments': uploaded_documents}
+    }
+    filing.save()
+
+    # a non-staff user is authorized to view the business, but not the staff-only static documents
+    expected_msg = {'documents': {
+        'receipt': f'{base_url}/api/v2/businesses/{identifier}/filings/1/documents/receipt'
+    }}
+
+    account_id = '1'
+    headers = create_header(jwt, [non_staff_role], identifier, account_id=account_id)
+
+    def mock_auth(one, two):  # pylint: disable=unused-argument; mocks of library methods
+        return headers[one]
+
+    with app.test_request_context():
+        monkeypatch.setattr('flask.request.headers.get', mock_auth)
+        with requests_mock.Mocker() as m:
+            m.get(f"{app.config.get('AUTH_SVC_URL')}/entities/{identifier}/authorizations",
+                  json={'roles': ['view']}, status_code=HTTPStatus.OK)
+            rv = client.get(f'/api/v2/businesses/{business.identifier}/filings/{filing.id}/documents',
+                            headers=headers)
+
+    rv_data = json.loads(re.sub(r"/\d+/", "/", rv.data.decode("utf-8")).replace("\n", ""))
+    expected = json.loads(re.sub(r"/\d+/", "/", json.dumps(expected_msg)))
+
+    assert rv.status_code == HTTPStatus.OK
+    assert 'staticDocuments' not in rv_data['documents']
     assert rv_data == expected
 
 

--- a/python/common/business-registry-model/src/business_model/models/document.py
+++ b/python/common/business-registry-model/src/business_model/models/document.py
@@ -31,6 +31,7 @@ class DocumentType(Enum):
 
     AFFIDAVIT = 'affidavit'
     AUTHORIZATION_FILE = 'authorization_file'
+    CONTINUATION_OUT = 'continuation_out'
     COOP_RULES = 'coop_rules'
     COOP_MEMORANDUM = 'coop_memorandum'
     COURT_ORDER = 'court_order'

--- a/queue_services/business-filer/pyproject.toml
+++ b/queue_services/business-filer/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "business-filer"
-version = "3.0.19"
+version = "3.0.20"
 description = "Business Registry Filer Service"
 authors = [
     {name = "thor",email = "1042854+thorwolpert@users.noreply.github.com"}

--- a/queue_services/business-filer/src/business_filer/filing_processors/continuation_out.py
+++ b/queue_services/business-filer/src/business_filer/filing_processors/continuation_out.py
@@ -35,11 +35,46 @@
 from contextlib import suppress
 
 import dpath
-from business_model.models import Business, Comment, Filing
+from business_model.models import Business, Comment, Document, DocumentType, Filing
 
 from business_filer.common.legislation_datetime import LegislationDatetime
 from business_filer.filing_meta import FilingMeta
 from business_filer.filing_processors.filing_components import filings
+
+# DocumentType.CONTINUATION_OUT is added to business-registry-model in this change, but the
+# filer installs that package from bcgov/lear@main, which won't have it until this lands.
+# Use the enum once it's available, otherwise fall back to the literal value (both are
+# "continuation_out"). This can drop to DocumentType.CONTINUATION_OUT.value once the model bumps.
+CONTINUATION_OUT_DOCUMENT_TYPE = (
+    DocumentType.CONTINUATION_OUT.value
+    if getattr(DocumentType, "CONTINUATION_OUT", None)
+    else "continuation_out"
+)
+
+
+def create_uploaded_documents(continuation_out: dict,
+                              business: Business,
+                              filing: Filing,
+                              filing_meta: FilingMeta):
+    """Create document records for the supporting documents uploaded with the continuation out filing."""
+    files = []
+    for file in continuation_out.get("documents", []):
+        document = Document()
+        document.type = CONTINUATION_OUT_DOCUMENT_TYPE
+        document.file_key = file.get("fileKey")
+        document.file_name = file.get("fileName")
+        document.filing_id = filing.id
+        business.documents.append(document)
+        files.append({
+            "fileKey": document.file_key,
+            "fileName": document.file_name
+        })
+
+    if files:
+        filing_meta.continuation_out = {
+            **filing_meta.continuation_out,
+            "uploadedDocuments": files,
+        }
 
 
 def process(business: Business, continuation_out_filing: Filing, filing: dict, filing_meta: FilingMeta):
@@ -85,3 +120,5 @@ def process(business: Business, continuation_out_filing: Filing, filing: dict, f
                 staff_id=continuation_out_filing.submitter_id
             )
         )
+
+    create_uploaded_documents(continuation_out_json, business, continuation_out_filing, filing_meta)

--- a/queue_services/business-filer/tests/unit/test_filer/test_continuation_out.py
+++ b/queue_services/business-filer/tests/unit/test_filer/test_continuation_out.py
@@ -36,13 +36,14 @@ import copy
 import random
 
 from datetime import datetime, timezone
-from business_model.models import Business, Filing
+from business_model.models import Business, Document, Filing
 
 from registry_schemas.example_data import CONTINUATION_OUT, FILING_TEMPLATE
 from business_filer.common.legislation_datetime import LegislationDatetime
 
 from business_filer.filing_meta import FilingMeta
 from business_filer.filing_processors import continuation_out
+from business_filer.filing_processors.continuation_out import CONTINUATION_OUT_DOCUMENT_TYPE
 from tests.unit import create_business, create_filing
 
 
@@ -85,3 +86,70 @@ def tests_filer_continuation_out(app, session):
     assert filing_meta.continuation_out['region'] == foreign_jurisdiction_json['region']
     assert filing_meta.continuation_out['continuationOutDate'] == continuation_out_date_str
     assert filing_meta.continuation_out['legalName'] == filing_json['filing']['continuationOut']['legalName']
+
+
+def tests_filer_continuation_out_uploaded_documents(app, session):
+    """Assert that uploaded supporting documents are persisted as Document records and filing meta data."""
+    identifier = f'BC{random.SystemRandom().randint(1000000, 9999999)}'
+    business = create_business(identifier, legal_type='CP')
+
+    uploaded_documents = [
+        {'fileKey': 'aaaaaaaa-1111-2222-3333-444444444444', 'fileName': 'supporting-document-1.pdf'},
+        {'fileKey': 'bbbbbbbb-5555-6666-7777-888888888888', 'fileName': 'supporting-document-2.pdf'}
+    ]
+
+    filing_json = copy.deepcopy(FILING_TEMPLATE)
+    filing_json['filing']['business']['identifier'] = identifier
+    filing_json['filing']['header']['name'] = 'continuationOut'
+    filing_json['filing']['continuationOut'] = copy.deepcopy(CONTINUATION_OUT)
+    filing_json['filing']['continuationOut']['documents'] = uploaded_documents
+
+    payment_id = str(random.SystemRandom().getrandbits(0x58))
+    continuation_out_filing = create_filing(payment_id, filing_json, business_id=business.id)
+
+    filing_meta = FilingMeta()
+
+    # Test
+    continuation_out.process(business, continuation_out_filing, filing_json['filing'], filing_meta)
+    business.save()
+
+    # Check outcome
+    final_filing = Filing.find_by_id(continuation_out_filing.id)
+
+    documents = Document.find_all_by(final_filing.id, CONTINUATION_OUT_DOCUMENT_TYPE)
+    assert len(documents) == len(uploaded_documents)
+    for document in documents:
+        file = next(x for x in uploaded_documents if x.get('fileKey') == document.file_key)
+        assert document.file_name == file.get('fileName')
+        assert document.filing_id == final_filing.id
+
+    meta_documents = filing_meta.continuation_out['uploadedDocuments']
+    assert len(meta_documents) == len(uploaded_documents)
+    for file in uploaded_documents:
+        assert file in meta_documents
+
+
+def tests_filer_continuation_out_no_uploaded_documents(app, session):
+    """Assert that no uploadedDocuments meta data is set when no documents are uploaded."""
+    identifier = f'BC{random.SystemRandom().randint(1000000, 9999999)}'
+    business = create_business(identifier, legal_type='CP')
+
+    filing_json = copy.deepcopy(FILING_TEMPLATE)
+    filing_json['filing']['business']['identifier'] = identifier
+    filing_json['filing']['header']['name'] = 'continuationOut'
+    filing_json['filing']['continuationOut'] = copy.deepcopy(CONTINUATION_OUT)
+    filing_json['filing']['continuationOut'].pop('documents', None)
+
+    payment_id = str(random.SystemRandom().getrandbits(0x58))
+    continuation_out_filing = create_filing(payment_id, filing_json, business_id=business.id)
+
+    filing_meta = FilingMeta()
+
+    # Test
+    continuation_out.process(business, continuation_out_filing, filing_json['filing'], filing_meta)
+    business.save()
+
+    # Check outcome
+    final_filing = Filing.find_by_id(continuation_out_filing.id)
+    assert Document.find_all_by(final_filing.id, CONTINUATION_OUT_DOCUMENT_TYPE) == []
+    assert 'uploadedDocuments' not in filing_meta.continuation_out


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33690

*Description of changes:*

Persist the supporting documents uploaded with a Continuation Out filing and surface them on the filing's documents endpoint so the dashboard ledger can render download links (staff-only, matching the existing staticDocuments gate).
*Description of changes:*
- business-filer: create_uploaded_documents() creates Document rows from continuationOut.documents and records them in filing meta_data.
- legal-api: get_static_documents() returns a continuationOut branch.
- models: add DocumentType.CONTINUATION_OUT.
- tests: filer + documents endpoint coverage.

*Testing*
[RUN_FILER_LOCALLY_&_CALL_API.md](https://github.com/user-attachments/files/28896455/RUN_FILER_LOCALLY_._CALL_API.md) - copy and paste scripts
`run_filer.py` runs the business-filer's process_filing() directly against the local database 
The run_filer.py script proves the write path (the filer persists the uploaded Continuation Out documents as rows plus meta_data in the database)
<pre>
  Query 1 — the documents rows:
  1092|continuation_out|demo-key-0001|Continuation Out Support 1.pdf
  1093|continuation_out|demo-key-0002|Continuation Out Support 2.pdf
  (Two rows = the two uploaded files. type is continuation_out; the ids are auto-assigned so they'll differ per run.)

  Query 2 — the filing's meta_data.continuationOut.uploadedDocuments:
  [{"fileKey": "demo-key-0001", "fileName": "Continuation Out Support 1.pdf"}, {"fileKey": "demo-key-0002", "fileName": "Continuation Out Support 2.pdf"}]
</pre>

The curl to `http://127.0.0.1:5000/api/v2/businesses/BC0791952/filings/3080798/documents` proves the read path (the API returns those documents, staff-gated, in the shape the dashboard ledger renders as download links).
<pre>
  curl -sS "http://127.0.0.1:5000/api/v2/businesses/BC0791952/filings/3080798/documents" \
    -H "Authorization: Bearer $TOKEN" \
    -H "Accept: application/json" \
    -w $'\nHTTP %{http_code}\n'

  The result (staff token)

  {
    "documents": {
      "receipt": "/api/v2/businesses/BC0791952/filings/3080798/documents/receipt",
      "staticDocuments": [
        {
          "name": "BC0791952 - Continuation Out Filer Doc 1.pdf",
          "url": "/api/v2/businesses/BC0791952/filings/3080798/documents/static/33690-FILER-aaaa-0001"
        },
        {
          "name": "BC0791952 - Continuation Out Filer Doc 2.pdf",
          "url": "/api/v2/businesses/BC0791952/filings/3080798/documents/static/33690-FILER-aaaa-0002"
        }
      ]
    }
  }
  HTTP 200

  For contrast, the same path with a non-staff token

  {
    "documents": {
      "receipt": "/api/v2/businesses/BC0791952/filings/3080798/documents/receipt"
    }
  }
  HTTP 200
</pre>
[run_filer.py](https://github.com/user-attachments/files/28897484/run_filer.py)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
