### PR TITLE
33803 legal-api - incorporation noa bug fix

### DIFF
--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -402,7 +402,7 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
 
         if is_corp_incorp and incorp_compparty_stmnt_enabled:
             if self._filing.submitter_roles in [UserRoles.staff]:
-                filing["header"]["certifiedBy"] = filing["header"].get("certifiedBy")
+                filing["header"]["certifiedBy"] = self._filing.filing_json["filing"]["header"].get("certifiedBy")
             else:
                 filing["header"]["certifiedBy"] = self._filing.filing_submitter.display_name
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33803

*Description of changes:*
- fix incorrect certified by reference for staff filed incorporation noa generation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
