### PR TITLE
33813 - update legal-api version

### DIFF
--- a/legal-api/src/legal_api/version.py
+++ b/legal-api/src/legal_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = "2.171.10"  # pylint: disable=invalid-name
+__version__ = "2.171.11"  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33813

*Description of changes:*
- Bump legal-api version 2.171.10 → 2.171.11.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).