### PR TITLE
33809 Fix verify auth flow invite bug

### DIFF
--- a/data-tool/flows/auth/verify_auth_flow.py
+++ b/data-tool/flows/auth/verify_auth_flow.py
@@ -226,7 +226,6 @@ _INVITE_READ_SQL = """
     SELECT entity_id, COUNT(*) AS invite_count
     FROM affiliation_invitations
     WHERE entity_id IN :entity_ids
-      AND COALESCE(is_deleted, false) = false
     GROUP BY entity_id
 """.strip()
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33809

*Description of changes:*
- Update verify auth flow affiliations invite check logic to just check for existence of an invite.  Was checking `is_deleted = false` previously which is problematic as accepted invites would be excluded.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
