### PR TITLE
33839 Add script for dumping COLIN extract without views

### DIFF
--- a/data-tool/dump_colin_extract_without_views.sh
+++ b/data-tool/dump_colin_extract_without_views.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# dump_colin_extract_without_views.sh
+#
+# Dumps the COLIN extract database while excluding the derived view/materialized-view layer.
+
+set -euo pipefail
+
+##############################################################################
+# USER-TUNABLE PARAMETERS
+##############################################################################
+
+# -- Runtime mode --------------------------------------------------------------
+MODE="${MODE:-dump}"                   # dump | print
+PG_DUMP_BIN="${PG_DUMP_BIN:-pg_dump}"
+
+# -- Connection ----------------------------------------------------------------
+PGHOST="${PGHOST:-localhost}"          # or --host
+PGPORT="${PGPORT:-5432}"               # or --port
+PGUSER="${PGUSER:-postgres}"           # or --user
+PGDATABASE="${PGDATABASE:-colin-mig-corps-test}" # or --dbname
+PGSCHEMA="${PGSCHEMA:-public}"
+# Supply the password *either* via a .pgpass file *or* one-shot:
+#   PGPASSWORD=secret MODE=dump ./dump_colin_extract_without_views.sh
+##############################################################################
+
+# -- Runtime options -----------------------------------------------------------
+BACKUP_DIR="${BACKUP_DIR:-.}"
+if [[ -z "${DUMP:-}" ]]; then
+  DUMP="${BACKUP_DIR}/pg_colin_mig_corps_${PGDATABASE}_no_views_$(date +%Y%m%d).tar"
+fi
+
+##############################################################################
+# INTERNAL HELPERS
+##############################################################################
+
+die() { printf >&2 "error: %s\n" "$*"; exit 1; }
+
+print_command() {
+  local i
+  for i in "${!CMD[@]}"; do
+    if [[ "$i" -eq 0 ]]; then
+      printf '  %q' "${CMD[$i]}"
+    else
+      printf ' \\\n    %q' "${CMD[$i]}"
+    fi
+  done
+  printf '\n'
+}
+
+##############################################################################
+# DERIVED VIEW/MV EXCLUSIONS
+##############################################################################
+
+# Intentionally duplicated from data-tool/scripts/colin_corps_extract_generate_view_drop.sql.
+# Keep this list synchronized with that canonical allowlist.
+EXCLUDED_OBJECTS=(
+  v_addr_links
+  v_addr_issues
+  v_auth_component_operation_audit
+  v_business_state
+  v_corp_issue_flags_long
+  mv_corps_with_officers
+  mv_corps_party_role_count
+  mv_admin_email_count
+  mv_admin_email_domain_count
+  mv_addr_issue_counts_by_entity
+  mv_addr_quality_by_corp
+  mv_addr_quality_screening_by_corp
+  mv_share_class_issue_flags
+  mv_corp_event_filing_rollup
+  mv_legacy_corps_data
+  mv_corp_issue_flags
+  mv_issue_counts_by_corp_type
+)
+
+case "$MODE" in
+  print|dump) ;;
+  *) die "MODE must be 'print' or 'dump'" ;;
+esac
+
+CMD=(
+  "$PG_DUMP_BIN"
+  -F t
+  -b
+  -v
+  --no-owner
+  --no-acl
+  -h "$PGHOST"
+  -p "$PGPORT"
+  -U "$PGUSER"
+  -d "$PGDATABASE"
+)
+
+for object in "${EXCLUDED_OBJECTS[@]}"; do
+  CMD+=("--exclude-table=${PGSCHEMA}.${object}")
+done
+
+CMD+=(-f "$DUMP")
+
+printf "📦  COLIN extract dump without derived views/materialized views\n"
+printf "Mode: %s\n" "$MODE"
+printf "Database: %s@%s:%s/%s\n" "$PGUSER" "$PGHOST" "$PGPORT" "$PGDATABASE"
+printf "Schema: %s\n" "$PGSCHEMA"
+printf "Output: %s\n" "$DUMP"
+printf "Excluded objects:\n"
+for object in "${EXCLUDED_OBJECTS[@]}"; do
+  printf "  - %s.%s\n" "$PGSCHEMA" "$object"
+done
+printf "Command:\n"
+print_command
+
+if [[ "$MODE" == "print" ]]; then
+  printf "\nPrint mode only; no output directory created and pg_dump was not run.\n"
+  exit 0
+fi
+
+mkdir -p "$(dirname "$DUMP")"
+printf "\nRunning pg_dump...\n"
+"${CMD[@]}"
+printf "✅  Dump written to %s\n" "$DUMP"

--- a/data-tool/scripts/README_COLIN_Corps_Extract.md
+++ b/data-tool/scripts/README_COLIN_Corps_Extract.md
@@ -133,6 +133,39 @@ Safety rules:
 
 ---
 
+## Dumping the extract DB without derived views/materialized views
+
+Creates a tar-format `pg_dump` archive excluding the COLIN derived views/materialized views.
+
+```bash
+PGPASSFILE=~/.pgpass \
+  DUMP=/tmp/colin-no-views-test.tar \
+  ./data-tool/dump_colin_extract_without_views.sh
+```
+
+Options:
+- `MODE`: `dump` (default) runs `pg_dump`; `print` only prints the command.
+- `PG_DUMP_BIN`: `pg_dump` binary to use (default: `pg_dump`).
+- `PGHOST`: database host (default: `localhost`).
+- `PGPORT`: database port (default: `5432`).
+- `PGUSER`: database user (default: `postgres`).
+- `PGDATABASE`: source database (default: `colin-mig-corps-test`).
+- `PGSCHEMA`: schema for excluded views/materialized views (default: `public`).
+- `PGPASSFILE`: password file for libpq authentication, e.g. `~/.pgpass`.
+- `PGPASSWORD`: one-off password alternative to `PGPASSFILE`.
+- `BACKUP_DIR`: output directory when `DUMP` is not set (default: current directory).
+- `DUMP`: full output path and filename; overrides `BACKUP_DIR`.
+
+After restore, recreate the derived layer with `reset_colin_extract_views.sh --mode reset --yes --allow-empty ...` if needed.
+
+Quick check; no output means no view/materialized-view entries were found in the archive list:
+
+```bash
+pg_restore -l /tmp/colin-no-views-test.tar | grep -E 'VIEW|MATERIALIZED VIEW'
+```
+
+---
+
 ## Refreshing selected materialized views for data-only changes
 
 Use this when the **derived MV definitions have not changed** and you only need to rebuild the affected materialized views in dependency order.


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33839

## Summary

Adds a small `data-tool` helper script to create a tar-format `pg_dump` archive of the COLIN extract database while excluding the derived view/materialized-view layer. This makes it easier to share or restore the base extract data without paying the restore-time cost of recreating expensive materialized views.

## What changed

- Added `data-tool/dump_colin_extract_without_views.sh`.
- The script runs `pg_dump -F t` and excludes the known COLIN derived views/materialized views by exact name.
- `MODE=dump` is the default and writes the dump file.
- `MODE=print` prints the generated `pg_dump` command without running it.
- Output can be controlled with `DUMP` or `BACKUP_DIR`.
- PostgreSQL connection and auth use standard libpq-style environment variables such as `PGHOST`, `PGPORT`, `PGUSER`, `PGDATABASE`, `PGPASSFILE`, and `PGPASSWORD`.
- Updated `data-tool/scripts/README_COLIN_Corps_Extract.md` with minimal usage instructions and option descriptions.

## Usage example

```bash
PGPASSFILE=~/.pgpass \
  DUMP=/tmp/colin-no-views-test.tar \
  ./data-tool/dump_colin_extract_without_views.sh
```

Preview only:

```bash
MODE=print ./data-tool/dump_colin_extract_without_views.sh
```

Quick archive check:

```bash
pg_restore -l /tmp/colin-no-views-test.tar | grep -E 'VIEW|MATERIALIZED VIEW'
```

No output means no view/materialized-view entries were found in the archive list.

## Reviewer focus

- Confirm the excluded object list matches the COLIN derived view/materialized-view allowlist.
- Confirm the script does not use broad wildcard exclusions.
- Confirm the default behavior is `MODE=dump`, while `MODE=print` remains safe.
- Confirm `DUMP` overrides `BACKUP_DIR` and the default output path is reasonable.
- Confirm the README stays minimal but includes enough information for operators.

## Testing notes

- Ran shell syntax validation:

```bash
bash -n data-tool/dump_colin_extract_without_views.sh
```

- Ran print mode to verify the command can be previewed without invoking `pg_dump`:

```bash
MODE=print ./data-tool/dump_colin_extract_without_views.sh
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
