### PR TITLE
33878 split verify auth flow into two flows - verify and inspect

### DIFF
--- a/data-tool/.corps.env.sample
+++ b/data-tool/.corps.env.sample
@@ -113,40 +113,49 @@ AUTH_DRY_RUN=False
 # Separate from AFFILIATE_ENTITY_ACCOUNT_ID.
 AUTH_AFFILIATION_ACCOUNT_IDS=
 
-# Verify Auth controls.
-# Read-only verifier/inspector for Auth DB elements: entity, contact, affiliation, invite.
-# Uses the targeting block above. MIGRATION_FILTER is the main mode; MANUAL uses AUTH_CORP_NUMS.
+# Shared output directory/root for Auth flows that write reports.
+# Fixed verify and inspect filenames are derived under this path:
+# - verify-auth-summary.csv
+# - verify-auth-detail.csv
+# - verify-auth-scenario.txt
+# - inspect-auth-inspection.csv
+# - inspect-auth-summary.txt
+AUTH_OUTPUT_PATH=/tmp/auth
+
+# Shared read-only Auth reporting throughput for verify-auth and inspect-auth.
 # Keep default batch values at 0 so the sample fails fast until explicitly configured.
-VERIFY_AUTH_BATCHES=0
-VERIFY_AUTH_BATCH_SIZE=0
-# Report modes:
-# - VERIFY: default when unset/blank; writes summary/detail/scenario verify CSVs under VERIFY_AUTH_OUTPUT_PATH.
-# - INSPECT: writes factual inspection CSV under VERIFY_AUTH_OUTPUT_PATH.
-# - VERIFY_AND_INSPECT: writes all four fixed CSV outputs under VERIFY_AUTH_OUTPUT_PATH.
-VERIFY_AUTH_REPORT_MODE=VERIFY
-# Inspection filter is applied after Auth DB read-back; it does not change candidate selection.
-# Applies only when VERIFY_AUTH_REPORT_MODE is INSPECT or VERIFY_AND_INSPECT.
-# Default ALL writes every inspected candidate to CSV. Non-ALL filters write matched rows only.
-# With VERIFY_AUTH_CONSOLE_DETAIL=True, this filter also controls inspect identifier copy blocks:
-# non-ALL prints one active-filter AUTH_CORP_NUMS list; ALL prints non-empty concrete groups, no ALL mega-list.
-# Accepted: ALL,HAS_ANY_AUTH,HAS_ENTITY,MISSING_ENTITY,HAS_CONTACT,ENTITY_WITHOUT_CONTACT,
-#           HAS_AFFILIATION,ENTITY_WITHOUT_AFFILIATION,HAS_INVITE,ENTITY_WITHOUT_INVITE
-VERIFY_AUTH_INSPECT_FILTER=ALL
+AUTH_REPORT_BATCHES=0
+AUTH_REPORT_BATCH_SIZE=0
+
+# Verify Auth controls.
+# Read-only verifier for Auth DB elements: entity, contact, affiliation, invite.
+# Run with: make run-verify-auth
+# Uses the targeting block above. MIGRATION_FILTER is the main mode; MANUAL uses AUTH_CORP_NUMS.
 VERIFY_AUTH_CHECK_ENTITY=True
 VERIFY_AUTH_CHECK_CONTACT=True
 VERIFY_AUTH_CHECK_AFFILIATION=False
 VERIFY_AUTH_CHECK_INVITE=False
-# Boolean only. On: true/1. Off: false/0/blank/unset.
-# When True, prints scenario identifier lists, matched inspection row details, and inspect identifier copy blocks.
-# When False, inspect console output is summary-first only.
-VERIFY_AUTH_CONSOLE_DETAIL=False
-# Single output directory/root. Fixed filenames are derived under this path:
-# - verify-auth-summary.csv
-# - verify-auth-detail.csv
-# - verify-auth-scenario.csv
-# - verify-auth-inspection.csv
-VERIFY_AUTH_OUTPUT_PATH=/tmp/verify-auth
+# Console-only scenario identifier preview limit. Accepted: 0, positive integer, ALL.
+# 0 suppresses optional console sections; positive values cap scenario identifiers printed to console.
+# Console output may be incomplete; complete AUTH_CORP_NUMS copy lists are written to verify-auth-scenario.txt.
+VERIFY_AUTH_CONSOLE_LIMIT=25
 
+# Inspect Auth controls.
+# Read-only factual Auth DB state inspector.
+# Run with: make run-inspect-auth
+# Uses the targeting block above. INSPECT_AUTH_FILTER is applied after Auth DB read-back;
+# it does not change candidate selection.
+# Default ALL writes every inspected candidate to CSV. Non-ALL filters write matched rows only.
+# Accepted: ALL,HAS_ANY_AUTH,HAS_ENTITY,MISSING_ENTITY,HAS_CONTACT,ENTITY_WITHOUT_CONTACT,
+#           HAS_AFFILIATION,ENTITY_WITHOUT_AFFILIATION,HAS_INVITE,ENTITY_WITHOUT_INVITE
+# HAS_CONTACT / ENTITY_WITHOUT_CONTACT mean usable contact email, not merely any raw contact row.
+INSPECT_AUTH_FILTER=ALL
+# Console-only row/identifier preview limit. Accepted: 0, positive integer, ALL.
+# 0 suppresses optional console sections; positive values cap matched inspection rows and identifier groups printed to console.
+# Complete inspection rows are written to inspect-auth-inspection.csv.
+# Complete AUTH_CORP_NUMS copy lists are written to inspect-auth-summary.txt.
+# With filter ALL, inspect prints non-empty concrete identifier groups, no ALL mega-list.
+INSPECT_AUTH_CONSOLE_LIMIT=25
 # Delete/reset controls.
 AUTH_DELETE_AFFILIATIONS=False
 AUTH_DELETE_ENTITY=False

--- a/data-tool/Makefile
+++ b/data-tool/Makefile
@@ -136,9 +136,13 @@ run-verify-colin-updates: ## Run verify COLIN updates flow
 	. $(VENV_DIR)/bin/activate && \
 	python flows/verify_colin_updates_flow.py
 
-run-verify-auth: ## Run verify Auth flow
+run-verify-auth: ## Run verify Auth flow and write summary/detail CSVs plus scenario TXT copy list
 	. $(VENV_DIR)/bin/activate && \
 	$(AUTH_MODULE_RUNNER) auth.verify_auth_flow
+
+run-inspect-auth: ## Run inspect Auth flow and write inspect-auth-inspection.csv plus inspect-auth-summary.txt
+	. $(VENV_DIR)/bin/activate && \
+	$(AUTH_MODULE_RUNNER) auth.inspect_auth_flow
 
 run-auth-create: ## Run auth create flow
 	. $(VENV_DIR)/bin/activate && \

--- a/data-tool/flows/auth/auth_queries.py
+++ b/data-tool/flows/auth/auth_queries.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence
 
 from .auth_flow_utils import auth_custom_contact_email_override
 from .auth_models import (
@@ -16,6 +16,7 @@ from .auth_selection import (
 
 # Match the existing tombstone corp type cohort by default.
 CORP_TYPE_FILTER = "('BC', 'C', 'ULC', 'CUL', 'CC', 'CCC', 'QA', 'QB', 'QC', 'QD', 'QE')"
+_UNSET = object()
 
 
 def _escape_sql_literal(val: str) -> str:
@@ -240,7 +241,32 @@ def _parse_corp_nums_csv(csv_val: str | None) -> List[str]:
     return parse_auth_corp_nums_csv(csv_val)
 
 
-def get_auth_selected_corp_nums_query(config, selection_mode: AuthSelectionMode) -> str:
+def _corp_nums_for_sql(values: Sequence[str] | str | None) -> List[str]:
+    """Return normalized corp nums from settings-provided values."""
+    if values is None:
+        return []
+    if isinstance(values, str):
+        return parse_auth_corp_nums_csv(values)
+    return parse_auth_corp_nums_csv(",".join(str(value) for value in values))
+
+
+def _positive_int_sequence_for_sql(values: Sequence[int | str] | str | None, *, name: str) -> Optional[str]:
+    """Return normalized positive integer CSV from settings-provided values."""
+    if values is None:
+        return None
+    if isinstance(values, str):
+        return positive_int_csv_for_sql(values, name=name)
+    return positive_int_csv_for_sql(",".join(str(value) for value in values), name=name)
+
+
+def get_auth_selected_corp_nums_query(
+    config,
+    selection_mode: AuthSelectionMode,
+    *,
+    auth_corp_nums: Sequence[str] | str | None | Any = _UNSET,
+    auth_mig_group_ids: Sequence[int | str] | str | None | Any = _UNSET,
+    auth_mig_batch_ids: Sequence[int | str] | str | None | Any = _UNSET,
+) -> str:
     """Build SQL for the currently configured auth selection, returning one corp_num column.
 
     This cleanup/preview helper intentionally does not join auth_processing, does not apply
@@ -249,15 +275,36 @@ def get_auth_selected_corp_nums_query(config, selection_mode: AuthSelectionMode)
     selection_mode = AuthSelectionMode(selection_mode)
 
     if selection_mode == AuthSelectionMode.MIGRATION_FILTER:
-        mig_group_ids, mig_batch_ids = _auth_migration_filter_ids(config)
-        auth_corp_nums = _parse_corp_nums_csv(getattr(config, 'AUTH_CORP_NUMS', ''))
+        if auth_mig_group_ids is _UNSET and auth_mig_batch_ids is _UNSET:
+            mig_group_ids, mig_batch_ids = _auth_migration_filter_ids(config)
+        else:
+            mig_group_ids = _positive_int_sequence_for_sql(
+                () if auth_mig_group_ids is _UNSET else auth_mig_group_ids,
+                name='AUTH_MIG_GROUP_IDS',
+            )
+            mig_batch_ids = _positive_int_sequence_for_sql(
+                () if auth_mig_batch_ids is _UNSET else auth_mig_batch_ids,
+                name='AUTH_MIG_BATCH_IDS',
+            )
+            if not (mig_group_ids or mig_batch_ids):
+                raise ValueError(
+                    'AUTH_SELECTION_MODE=MIGRATION_FILTER requires AUTH_MIG_GROUP_IDS and/or AUTH_MIG_BATCH_IDS; '
+                    'AUTH_CORP_NUMS only narrows the migration-filter cohort and does not replace '
+                    'AUTH_MIG_GROUP_IDS/AUTH_MIG_BATCH_IDS; Auth flows do not fall back to global '
+                    'MIG_GROUP_IDS/MIG_BATCH_IDS'
+                )
+        candidate_corp_nums = (
+            _parse_corp_nums_csv(getattr(config, 'AUTH_CORP_NUMS', ''))
+            if auth_corp_nums is _UNSET
+            else _corp_nums_for_sql(auth_corp_nums)
+        )
         mig_extra_where = ""
         if mig_batch_ids:
             mig_extra_where += f" AND b.id IN ({mig_batch_ids})"
         if mig_group_ids:
             mig_extra_where += f" AND g.id IN ({mig_group_ids})"
-        if auth_corp_nums:
-            mig_extra_where += f" AND c.corp_num IN ({_quote_list(auth_corp_nums)})"
+        if candidate_corp_nums:
+            mig_extra_where += f" AND c.corp_num IN ({_quote_list(candidate_corp_nums)})"
 
         return f"""
         SELECT DISTINCT c.corp_num
@@ -273,7 +320,11 @@ def get_auth_selected_corp_nums_query(config, selection_mode: AuthSelectionMode)
         AND c.corp_type_cd IN {CORP_TYPE_FILTER}
         """
 
-    corp_nums = _parse_corp_nums_csv(getattr(config, 'AUTH_CORP_NUMS', ''))
+    corp_nums = (
+        _parse_corp_nums_csv(getattr(config, 'AUTH_CORP_NUMS', ''))
+        if auth_corp_nums is _UNSET
+        else _corp_nums_for_sql(auth_corp_nums)
+    )
     corp_filter = f"AND c.corp_num IN ({_quote_list(corp_nums)})" if corp_nums else "AND 1=0"
     return f"""
     SELECT c.corp_num

--- a/data-tool/flows/auth/auth_report_helpers.py
+++ b/data-tool/flows/auth/auth_report_helpers.py
@@ -1,0 +1,51 @@
+"""Shared Auth reporting helper import surface.
+
+This module gives inspect-auth a neutral dependency for helper functions that are
+currently implemented by ``verify_auth_flow.py`` for backwards compatibility.
+Keeping this import surface separate from the inspect entrypoint makes the shared
+contract explicit and provides the target module for a future physical helper
+extraction without changing inspect-auth imports again.
+"""
+
+from __future__ import annotations
+
+# readback helpers, and output helpers out of verify_auth_flow.py once this reporting
+# surface stabilizes. For now this module is a neutral import shim so inspect-auth no
+# longer depends directly on the verify-auth entrypoint.
+from auth.verify_auth_flow import (  # noqa: F401
+    AUTH_OUTPUT_PATH_ATTR,
+    CHECK_AFFILIATION,
+    CHECK_CONTACT,
+    CHECK_ENTITY,
+    CHECK_INVITE,
+    NO_CACHE,
+    AuthBatchResult,
+    ConsoleLimit,
+    blank_to_none,
+    build_candidate_queries,
+    build_inspection_identifier_rows,
+    build_inspection_rows,
+    build_inspection_summary,
+    calculate_batch_count,
+    dispose_engine,
+    filter_inspection_states,
+    flow,
+    format_console_limit,
+    get_candidate_count,
+    get_candidate_page,
+    is_csv_like_output_root,
+    parse_auth_selection_mode,
+    parse_console_limit,
+    parse_inspect_filter,
+    parse_manual_account_ids,
+    parse_positive_int_tuple,
+    print_inspection_identifier_rows,
+    print_inspection_rows,
+    print_inspection_summary,
+    read_expected_accounts_for_candidates,
+    resolve_task_result,
+    run_auth_batch,
+    task,
+    write_inspection_report,
+    write_inspection_summary_txt,
+)

--- a/data-tool/flows/auth/inspect_auth_flow.py
+++ b/data-tool/flows/auth/inspect_auth_flow.py
@@ -1,0 +1,383 @@
+"""Read-only Prefect inspection flow for Auth DB state.
+
+This module provides the dedicated inspect-auth entrypoint. It shares the
+verify-auth candidate selection, expected-account lookup, Auth DB read-back,
+inspection row builders, CSV writer, Prefect fallback decorators, and console
+limit helpers while using shared AUTH_REPORT_* throughput plus inspect-specific
+INSPECT_AUTH_* configuration.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+from sqlalchemy.engine import Engine
+
+from auth.auth_models import AuthSelectionMode
+from auth.auth_selection import parse_auth_corp_nums_csv
+from auth.auth_report_helpers import (
+    CHECK_AFFILIATION,
+    CHECK_CONTACT,
+    CHECK_ENTITY,
+    CHECK_INVITE,
+    AUTH_OUTPUT_PATH_ATTR,
+    AuthBatchResult,
+    ConsoleLimit,
+    blank_to_none,
+    dispose_engine,
+    format_console_limit,
+    is_csv_like_output_root,
+    parse_auth_selection_mode,
+    parse_manual_account_ids,
+    parse_positive_int_tuple,
+    resolve_task_result,
+    build_candidate_queries,
+    build_inspection_identifier_rows,
+    build_inspection_rows,
+    build_inspection_summary,
+    calculate_batch_count,
+    filter_inspection_states,
+    flow,
+    get_candidate_count,
+    get_candidate_page,
+    parse_console_limit,
+    parse_inspect_filter,
+    print_inspection_identifier_rows,
+    print_inspection_rows,
+    print_inspection_summary,
+    read_expected_accounts_for_candidates,
+    run_auth_batch,
+    task,
+    write_inspection_report,
+    write_inspection_summary_txt,
+    NO_CACHE,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+FLOW_NAME = "inspect-auth-flow"
+LOCAL_THREADED_EXECUTION_ASSUMPTION = (
+    "Inspect Auth assumes local/threaded Prefect execution because SQLAlchemy engine objects "
+    "are shared with submitted read-only tasks; do not use distributed/process task runners."
+)
+
+DEFAULT_INSPECT_AUTH_CONSOLE_LIMIT = 25
+INSPECTION_FILENAME = "inspect-auth-inspection.csv"
+INSPECTION_SUMMARY_FILENAME = "inspect-auth-summary.txt"
+INSPECT_AUTH_CONSOLE_LIMIT_ATTR = "INSPECT_AUTH_CONSOLE_LIMIT"
+INSPECT_AUTH_READ_CHECKS = (CHECK_ENTITY, CHECK_CONTACT, CHECK_AFFILIATION, CHECK_INVITE)
+
+
+@dataclass(frozen=True)
+class InspectAuthSettings:
+    """Validated inspect-only settings needed by the inspect-auth flow."""
+
+    batches: int
+    batch_size: int
+    inspect_filter: str
+    console_limit: ConsoleLimit
+    inspection_path: str
+    summary_path: str
+    selection_mode: AuthSelectionMode
+    auth_corp_nums: tuple[str, ...]
+    auth_mig_group_ids: tuple[int, ...]
+    auth_mig_batch_ids: tuple[int, ...]
+    manual_account_ids: tuple[str, ...]
+    selected_checks: tuple[str, ...] = ()
+
+    @property
+    def run_verify(self) -> bool:
+        """Return False so shared Auth batches only read Auth state."""
+        return False
+
+    @property
+    def auth_read_checks(self) -> tuple[str, ...]:
+        """Return the full Auth table read scope for inspection."""
+        return INSPECT_AUTH_READ_CHECKS
+
+    @property
+    def read_expected_accounts(self) -> bool:
+        """Return True when expected account IDs should be included in inspect rows."""
+        return self.selection_mode != AuthSelectionMode.MANUAL or bool(self.manual_account_ids)
+
+
+def _coerce_int_setting(config: Any, attr_name: str) -> int:
+    raw_value = getattr(config, attr_name, 0)
+    try:
+        return int(raw_value or 0)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{attr_name} must be a valid integer") from exc
+
+
+def _derive_inspection_path(output_root: str) -> str:
+    return str(Path(output_root).expanduser() / INSPECTION_FILENAME)
+
+
+def _derive_summary_path(output_root: str) -> str:
+    return str(Path(output_root).expanduser() / INSPECTION_SUMMARY_FILENAME)
+
+
+def _resolve_inspection_paths(config: Any) -> tuple[str, str]:
+    output_root = blank_to_none(getattr(config, AUTH_OUTPUT_PATH_ATTR, None))
+    if not output_root:
+        raise ValueError(f"{AUTH_OUTPUT_PATH_ATTR} must be set")
+    if is_csv_like_output_root(output_root):
+        raise ValueError(f"{AUTH_OUTPUT_PATH_ATTR} must be a directory/root path, not a .csv file path")
+    return _derive_inspection_path(output_root), _derive_summary_path(output_root)
+
+
+def validate_inspect_config(config: Any) -> InspectAuthSettings:
+    """Validate inspect-auth config before database connections are opened."""
+    batches = _coerce_int_setting(config, "AUTH_REPORT_BATCHES")
+    if batches <= 0:
+        raise ValueError("AUTH_REPORT_BATCHES must be greater than 0")
+
+    batch_size = _coerce_int_setting(config, "AUTH_REPORT_BATCH_SIZE")
+    if batch_size <= 0:
+        raise ValueError("AUTH_REPORT_BATCH_SIZE must be greater than 0")
+
+    inspect_filter = parse_inspect_filter(getattr(config, "INSPECT_AUTH_FILTER", None), "INSPECT_AUTH_FILTER")
+    console_limit = parse_console_limit(
+        getattr(config, INSPECT_AUTH_CONSOLE_LIMIT_ATTR, None),
+        INSPECT_AUTH_CONSOLE_LIMIT_ATTR,
+        DEFAULT_INSPECT_AUTH_CONSOLE_LIMIT,
+    )
+    inspection_path, summary_path = _resolve_inspection_paths(config)
+
+    selection_mode = parse_auth_selection_mode(config)
+    auth_corp_nums = tuple(parse_auth_corp_nums_csv(getattr(config, "AUTH_CORP_NUMS", None)))
+
+    auth_mig_group_ids: tuple[int, ...] = ()
+    auth_mig_batch_ids: tuple[int, ...] = ()
+    if selection_mode == AuthSelectionMode.MIGRATION_FILTER:
+        auth_mig_group_ids = parse_positive_int_tuple(config, "AUTH_MIG_GROUP_IDS")
+        auth_mig_batch_ids = parse_positive_int_tuple(config, "AUTH_MIG_BATCH_IDS")
+        if not (auth_mig_group_ids or auth_mig_batch_ids):
+            raise ValueError(
+                "AUTH_SELECTION_MODE=MIGRATION_FILTER requires AUTH_MIG_GROUP_IDS and/or AUTH_MIG_BATCH_IDS; "
+                "Auth inspection does not fall back to global MIG_GROUP_IDS/MIG_BATCH_IDS"
+            )
+
+    manual_account_ids: tuple[str, ...] = ()
+    if selection_mode == AuthSelectionMode.MANUAL:
+        manual_account_ids = parse_manual_account_ids(config)
+
+    return InspectAuthSettings(
+        batches=batches,
+        batch_size=batch_size,
+        inspect_filter=inspect_filter,
+        console_limit=console_limit,
+        inspection_path=inspection_path,
+        summary_path=summary_path,
+        selection_mode=selection_mode,
+        auth_corp_nums=auth_corp_nums,
+        auth_mig_group_ids=auth_mig_group_ids,
+        auth_mig_batch_ids=auth_mig_batch_ids,
+        manual_account_ids=manual_account_ids,
+    )
+
+
+@task(name="Count inspect Auth candidates", cache_policy=NO_CACHE)
+def get_inspect_candidate_count_task(
+    config: Any,
+    colin_extract_engine: Engine,
+    settings: InspectAuthSettings,
+) -> int:
+    """Prefect task wrapper for inspect selected-candidate counting."""
+    return get_candidate_count(config, colin_extract_engine, settings)
+
+
+@task(name="Page inspect Auth candidates", cache_policy=NO_CACHE)
+def get_inspect_candidate_page_task(
+    config: Any,
+    colin_extract_engine: Engine,
+    limit: int,
+    offset: int,
+    settings: InspectAuthSettings,
+) -> list[str]:
+    """Prefect task wrapper for deterministic inspect candidate paging."""
+    return get_candidate_page(config, colin_extract_engine, limit, offset, settings)
+
+
+@task(name="Read inspect Auth expected affiliation accounts", cache_policy=NO_CACHE)
+def read_inspect_expected_accounts_task(
+    config: Any,
+    colin_extract_engine: Engine,
+    business_identifiers: list[str],
+    settings: InspectAuthSettings,
+) -> dict[str, tuple[str, ...]]:
+    """Prefect task wrapper for read-only expected-account derivation."""
+    return read_expected_accounts_for_candidates(config, colin_extract_engine, business_identifiers, settings)
+
+
+@task(name="Inspect Auth DB batch", cache_policy=NO_CACHE)
+def inspect_auth_batch_task(
+    config: Any,
+    auth_engine: Engine,
+    business_identifiers: list[str],
+    expected_accounts_by_identifier: dict[str, Iterable[str]] | None,
+    settings: InspectAuthSettings,
+) -> AuthBatchResult:
+    """Prefect task wrapper for one inspect Auth DB read-back batch."""
+    return run_auth_batch(config, auth_engine, business_identifiers, expected_accounts_by_identifier, settings)
+
+
+def _submit_inspect_batch(
+    config: Any,
+    auth_engine: Engine,
+    business_identifiers: list[str],
+    expected_accounts_by_identifier: dict[str, Iterable[str]] | None,
+    settings: InspectAuthSettings,
+) -> Any:
+    """Submit one Auth inspection task, with a sync fallback for non-Prefect tests."""
+    args = (config, auth_engine, business_identifiers, expected_accounts_by_identifier, settings)
+    if hasattr(inspect_auth_batch_task, "submit"):
+        return inspect_auth_batch_task.submit(*args)
+    return inspect_auth_batch_task(*args)
+
+
+def _format_start_message(settings: InspectAuthSettings) -> str:
+    return (
+        "👷 Inspect Auth starting. "
+        f"SelectionMode={settings.selection_mode.value}, "
+        f"InspectFilter={settings.inspect_filter}, "
+        f"AuthReadChecks={','.join(settings.auth_read_checks)}, "
+        f"ConsoleLimit={format_console_limit(settings.console_limit)}, "
+        f"ConfiguredBatches={settings.batches}, BatchSize={settings.batch_size}, "
+        "RunnerAssumption=local/threaded"
+    )
+
+
+def _run_inspect_auth_flow_with_engines(
+    config: Any,
+    settings: InspectAuthSettings,
+    colin_extract_engine: Engine,
+    auth_engine: Engine,
+) -> dict[str, int | str]:
+    """Run inspect-auth orchestration using already-initialized engines."""
+    total_candidates = get_inspect_candidate_count_task(config, colin_extract_engine, settings)
+    total_candidates = int(resolve_task_result(total_candidates) or 0)
+    batch_count = calculate_batch_count(total_candidates, settings.batch_size, settings.batches)
+    print(
+        "👷 Auth candidate selection ready. "
+        f"TotalCandidates={total_candidates}, BatchCount={batch_count}, "
+        f"SelectionMode={settings.selection_mode.value}, "
+        f"AuthMigGroupIds={settings.auth_mig_group_ids or '(none)'}, "
+        f"AuthMigBatchIds={settings.auth_mig_batch_ids or '(none)'}, "
+        f"InspectFilter={settings.inspect_filter}"
+    )
+
+    futures: list[Any] = []
+    for batch_index in range(batch_count):
+        offset = batch_index * settings.batch_size
+        business_identifiers = get_inspect_candidate_page_task(
+            config,
+            colin_extract_engine,
+            settings.batch_size,
+            offset,
+            settings,
+        )
+        business_identifiers = [str(identifier) for identifier in (resolve_task_result(business_identifiers) or [])]
+
+        expected_accounts_by_identifier: dict[str, Iterable[str]] | None = None
+        if settings.read_expected_accounts:
+            expected_accounts_by_identifier = read_inspect_expected_accounts_task(
+                config,
+                colin_extract_engine,
+                business_identifiers,
+                settings,
+            )
+            expected_accounts_by_identifier = resolve_task_result(expected_accounts_by_identifier) or {}
+
+        print(
+            f"🚀 Submitting inspect-auth batch {batch_index + 1}/{batch_count}: "
+            f"offset={offset}, candidate_count={len(business_identifiers)}"
+        )
+        futures.append(
+            _submit_inspect_batch(
+                config,
+                auth_engine,
+                business_identifiers,
+                expected_accounts_by_identifier,
+                settings,
+            )
+        )
+
+    states = []
+    for future in futures:
+        batch_result = resolve_task_result(future)
+        if isinstance(batch_result, AuthBatchResult):
+            states.extend(batch_result.states)
+        else:
+            # Compatibility for simple task doubles that return raw AuthBusinessState lists.
+            states.extend(batch_result or [])
+
+    matched_states = filter_inspection_states(states, settings.inspect_filter)
+    inspection_rows = build_inspection_rows(matched_states)
+    identifier_rows = build_inspection_identifier_rows(states, matched_states, settings.inspect_filter)
+    summary = build_inspection_summary(states, matched_states, settings.inspect_filter)
+
+    print(
+        "🌟 Inspect Auth tasks complete. "
+        f"TotalInspected={summary['inspected_count']}, Matched={summary['matched_count']}, "
+        f"IdentifierGroups={len(identifier_rows)}"
+    )
+    print_inspection_summary(states, matched_states, settings.inspect_filter)
+    print_inspection_rows(
+        inspection_rows,
+        console_limit=settings.console_limit,
+        report_path=settings.inspection_path,
+        limit_config_key=INSPECT_AUTH_CONSOLE_LIMIT_ATTR,
+    )
+    print_inspection_identifier_rows(
+        identifier_rows,
+        settings.inspect_filter,
+        console_limit=settings.console_limit,
+        copy_list_path=settings.summary_path,
+        limit_config_key=INSPECT_AUTH_CONSOLE_LIMIT_ATTR,
+    )
+
+    write_inspection_report(settings.inspection_path, matched_states)
+    write_inspection_summary_txt(settings.summary_path, identifier_rows, summary)
+    print(
+        "🌰 Inspect Auth reports written. "
+        f"InspectionPath={settings.inspection_path}, SummaryPath={settings.summary_path}"
+    )
+
+    return summary
+
+
+def _initialize_and_run_inspect_auth_flow() -> dict[str, int | str]:
+    """Validate config, initialize engines once, and run inspect-auth orchestration."""
+    from common.init_utils import auth_init, colin_extract_init, get_config
+
+    config = get_config()
+    settings = validate_inspect_config(config)
+    print(_format_start_message(settings))
+    LOGGER.info(LOCAL_THREADED_EXECUTION_ASSUMPTION)
+
+    # Build once before connecting so config/query validation happens early. INSPECT_AUTH_FILTER
+    # is intentionally not involved in candidate SQL; it is applied after Auth read-back.
+    build_candidate_queries(config, settings)
+
+    colin_extract_engine = colin_extract_init(config)
+    auth_engine = None
+    try:
+        auth_engine = auth_init(config)
+        return _run_inspect_auth_flow_with_engines(config, settings, colin_extract_engine, auth_engine)
+    finally:
+        dispose_engine(auth_engine)
+        dispose_engine(colin_extract_engine)
+
+
+@flow(name="Inspect-Auth-Flow", log_prints=True)
+def inspect_auth_flow() -> dict[str, int | str]:
+    """Validate config, inspect selected Auth DB candidates, and write report."""
+    return _initialize_and_run_inspect_auth_flow()
+
+
+if __name__ == "__main__":
+    inspect_auth_flow()

--- a/data-tool/flows/auth/verify_auth_flow.py
+++ b/data-tool/flows/auth/verify_auth_flow.py
@@ -1426,21 +1426,21 @@ def write_inspection_csv(path: str, states: list[AuthBusinessState]) -> None:
 
 
 _INSPECTION_FILTER_SUMMARY_METRICS = {
-    INSPECT_FILTER_HAS_ANY_AUTH: ("HasAnyAuth", "has_any_auth_count"),
-    INSPECT_FILTER_MISSING_ENTITY: ("MissingEntity", "missing_entity_count"),
-    INSPECT_FILTER_HAS_ENTITY: ("HasEntity", "has_entity_count"),
-    INSPECT_FILTER_HAS_CONTACT: ("HasUsableContactEmail", "has_contact_count"),
-    INSPECT_FILTER_ENTITY_WITHOUT_CONTACT: (
-        "EntityWithoutUsableContactEmail",
-        "entity_without_contact_count",
-    ),
-    INSPECT_FILTER_HAS_AFFILIATION: ("HasAffiliation", "has_affiliation_count"),
-    INSPECT_FILTER_ENTITY_WITHOUT_AFFILIATION: (
-        "EntityWithoutAffiliation",
-        "entity_without_affiliation_count",
-    ),
-    INSPECT_FILTER_HAS_INVITE: ("HasInvite", "has_invite_count"),
-    INSPECT_FILTER_ENTITY_WITHOUT_INVITE: ("EntityWithoutInvite", "entity_without_invite_count"),
+    INSPECT_FILTER_HAS_ANY_AUTH: {"label": "HasAnyAuth", "summary_key": "has_any_auth_count"},
+    INSPECT_FILTER_MISSING_ENTITY: {"label": "MissingEntity", "summary_key": "missing_entity_count"},
+    INSPECT_FILTER_HAS_ENTITY: {"label": "HasEntity", "summary_key": "has_entity_count"},
+    INSPECT_FILTER_HAS_CONTACT: {"label": "HasUsableContactEmail", "summary_key": "has_contact_count"},
+    INSPECT_FILTER_ENTITY_WITHOUT_CONTACT: {
+        "label": "EntityWithoutUsableContactEmail",
+        "summary_key": "entity_without_contact_count",
+    },
+    INSPECT_FILTER_HAS_AFFILIATION: {"label": "HasAffiliation", "summary_key": "has_affiliation_count"},
+    INSPECT_FILTER_ENTITY_WITHOUT_AFFILIATION: {
+        "label": "EntityWithoutAffiliation",
+        "summary_key": "entity_without_affiliation_count",
+    },
+    INSPECT_FILTER_HAS_INVITE: {"label": "HasInvite", "summary_key": "has_invite_count"},
+    INSPECT_FILTER_ENTITY_WITHOUT_INVITE: {"label": "EntityWithoutInvite", "summary_key": "entity_without_invite_count"},
 }
 
 
@@ -1473,8 +1473,7 @@ def _inspection_summary_metric_rows(summary: dict[str, int | str]) -> list[tuple
     ]
     filter_metric = _INSPECTION_FILTER_SUMMARY_METRICS.get(inspect_filter)
     if filter_metric:
-        label, summary_key = filter_metric
-        rows.append((label, summary.get(summary_key, 0)))
+        rows.append((filter_metric["label"], summary.get(filter_metric["summary_key"], 0)))
     return rows
 
 

--- a/data-tool/flows/auth/verify_auth_flow.py
+++ b/data-tool/flows/auth/verify_auth_flow.py
@@ -20,7 +20,7 @@ import math
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Iterable
+from typing import Any, Callable, Iterable, Protocol
 
 from sqlalchemy import bindparam, text
 from sqlalchemy.engine import Engine
@@ -28,7 +28,7 @@ from sqlalchemy.sql.elements import TextClause
 
 from auth.auth_models import AuthSelectionMode
 from auth.auth_queries import get_auth_selected_corp_nums_query
-from auth.auth_selection import parse_positive_int_csv
+from auth.auth_selection import parse_auth_corp_nums_csv, parse_positive_int_csv
 
 try:  # pragma: no cover - exercised when Prefect is installed in runtime environments.
     from prefect import flow, task
@@ -78,17 +78,14 @@ CHECK_CONTACT = "contact"
 CHECK_AFFILIATION = "affiliation"
 CHECK_INVITE = "invite"
 
-REPORT_MODE_VERIFY = "VERIFY"
-REPORT_MODE_INSPECT = "INSPECT"
-REPORT_MODE_VERIFY_AND_INSPECT = "VERIFY_AND_INSPECT"
-REPORT_MODES = (REPORT_MODE_VERIFY, REPORT_MODE_INSPECT, REPORT_MODE_VERIFY_AND_INSPECT)
-
 INSPECT_FILTER_ALL = "ALL"
 INSPECT_FILTER_HAS_ANY_AUTH = "HAS_ANY_AUTH"
 INSPECT_FILTER_HAS_ENTITY = "HAS_ENTITY"
 INSPECT_FILTER_MISSING_ENTITY = "MISSING_ENTITY"
 INSPECT_FILTER_HAS_CONTACT = "HAS_CONTACT"
 INSPECT_FILTER_ENTITY_WITHOUT_CONTACT = "ENTITY_WITHOUT_CONTACT"
+# Inspect "contact" filters intentionally mean usable contact with a non-blank email,
+# not merely any Auth contact row. Raw contact row count remains available as contact_count.
 INSPECT_FILTER_HAS_AFFILIATION = "HAS_AFFILIATION"
 INSPECT_FILTER_ENTITY_WITHOUT_AFFILIATION = "ENTITY_WITHOUT_AFFILIATION"
 INSPECT_FILTER_HAS_INVITE = "HAS_INVITE"
@@ -116,18 +113,22 @@ _CHECK_CONFIG_ATTRS = {
     CHECK_INVITE: "VERIFY_AUTH_CHECK_INVITE",
 }
 
-VERIFY_AUTH_OUTPUT_PATH_ATTR = "VERIFY_AUTH_OUTPUT_PATH"
+AUTH_OUTPUT_PATH_ATTR = "AUTH_OUTPUT_PATH"
 SUMMARY_PATH_KEY = "summary_path"
 DETAIL_PATH_KEY = "detail_path"
 SCENARIO_PATH_KEY = "scenario_path"
-INSPECTION_PATH_KEY = "inspection_path"
 
 _DERIVED_OUTPUT_FILENAMES = {
     SUMMARY_PATH_KEY: "verify-auth-summary.csv",
     DETAIL_PATH_KEY: "verify-auth-detail.csv",
-    SCENARIO_PATH_KEY: "verify-auth-scenario.csv",
-    INSPECTION_PATH_KEY: "verify-auth-inspection.csv",
+    SCENARIO_PATH_KEY: "verify-auth-scenario.txt",
 }
+
+
+DEFAULT_VERIFY_AUTH_CONSOLE_LIMIT = 25
+ANSI_BOLD_RED = "\033[1;31m"
+ANSI_RESET = "\033[0m"
+IDENTIFIER_GROUP_SEPARATOR = "─" * 88
 
 _DEPENDENT_CHECKS = (CHECK_CONTACT, CHECK_AFFILIATION, CHECK_INVITE)
 _ALL_CHECKS = (CHECK_ENTITY, CHECK_CONTACT, CHECK_AFFILIATION, CHECK_INVITE)
@@ -176,8 +177,6 @@ DETAIL_FIELDNAMES = [
     "missing_account_ids",
     "invite_count",
 ]
-
-SCENARIO_FIELDNAMES = ["scenario", "count", "identifiers_csv", "recommended_action"]
 
 INSPECTION_FIELDNAMES = [
     "business_identifier",
@@ -231,34 +230,69 @@ _INVITE_READ_SQL = """
 """.strip()
 
 
+class AuthBatchSettings(Protocol):
+    """Structural settings surface consumed by the shared Auth batch reader."""
+
+    batch_size: int
+    selected_checks: tuple[str, ...]
+
+    @property
+    def run_verify(self) -> bool:
+        """Return True when verification classifications should be built."""
+        ...
+
+    @property
+    def auth_read_checks(self) -> tuple[str, ...]:
+        """Return Auth DB table read scope for this batch."""
+        ...
+
+
+class AuthCandidateSettings(Protocol):
+    """Structural settings surface consumed by shared candidate/account helpers."""
+
+    selection_mode: AuthSelectionMode
+    auth_corp_nums: tuple[str, ...]
+    auth_mig_group_ids: tuple[int, ...]
+    auth_mig_batch_ids: tuple[int, ...]
+    manual_account_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ConsoleLimit:
+    """Console output detail limit.
+
+    ``disabled=True`` represents ``0`` and suppresses optional detail/identifier
+    console sections. ``max_rows=None`` represents ``ALL``. Positive
+    ``max_rows`` values cap preview-style console output; for verify scenario
+    identifiers, the cap is applied per scenario bucket while CSV output remains
+    complete.
+    """
+
+    disabled: bool = False
+    max_rows: int | None = DEFAULT_VERIFY_AUTH_CONSOLE_LIMIT
+
+
 @dataclass(frozen=True)
 class VerifyAuthSettings:
-    """Validated settings needed by the verify-auth candidate phase."""
+    """Validated verify-only settings needed by the verify-auth flow."""
 
     batches: int
     batch_size: int
-    report_mode: str
-    inspect_filter: str
     selected_checks: tuple[str, ...]
-    console_detail: bool
+    console_limit: ConsoleLimit
     summary_path: str | None
     detail_path: str | None
     scenario_path: str | None
-    inspection_path: str | None
     selection_mode: AuthSelectionMode
+    auth_corp_nums: tuple[str, ...]
     auth_mig_group_ids: tuple[int, ...]
     auth_mig_batch_ids: tuple[int, ...]
     manual_account_ids: tuple[str, ...]
 
     @property
     def run_verify(self) -> bool:
-        """Return True when verify summary/detail/scenario reports are enabled."""
-        return self.report_mode in {REPORT_MODE_VERIFY, REPORT_MODE_VERIFY_AND_INSPECT}
-
-    @property
-    def run_inspection(self) -> bool:
-        """Return True when factual inspection output is enabled."""
-        return self.report_mode in {REPORT_MODE_INSPECT, REPORT_MODE_VERIFY_AND_INSPECT}
+        """Return True for the verify-only flow."""
+        return True
 
     @property
     def check_affiliation(self) -> bool:
@@ -268,12 +302,12 @@ class VerifyAuthSettings:
     @property
     def read_expected_accounts(self) -> bool:
         """Return True when expected account IDs should be derived for this run."""
-        return self.check_affiliation or self.run_inspection
+        return self.check_affiliation
 
     @property
     def auth_read_checks(self) -> tuple[str, ...]:
-        """Return Auth DB table read scope for verification and/or inspection."""
-        return _ALL_CHECKS if self.run_inspection else self.selected_checks
+        """Return Auth DB table read scope for verification."""
+        return self.selected_checks
 
 
 @dataclass(frozen=True)
@@ -352,7 +386,11 @@ class AuthBusinessState:
 
 
 def auth_state_has_any_auth(state: AuthBusinessState) -> bool:
-    """Return True when any inspected Auth component is present for a business."""
+    """Return True when any inspected Auth component is present for a business.
+
+    Contact presence means a usable contact with a non-blank email; raw contact
+    row presence remains visible separately through ``contact_count``.
+    """
     return (
         state.entity_exists
         or state.usable_contact_count > 0
@@ -362,7 +400,11 @@ def auth_state_has_any_auth(state: AuthBusinessState) -> bool:
 
 
 def auth_state_matches_inspect_filter(state: AuthBusinessState, inspect_filter: str) -> bool:
-    """Evaluate one AuthBusinessState against a validated inspect filter."""
+    """Evaluate one AuthBusinessState against a validated inspect filter.
+
+    ``HAS_CONTACT`` and ``ENTITY_WITHOUT_CONTACT`` intentionally use
+    ``usable_contact_count`` (non-blank email), not raw ``contact_count``.
+    """
     if inspect_filter == INSPECT_FILTER_ALL:
         return True
     if inspect_filter == INSPECT_FILTER_HAS_ANY_AUTH:
@@ -384,7 +426,7 @@ def auth_state_matches_inspect_filter(state: AuthBusinessState, inspect_filter: 
     if inspect_filter == INSPECT_FILTER_ENTITY_WITHOUT_INVITE:
         return state.entity_exists and state.invite_count == 0
     allowed = ", ".join(INSPECT_FILTERS)
-    raise ValueError(f"Unknown VERIFY_AUTH_INSPECT_FILTER: {inspect_filter}; expected one of {allowed}")
+    raise ValueError(f"Unknown inspect filter: {inspect_filter}; expected one of {allowed}")
 
 
 def filter_inspection_states(states: list[AuthBusinessState], inspect_filter: str) -> list[AuthBusinessState]:
@@ -439,7 +481,7 @@ def _coerce_bool_setting(config: Any, attr_name: str, default: bool = False) -> 
     return bool(raw_value)
 
 
-def _blank_to_none(value: Any) -> str | None:
+def blank_to_none(value: Any) -> str | None:
     """Return a stripped config string, or None for unset/blank values."""
     if value is None:
         return None
@@ -447,9 +489,17 @@ def _blank_to_none(value: Any) -> str | None:
     return stripped or None
 
 
-def _is_csv_like_output_root(path: str) -> bool:
+# Backwards-compatible private alias for existing callers/tests.
+_blank_to_none = blank_to_none
+
+
+def is_csv_like_output_root(path: str) -> bool:
     """Return True when a root value looks like an old-style CSV file path."""
     return path.rstrip("/\\").lower().endswith(".csv")
+
+
+# Backwards-compatible private alias for existing callers/tests.
+_is_csv_like_output_root = is_csv_like_output_root
 
 
 def _derive_output_paths_from_root(output_root: str) -> dict[str, str]:
@@ -460,35 +510,52 @@ def _derive_output_paths_from_root(output_root: str) -> dict[str, str]:
 
 def _resolve_output_paths(config: Any) -> dict[str, str]:
     """Resolve concrete output file paths from the single configured output root."""
-    output_root = _blank_to_none(getattr(config, VERIFY_AUTH_OUTPUT_PATH_ATTR, None))
+    output_root = blank_to_none(getattr(config, AUTH_OUTPUT_PATH_ATTR, None))
     if not output_root:
-        raise ValueError(f"{VERIFY_AUTH_OUTPUT_PATH_ATTR} must be set")
-    if _is_csv_like_output_root(output_root):
-        raise ValueError(f"{VERIFY_AUTH_OUTPUT_PATH_ATTR} must be a directory/root path, not a .csv file path")
+        raise ValueError(f"{AUTH_OUTPUT_PATH_ATTR} must be set")
+    if is_csv_like_output_root(output_root):
+        raise ValueError(f"{AUTH_OUTPUT_PATH_ATTR} must be a directory/root path, not a .csv file path")
     return _derive_output_paths_from_root(output_root)
 
 
-def _parse_report_mode(config: Any) -> str:
-    raw = (getattr(config, "VERIFY_AUTH_REPORT_MODE", None) or REPORT_MODE_VERIFY).strip().upper()
-    if not raw:
-        return REPORT_MODE_VERIFY
-    if raw not in REPORT_MODES:
-        allowed = ", ".join(REPORT_MODES)
-        raise ValueError(f"Unknown VERIFY_AUTH_REPORT_MODE: {raw}; expected one of {allowed}")
-    return raw
+def parse_console_limit(raw_value: Any, config_key: str, default: int = DEFAULT_VERIFY_AUTH_CONSOLE_LIMIT) -> ConsoleLimit:
+    """Parse a console row/table preview limit.
+
+    Accepted values are unset/blank (caller default), ``0`` (disabled), positive
+    integers, and ``ALL`` (unbounded). The parser is intentionally local to this
+    flow surface and does not broaden config.py boolean/int parsing behavior.
+    """
+    raw = blank_to_none(raw_value)
+    if raw is None:
+        if default <= 0:
+            raise ValueError(f"Default {config_key} must be a positive integer")
+        return ConsoleLimit(disabled=False, max_rows=default)
+
+    normalized = raw.upper()
+    if normalized == "ALL":
+        return ConsoleLimit(disabled=False, max_rows=None)
+    try:
+        parsed = int(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{config_key} must be 0, a positive integer, or ALL") from exc
+    if parsed < 0:
+        raise ValueError(f"{config_key} must be 0, a positive integer, or ALL")
+    if parsed == 0:
+        return ConsoleLimit(disabled=True, max_rows=0)
+    return ConsoleLimit(disabled=False, max_rows=parsed)
 
 
-def _parse_inspect_filter(config: Any) -> str:
-    raw = (getattr(config, "VERIFY_AUTH_INSPECT_FILTER", None) or INSPECT_FILTER_ALL).strip().upper()
-    if not raw:
-        return INSPECT_FILTER_ALL
+def parse_inspect_filter(raw_value: Any, config_key: str = "INSPECT_AUTH_FILTER") -> str:
+    """Parse an inspect filter value using the provided config key in errors."""
+    raw = (blank_to_none(raw_value) or INSPECT_FILTER_ALL).upper()
     if raw not in INSPECT_FILTERS:
         allowed = ", ".join(INSPECT_FILTERS)
-        raise ValueError(f"Unknown VERIFY_AUTH_INSPECT_FILTER: {raw}; expected one of {allowed}")
+        raise ValueError(f"Unknown {config_key}: {raw}; expected one of {allowed}")
     return raw
 
 
-def _parse_selection_mode(config: Any) -> AuthSelectionMode:
+
+def parse_auth_selection_mode(config: Any) -> AuthSelectionMode:
     raw = (getattr(config, "AUTH_SELECTION_MODE", "MIGRATION_FILTER") or "MIGRATION_FILTER").strip().upper()
     try:
         return AuthSelectionMode(raw)
@@ -497,18 +564,26 @@ def _parse_selection_mode(config: Any) -> AuthSelectionMode:
         raise ValueError(f"Unknown AUTH_SELECTION_MODE: {raw}; expected one of {allowed}") from exc
 
 
-def _parse_positive_int_tuple(config: Any, attr_name: str) -> tuple[int, ...]:
+# Backwards-compatible private alias for existing callers/tests.
+_parse_selection_mode = parse_auth_selection_mode
+
+
+def parse_positive_int_tuple(config: Any, attr_name: str) -> tuple[int, ...]:
     values = parse_positive_int_csv(getattr(config, attr_name, None), name=attr_name)
     return tuple(int(value) for value in values)
 
 
-def _manual_account_ids(config: Any) -> tuple[str, ...]:
+# Backwards-compatible private alias for existing callers/tests.
+_parse_positive_int_tuple = parse_positive_int_tuple
+
+
+def parse_manual_account_ids(config: Any) -> tuple[str, ...]:
     raw_env = getattr(config, "AUTH_AFFILIATION_ACCOUNT_IDS_RAW", None)
-    if _blank_to_none(raw_env) is not None:
+    if blank_to_none(raw_env) is not None:
         return tuple(parse_positive_int_csv(raw_env, name="AUTH_AFFILIATION_ACCOUNT_IDS"))
 
     raw_csv = getattr(config, "AUTH_AFFILIATION_ACCOUNT_IDS_CSV", None)
-    if _blank_to_none(raw_csv) is not None:
+    if blank_to_none(raw_csv) is not None:
         return tuple(parse_positive_int_csv(raw_csv, name="AUTH_AFFILIATION_ACCOUNT_IDS"))
 
     configured = getattr(config, "AUTH_AFFILIATION_ACCOUNT_IDS", None)
@@ -526,6 +601,10 @@ def _manual_account_ids(config: Any) -> tuple[str, ...]:
     return ()
 
 
+# Backwards-compatible private alias for existing callers/tests.
+_manual_account_ids = parse_manual_account_ids
+
+
 def get_selected_checks(config: Any) -> tuple[str, ...]:
     """Return enabled verify-auth checks in stable order."""
     return tuple(
@@ -537,32 +616,34 @@ def get_selected_checks(config: Any) -> tuple[str, ...]:
 
 def validate_config(config: Any) -> VerifyAuthSettings:
     """Validate verify-auth config before database connections are opened."""
-    batches = _coerce_int_setting(config, "VERIFY_AUTH_BATCHES")
+    batches = _coerce_int_setting(config, "AUTH_REPORT_BATCHES")
     if batches <= 0:
-        raise ValueError("VERIFY_AUTH_BATCHES must be greater than 0")
+        raise ValueError("AUTH_REPORT_BATCHES must be greater than 0")
 
-    batch_size = _coerce_int_setting(config, "VERIFY_AUTH_BATCH_SIZE")
+    batch_size = _coerce_int_setting(config, "AUTH_REPORT_BATCH_SIZE")
     if batch_size <= 0:
-        raise ValueError("VERIFY_AUTH_BATCH_SIZE must be greater than 0")
-
-    report_mode = _parse_report_mode(config)
-    inspect_filter = _parse_inspect_filter(config)
-    run_verify = report_mode in {REPORT_MODE_VERIFY, REPORT_MODE_VERIFY_AND_INSPECT}
-    run_inspection = report_mode in {REPORT_MODE_INSPECT, REPORT_MODE_VERIFY_AND_INSPECT}
+        raise ValueError("AUTH_REPORT_BATCH_SIZE must be greater than 0")
 
     selected_checks = get_selected_checks(config)
-    if run_verify and not selected_checks:
+    if not selected_checks:
         raise ValueError("At least one VERIFY_AUTH_CHECK_* option must be enabled")
+
+    console_limit = parse_console_limit(
+        getattr(config, "VERIFY_AUTH_CONSOLE_LIMIT", None),
+        "VERIFY_AUTH_CONSOLE_LIMIT",
+        DEFAULT_VERIFY_AUTH_CONSOLE_LIMIT,
+    )
 
     paths = _resolve_output_paths(config)
 
-    selection_mode = _parse_selection_mode(config)
+    selection_mode = parse_auth_selection_mode(config)
+    auth_corp_nums = tuple(parse_auth_corp_nums_csv(getattr(config, "AUTH_CORP_NUMS", None)))
 
     auth_mig_group_ids: tuple[int, ...] = ()
     auth_mig_batch_ids: tuple[int, ...] = ()
     if selection_mode == AuthSelectionMode.MIGRATION_FILTER:
-        auth_mig_group_ids = _parse_positive_int_tuple(config, "AUTH_MIG_GROUP_IDS")
-        auth_mig_batch_ids = _parse_positive_int_tuple(config, "AUTH_MIG_BATCH_IDS")
+        auth_mig_group_ids = parse_positive_int_tuple(config, "AUTH_MIG_GROUP_IDS")
+        auth_mig_batch_ids = parse_positive_int_tuple(config, "AUTH_MIG_BATCH_IDS")
         if not (auth_mig_group_ids or auth_mig_batch_ids):
             raise ValueError(
                 "AUTH_SELECTION_MODE=MIGRATION_FILTER requires AUTH_MIG_GROUP_IDS and/or AUTH_MIG_BATCH_IDS; "
@@ -570,9 +651,9 @@ def validate_config(config: Any) -> VerifyAuthSettings:
             )
 
     manual_account_ids: tuple[str, ...] = ()
-    if selection_mode == AuthSelectionMode.MANUAL and (run_inspection or CHECK_AFFILIATION in selected_checks):
-        manual_account_ids = _manual_account_ids(config)
-    if run_verify and CHECK_AFFILIATION in selected_checks and selection_mode == AuthSelectionMode.MANUAL and not manual_account_ids:
+    if selection_mode == AuthSelectionMode.MANUAL and CHECK_AFFILIATION in selected_checks:
+        manual_account_ids = parse_manual_account_ids(config)
+    if CHECK_AFFILIATION in selected_checks and selection_mode == AuthSelectionMode.MANUAL and not manual_account_ids:
         raise ValueError(
             "VERIFY_AUTH_CHECK_AFFILIATION=True with AUTH_SELECTION_MODE=MANUAL requires "
             "AUTH_AFFILIATION_ACCOUNT_IDS"
@@ -581,25 +662,29 @@ def validate_config(config: Any) -> VerifyAuthSettings:
     return VerifyAuthSettings(
         batches=batches,
         batch_size=batch_size,
-        report_mode=report_mode,
-        inspect_filter=inspect_filter,
         selected_checks=selected_checks,
-        console_detail=_coerce_bool_setting(config, "VERIFY_AUTH_CONSOLE_DETAIL", False),
+        console_limit=console_limit,
         summary_path=paths[SUMMARY_PATH_KEY],
         detail_path=paths[DETAIL_PATH_KEY],
         scenario_path=paths[SCENARIO_PATH_KEY],
-        inspection_path=paths[INSPECTION_PATH_KEY],
         selection_mode=selection_mode,
+        auth_corp_nums=auth_corp_nums,
         auth_mig_group_ids=auth_mig_group_ids,
         auth_mig_batch_ids=auth_mig_batch_ids,
         manual_account_ids=manual_account_ids,
     )
 
 
-def build_candidate_queries(config: Any, settings: VerifyAuthSettings | None = None) -> CandidateQueries:
+def build_candidate_queries(config: Any, settings: AuthCandidateSettings | None = None) -> CandidateQueries:
     """Build aligned count/page candidate queries from Auth targeting semantics."""
     settings = settings or validate_config(config)
-    base_sql = get_auth_selected_corp_nums_query(config, settings.selection_mode).strip()
+    base_sql = get_auth_selected_corp_nums_query(
+        config,
+        settings.selection_mode,
+        auth_corp_nums=settings.auth_corp_nums,
+        auth_mig_group_ids=settings.auth_mig_group_ids,
+        auth_mig_batch_ids=settings.auth_mig_batch_ids,
+    ).strip()
 
     count_sql = f"""
         SELECT COUNT(*)
@@ -623,7 +708,7 @@ def build_candidate_queries(config: Any, settings: VerifyAuthSettings | None = N
 def get_candidate_count(
     config: Any,
     colin_extract_engine: Engine,
-    settings: VerifyAuthSettings | None = None,
+    settings: AuthCandidateSettings | None = None,
 ) -> int:
     """Execute the selected-candidate count query on the COLIN extract engine."""
     queries = build_candidate_queries(config, settings)
@@ -636,7 +721,7 @@ def get_candidate_page(
     colin_extract_engine: Engine,
     limit: int,
     offset: int,
-    settings: VerifyAuthSettings | None = None,
+    settings: AuthCandidateSettings | None = None,
 ) -> list[str]:
     """Execute the deterministic selected-candidate page query on the COLIN extract engine."""
     queries = build_candidate_queries(config, settings)
@@ -645,7 +730,7 @@ def get_candidate_page(
     return [str(_row_value(row, 0, "corp_num")) for row in rows]
 
 
-def _expected_accounts_query(config: Any, settings: VerifyAuthSettings, corp_nums: Iterable[str]) -> ExpectedAccountsQuery:
+def _expected_accounts_query(config: Any, settings: AuthCandidateSettings, corp_nums: Iterable[str]) -> ExpectedAccountsQuery:
     """Build a COLIN-extract query deriving migration expected-account IDs for a candidate page."""
     normalized_corp_nums = [str(corp_num) for corp_num in corp_nums]
     params: dict[str, Any] = {
@@ -683,7 +768,7 @@ def _expected_accounts_query(config: Any, settings: VerifyAuthSettings, corp_num
 def build_expected_accounts_query(
     config: Any,
     corp_nums: Iterable[str],
-    settings: VerifyAuthSettings | None = None,
+    settings: AuthCandidateSettings | None = None,
 ) -> ExpectedAccountsQuery | None:
     """Return migration expected-account SQL, or None when manual accounts are configured.
 
@@ -700,7 +785,7 @@ def read_expected_accounts_for_candidates(
     config: Any,
     colin_extract_engine: Engine,
     corp_nums: Iterable[str],
-    settings: VerifyAuthSettings | None = None,
+    settings: AuthCandidateSettings | None = None,
 ) -> dict[str, tuple[str, ...]]:
     """Return expected affiliation account IDs per candidate business identifier.
 
@@ -971,15 +1056,15 @@ def run_auth_batch(
     auth_engine: Engine,
     business_identifiers: Iterable[str],
     expected_accounts_by_identifier: dict[str, Iterable[str]] | None = None,
-    settings: VerifyAuthSettings | None = None,
+    settings: AuthBatchSettings | None = None,
 ) -> AuthBatchResult:
     """Read one configured candidate batch and optionally classify verification results."""
     settings = settings or validate_config(config)
     candidates = [str(identifier) for identifier in business_identifiers]
     if len(candidates) > settings.batch_size:
         raise ValueError(
-            f"Verifier batch contains {len(candidates)} candidates, exceeding configured "
-            f"VERIFY_AUTH_BATCH_SIZE {settings.batch_size}"
+            f"Auth batch contains {len(candidates)} candidates, exceeding configured "
+            f"batch size {settings.batch_size}"
         )
     states = read_auth_states_for_candidates(
         auth_engine,
@@ -996,18 +1081,20 @@ def verify_auth_batch_result(
     auth_engine: Engine,
     business_identifiers: Iterable[str],
     expected_accounts_by_identifier: dict[str, Iterable[str]] | None = None,
+    settings: AuthBatchSettings | None = None,
 ) -> AuthBatchResult:
     """Read one configured candidate batch and return raw states plus verification results.
 
-    Use this helper in INSPECT mode when callers need inspection rows from
-    ``AuthBatchResult.states``. ``verify_auth_batch`` remains as the legacy
-    convenience wrapper for verification results only.
+    Use this helper when callers need raw read-back rows from
+    ``AuthBatchResult.states``. ``verify_auth_batch`` remains the convenience
+    wrapper for verification results only.
     """
     return run_auth_batch(
         config,
         auth_engine,
         business_identifiers,
         expected_accounts_by_identifier,
+        settings,
     )
 
 
@@ -1016,18 +1103,19 @@ def verify_auth_batch(
     auth_engine: Engine,
     business_identifiers: Iterable[str],
     expected_accounts_by_identifier: dict[str, Iterable[str]] | None = None,
+    settings: AuthBatchSettings | None = None,
 ) -> list[VerificationResult]:
     """Read and verify one configured candidate batch against Auth DB state.
 
-    Returns verification results only. In INSPECT mode this list is empty; use
-    ``verify_auth_batch_result`` to access ``AuthBatchResult.states`` for
-    inspection rows.
+    Returns verification results only. Use ``verify_auth_batch_result`` to access
+    ``AuthBatchResult.states`` for shared read-back/inspection helpers.
     """
     return verify_auth_batch_result(
         config,
         auth_engine,
         business_identifiers,
         expected_accounts_by_identifier,
+        settings,
     ).verification_results
 
 
@@ -1035,27 +1123,29 @@ def verify_auth_batch_result_from_config(
     config: Any,
     business_identifiers: Iterable[str],
     expected_accounts_by_identifier: dict[str, Iterable[str]] | None = None,
+    settings: AuthBatchSettings | None = None,
 ) -> AuthBatchResult:
     """Initialize Auth DB via ``auth_init(config)`` and return the full Auth batch result."""
     from common.init_utils import auth_init  # Imported lazily to keep helper imports lightweight.
 
     auth_engine = auth_init(config)
     try:
-        return verify_auth_batch_result(config, auth_engine, business_identifiers, expected_accounts_by_identifier)
+        return verify_auth_batch_result(config, auth_engine, business_identifiers, expected_accounts_by_identifier, settings)
     finally:
-        _dispose_engine(auth_engine)
+        dispose_engine(auth_engine)
 
 
 def verify_auth_batch_from_config(
     config: Any,
     business_identifiers: Iterable[str],
     expected_accounts_by_identifier: dict[str, Iterable[str]] | None = None,
+    settings: AuthBatchSettings | None = None,
 ) -> list[VerificationResult]:
     """Initialize Auth DB via ``auth_init(config)`` and verify one read-only batch.
 
-    Returns verification results only. In INSPECT mode this list is empty; use
-    ``verify_auth_batch_result_from_config`` to access ``AuthBatchResult.states``
-    for inspection rows. The engine is disposed in ``finally`` so callers that
+    Returns verification results only. Use ``verify_auth_batch_result_from_config``
+    to access ``AuthBatchResult.states`` for shared read-back/inspection helpers.
+    The engine is disposed in ``finally`` so callers that
     use this one-shot wrapper do not leak connection-pool resources after success
     or failure.
     """
@@ -1063,6 +1153,7 @@ def verify_auth_batch_from_config(
         config,
         business_identifiers,
         expected_accounts_by_identifier,
+        settings,
     ).verification_results
 
 
@@ -1157,7 +1248,11 @@ def _dependent_state(entity_exists: bool, present: bool) -> str:
 
 
 def build_inspection_rows(states: list[AuthBusinessState]) -> list[dict[str, str | int]]:
-    """Build factual inspection rows from the provided Auth DB states."""
+    """Build factual inspection rows from the provided Auth DB states.
+
+    ``contact_state`` is based on usable contacts with non-blank email; raw
+    contact row totals remain available in ``contact_count``.
+    """
     rows: list[dict[str, str | int]] = []
     for state in states:
         entity_exists = state.entity_exists
@@ -1244,22 +1339,202 @@ def write_detail_csv(path: str, results: list[VerificationResult]) -> None:
         writer.writerows(build_detail_rows(results))
 
 
-def write_scenario_csv(path: str, results: list[VerificationResult]) -> None:
-    """Write operational scenario bucket CSV rows."""
+def _format_sql_quoted_identifier_list(identifiers_csv: Any) -> str:
+    """Return identifiers as a SQL-friendly single-quoted comma-delimited list."""
+    identifiers = _split_identifiers_csv(identifiers_csv)
+    return ",".join("'" + identifier.replace("'", "''") + "'" for identifier in identifiers)
+
+
+def _write_identifier_copy_list_section(
+    txt_file: Any,
+    rows: list[dict[str, str | int]],
+    *,
+    label_key: str,
+    title: str,
+    action_key: str | None = None,
+) -> None:
+    """Write copy-friendly AUTH_CORP_NUMS lists to an open text file."""
+    txt_file.write(f"# {title}\n")
+    txt_file.write("# Copy the AUTH_CORP_NUMS=... line for the group you want to run.\n")
+    if not rows:
+        txt_file.write("# No identifier groups emitted.\n")
+        return
+    for row in rows:
+        label = str(row[label_key])
+        count = row.get("count", 0)
+        txt_file.write("\n")
+        txt_file.write(f"[{label}] count={count}\n")
+        if action_key and row.get(action_key):
+            txt_file.write(f"# {row[action_key]}\n")
+        identifiers_csv = row.get("identifiers_csv", "")
+        txt_file.write(f"AUTH_CORP_NUMS={identifiers_csv}\n")
+        txt_file.write("\n")
+        txt_file.write("# SQL IN (...) fragment value for manual database queries.\n")
+        txt_file.write(f"SQL_IN_IDENTIFIERS={_format_sql_quoted_identifier_list(identifiers_csv)}\n")
+
+
+def _write_identifier_copy_list_txt(
+    path: str,
+    rows: list[dict[str, str | int]],
+    *,
+    label_key: str,
+    title: str,
+    action_key: str | None = None,
+) -> None:
+    """Write copy-friendly AUTH_CORP_NUMS lists as plain text."""
     expanded_path = _ensure_parent_dir(path)
-    with open(expanded_path, "w", newline="", encoding="utf-8") as csv_file:
-        writer = csv.DictWriter(csv_file, fieldnames=SCENARIO_FIELDNAMES)
-        writer.writeheader()
-        writer.writerows(build_scenario_rows(results))
+    with open(expanded_path, "w", encoding="utf-8") as txt_file:
+        _write_identifier_copy_list_section(
+            txt_file,
+            rows,
+            label_key=label_key,
+            title=title,
+            action_key=action_key,
+        )
+
+
+def write_scenario_txt(path: str, results: list[VerificationResult]) -> None:
+    """Write operational scenario summary and identifier copy lists as plain text."""
+    scenario_rows = build_scenario_rows(results)
+    expanded_path = _ensure_parent_dir(path)
+    with open(expanded_path, "w", encoding="utf-8") as txt_file:
+        txt_file.write("# Verify Auth scenario summary\n")
+        if scenario_rows:
+            summary_columns = ("scenario", "count", "recommended_action")
+            table_rows = [{column: str(row.get(column, "")) for column in summary_columns} for row in scenario_rows]
+            for line in _render_table_lines(table_rows, summary_columns, right_aligned_columns=("count",)):
+                txt_file.write(f"{line}\n")
+        else:
+            txt_file.write("# No populated scenario buckets.\n")
+        txt_file.write("\n")
+        _write_identifier_copy_list_section(
+            txt_file,
+            scenario_rows,
+            label_key="scenario",
+            title="Verify Auth scenario identifier copy lists",
+            action_key="recommended_action",
+        )
 
 
 def write_inspection_csv(path: str, states: list[AuthBusinessState]) -> None:
-    """Write factual Auth DB inspection CSV rows for the provided states."""
+    """Write factual Auth DB inspection detail CSV rows for the provided states."""
     expanded_path = _ensure_parent_dir(path)
     with open(expanded_path, "w", newline="", encoding="utf-8") as csv_file:
         writer = csv.DictWriter(csv_file, fieldnames=INSPECTION_FIELDNAMES)
         writer.writeheader()
         writer.writerows(build_inspection_rows(states))
+
+
+_INSPECTION_FILTER_SUMMARY_METRICS = {
+    INSPECT_FILTER_HAS_ANY_AUTH: ("HasAnyAuth", "has_any_auth_count"),
+    INSPECT_FILTER_MISSING_ENTITY: ("MissingEntity", "missing_entity_count"),
+    INSPECT_FILTER_HAS_ENTITY: ("HasEntity", "has_entity_count"),
+    INSPECT_FILTER_HAS_CONTACT: ("HasUsableContactEmail", "has_contact_count"),
+    INSPECT_FILTER_ENTITY_WITHOUT_CONTACT: (
+        "EntityWithoutUsableContactEmail",
+        "entity_without_contact_count",
+    ),
+    INSPECT_FILTER_HAS_AFFILIATION: ("HasAffiliation", "has_affiliation_count"),
+    INSPECT_FILTER_ENTITY_WITHOUT_AFFILIATION: (
+        "EntityWithoutAffiliation",
+        "entity_without_affiliation_count",
+    ),
+    INSPECT_FILTER_HAS_INVITE: ("HasInvite", "has_invite_count"),
+    INSPECT_FILTER_ENTITY_WITHOUT_INVITE: ("EntityWithoutInvite", "entity_without_invite_count"),
+}
+
+
+def _all_inspection_summary_metric_rows(summary: dict[str, int | str]) -> list[tuple[str, int | str]]:
+    """Return display-ordered full inspect summary metric rows."""
+    return [
+        ("Inspected", summary.get("inspected_count", 0)),
+        ("MatchedByFilter", summary.get("matched_count", 0)),
+        ("HasAnyAuth", summary.get("has_any_auth_count", 0)),
+        ("MissingEntity", summary.get("missing_entity_count", 0)),
+        ("HasEntity", summary.get("has_entity_count", 0)),
+        ("HasUsableContactEmail", summary.get("has_contact_count", 0)),
+        ("EntityWithoutUsableContactEmail", summary.get("entity_without_contact_count", 0)),
+        ("HasAffiliation", summary.get("has_affiliation_count", 0)),
+        ("EntityWithoutAffiliation", summary.get("entity_without_affiliation_count", 0)),
+        ("HasInvite", summary.get("has_invite_count", 0)),
+        ("EntityWithoutInvite", summary.get("entity_without_invite_count", 0)),
+    ]
+
+
+def _inspection_summary_metric_rows(summary: dict[str, int | str]) -> list[tuple[str, int | str]]:
+    """Return filter-aware inspect summary metric rows."""
+    inspect_filter = str(summary.get("inspect_filter", INSPECT_FILTER_ALL))
+    if inspect_filter == INSPECT_FILTER_ALL:
+        return _all_inspection_summary_metric_rows(summary)
+
+    rows: list[tuple[str, int | str]] = [
+        ("Inspected", summary.get("inspected_count", 0)),
+        ("MatchedByFilter", summary.get("matched_count", 0)),
+    ]
+    filter_metric = _INSPECTION_FILTER_SUMMARY_METRICS.get(inspect_filter)
+    if filter_metric:
+        label, summary_key = filter_metric
+        rows.append((label, summary.get(summary_key, 0)))
+    return rows
+
+
+def write_inspection_summary_txt(
+    path: str,
+    identifier_rows: list[dict[str, str | int]],
+    summary: dict[str, int | str] | None = None,
+) -> None:
+    """Write inspect summary and copy-friendly identifier groups as plain text."""
+    expanded_path = _ensure_parent_dir(path)
+    with open(expanded_path, "w", encoding="utf-8") as txt_file:
+        if summary is not None:
+            txt_file.write("# Inspect Auth summary\n")
+            txt_file.write(f"Filter={summary.get('inspect_filter', '')}\n")
+            table_rows = [
+                {"metric": label, "count": str(value)}
+                for label, value in _inspection_summary_metric_rows(summary)
+            ]
+            for line in _render_table_lines(table_rows, ("metric", "count"), right_aligned_columns=("count",)):
+                txt_file.write(f"{line}\n")
+            txt_file.write("\n")
+
+        _write_identifier_copy_list_section(
+            txt_file,
+            identifier_rows,
+            label_key="inspect_filter",
+            title="Inspect Auth identifier copy lists",
+        )
+
+
+def _table_header_border(widths: dict[str, int], columns: tuple[str, ...]) -> str:
+    """Return a strong separator sized to the rendered table header."""
+    return "─┼─".join("─" * widths[column] for column in columns)
+
+
+def _render_table_lines(
+    table_rows: list[dict[str, str]],
+    columns: tuple[str, ...],
+    *,
+    right_aligned_columns: tuple[str, ...] = (),
+) -> list[str]:
+    """Return rendered table lines using the same header style as console tables."""
+    widths = {
+        column: max(len(column), *(len(row[column]) for row in table_rows))
+        for column in columns
+    }
+    header_border = _table_header_border(widths, columns)
+    lines = [
+        header_border,
+        " | ".join(column.ljust(widths[column]) for column in columns),
+        header_border,
+    ]
+    for row in table_rows:
+        lines.append(
+            " | ".join(
+                row[column].rjust(widths[column]) if column in right_aligned_columns else row[column].ljust(widths[column])
+                for column in columns
+            )
+        )
+    return lines
 
 
 def print_scenario_summary_rows(scenario_rows: list[dict[str, str | int]]) -> None:
@@ -1275,26 +1550,194 @@ def print_scenario_summary_rows(scenario_rows: list[dict[str, str | int]]) -> No
         for column in summary_columns
     }
 
+    header_border = _table_header_border(widths, summary_columns)
     print("🧭 Verify Auth scenario summary:")
+    print(header_border)
     print(" | ".join(column.ljust(widths[column]) for column in summary_columns))
+    print(header_border)
     for row in table_rows:
-        print(" | ".join(row[column].ljust(widths[column]) for column in summary_columns))
+        print(
+            " | ".join(
+                row[column].rjust(widths[column]) if column == "count" else row[column].ljust(widths[column])
+                for column in summary_columns
+            )
+        )
 
 
-def print_scenario_rows(scenario_rows: list[dict[str, str | int]]) -> None:
+def _console_limit_value(console_limit: ConsoleLimit | None) -> str:
+    """Return the configured console limit value used for operator-facing output."""
+    if console_limit is None or console_limit.max_rows is None:
+        return "ALL"
+    if console_limit.disabled:
+        return "0"
+    return str(console_limit.max_rows)
+
+
+def _console_cap_label(console_limit: ConsoleLimit | None, limit_config_key: str, *, unit: str) -> str:
+    """Return a short human-readable label for console cap state."""
+    configured_limit = _console_limit_value(console_limit)
+    if configured_limit == "ALL":
+        return f"console cap: ALL {unit}; ConfiguredConsoleLimit=ALL"
+    if configured_limit == "0":
+        return f"console cap: 0 {unit}; ConfiguredConsoleLimit=0"
+    return (
+        f"console cap: {configured_limit} {unit}; "
+        f"ConfiguredConsoleLimit={configured_limit}; set {limit_config_key}=ALL for full console output"
+    )
+
+
+def _split_identifiers_csv(value: Any) -> list[str]:
+    """Split a comma-delimited identifier cell into non-blank identifier tokens."""
+    return [token.strip() for token in str(value or "").split(",") if token.strip()]
+
+
+def _limited_identifiers(
+    identifiers: list[str],
+    console_limit: ConsoleLimit | None,
+) -> tuple[list[str], bool]:
+    """Return identifiers to print and whether output was truncated."""
+    if console_limit is None or console_limit.max_rows is None:
+        return identifiers, False
+    if console_limit.disabled:
+        return [], bool(identifiers)
+    max_rows = max(console_limit.max_rows, 0)
+    shown = identifiers[:max_rows]
+    return shown, len(identifiers) > len(shown)
+
+
+def _format_identifier_console_list(identifiers: list[str], *, truncated: bool) -> str:
+    """Return a copy-list preview, visibly marked when capped."""
+    rendered = ",".join(identifiers)
+    if not truncated:
+        return rendered
+    return f"{rendered},..." if rendered else "..."
+
+
+def _format_sql_identifier_console_list(identifiers: list[str], *, truncated: bool) -> str:
+    """Return a SQL-friendly identifier preview, visibly marked when capped."""
+    rendered = _format_sql_quoted_identifier_list(",".join(identifiers))
+    if not truncated:
+        return rendered
+    return f"{rendered},..." if rendered else "..."
+
+
+def _copy_list_guidance(copy_list_path: str | None, fallback_filename: str) -> str:
+    """Return explicit operator guidance for complete copy lists."""
+    if copy_list_path:
+        return f"Copy the full list from CopyListPath={copy_list_path}."
+    return f"Copy the full list from {fallback_filename}."
+
+
+def _print_identifier_group_block(
+    *,
+    label_name: str,
+    label_value: str,
+    count: Any,
+    identifiers_preview: str,
+    sql_identifiers_preview: str,
+) -> None:
+    """Print one visually separated identifier copy-list group."""
+    print()
+    print(IDENTIFIER_GROUP_SEPARATOR)
+    print(f"{label_name}: {label_value}  |  Count: {count}")
+    print("AUTH_CORP_NUMS identifiers:")
+    print(identifiers_preview)
+    print("SQL IN identifiers:")
+    print(sql_identifiers_preview)
+
+
+def _bold_red(text: str) -> str:
+    """Return text styled as bold red for console warning labels."""
+    return f"{ANSI_BOLD_RED}{text}{ANSI_RESET}"
+
+
+def _print_identifier_cap_warning(
+    *,
+    label: str,
+    bucket_name: str,
+    total_identifiers: int,
+    identifiers_shown: int,
+    configured_console_limit: str,
+    copy_list_path: str | None,
+    fallback_filename: str,
+    limit_config_key: str,
+) -> None:
+    """Print high-visibility guidance when identifier console output is capped."""
+    print(f"🚫 {_bold_red('DO NOT COPY FROM CONSOLE')}: AUTH_CORP_NUMS list below/above is capped and INCOMPLETE.")
+    print(
+        f"⚠️ {label} capped by {limit_config_key}. "
+        f"ConfiguredConsoleLimit={configured_console_limit}. "
+        f"{bucket_name}, TotalIdentifiers={total_identifiers}, IdentifiersShown={identifiers_shown}."
+    )
+    print(f"✅ {_copy_list_guidance(copy_list_path, fallback_filename)}")
+    print(f"🔧 Set {limit_config_key}=ALL only if you intentionally want the full list printed in console.")
+
+
+def _print_scenario_identifier_truncated_message(
+    scenario: str,
+    total_identifiers: int,
+    identifiers_shown: int,
+    copy_list_path: str | None,
+    limit_config_key: str,
+    configured_console_limit: str,
+) -> None:
+    """Print guidance when verify scenario identifier console output is truncated."""
+    _print_identifier_cap_warning(
+        label="Verify Auth scenario identifiers console output",
+        bucket_name=f"Scenario={scenario}",
+        total_identifiers=total_identifiers,
+        identifiers_shown=identifiers_shown,
+        configured_console_limit=configured_console_limit,
+        copy_list_path=copy_list_path,
+        fallback_filename="verify-auth-scenario.txt",
+        limit_config_key=limit_config_key,
+    )
+
+
+def print_scenario_rows(
+    scenario_rows: list[dict[str, str | int]],
+    console_limit: ConsoleLimit | None = None,
+    copy_list_path: str | None = None,
+    limit_config_key: str = "VERIFY_AUTH_CONSOLE_LIMIT",
+) -> None:
     """Print copy-friendly scenario bucket identifiers from already-built scenario rows."""
+    if console_limit is not None and console_limit.disabled:
+        return
+
     if not scenario_rows:
         print("✅ Verify Auth scenario identifiers: no identifiers to copy into AUTH_CORP_NUMS.")
         return
 
-    print("📋 Verify Auth scenario identifiers for AUTH_CORP_NUMS:")
+    cap_label = _console_cap_label(console_limit, limit_config_key, unit="identifiers per bucket")
+    print(f"📋 Verify Auth scenario identifiers for AUTH_CORP_NUMS ({cap_label}):")
     for row in scenario_rows:
-        print(f"{row['scenario']} ({row['count']}):")
-        print(row["identifiers_csv"])
+        scenario = str(row["scenario"])
+        identifiers = _split_identifiers_csv(row.get("identifiers_csv", ""))
+        identifiers_to_print, truncated = _limited_identifiers(identifiers, console_limit)
+        _print_identifier_group_block(
+            label_name="Scenario",
+            label_value=scenario,
+            count=row["count"],
+            identifiers_preview=_format_identifier_console_list(identifiers_to_print, truncated=truncated),
+            sql_identifiers_preview=_format_sql_identifier_console_list(identifiers_to_print, truncated=truncated),
+        )
+        if truncated:
+            _print_scenario_identifier_truncated_message(
+                scenario=scenario,
+                total_identifiers=len(identifiers),
+                identifiers_shown=len(identifiers_to_print),
+                copy_list_path=copy_list_path,
+                limit_config_key=limit_config_key,
+                configured_console_limit=_console_limit_value(console_limit),
+            )
 
 
 def build_inspection_summary(states: list[AuthBusinessState], matched_states: list[AuthBusinessState], inspect_filter: str) -> dict[str, int | str]:
-    """Build compact full-population inspection summary counts."""
+    """Build full-population inspection summary counts.
+
+    ``has_contact_count`` and ``entity_without_contact_count`` use usable contact
+    email, not merely raw contact row presence.
+    """
     return {
         "inspect_filter": inspect_filter,
         "inspected_count": len(states),
@@ -1304,37 +1747,82 @@ def build_inspection_summary(states: list[AuthBusinessState], matched_states: li
         "missing_entity_count": sum(1 for state in states if auth_state_matches_inspect_filter(state, INSPECT_FILTER_MISSING_ENTITY)),
         "has_entity_count": sum(1 for state in states if auth_state_matches_inspect_filter(state, INSPECT_FILTER_HAS_ENTITY)),
         "has_contact_count": sum(1 for state in states if auth_state_matches_inspect_filter(state, INSPECT_FILTER_HAS_CONTACT)),
+        "entity_without_contact_count": sum(
+            1 for state in states if auth_state_matches_inspect_filter(state, INSPECT_FILTER_ENTITY_WITHOUT_CONTACT)
+        ),
         "has_affiliation_count": sum(1 for state in states if auth_state_matches_inspect_filter(state, INSPECT_FILTER_HAS_AFFILIATION)),
+        "entity_without_affiliation_count": sum(
+            1 for state in states if auth_state_matches_inspect_filter(state, INSPECT_FILTER_ENTITY_WITHOUT_AFFILIATION)
+        ),
         "has_invite_count": sum(1 for state in states if auth_state_matches_inspect_filter(state, INSPECT_FILTER_HAS_INVITE)),
+        "entity_without_invite_count": sum(
+            1 for state in states if auth_state_matches_inspect_filter(state, INSPECT_FILTER_ENTITY_WITHOUT_INVITE)
+        ),
     }
 
 
 def print_inspection_summary(states: list[AuthBusinessState], matched_states: list[AuthBusinessState], inspect_filter: str) -> None:
-    """Print compact summary-first inspection output."""
+    """Print readable summary-first inspection output."""
     summary = build_inspection_summary(states, matched_states, inspect_filter)
-    print(
-        "🔎 Verify Auth inspection summary. "
-        f"Filter={summary['inspect_filter']}, "
-        f"Inspected={summary['inspected_count']}, "
-        f"Matched={summary['matched_count']}, "
-        f"Emitted={summary['emitted_count']}, "
-        f"HasAnyAuth={summary['has_any_auth_count']}, "
-        f"MissingEntity={summary['missing_entity_count']}, "
-        f"HasEntity={summary['has_entity_count']}, "
-        f"HasContact={summary['has_contact_count']}, "
-        f"HasAffiliation={summary['has_affiliation_count']}, "
-        f"HasInvite={summary['has_invite_count']}"
-    )
+    metric_rows = [(label, str(value)) for label, value in _inspection_summary_metric_rows(summary)]
+    metric_width = max(len("metric"), *(len(label) for label, _ in metric_rows))
+    count_width = max(len("count"), *(len(value) for _, value in metric_rows))
+    header_border = f"{'─' * metric_width}─┼─{'─' * count_width}"
+
+    print(f"🔎 Inspect Auth summary (Filter={summary['inspect_filter']}):")
+    print(header_border)
+    print(f"{'metric'.ljust(metric_width)} | {'count'.rjust(count_width)}")
+    print(header_border)
+    for label, value in metric_rows:
+        print(f"{label.ljust(metric_width)} | {value.rjust(count_width)}")
+    print()
     if not states:
-        print("🔎 Verify Auth inspection: no selected businesses to inspect.")
+        print("🔎 Inspect Auth: no selected businesses to inspect.")
     elif not matched_states:
-        print("🔎 Verify Auth inspection: no rows matched the active inspect filter.")
+        print("🔎 Inspect Auth: no rows matched the active inspect filter.")
 
 
-def print_inspection_rows(inspection_rows: list[dict[str, str | int]]) -> None:
+def _preview_rows(rows: list[dict[str, str | int]], console_limit: ConsoleLimit | None) -> list[dict[str, str | int]]:
+    """Return rows permitted by a console preview limit."""
+    if console_limit is None or console_limit.max_rows is None:
+        return rows
+    if console_limit.disabled:
+        return []
+    return rows[: console_limit.max_rows]
+
+
+def _print_preview_truncated_message(
+    *,
+    label: str,
+    total_rows: int,
+    shown_rows: int,
+    report_path: str | None,
+    limit_config_key: str,
+) -> None:
+    """Print standard guidance when a row/table preview is truncated."""
+    path_fragment = f" ReportPath={report_path}." if report_path else ""
+    print(
+        f"⚠️ {label} console preview capped by {limit_config_key}. "
+        f"ConfiguredConsoleLimit={shown_rows}. TotalRows={total_rows}, RowsShown={shown_rows}."
+        f"{path_fragment} Set {limit_config_key}=ALL to print all preview rows, or 0 to suppress previews."
+    )
+
+
+def print_inspection_rows(
+    inspection_rows: list[dict[str, str | int]],
+    console_limit: ConsoleLimit | None = None,
+    report_path: str | None = None,
+    limit_config_key: str = "INSPECT_AUTH_CONSOLE_LIMIT",
+) -> None:
     """Print a compact factual inspection table for matched inspection rows."""
+    if console_limit is not None and console_limit.disabled:
+        return
     if not inspection_rows:
-        print("🔎 Verify Auth inspection detail: no matched rows to print.")
+        print("🔎 Inspect Auth detail: no matched rows to print.")
+        return
+
+    preview_rows = _preview_rows(inspection_rows, console_limit)
+    if not preview_rows:
         return
 
     columns = (
@@ -1347,44 +1835,124 @@ def print_inspection_rows(inspection_rows: list[dict[str, str | int]]) -> None:
         "found_account_ids",
         "found_account_names",
     )
-    table_rows = [{column: str(row.get(column, "")) for column in columns} for row in inspection_rows]
+    table_rows = [{column: str(row.get(column, "")) for column in columns} for row in preview_rows]
+    truncated = len(preview_rows) < len(inspection_rows)
+    if truncated:
+        remaining_rows = len(inspection_rows) - len(preview_rows)
+        table_rows.append(
+            {
+                "business_identifier": f"⚠️ {remaining_rows} MORE ROWS NOT SHOWN",
+                "business_names": f"console capped by {limit_config_key}",
+                "entity_state": "CSV complete",
+                "contact_state": "set ALL",
+                "affiliation_state": "for full console",
+                "invite_state": "",
+                "found_account_ids": "",
+                "found_account_names": "",
+            }
+        )
     widths = {
         column: max(len(column), *(len(row[column]) for row in table_rows))
         for column in columns
     }
 
-    print("🔎 Verify Auth inspection state:")
+    cap_label = _console_cap_label(console_limit, limit_config_key, unit="rows")
+    header_border = _table_header_border(widths, columns)
+    marker_separator = "-+-".join("-" * widths[column] for column in columns)
+    print(f"🔎 Inspect Auth state (contact_state uses usable contact email; {cap_label}):")
+    print(header_border)
     print(" | ".join(column.ljust(widths[column]) for column in columns))
+    print(header_border)
     for row in table_rows:
-        print(" | ".join(row[column].ljust(widths[column]) for column in columns))
+        rendered_row = " | ".join(row[column].ljust(widths[column]) for column in columns)
+        if row["business_identifier"].startswith("⚠️ "):
+            print(marker_separator)
+            print(rendered_row)
+            print(marker_separator)
+        else:
+            print(rendered_row)
+
+    if truncated:
+        _print_preview_truncated_message(
+            label="Inspect Auth state",
+            total_rows=len(inspection_rows),
+            shown_rows=len(preview_rows),
+            report_path=report_path,
+            limit_config_key=limit_config_key,
+        )
+
+
+def _print_inspection_identifier_truncated_message(
+    inspect_filter: str,
+    total_identifiers: int,
+    identifiers_shown: int,
+    copy_list_path: str | None,
+    limit_config_key: str,
+    configured_console_limit: str,
+) -> None:
+    """Print guidance when inspect identifier console output is truncated."""
+    _print_identifier_cap_warning(
+        label="Inspect Auth identifiers console output",
+        bucket_name=f"Filter={inspect_filter}",
+        total_identifiers=total_identifiers,
+        identifiers_shown=identifiers_shown,
+        configured_console_limit=configured_console_limit,
+        copy_list_path=copy_list_path,
+        fallback_filename="inspect-auth-summary.txt",
+        limit_config_key=limit_config_key,
+    )
 
 
 def print_inspection_identifier_rows(
     identifier_rows: list[dict[str, str | int]],
     inspect_filter: str,
+    console_limit: ConsoleLimit | None = None,
+    copy_list_path: str | None = None,
+    limit_config_key: str = "INSPECT_AUTH_CONSOLE_LIMIT",
 ) -> None:
     """Print copy-friendly inspect identifiers for AUTH_CORP_NUMS."""
+    if console_limit is not None and console_limit.disabled:
+        return
+
     if not identifier_rows:
         if inspect_filter != INSPECT_FILTER_ALL:
             print(
-                "✅ Verify Auth inspection identifiers: "
+                "✅ Inspect Auth identifiers: "
                 f"no identifiers matched {inspect_filter} for AUTH_CORP_NUMS."
             )
             return
-        print("✅ Verify Auth inspection identifiers: no concrete inspect identifier groups to copy into AUTH_CORP_NUMS.")
+        print("✅ Inspect Auth identifiers: no concrete inspect identifier groups to copy into AUTH_CORP_NUMS.")
         return
 
     if inspect_filter != INSPECT_FILTER_ALL and not int(identifier_rows[0]["count"]):
         print(
-            "✅ Verify Auth inspection identifiers: "
+            "✅ Inspect Auth identifiers: "
             f"no identifiers matched {inspect_filter} for AUTH_CORP_NUMS."
         )
         return
 
-    print("📋 Verify Auth inspection identifiers for AUTH_CORP_NUMS:")
+    cap_label = _console_cap_label(console_limit, limit_config_key, unit="identifiers per group")
+    print(f"📋 Inspect Auth identifiers for AUTH_CORP_NUMS ({cap_label}):")
     for row in identifier_rows:
-        print(f"{row['inspect_filter']} ({row['count']}):")
-        print(row["identifiers_csv"])
+        row_filter = str(row["inspect_filter"])
+        identifiers = _split_identifiers_csv(row.get("identifiers_csv", ""))
+        identifiers_to_print, truncated = _limited_identifiers(identifiers, console_limit)
+        _print_identifier_group_block(
+            label_name="Filter",
+            label_value=row_filter,
+            count=row["count"],
+            identifiers_preview=_format_identifier_console_list(identifiers_to_print, truncated=truncated),
+            sql_identifiers_preview=_format_sql_identifier_console_list(identifiers_to_print, truncated=truncated),
+        )
+        if truncated:
+            _print_inspection_identifier_truncated_message(
+                inspect_filter=row_filter,
+                total_identifiers=len(identifiers),
+                identifiers_shown=len(identifiers_to_print),
+                copy_list_path=copy_list_path,
+                limit_config_key=limit_config_key,
+                configured_console_limit=_console_limit_value(console_limit),
+            )
 
 
 def write_verification_reports(settings: VerifyAuthSettings, results: list[VerificationResult]) -> None:
@@ -1393,14 +1961,14 @@ def write_verification_reports(settings: VerifyAuthSettings, results: list[Verif
         raise ValueError("Verify report paths must be set before writing verification reports")
     write_summary_csv(settings.summary_path, results, settings.selected_checks)
     write_detail_csv(settings.detail_path, results)
-    write_scenario_csv(settings.scenario_path, results)
+    write_scenario_txt(settings.scenario_path, results)
 
 
-def write_inspection_report(settings: VerifyAuthSettings, states: list[AuthBusinessState]) -> None:
-    """Write the configured inspection CSV report."""
-    if not settings.inspection_path:
-        raise ValueError("VERIFY_AUTH_OUTPUT_PATH must be set before writing inspection reports")
-    write_inspection_csv(settings.inspection_path, states)
+def write_inspection_report(path: str, states: list[AuthBusinessState]) -> None:
+    """Write an inspection CSV report to the provided path."""
+    if not path:
+        raise ValueError("Inspection output path must be set before writing inspection reports")
+    write_inspection_csv(path, states)
 
 
 def calculate_batch_count(total_candidates: int, batch_size: int, configured_batches: int) -> int:
@@ -1410,9 +1978,13 @@ def calculate_batch_count(total_candidates: int, batch_size: int, configured_bat
     return min(math.ceil(total_candidates / batch_size), configured_batches)
 
 
-def _resolve_task_result(value: Any) -> Any:
+def resolve_task_result(value: Any) -> Any:
     """Resolve Prefect futures while leaving plain test doubles untouched."""
     return value.result() if hasattr(value, "result") else value
+
+
+# Backwards-compatible private alias for existing callers/tests.
+_resolve_task_result = resolve_task_result
 
 
 def _accepts_settings_argument(callable_obj: Callable[..., Any], current_arg_count: int) -> bool:
@@ -1481,7 +2053,7 @@ def _submit_verify_batch(
 def get_candidate_count_task(
     config: Any,
     colin_extract_engine: Engine,
-    settings: VerifyAuthSettings | None = None,
+    settings: AuthCandidateSettings | None = None,
 ) -> int:
     """Prefect task wrapper for the aligned selected-candidate count query."""
     return get_candidate_count(config, colin_extract_engine, settings)
@@ -1493,7 +2065,7 @@ def get_candidate_page_task(
     colin_extract_engine: Engine,
     limit: int,
     offset: int,
-    settings: VerifyAuthSettings | None = None,
+    settings: AuthCandidateSettings | None = None,
 ) -> list[str]:
     """Prefect task wrapper for deterministic selected-candidate paging."""
     return get_candidate_page(config, colin_extract_engine, limit, offset, settings)
@@ -1504,7 +2076,7 @@ def read_expected_accounts_task(
     config: Any,
     colin_extract_engine: Engine,
     business_identifiers: list[str],
-    settings: VerifyAuthSettings | None = None,
+    settings: AuthCandidateSettings | None = None,
 ) -> dict[str, tuple[str, ...]]:
     """Prefect task wrapper for read-only expected-account derivation."""
     return read_expected_accounts_for_candidates(config, colin_extract_engine, business_identifiers, settings)
@@ -1516,7 +2088,7 @@ def verify_auth_batch_task(
     auth_engine: Engine,
     business_identifiers: list[str],
     expected_accounts_by_identifier: dict[str, Iterable[str]] | None = None,
-    settings: VerifyAuthSettings | None = None,
+    settings: AuthBatchSettings | None = None,
 ) -> AuthBatchResult:
     """Prefect task wrapper for one Auth DB read-back batch."""
     return run_auth_batch(config, auth_engine, business_identifiers, expected_accounts_by_identifier, settings)
@@ -1528,14 +2100,24 @@ def warn_if_affiliation_and_invite_selected(settings: VerifyAuthSettings) -> Non
         LOGGER.warning(AFFILIATION_INVITE_WARNING)
 
 
+def format_console_limit(console_limit: ConsoleLimit) -> str:
+    if console_limit.disabled:
+        return "0"
+    if console_limit.max_rows is None:
+        return "ALL"
+    return str(console_limit.max_rows)
+
+
+# Backwards-compatible private alias for existing callers/tests.
+_format_console_limit = format_console_limit
+
+
 def _format_start_message(settings: VerifyAuthSettings) -> str:
     return (
         "👷 Verify Auth starting. "
         f"SelectionMode={settings.selection_mode.value}, "
-        f"ReportMode={settings.report_mode}, "
-        f"InspectFilter={settings.inspect_filter}, "
         f"SelectedChecks={','.join(settings.selected_checks) or '(none)'}, "
-        f"ConsoleDetail={settings.console_detail}, "
+        f"ConsoleLimit={format_console_limit(settings.console_limit)}, "
         f"ConfiguredBatches={settings.batches}, BatchSize={settings.batch_size}, "
         "RunnerAssumption=local/threaded"
     )
@@ -1553,7 +2135,7 @@ def _run_verify_auth_flow_with_engines(
     engines/task results without opening live database connections.
     """
     total_candidates = _call_candidate_count_task(config, colin_extract_engine, settings)
-    total_candidates = int(_resolve_task_result(total_candidates) or 0)
+    total_candidates = int(resolve_task_result(total_candidates) or 0)
     batch_count = calculate_batch_count(total_candidates, settings.batch_size, settings.batches)
     print(
         "👷 Auth candidate selection ready. "
@@ -1573,7 +2155,7 @@ def _run_verify_auth_flow_with_engines(
             offset,
             settings,
         )
-        business_identifiers = [str(identifier) for identifier in (_resolve_task_result(business_identifiers) or [])]
+        business_identifiers = [str(identifier) for identifier in (resolve_task_result(business_identifiers) or [])]
 
         expected_accounts_by_identifier: dict[str, Iterable[str]] | None = None
         if settings.read_expected_accounts:
@@ -1583,7 +2165,7 @@ def _run_verify_auth_flow_with_engines(
                 business_identifiers,
                 settings,
             )
-            expected_accounts_by_identifier = _resolve_task_result(expected_accounts_by_identifier) or {}
+            expected_accounts_by_identifier = resolve_task_result(expected_accounts_by_identifier) or {}
 
         print(
             f"🚀 Submitting verify-auth batch {batch_index + 1}/{batch_count}: "
@@ -1599,75 +2181,49 @@ def _run_verify_auth_flow_with_engines(
             )
         )
 
-    states: list[AuthBusinessState] = []
     results: list[VerificationResult] = []
     for future in futures:
-        batch_result = _resolve_task_result(future)
+        batch_result = resolve_task_result(future)
         if isinstance(batch_result, AuthBatchResult):
-            states.extend(batch_result.states)
             results.extend(batch_result.verification_results)
         else:
             # Backwards-compatible path for existing tests/doubles that return verification results directly.
             results.extend(batch_result or [])
 
-    matched_inspection_states: list[AuthBusinessState] = []
-    if settings.run_inspection:
-        matched_inspection_states = filter_inspection_states(states, settings.inspect_filter)
+    summary = build_summary_row(results, settings.selected_checks)
+    scenario_rows = build_scenario_rows(results)
+    print(
+        "🌟 Verify Auth tasks complete. "
+        f"TotalVerified={summary['total_count']}, Success={summary['success_count']}, "
+        f"Failure={summary['failure_count']}, ScenarioBuckets={len(scenario_rows)}"
+    )
+    print_scenario_summary_rows(scenario_rows)
+    print_scenario_rows(
+        scenario_rows,
+        console_limit=settings.console_limit,
+        copy_list_path=settings.scenario_path,
+        limit_config_key="VERIFY_AUTH_CONSOLE_LIMIT",
+    )
 
-    summary: dict[str, int]
-    if settings.run_verify:
-        summary = build_summary_row(results, settings.selected_checks)
-        scenario_rows = build_scenario_rows(results)
-        print(
-            "🌟 Verify Auth tasks complete. "
-            f"TotalVerified={summary['total_count']}, Success={summary['success_count']}, "
-            f"Failure={summary['failure_count']}, ScenarioBuckets={len(scenario_rows)}"
-        )
-        print_scenario_summary_rows(scenario_rows)
-        if settings.console_detail:
-            print_scenario_rows(scenario_rows)
-    else:
-        summary = {
-            "total_count": len(states),
-            "inspected_count": len(states),
-            "matched_count": len(matched_inspection_states),
-            "emitted_count": len(matched_inspection_states),
-        }
-        print(
-            "🌟 Verify Auth inspection tasks complete. "
-            f"TotalInspected={len(states)}, Matched={len(matched_inspection_states)}, "
-            f"Filter={settings.inspect_filter}"
-        )
-
-    if settings.run_inspection:
-        print_inspection_summary(states, matched_inspection_states, settings.inspect_filter)
-        if settings.console_detail:
-            print_inspection_rows(build_inspection_rows(matched_inspection_states))
-            print_inspection_identifier_rows(
-                build_inspection_identifier_rows(states, matched_inspection_states, settings.inspect_filter),
-                settings.inspect_filter,
-            )
-
-    if settings.run_verify:
-        write_verification_reports(settings, results)
-        print(
-            "🌰 Verify Auth reports written. "
-            f"SummaryPath={settings.summary_path}, DetailPath={settings.detail_path}, "
-            f"ScenarioPath={settings.scenario_path}"
-        )
-
-    if settings.run_inspection:
-        write_inspection_report(settings, matched_inspection_states)
-        print("🌰 Verify Auth inspection report written. " f"InspectionPath={settings.inspection_path}")
+    write_verification_reports(settings, results)
+    print(
+        "🌰 Verify Auth reports written. "
+        f"SummaryPath={settings.summary_path}, DetailPath={settings.detail_path}, "
+        f"ScenarioPath={settings.scenario_path}"
+    )
 
     return summary
 
 
-def _dispose_engine(engine: Any) -> None:
+def dispose_engine(engine: Any) -> None:
     """Dispose a SQLAlchemy engine if the object supports disposal."""
     dispose = getattr(engine, "dispose", None)
     if callable(dispose):
         dispose()
+
+
+# Backwards-compatible private alias for existing callers/tests.
+_dispose_engine = dispose_engine
 
 
 def _initialize_and_run_verify_auth_flow() -> dict[str, int]:
@@ -1689,8 +2245,8 @@ def _initialize_and_run_verify_auth_flow() -> dict[str, int]:
         auth_engine = auth_init(config)
         return _run_verify_auth_flow_with_engines(config, settings, colin_extract_engine, auth_engine)
     finally:
-        _dispose_engine(auth_engine)
-        _dispose_engine(colin_extract_engine)
+        dispose_engine(auth_engine)
+        dispose_engine(colin_extract_engine)
 
 
 @flow(name="Verify-Auth-Flow", log_prints=True)

--- a/data-tool/flows/config.py
+++ b/data-tool/flows/config.py
@@ -222,17 +222,33 @@ class _Config():  # pylint: disable=too-few-public-methods
     VERIFY_COLIN_UPDATES_DETAIL_PATH = os.getenv('VERIFY_COLIN_UPDATES_DETAIL_PATH')
     VERIFY_COLIN_UPDATES_SUMMARY_PATH = os.getenv('VERIFY_COLIN_UPDATES_SUMMARY_PATH')
 
+    # Auth output root shared by Auth flows that write report files.
+    AUTH_OUTPUT_PATH = os.getenv('AUTH_OUTPUT_PATH')
+
+    # Auth reporting throughput shared by verify-auth and inspect-auth.
+    # Keep raw at shared config-load time so invalid reporting env vars do not
+    # prevent unrelated data-tool/Auth flows from starting. The active reporting
+    # entrypoint performs strict positive-integer validation.
+    AUTH_REPORT_BATCHES = os.getenv('AUTH_REPORT_BATCHES', '0')
+    AUTH_REPORT_BATCH_SIZE = os.getenv('AUTH_REPORT_BATCH_SIZE', '0')
+
     # verify Auth flow
-    VERIFY_AUTH_BATCHES = _get_strict_int('VERIFY_AUTH_BATCHES', 0)
-    VERIFY_AUTH_BATCH_SIZE = _get_strict_int('VERIFY_AUTH_BATCH_SIZE', 0)
-    VERIFY_AUTH_REPORT_MODE = (os.getenv('VERIFY_AUTH_REPORT_MODE') or 'VERIFY').strip() or 'VERIFY'
-    VERIFY_AUTH_INSPECT_FILTER = (os.getenv('VERIFY_AUTH_INSPECT_FILTER') or 'ALL').strip() or 'ALL'
     VERIFY_AUTH_CHECK_ENTITY = _get_bool('VERIFY_AUTH_CHECK_ENTITY', True)
     VERIFY_AUTH_CHECK_CONTACT = _get_bool('VERIFY_AUTH_CHECK_CONTACT', True)
     VERIFY_AUTH_CHECK_AFFILIATION = _get_bool('VERIFY_AUTH_CHECK_AFFILIATION', False)
     VERIFY_AUTH_CHECK_INVITE = _get_bool('VERIFY_AUTH_CHECK_INVITE', False)
-    VERIFY_AUTH_CONSOLE_DETAIL = _get_bool('VERIFY_AUTH_CONSOLE_DETAIL', False)
-    VERIFY_AUTH_OUTPUT_PATH = os.getenv('VERIFY_AUTH_OUTPUT_PATH')
+    # Console-only verify scenario identifier limit: 0 suppresses optional sections,
+    # a positive integer caps console identifiers per scenario bucket, and ALL prints all.
+    # File outputs remain complete, including verify-auth-scenario.txt.
+    VERIFY_AUTH_CONSOLE_LIMIT = os.getenv('VERIFY_AUTH_CONSOLE_LIMIT', '25')
+
+    # inspect Auth flow. HAS_CONTACT / ENTITY_WITHOUT_CONTACT mean usable contact email,
+    # not merely any raw contact row.
+    INSPECT_AUTH_FILTER = (os.getenv('INSPECT_AUTH_FILTER') or 'ALL').strip() or 'ALL'
+    # Console-only inspect preview/identifier limit: 0 suppresses optional sections,
+    # a positive integer caps console rows/identifiers, and ALL prints all.
+    # File outputs remain complete, including inspect-auth-inspection.csv and inspect-auth-summary.txt.
+    INSPECT_AUTH_CONSOLE_LIMIT = os.getenv('INSPECT_AUTH_CONSOLE_LIMIT', '25')
 
     # freeze flow
     FREEZE_BATCHES = _get_int('FREEZE_BATCHES', 0)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33878

# Split Auth verify and inspect reporting into dedicated read-only flows

## Summary

This PR separates Auth reporting into two explicit read-only operator flows:

- `make run-verify-auth` runs a verify-only flow that checks selected Auth DB components and writes verify reports.
- `make run-inspect-auth` runs a dedicated factual inspection flow that reads Auth DB state, applies inspect filters after read-back, and writes inspection/copy-list reports.

The old combined verify/report-mode contract is replaced with clearer entrypoints, shared report output/throughput config, fixed filenames, capped console previews, and complete CSV/TXT file outputs for review/copy workflows.

## What changed

### Verify flow

- `verify_auth_flow.py` is now verify-only.
- Removed public inspect/report-mode behavior from the verify entrypoint.
- Uses shared reporting config:
  - `AUTH_OUTPUT_PATH`
  - `AUTH_REPORT_BATCHES`
  - `AUTH_REPORT_BATCH_SIZE`
- Writes fixed files under `AUTH_OUTPUT_PATH`:
  - `verify-auth-summary.csv`
  - `verify-auth-detail.csv`
  - `verify-auth-scenario.txt`
- Scenario output is now TXT, not CSV, with:
  - scenario summary table
  - copy-friendly `AUTH_CORP_NUMS=...` blocks
  - `SQL_IN_IDENTIFIERS=...` blocks for manual SQL `IN (...)` queries
- Console scenario summaries/lists are capped by `VERIFY_AUTH_CONSOLE_LIMIT` and clearly warn when console identifiers are incomplete.

### Inspect flow

- Adds `inspect_auth_flow.py` and `make run-inspect-auth`.
- Inspect reads full Auth state for every selected candidate:
  - entity
  - contact
  - affiliation
  - invite
- Applies `INSPECT_AUTH_FILTER` after Auth DB read-back; it does not change candidate SQL.
- Contact-related inspect filters mean usable contact email, not merely any raw contact row.
- Writes fixed files under `AUTH_OUTPUT_PATH`:
  - `inspect-auth-inspection.csv`
  - `inspect-auth-summary.txt`
- `inspect-auth-summary.txt` includes:
  - the same summary table shape used in console
  - filter-aware metrics, so non-`ALL` filters only show the relevant count columns
  - copy-friendly `AUTH_CORP_NUMS=...` blocks
  - `SQL_IN_IDENTIFIERS=...` blocks for manual SQL `IN (...)` queries
- Console inspect rows and identifier lists are capped by `INSPECT_AUTH_CONSOLE_LIMIT` and point operators to the complete files when capped.

## Config / operator contract

### Current config at a glance

| Area | Verify auth uses | Inspect auth uses |
|---|---|---|
| Command | `make run-verify-auth` | `make run-inspect-auth` |
| Output root | `AUTH_OUTPUT_PATH` | `AUTH_OUTPUT_PATH` |
| Batch count | `AUTH_REPORT_BATCHES` | `AUTH_REPORT_BATCHES` |
| Batch size | `AUTH_REPORT_BATCH_SIZE` | `AUTH_REPORT_BATCH_SIZE` |
| Candidate scope | `AUTH_SELECTION_MODE`, `AUTH_MIG_GROUP_IDS`, `AUTH_MIG_BATCH_IDS`, `AUTH_CORP_NUMS` | same |
| Flow-specific behavior | `VERIFY_AUTH_CHECK_*` | `INSPECT_AUTH_FILTER` |
| Console cap | `VERIFY_AUTH_CONSOLE_LIMIT` | `INSPECT_AUTH_CONSOLE_LIMIT` |
| Default console cap | `25` | `25` |

### Shared reporting config

```env
AUTH_OUTPUT_PATH=/tmp/auth
AUTH_REPORT_BATCHES=...
AUTH_REPORT_BATCH_SIZE=...
```

### Verify-specific config

```env
VERIFY_AUTH_CHECK_ENTITY=True
VERIFY_AUTH_CHECK_CONTACT=True
VERIFY_AUTH_CHECK_AFFILIATION=False
VERIFY_AUTH_CHECK_INVITE=False
VERIFY_AUTH_CONSOLE_LIMIT=25
```

### Inspect-specific config

```env
INSPECT_AUTH_FILTER=ALL
INSPECT_AUTH_CONSOLE_LIMIT=25
```

### Removed/replaced config

These are no longer the Auth reporting contract:

| Removed / stale | Use instead |
|---|---|
| `VERIFY_AUTH_BATCHES` | `AUTH_REPORT_BATCHES` |
| `VERIFY_AUTH_BATCH_SIZE` | `AUTH_REPORT_BATCH_SIZE` |
| `VERIFY_AUTH_OUTPUT_PATH` | `AUTH_OUTPUT_PATH` |
| `VERIFY_AUTH_REPORT_MODE` | `make run-verify-auth` / `make run-inspect-auth` |
| `VERIFY_AUTH_INSPECT_FILTER` | `INSPECT_AUTH_FILTER` |
| `VERIFY_AUTH_CONSOLE_DETAIL` | `VERIFY_AUTH_CONSOLE_LIMIT` / `INSPECT_AUTH_CONSOLE_LIMIT` |

## Output files

All report files are derived under `AUTH_OUTPUT_PATH`:

```text
AUTH_OUTPUT_PATH/
├── verify-auth-summary.csv
├── verify-auth-detail.csv
├── verify-auth-scenario.txt
├── inspect-auth-inspection.csv
└── inspect-auth-summary.txt
```

## Console limits

Both flows support bounded console output:

| Value | Behavior |
|---|---|
| unset / blank | default cap `25` |
| `0` | suppress optional console preview/identifier sections |
| positive integer | cap console row/list previews |
| `ALL` | print all console detail |

When identifier output is capped, the console marks it as incomplete and tells operators to copy from the TXT file instead.

## Reviewer focus areas

- Verify that `run-verify-auth` no longer performs inspect/report-mode work.
- Verify that `run-inspect-auth` does not require verify checks and always reads the full Auth state needed for factual inspection.
- Review config migration from old verify-prefixed report settings to shared `AUTH_OUTPUT_PATH` / `AUTH_REPORT_*` plus flow-specific console/filter settings.
- Review candidate selection semantics:
  - `AUTH_MIG_GROUP_IDS` and/or `AUTH_MIG_BATCH_IDS` are required for `AUTH_SELECTION_MODE=MIGRATION_FILTER`.
  - `AUTH_CORP_NUMS` narrows the selected migration/manual cohort; it does not replace migration scope.
- Review console/file output safety:
  - console output is capped by default
  - capped identifier lists are visually marked incomplete
  - complete copy lists live in TXT files
  - complete inspect detail lives in CSV




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
