### PR TITLE
33508 legal-api - fix cd, don't init dbc for migration job

### DIFF
--- a/legal-api/src/legal_api/__init__.py
+++ b/legal-api/src/legal_api/__init__.py
@@ -75,7 +75,6 @@ def create_app(environment: str = os.getenv("DEPLOYMENT_ENV", "production"), **k
     init_db(app)
 
     with app.app_context():  # db require app context
-        digital_credentials.init_app(app)
         if app.config.get("CLOUDSQL_INSTANCE_CONNECTION_NAME"):  # pragma: no cover
             setup_pg8000_close_event_listener(db.engine)
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33508

*Description of changes:*
- migration job doesn't inlcude all the variables needed to init the dbc service
- dbc service isn't needed for the migration job so moved it (was being initialed twice - rebase error on my part)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
