### PR TITLE
fix: pin legal-api to python 3.13.3 to match business-filer

### DIFF
--- a/legal-api/Dockerfile
+++ b/legal-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-bullseye AS development_build
+FROM python:3.13.3-bullseye AS development_build
 
 USER root
 


### PR DESCRIPTION
python:3.13 floating tag resolved to 3.13.4+ at build time, which tightened asyncio event loop handling from non-main threads and caused cloud-sql-python-connector's background thread to hang on IAM auth. Pinning to 3.13.3 (same as business-filer which works) restores the previous behaviour until the upstream connector adds explicit 3.13.4+ support.

*Issue #:* /bcgov/entity###

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
