### PR TITLE
32035 legal-api - amalg outputs, apply newest changes for summary to report

### DIFF
--- a/legal-api/src/legal_api/reports/business_document.py
+++ b/legal-api/src/legal_api/reports/business_document.py
@@ -25,10 +25,10 @@ from business_common.utils.legislation_datetime import LegislationDatetime
 from business_model.models import Alias, AmalgamatingBusiness, Amalgamation, Business, CorpType, Filing, Jurisdiction
 from legal_api.reports.document_service import DocumentService
 from legal_api.reports.registrar_meta import RegistrarInfo
-from legal_api.reports.utils import get_amalg_formatted_jurisdiction
+from legal_api.reports.utils import get_formatted_amalg_business_data
 from legal_api.resources.v2.business import get_addresses, get_directors
 from legal_api.resources.v2.business.business_parties import get_parties
-from legal_api.services import VersionedBusinessDetailsService, colin, flags
+from legal_api.services import VersionedBusinessDetailsService, flags
 from legal_api.services.request_context import RequestContext, get_request_context
 from legal_api.utils.auth import jwt
 
@@ -592,41 +592,17 @@ class BusinessDocument:
                 amalgamating_businesses = AmalgamatingBusiness.get_revision(amalgamation_application.transaction_id,
                                                                             amalgamation.id)
                 for amalgamating_business in amalgamating_businesses:
-                    if amalgamating_business.foreign_name:
-                        # Set identifier to 'N/A' for foreign businesses (we are showing the 'Number in BC' in the output)
-                        identifier = "N/A"
-                        foreign_identifier = amalgamating_business.foreign_identifier
-                        business_legal_name = amalgamating_business.foreign_name or "N/A"
-                        country_code = amalgamating_business.foreign_jurisdiction
-                        region_code = amalgamating_business.foreign_jurisdiction_region
-                        # FUTURE: rework this once expros are in lear
-                        # Check if this is an expro
-                        if (foreign_identifier.startswith("A")
-                            and (colin_resp := colin.query_business(foreign_identifier))
-                            and colin_resp.status_code == HTTPStatus.OK
-                        ):
-                            # this is an expro so set the identifier (it is the BC expro identifier)
-                            identifier = foreign_identifier
-                            # overwrite the region_code if jurisdiction is available in the response
-                            region_code = colin_resp.json().get("business", {}).get("jurisdiction")
-                            
-                    else:
-                        ting_business = VersionedBusinessDetailsService.get_business_revision_obj(
-                            amalgamation_application,
-                            amalgamating_business.business_id)
-                        identifier = ting_business._identifier  # pylint: disable=protected-access;
-                        business_legal_name = ting_business.legal_name
-                        country_code = "CA"
-                        region_code = "BC"
-
-                    jurisdiction = get_amalg_formatted_jurisdiction(identifier, country_code, region_code)
-                    
-                    amalgamated_businesses_info = {
-                        "legalName": business_legal_name or "N/A",
-                        "identifier": identifier or "N/A",
-                        "jurisdiction": jurisdiction or "N/A"
-                    }
+                    ting_business = None
+                    if not (foreign_name := amalgamating_business.foreign_name):
+                        ting_business = VersionedBusinessDetailsService.get_business_revision_obj(amalgamation_application,
+                                                                                                  amalgamating_business.business_id)
+                    amalgamated_businesses_info = get_formatted_amalg_business_data(amalgamating_business.foreign_identifier,
+                                                                                    foreign_name,
+                                                                                    amalgamating_business.foreign_jurisdiction,
+                                                                                    amalgamating_business.foreign_jurisdiction_region,
+                                                                                    ting_business)
                     amalgamated_businesses.append(amalgamated_businesses_info)
+
         business["amalgamatedEntities"] = amalgamated_businesses
 
     def _set_amalgamating_details(self, business: dict):

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -42,7 +42,7 @@ from legal_api.core.meta.filing import FILINGS, FilingMeta
 from legal_api.exceptions import BusinessException
 from legal_api.reports.document_service import DocumentService, ReportTypes
 from legal_api.reports.registrar_meta import RegistrarInfo
-from legal_api.reports.utils import get_amalg_formatted_jurisdiction
+from legal_api.reports.utils import get_formatted_amalg_business_data
 from legal_api.services import VersionedBusinessDetailsService, flags
 from legal_api.services.request_context import get_request_context
 from legal_api.utils.auth import jwt
@@ -957,7 +957,6 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
 
     def _set_amalgamating_businesses(self, filing):
         ting_businesses = []
-        business_legal_name = None
         # Determine the source filing for amalgamating businesses
         if correction := filing.get("correction"):
             original_filing = Filing.find_by_id(correction.get("correctedFilingId"))
@@ -972,23 +971,16 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
 
         for amalgamating_business in amalgamating_businesses:
             identifier = amalgamating_business.get("identifier")
-            if foreign_legal_name := amalgamating_business.get("legalName"):
-                business_legal_name = foreign_legal_name
-                country_code = amalgamating_business.get("foreignJurisdiction", {}).get("country")
-                region_code = amalgamating_business.get("foreignJurisdiction", {}).get("region")
+            ting_business = None
+            if not (foreign_name := amalgamating_business.get("legalName")):
+                ting_business = self._get_versioned_amalgamating_business(identifier)
+            amalgamated_businesses_info = get_formatted_amalg_business_data(identifier,
+                                                                            foreign_name,
+                                                                            amalgamating_business.get("foreignJurisdiction", {}).get("country"),
+                                                                            amalgamating_business.get("foreignJurisdiction", {}).get("region"),
+                                                                            ting_business)
+            ting_businesses.append(amalgamated_businesses_info)
 
-            elif ting_business := self._get_versioned_amalgamating_business(identifier):
-                business_legal_name = ting_business.legal_name
-                country_code = "CA"
-                region_code = "BC"
-
-            jurisdiction = get_amalg_formatted_jurisdiction(identifier, country_code, region_code)
-
-            ting_businesses.append({
-                "legalName": business_legal_name or "N/A",
-                "identifier": identifier or "N/A",
-                "jurisdiction": jurisdiction or "N/A"
-            })
         filing["amalgamatingBusinesses"] = ting_businesses
 
     def _get_versioned_amalgamating_business(self, identifier):

--- a/legal-api/src/legal_api/reports/utils.py
+++ b/legal-api/src/legal_api/reports/utils.py
@@ -25,8 +25,14 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """Common helper functions for reports flows."""
+from http import HTTPStatus
+
 import pycountry
 from flask import current_app
+
+from business_model.models import Business
+from legal_api.exceptions import BusinessException
+from legal_api.services.colin import ColinService
 
 
 def get_amalg_formatted_jurisdiction(identifier: str, country_code: str, region_code: str | None = None):
@@ -49,3 +55,49 @@ def get_amalg_formatted_jurisdiction(identifier: str, country_code: str, region_
                                    region_code,
                                    err.with_traceback(None))
         return "N/A"
+
+
+def get_formatted_amalg_business_data(
+    identifier: str | None = None,
+    foreign_name: str | None = None,
+    foreign_country_code: str | None = None,
+    foreign_region_code: str | None = None,
+    ting_business: Business | None = None
+):
+    """Return the amalgamation business data for the report output."""
+    if foreign_name:
+        # Set identifier to 'N/A' for foreign businesses (we are showing the 'Number in BC' in the output)
+        display_identifier = "N/A"
+        business_legal_name = foreign_name or "N/A"
+        country_code = foreign_country_code
+        region_code = foreign_region_code
+        # FUTURE: rework this once expros are in lear
+        # Check if this is an expro
+        if (identifier
+            and identifier.startswith("A")
+            and (colin_resp := ColinService.query_business(identifier))
+            and colin_resp.status_code == HTTPStatus.OK
+        ):
+            # this is an expro so set the identifier (it is the BC expro identifier)
+            display_identifier = identifier
+            # overwrite the region_code if jurisdiction is available in the response
+            region_code = colin_resp.json().get("business", {}).get("jurisdiction")
+            
+    else:
+        if not ting_business:
+            raise BusinessException(
+                "Error: Tried to process an amalgamating business which is not a foreign business or a ting business",
+                HTTPStatus.UNPROCESSABLE_ENTITY)
+
+        display_identifier = ting_business._identifier
+        business_legal_name = ting_business.legal_name
+        country_code = "CA"
+        region_code = "BC"
+
+    jurisdiction = get_amalg_formatted_jurisdiction(identifier, country_code, region_code)
+    
+    return {
+        "legalName": business_legal_name or "N/A",
+        "identifier": display_identifier or "N/A",
+        "jurisdiction": jurisdiction or "N/A"
+    }

--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_documents.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_documents.py
@@ -20,6 +20,7 @@ from typing import Final
 
 import requests
 from flask import current_app, jsonify, request
+from flask.globals import request_ctx
 from flask_cors import cross_origin
 from flask_pydantic import validate as pydantic_validate
 from pydantic import BaseModel
@@ -102,7 +103,7 @@ def get_documents(identifier: str, # noqa: PLR0911, PLR0912
             ), HTTPStatus.NOT_FOUND
 
         if _should_regenerate(legal_filing_name):
-            if jwt.contains_role([UserRoles.staff, UserRoles.system]):
+            if jwt.contains_role(request_ctx.current_user, [UserRoles.staff, UserRoles.system]):
                 return get_pdf(filing.storage, legal_filing_name, True)
             else:
                 return jsonify(

--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_documents.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_documents.py
@@ -20,7 +20,6 @@ from typing import Final
 
 import requests
 from flask import current_app, jsonify, request
-from flask.globals import request_ctx
 from flask_cors import cross_origin
 from flask_pydantic import validate as pydantic_validate
 from pydantic import BaseModel
@@ -103,7 +102,7 @@ def get_documents(identifier: str, # noqa: PLR0911, PLR0912
             ), HTTPStatus.NOT_FOUND
 
         if _should_regenerate(legal_filing_name):
-            if jwt.contains_role(request_ctx.current_user, [UserRoles.staff, UserRoles.system]):
+            if jwt.contains_role([UserRoles.staff, UserRoles.system]):
                 return get_pdf(filing.storage, legal_filing_name, True)
             else:
                 return jsonify(

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -36,6 +36,7 @@ from legal_api.services import MinioService, colin, flags, namex
 from legal_api.services.permissions import ListActionsPermissionsAllowed, PermissionService
 from legal_api.services.request_context import get_request_context
 from legal_api.services.utils import get_str
+from legal_api.utils.auth import jwt
 
 NO_POSTAL_CODE_COUNTRY_CODES = {
     "AO", "AG", "AW", "BS", "BZ", "BJ", "BM", "BO", "BQ", "BW", "BF", "BI",
@@ -1434,8 +1435,8 @@ def validate_completing_party(filing_json: dict, filing_type: str, org_id: int) 
     filing_firstname = officer.get("firstName")
     filing_lastname = officer.get("lastName")
     filing_email = officer.get("email")
-    
-    contacts_response = AccountService.get_contacts(current_app.config, org_id)
+
+    contacts_response = AccountService.get_contacts(org_id, jwt.get_token_auth_header())
     if contacts_response is None:
         return {
             "error":[{
@@ -1508,7 +1509,7 @@ def validate_document_delivery_email_changed(email: str, org_id: int) -> dict:
     if not email:
         return result
 
-    contacts_response = AccountService.get_contacts(current_app.config, org_id)
+    contacts_response = AccountService.get_contacts(org_id, jwt.get_token_auth_header())
     if contacts_response is None:
         result["errors"].append({
             "error": "Unable to verify document delivery email against account contacts."

--- a/legal-api/tests/unit/reports/__init__.py
+++ b/legal-api/tests/unit/reports/__init__.py
@@ -28,7 +28,8 @@
 from unittest.mock import MagicMock
 
 from legal_api.reports import business_document
-from legal_api.reports.business_document import Amalgamation, AmalgamatingBusiness, BusinessDocument, Filing, colin
+from legal_api.reports.business_document import Amalgamation, AmalgamatingBusiness, BusinessDocument, Filing
+from legal_api.reports.utils import ColinService
 from legal_api.services.authz import STAFF_ROLE
 from tests.unit.services.utils import create_header
 
@@ -87,7 +88,7 @@ def set_amalgamation_details(app, jwt, session, monkeypatch,
 
     # Optionally patch colin.query_business.
     if colin_query_side_effect is not None:
-        monkeypatch.setattr(colin, 'query_business', colin_query_side_effect)
+        monkeypatch.setattr(ColinService, 'query_business', colin_query_side_effect)
 
     request_ctx = app.test_request_context(headers=create_header(jwt, [STAFF_ROLE], identifier))
     with request_ctx:

--- a/legal-api/tests/unit/reports/test_report.py
+++ b/legal-api/tests/unit/reports/test_report.py
@@ -18,7 +18,7 @@ from contextlib import suppress
 from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import current_app
@@ -48,7 +48,8 @@ from registry_schemas.example_data import (
     SPECIAL_RESOLUTION,
     TRANSITION_FILING_TEMPLATE,
 )
-from tests.unit.models import factory_address, factory_business, factory_business_office, factory_completed_filing, factory_party_role, factory_pending_filing # noqa:E501,I001
+from tests.unit.models import factory_address, factory_business, factory_business_office, factory_completed_filing, factory_party_role, factory_pending_filing
+from legal_api.reports.utils import ColinService
 
 
 def create_report(identifier, entity_type, report_type, filing_type, template):
@@ -928,3 +929,158 @@ def test_format_change_address_liquidator_data(session, mocker):
     assert 'recordsOffice' in filing_data
     assert filing_data['recordsOffice']['mailingAddress']['changed'] is True
     assert filing_data['recordsOffice']['deliveryAddress']['changed'] is True
+
+# ---------------------------------------------------------------------------
+# Tests for Report._set_amalgamating_businesses
+# ---------------------------------------------------------------------------
+
+def _make_report_with_amalgamating_businesses(amalgamating_businesses_list, session,
+                                               identifier='BC9900001', entity_type='BC'):
+    """Return a Report instance whose filing_json contains the given amalgamatingBusinesses list."""
+    filing_json = copy.deepcopy(FILING_HEADER)
+    filing_json['filing']['header']['name'] = 'amalgamationApplication'
+    filing_json['filing']['business']['identifier'] = identifier
+    filing_json['filing']['business']['legalType'] = entity_type
+    filing_json['filing']['amalgamationApplication'] = {
+        'amalgamatingBusinesses': amalgamating_businesses_list,
+        'type': 'regular',
+        'courtApproval': False,
+    }
+
+    business = factory_business(identifier=identifier, entity_type=entity_type)
+    filing = factory_completed_filing(business, filing_json)
+
+    report = Report(filing)
+    report._business = business
+    report._report_key = 'amalgamationApplication'
+    return report
+
+
+@pytest.mark.parametrize(
+    'test_name, foreign_jurisdiction, foreign_region, colin_status, colin_jurisdiction, expected_id, expected_jurisdiction',
+    [
+        ('expro-on', 'CA', 'BC', HTTPStatus.OK, 'ON', 'A1234567', 'Ontario'),
+        ('expro-federal', 'CA', 'BC', HTTPStatus.OK, 'FD', 'A1234567', 'Federal'),
+        ('a-prefix-colin-404', 'US', 'WA', HTTPStatus.NOT_FOUND, None, 'N/A', 'United States'),
+    ],
+    ids=[
+        '_set_amalgamating_businesses: expro ON',
+        '_set_amalgamating_businesses: expro FD federal',
+        '_set_amalgamating_businesses: A-prefix colin 404 stays N/A',
+    ]
+)
+def test_set_amalgamating_businesses_foreign(
+        session, monkeypatch, test_name,
+        foreign_jurisdiction, foreign_region,
+        colin_status, colin_jurisdiction,
+        expected_id, expected_jurisdiction):
+    """Assert that _set_amalgamating_businesses correctly formats foreign and expro entries."""
+    foreign_identifier = 'A1234567'
+    foreign_name = 'Foreign Expro Corp'
+
+    amalgamating_businesses = [
+        {
+            'identifier': foreign_identifier,
+            'legalName': foreign_name,
+            'foreignJurisdiction': {
+                'country': foreign_jurisdiction,
+                'region': foreign_region,
+            },
+        }
+    ]
+
+    report = _make_report_with_amalgamating_businesses(amalgamating_businesses, session)
+
+    colin_call_count = {'count': 0}
+
+    def mock_colin(id_):
+        colin_call_count['count'] += 1
+        resp = MagicMock()
+        resp.status_code = colin_status
+        resp.json.return_value = {'business': {'jurisdiction': colin_jurisdiction}}
+        return resp
+
+    monkeypatch.setattr(ColinService, 'query_business', mock_colin)
+
+    filing = report._filing.filing_json['filing']
+    report._set_amalgamating_businesses(filing)
+
+    ting_businesses = filing.get('amalgamatingBusinesses', [])
+    assert len(ting_businesses) == 1
+    entry = ting_businesses[0]
+
+    assert entry['legalName'] == foreign_name
+    assert entry['identifier'] == expected_id
+    assert entry['jurisdiction'] == expected_jurisdiction
+
+
+def test_set_amalgamating_businesses_bc_domestic(session, monkeypatch):
+    """Assert that _set_amalgamating_businesses correctly formats a domestic BC ting business."""
+    bc_identifier = 'BC8887776'
+    bc_legal_name = 'Ting Corp Ltd.'
+
+    amalgamating_businesses = [
+        {
+            'identifier': bc_identifier,
+            # No legalName key: domestic businesses trigger the ting_business path
+        }
+    ]
+
+    report = _make_report_with_amalgamating_businesses(amalgamating_businesses, session)
+
+    # Provide a mock ting_business from _get_versioned_amalgamating_business
+    ting_mock = MagicMock()
+    ting_mock._identifier = bc_identifier  # pylint: disable=protected-access
+    ting_mock.legal_name = bc_legal_name
+    report._get_versioned_amalgamating_business = lambda id_: ting_mock
+
+    # COLIN must not be called for domestic businesses
+    monkeypatch.setattr(ColinService, 'query_business',
+                        lambda id_: (_ for _ in ()).throw(AssertionError('COLIN must not be called for domestic businesses')))
+
+    filing = report._filing.filing_json['filing']
+    report._set_amalgamating_businesses(filing)
+
+    ting_businesses = filing.get('amalgamatingBusinesses', [])
+    assert len(ting_businesses) == 1
+    entry = ting_businesses[0]
+
+    assert entry['legalName'] == bc_legal_name
+    assert entry['identifier'] == bc_identifier
+    assert entry['jurisdiction'] == 'British Columbia'
+
+
+def test_set_amalgamating_businesses_foreign_non_a_prefix(session, monkeypatch):
+    """Assert that a foreign business with a non-A identifier is not treated as expro and COLIN is not called."""
+    foreign_identifier = 'UK9876543'
+    foreign_name = 'UK Corp'
+
+    amalgamating_businesses = [
+        {
+            'identifier': foreign_identifier,
+            'legalName': foreign_name,
+            'foreignJurisdiction': {'country': 'GB', 'region': None},
+        }
+    ]
+
+    report = _make_report_with_amalgamating_businesses(amalgamating_businesses, session)
+
+    colin_call_count = {'count': 0}
+
+    def mock_colin_no_call(id_):
+        colin_call_count['count'] += 1
+        return MagicMock()
+
+    monkeypatch.setattr(ColinService, 'query_business', mock_colin_no_call)
+
+    filing = report._filing.filing_json['filing']
+    report._set_amalgamating_businesses(filing)
+
+    ting_businesses = filing.get('amalgamatingBusinesses', [])
+    assert len(ting_businesses) == 1
+    entry = ting_businesses[0]
+
+    assert entry['identifier'] == 'N/A'
+    assert entry['legalName'] == foreign_name
+    assert entry['jurisdiction'] == 'United Kingdom'
+    assert colin_call_count['count'] == 0

--- a/legal-api/tests/unit/reports/test_utils.py
+++ b/legal-api/tests/unit/reports/test_utils.py
@@ -25,9 +25,13 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """Test-Suite to ensure that the Report utils are working as expected."""
+from http import HTTPStatus
+from unittest.mock import MagicMock
+
 import pytest
 
-from legal_api.reports.utils import get_amalg_formatted_jurisdiction
+from legal_api.exceptions import BusinessException
+from legal_api.reports.utils import ColinService, get_amalg_formatted_jurisdiction, get_formatted_amalg_business_data
 
 
 @pytest.mark.parametrize(
@@ -73,3 +77,177 @@ def test_get_amalg_formatted_jurisdiction_error_paths(
         result = get_amalg_formatted_jurisdiction(identifier, country_code, region_code)
 
     assert result == 'N/A'
+
+
+# ---------------------------------------------------------------------------
+# Tests for get_formatted_amalg_business_data
+# ---------------------------------------------------------------------------
+
+def _make_ting_business(identifier='BC1234567', legal_name='Ting Corp Ltd.'):
+    """Return a lightweight mock that behaves like a versioned Business object."""
+    ting = MagicMock()
+    ting._identifier = identifier  # pylint: disable=protected-access
+    ting.legal_name = legal_name
+    return ting
+
+
+def _make_colin_response(status_code, jurisdiction=None):
+    """Return a mock HTTP response imitating a ColinService.query_business result."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = {'business': {'jurisdiction': jurisdiction}}
+    return resp
+
+
+@pytest.mark.parametrize('test_name, identifier, foreign_name, country_code, region_code, expected_id, expected_name, expected_jurisdiction', [
+    ('us-foreign-non-expro', 'UK1234567', 'Foreign Corp USA', 'US', 'WA', 'N/A', 'Foreign Corp USA', 'United States'),
+    ('gb-foreign-non-expro', 'GB9999999', 'British Co', 'GB', None, 'N/A', 'British Co', 'United Kingdom'),
+    ('ca-on-foreign-non-expro', 'ON1234567', 'Ontario Corp', 'CA', 'ON', 'N/A', 'Ontario Corp', 'Ontario'),
+], ids=[
+    'foreign non-expro US',
+    'foreign non-expro GB',
+    'foreign non-expro CA-ON',
+])
+def test_get_formatted_amalg_business_data_foreign_non_expro(
+        app, monkeypatch, test_name, identifier, foreign_name, country_code, region_code,
+        expected_id, expected_name, expected_jurisdiction):
+    """Assert that a foreign non-expro business returns N/A identifier and correct jurisdiction without calling COLIN."""
+    colin_call_count = {'count': 0}
+
+    def mock_colin(id_):
+        colin_call_count['count'] += 1
+        return _make_colin_response(HTTPStatus.OK)
+
+    monkeypatch.setattr(ColinService, 'query_business', mock_colin)
+
+    with app.app_context():
+        result = get_formatted_amalg_business_data(
+            identifier=identifier,
+            foreign_name=foreign_name,
+            foreign_country_code=country_code,
+            foreign_region_code=region_code,
+        )
+
+    assert result['identifier'] == expected_id
+    assert result['legalName'] == expected_name
+    assert result['jurisdiction'] == expected_jurisdiction
+    # COLIN must NOT be called for identifiers that do not start with 'A'
+    assert colin_call_count['count'] == 0
+
+
+@pytest.mark.parametrize('test_name, colin_jurisdiction, expected_id, expected_jurisdiction', [
+    ('expro-on-province', 'ON', 'A1234567', 'Ontario'),
+    ('expro-federal', 'FD', 'A1234567', 'Federal'),
+    ('expro-no-jurisdiction-in-colin', None, 'A1234567', 'N/A'),
+], ids=[
+    'expro ON province',
+    'expro FD federal',
+    'expro no jurisdiction in colin',
+])
+def test_get_formatted_amalg_business_data_foreign_expro_colin_200(
+        app, monkeypatch, test_name, colin_jurisdiction, expected_id, expected_jurisdiction):
+    """Assert that a foreign business whose identifier starts with A and COLIN returns 200 is treated as an expro."""
+    foreign_identifier = 'A1234567'
+    foreign_name = 'Expro Corp'
+    colin_call_count = {'count': 0}
+
+    def mock_colin(id_):
+        colin_call_count['count'] += 1
+        return _make_colin_response(HTTPStatus.OK, jurisdiction=colin_jurisdiction)
+
+    monkeypatch.setattr(ColinService, 'query_business', mock_colin)
+
+    with app.app_context():
+        result = get_formatted_amalg_business_data(
+            identifier=foreign_identifier,
+            foreign_name=foreign_name,
+            foreign_country_code='CA',
+            foreign_region_code='BC',
+        )
+
+    assert result['identifier'] == expected_id
+    assert result['legalName'] == foreign_name
+    assert result['jurisdiction'] == expected_jurisdiction
+    assert colin_call_count['count'] == 1
+
+
+def test_get_formatted_amalg_business_data_foreign_a_prefix_colin_non_200(app, monkeypatch):
+    """Assert that a foreign A-prefix business where COLIN returns non-200 keeps N/A identifier and original jurisdiction."""
+    foreign_identifier = 'A1234567'
+    foreign_name = 'Would-be Expro Corp'
+    colin_call_count = {'count': 0}
+
+    def mock_colin(id_):
+        colin_call_count['count'] += 1
+        return _make_colin_response(HTTPStatus.NOT_FOUND)
+
+    monkeypatch.setattr(ColinService, 'query_business', mock_colin)
+
+    with app.app_context():
+        result = get_formatted_amalg_business_data(
+            identifier=foreign_identifier,
+            foreign_name=foreign_name,
+            foreign_country_code='US',
+            foreign_region_code='WA',
+        )
+
+    assert result['identifier'] == 'N/A'
+    assert result['legalName'] == foreign_name
+    assert result['jurisdiction'] == 'United States'
+    assert colin_call_count['count'] == 1
+
+
+def test_get_formatted_amalg_business_data_bc_business_with_ting(app):
+    """Assert that a domestic BC business returns the ting_business identifier, legal name, and BC jurisdiction."""
+    ting = _make_ting_business(identifier='BC9876543', legal_name='Ting Corp Ltd.')
+
+    with app.app_context():
+        result = get_formatted_amalg_business_data(
+            identifier=None,
+            foreign_name=None,
+            foreign_country_code=None,
+            foreign_region_code=None,
+            ting_business=ting,
+        )
+
+    assert result['identifier'] == 'BC9876543'
+    assert result['legalName'] == 'Ting Corp Ltd.'
+    assert result['jurisdiction'] == 'British Columbia'
+
+
+def test_get_formatted_amalg_business_data_raises_when_no_foreign_name_and_no_ting(app):
+    """Assert that BusinessException with UNPROCESSABLE_ENTITY is raised when neither foreign_name nor ting_business is provided."""
+    with app.app_context():
+        with pytest.raises(BusinessException) as exc_info:
+            get_formatted_amalg_business_data(
+                identifier='BC1234567',
+                foreign_name=None,
+                foreign_country_code=None,
+                foreign_region_code=None,
+                ting_business=None,
+            )
+
+    assert exc_info.value.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+def test_get_formatted_amalg_business_data_foreign_no_identifier_skips_colin(app, monkeypatch):
+    """Assert that a foreign business with no identifier does not call COLIN and returns N/A identifier."""
+    colin_called = {'called': False}
+
+    def mock_colin(id_):
+        colin_called['called'] = True
+        return _make_colin_response(HTTPStatus.OK)
+
+    monkeypatch.setattr(ColinService, 'query_business', mock_colin)
+
+    with app.app_context():
+        result = get_formatted_amalg_business_data(
+            identifier=None,
+            foreign_name='No ID Foreign Corp',
+            foreign_country_code='US',
+            foreign_region_code='WA',
+        )
+
+    assert result['identifier'] == 'N/A'
+    assert result['legalName'] == 'No ID Foreign Corp'
+    assert not colin_called['called']


### PR DESCRIPTION
*Issue #:* /bcgov/entity#32035

*Description of changes:*
- applied recent changes for summary amalg output to the amalg report
- created shared method so that both are using the same code for setting amalg business details
- added tests

example of summary and amalg:
[32035-updated-amalg.pdf](https://github.com/user-attachments/files/29294231/32035-updated-amalg.pdf)
[32035-updated-amalg-summary.pdf](https://github.com/user-attachments/files/29294234/32035-updated-amalg-summary.pdf)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
