### PR TITLE
33576 - add receivership flag to business summary

### DIFF
--- a/legal-api/report-templates/template-parts/business-summary/businessDetails.html
+++ b/legal-api/report-templates/template-parts/business-summary/businessDetails.html
@@ -101,6 +101,14 @@
         <span class="section-data">No</span>
         {% endif %}
     </div>
+    <div class="mt-2">
+        <span class="section-sub-title">Receiver: </span>
+        {% if receivers|length > 0 %}
+        <span class="section-data">Yes</span>
+        {% else %}
+        <span class="section-data">No</span>
+        {% endif %}
+    </div>
     {% if business.restorationExpiryDate %}
     <div class="mt-2">
         <span class="section-sub-title">This company is in Limited Restoration with an Expiry Date of </span>

--- a/legal-api/tests/unit/reports/templates/business-summary/test_business_details.py
+++ b/legal-api/tests/unit/reports/templates/business-summary/test_business_details.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2026, Province of British Columbia
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""Business Details (business-summary) template tests."""
+import pytest
+
+from tests.unit.reports.templates import get_template
+
+
+DETAILS_TEMPLATE = '/template-parts/business-summary/businessDetails.html'
+
+
+@pytest.mark.parametrize('has_receiver', [True, False])
+def test_render_summary_has_receivers(session, has_receiver):
+    """Assert receiver flag is rendered correctly"""
+    template = get_template(DETAILS_TEMPLATE)
+    business = {'legalType': 'BC'}
+
+    if has_receiver:
+        rendered = template.render(business=business, receivers={'name': 'test receiver'})
+        rendered = " ".join(rendered.split())
+        expected = '<div class="mt-2"> <span class="section-sub-title">Receiver: </span> <span class="section-data">Yes</span> </div>'
+        assert expected in rendered
+    else:
+        rendered = template.render(business=business, receivers=[])
+        rendered = " ".join(rendered.split())
+        expected = '<div class="mt-2"> <span class="section-sub-title">Receiver: </span> <span class="section-data">No</span> </div>'
+        assert expected in rendered

--- a/legal-api/tests/unit/reports/test_business_document.py
+++ b/legal-api/tests/unit/reports/test_business_document.py
@@ -173,8 +173,7 @@ def test_set_amalgamation_details(
 
 @pytest.mark.parametrize('has_receiver, cessation_date, expected_count', [
     (True, None, 1),
-    (False, '2026-06-01', 0),
-    (False, None, 0)
+    (False, '2026-06-02', 0)
 ])
 def test_summary_includes_receivers(session, app, jwt, has_receiver, cessation_date, expected_count):
     """Assert that the business summary correctly includes receivers."""
@@ -186,25 +185,24 @@ def test_summary_includes_receivers(session, app, jwt, has_receiver, cessation_d
         business = factory_business(identifier=identifier, entity_type='BC')
         factory_business_mailing_address(business)
 
-        if has_receiver:
-            receiver = factory_party_role(
-                delivery_address=factory_address('delivery street', 'delivery'),
-                mailing_address=factory_address('mailing street', 'mailing'),
-                appointment_date='2026-01-01',
-                cessation_date=cessation_date,
-                officer={
-                    'firstName': 'first',
-                    'lastName': 'last',
-                    'middleInitial': 'mid',
-                    'partyType': 'person',
-                    'organizationName': ''
-                },
-                role_type=PartyRole.RoleTypes.RECEIVER
-            )
+        receiver = factory_party_role(
+            delivery_address=factory_address('delivery street', 'delivery'),
+            mailing_address=factory_address('mailing street', 'mailing'),
+            appointment_date='2026-01-01',
+            cessation_date=cessation_date,
+            officer={
+                'firstName': 'first',
+                'lastName': 'last',
+                'middleInitial': 'mid',
+                'partyType': 'person',
+                'organizationName': ''
+            },
+            role_type=PartyRole.RoleTypes.RECEIVER
+        )
 
-            receiver.business_id = business.id
-            session.add(receiver)
-            session.commit()
+        receiver.business_id = business.id
+        session.add(receiver)
+        session.commit()
 
         report = BusinessDocument(business, 'summary')
         filename = report._get_report_filename()

--- a/legal-api/tests/unit/reports/test_business_document.py
+++ b/legal-api/tests/unit/reports/test_business_document.py
@@ -18,11 +18,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from business_model.models import PartyRole
 from legal_api.reports.business_document import BusinessDocument
 from legal_api.services.authz import STAFF_ROLE
 from tests.unit.services.utils import create_header
 
-from tests.unit.models import factory_business, factory_business_mailing_address
+from tests.unit.models import factory_address, factory_business, factory_business_mailing_address, factory_party_role
 from tests.unit.reports import make_amalgamation_filing_mock, make_foreign_amalgamating_business, set_amalgamation_details
 
 
@@ -168,3 +169,52 @@ def test_set_amalgamation_details(
     assert entity['identifier'] == expected_id
     assert entity['jurisdiction'] == expected_jurisdiction
     assert entity['legalName'] == foreign_name
+
+
+@pytest.mark.parametrize('has_receiver, cessation_date, expected_count', [
+    (True, None, 1),
+    (False, '2026-06-01', 0),
+    (False, None, 0)
+])
+def test_summary_includes_receivers(session, app, jwt, has_receiver, cessation_date, expected_count):
+    """Assert that the business summary correctly includes receivers."""
+    identifier = 'BC7654321'
+    request_ctx = app.test_request_context(
+        headers=create_header(jwt, [STAFF_ROLE], identifier)
+    )
+    with request_ctx:
+        business = factory_business(identifier=identifier, entity_type='BC')
+        factory_business_mailing_address(business)
+
+        if has_receiver:
+            receiver = factory_party_role(
+                delivery_address=factory_address('delivery street', 'delivery'),
+                mailing_address=factory_address('mailing street', 'mailing'),
+                appointment_date='2026-01-01',
+                cessation_date=cessation_date,
+                officer={
+                    'firstName': 'first',
+                    'lastName': 'last',
+                    'middleInitial': 'mid',
+                    'partyType': 'person',
+                    'organizationName': ''
+                },
+                role_type=PartyRole.RoleTypes.RECEIVER
+            )
+
+            receiver.business_id = business.id
+            session.add(receiver)
+            session.commit()
+
+        report = BusinessDocument(business, 'summary')
+        filename = report._get_report_filename()
+        assert filename
+        template = report._get_template()
+        assert template
+        template_data = report._get_template_data()
+
+        assert 'receivers' in template_data
+        assert len(template_data['receivers']) == expected_count
+
+        if expected_count > 0:
+            assert template_data['receivers'][0]['role'] == 'receiver'


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33576

*Description of changes:*
- add receivership flag to business summary

<img width="605" height="404" alt="Screenshot 2026-06-24 at 11 29 05 AM" src="https://github.com/user-attachments/assets/4034d780-39eb-48f2-8678-71879f2843d6" />
<img width="606" height="355" alt="Screenshot 2026-06-24 at 11 28 32 AM" src="https://github.com/user-attachments/assets/7bffd19c-ed77-49bf-829b-1ea54d3696cc" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
