### PR TITLE
33867_33957 Add email domain filters and optimize views for mv_legacy_corps_data

### DIFF
--- a/data-tool/backup_extract_tables.sh
+++ b/data-tool/backup_extract_tables.sh
@@ -19,7 +19,7 @@ PGDATABASE="${PGDATABASE:-colin-mig-corps-test}"     # or ‑‑dbname
 ##############################################################################
 
 # -- Tables to keep ------------------------------------------------------------
-KEEP=(corp_processing auth_processing auth_component_operation colin_tracking mig_group mig_batch mig_corp_batch mig_corp_account corps_with_third_party email_domain_groups bar_corps bad_emails exclude_corps)
+KEEP=(corp_processing auth_processing auth_component_operation colin_tracking mig_group mig_batch mig_corp_batch mig_corp_account corps_with_third_party email_domain_groups bar_corps bad_emails exclude_corps excluded_emails excluded_email_domains excluded_email_domain_patterns)
 
 # -- Runtime options -----------------------------------------------------------
 BACKUP_DIR="${BACKUP_DIR:-/backups}"

--- a/data-tool/dump_colin_extract_without_views.sh
+++ b/data-tool/dump_colin_extract_without_views.sh
@@ -68,6 +68,7 @@ EXCLUDED_OBJECTS=(
   mv_addr_quality_screening_by_corp
   mv_share_class_issue_flags
   mv_corp_event_filing_rollup
+  mv_admin_email_bad_email_flags
   mv_legacy_corps_data
   mv_corp_issue_flags
   mv_issue_counts_by_corp_type

--- a/data-tool/flows/common/query_utils.py
+++ b/data-tool/flows/common/query_utils.py
@@ -77,6 +77,7 @@ def get_candidates_not_matching_saf_criteria_query(updated_corp_nums: list) -> s
     AND has_bar_filing = false
     AND directors_within_bc = true
     AND is_bad_email = false
+    AND is_email_excluded = false
     AND is_migration_excluded = false
     )
 """

--- a/data-tool/refresh_colin_extract_views.sh
+++ b/data-tool/refresh_colin_extract_views.sh
@@ -41,6 +41,7 @@ canonical_mv_order=(
   mv_addr_quality_screening_by_corp
   mv_share_class_issue_flags
   mv_corp_event_filing_rollup
+  mv_admin_email_bad_email_flags
   mv_legacy_corps_data
   mv_corp_issue_flags
   mv_issue_counts_by_corp_type
@@ -65,30 +66,33 @@ Options:
   -h, --help                 show help
 
 Refresh profiles:
-  legacy        refresh mv_corp_event_filing_rollup, then mv_legacy_corps_data
-                (safe default for legacy-screening data, including rolling two-year counts)
+  legacy        refresh mv_corp_event_filing_rollup, mv_admin_email_bad_email_flags,
+                then mv_legacy_corps_data
+                (safe default for legacy-screening data, including rolling two-year counts
+                and bad-email flag updates)
   legacy-direct refresh mv_legacy_corps_data only
-                (advanced/leaf-only path when all upstream derived MVs are already current)
+                (advanced/leaf-only path when all upstream sidecars/derived MVs are already current)
   event-filing  alias of legacy; refresh mv_corp_event_filing_rollup,
-                then mv_legacy_corps_data
+                mv_admin_email_bad_email_flags, then mv_legacy_corps_data
   share         refresh mv_share_class_issue_flags, plus the event rollup,
-                then mv_legacy_corps_data
+                mv_admin_email_bad_email_flags, then mv_legacy_corps_data
   address       refresh the shared address entity rollup and the legacy-only
                 address screening chain: mv_addr_issue_counts_by_entity,
                 mv_addr_quality_screening_by_corp, then mv_corp_event_filing_rollup,
-                then mv_legacy_corps_data
+                mv_admin_email_bad_email_flags, then mv_legacy_corps_data
   address-full  refresh the shared address entity rollup, both address-quality
-                layers, the event rollup, legacy MV, and corp issue reporting MVs
+                layers, the event rollup, mv_admin_email_bad_email_flags,
+                legacy MV, and corp issue reporting MVs
   party         refresh the legacy-only corp_party screening chain plus the
                 shared address entity rollup: mv_corps_with_officers,
                 mv_corps_party_role_count, mv_addr_issue_counts_by_entity,
                 mv_addr_quality_screening_by_corp, then mv_corp_event_filing_rollup,
-                then mv_legacy_corps_data
+                mv_admin_email_bad_email_flags, then mv_legacy_corps_data
   party-full    refresh the corp_party chain, shared address entity rollup,
-                both address-quality layers, event rollup, legacy MV,
-                and corp issue reporting MVs
+                both address-quality layers, event rollup, mv_admin_email_bad_email_flags,
+                legacy MV, and corp issue reporting MVs
   admin-email   refresh mv_admin_email_count, plus the event rollup,
-                then mv_legacy_corps_data
+                mv_admin_email_bad_email_flags, then mv_legacy_corps_data
   email-domain  refresh mv_admin_email_domain_count only
   corp-issues   refresh mv_addr_issue_counts_by_entity, mv_addr_quality_by_corp,
                 mv_corp_issue_flags, then mv_issue_counts_by_corp_type
@@ -115,9 +119,9 @@ Examples:
     --db colin-mig-corps-test-subset
 
 Notes:
-  - Any profile that refreshes `mv_legacy_corps_data` now refreshes the event/filing rollup first, except `legacy-direct`.
-  - `legacy` is the safe/default profile for legacy-screening data.
-  - `legacy-direct` is an advanced/leaf-only path that assumes all upstream derived MVs are already current; otherwise `mv_legacy_corps_data` can be refreshed against stale inputs.
+  - Any safe profile that refreshes `mv_legacy_corps_data` now refreshes the event/filing rollup and `mv_admin_email_bad_email_flags` first, except `legacy-direct`.
+  - `legacy` is the safe/default profile for legacy-screening data, including manual `bad_emails` row edits.
+  - `legacy-direct` is an advanced/leaf-only path that assumes all upstream sidecars/derived MVs, including `mv_admin_email_bad_email_flags`, are already current; otherwise `mv_legacy_corps_data` can be refreshed against stale inputs.
   - `event-filing` is kept as an explicit alias of `legacy` for event/filing-driven refreshes.
   - Address-driven profiles now refresh `mv_addr_issue_counts_by_entity` first so the slim and full address-quality MVs share the same upstream rollup.
   - `address` / `party` stop at the slim screening MV for legacy-only refreshes.
@@ -261,6 +265,7 @@ expand_target() {
   case "$target" in
     legacy|event-filing)
       append_unique_mv mv_corp_event_filing_rollup
+      append_unique_mv mv_admin_email_bad_email_flags
       append_unique_mv mv_legacy_corps_data
       ;;
     legacy-direct)
@@ -269,12 +274,14 @@ expand_target() {
     share)
       append_unique_mv mv_share_class_issue_flags
       append_unique_mv mv_corp_event_filing_rollup
+      append_unique_mv mv_admin_email_bad_email_flags
       append_unique_mv mv_legacy_corps_data
       ;;
     address)
       append_unique_mv mv_addr_issue_counts_by_entity
       append_unique_mv mv_addr_quality_screening_by_corp
       append_unique_mv mv_corp_event_filing_rollup
+      append_unique_mv mv_admin_email_bad_email_flags
       append_unique_mv mv_legacy_corps_data
       ;;
     address-full)
@@ -282,6 +289,7 @@ expand_target() {
       append_unique_mv mv_addr_quality_by_corp
       append_unique_mv mv_addr_quality_screening_by_corp
       append_unique_mv mv_corp_event_filing_rollup
+      append_unique_mv mv_admin_email_bad_email_flags
       append_unique_mv mv_legacy_corps_data
       append_unique_mv mv_corp_issue_flags
       append_unique_mv mv_issue_counts_by_corp_type
@@ -292,6 +300,7 @@ expand_target() {
       append_unique_mv mv_addr_issue_counts_by_entity
       append_unique_mv mv_addr_quality_screening_by_corp
       append_unique_mv mv_corp_event_filing_rollup
+      append_unique_mv mv_admin_email_bad_email_flags
       append_unique_mv mv_legacy_corps_data
       ;;
     party-full)
@@ -301,6 +310,7 @@ expand_target() {
       append_unique_mv mv_addr_quality_by_corp
       append_unique_mv mv_addr_quality_screening_by_corp
       append_unique_mv mv_corp_event_filing_rollup
+      append_unique_mv mv_admin_email_bad_email_flags
       append_unique_mv mv_legacy_corps_data
       append_unique_mv mv_corp_issue_flags
       append_unique_mv mv_issue_counts_by_corp_type
@@ -308,6 +318,7 @@ expand_target() {
     admin-email)
       append_unique_mv mv_admin_email_count
       append_unique_mv mv_corp_event_filing_rollup
+      append_unique_mv mv_admin_email_bad_email_flags
       append_unique_mv mv_legacy_corps_data
       ;;
     email-domain)
@@ -355,15 +366,15 @@ resolve_targets() {
 print_targets() {
   cat <<'TARGETS'
 Available refresh profiles:
-  legacy        -> mv_corp_event_filing_rollup -> mv_legacy_corps_data
-  legacy-direct -> mv_legacy_corps_data only (advanced/leaf-only path; assumes upstream MVs are current)
+  legacy        -> mv_corp_event_filing_rollup -> mv_admin_email_bad_email_flags -> mv_legacy_corps_data
+  legacy-direct -> mv_legacy_corps_data only (advanced/leaf-only path; assumes upstream sidecars/MVs are current)
   event-filing  -> alias of legacy
-  share         -> mv_share_class_issue_flags -> mv_corp_event_filing_rollup -> mv_legacy_corps_data
-  address       -> mv_addr_issue_counts_by_entity -> mv_addr_quality_screening_by_corp -> mv_corp_event_filing_rollup -> mv_legacy_corps_data
-  address-full  -> mv_addr_issue_counts_by_entity -> mv_addr_quality_by_corp -> mv_addr_quality_screening_by_corp -> mv_corp_event_filing_rollup -> mv_legacy_corps_data -> mv_corp_issue_flags -> mv_issue_counts_by_corp_type
-  party         -> mv_corps_with_officers -> mv_corps_party_role_count -> mv_addr_issue_counts_by_entity -> mv_addr_quality_screening_by_corp -> mv_corp_event_filing_rollup -> mv_legacy_corps_data
-  party-full    -> mv_corps_with_officers -> mv_corps_party_role_count -> mv_addr_issue_counts_by_entity -> mv_addr_quality_by_corp -> mv_addr_quality_screening_by_corp -> mv_corp_event_filing_rollup -> mv_legacy_corps_data -> mv_corp_issue_flags -> mv_issue_counts_by_corp_type
-  admin-email   -> mv_admin_email_count -> mv_corp_event_filing_rollup -> mv_legacy_corps_data
+  share         -> mv_share_class_issue_flags -> mv_corp_event_filing_rollup -> mv_admin_email_bad_email_flags -> mv_legacy_corps_data
+  address       -> mv_addr_issue_counts_by_entity -> mv_addr_quality_screening_by_corp -> mv_corp_event_filing_rollup -> mv_admin_email_bad_email_flags -> mv_legacy_corps_data
+  address-full  -> mv_addr_issue_counts_by_entity -> mv_addr_quality_by_corp -> mv_addr_quality_screening_by_corp -> mv_corp_event_filing_rollup -> mv_admin_email_bad_email_flags -> mv_legacy_corps_data -> mv_corp_issue_flags -> mv_issue_counts_by_corp_type
+  party         -> mv_corps_with_officers -> mv_corps_party_role_count -> mv_addr_issue_counts_by_entity -> mv_addr_quality_screening_by_corp -> mv_corp_event_filing_rollup -> mv_admin_email_bad_email_flags -> mv_legacy_corps_data
+  party-full    -> mv_corps_with_officers -> mv_corps_party_role_count -> mv_addr_issue_counts_by_entity -> mv_addr_quality_by_corp -> mv_addr_quality_screening_by_corp -> mv_corp_event_filing_rollup -> mv_admin_email_bad_email_flags -> mv_legacy_corps_data -> mv_corp_issue_flags -> mv_issue_counts_by_corp_type
+  admin-email   -> mv_admin_email_count -> mv_corp_event_filing_rollup -> mv_admin_email_bad_email_flags -> mv_legacy_corps_data
   email-domain  -> mv_admin_email_domain_count
   corp-issues   -> mv_addr_issue_counts_by_entity -> mv_addr_quality_by_corp -> mv_corp_issue_flags -> mv_issue_counts_by_corp_type
   all           -> full COLIN MV layer in dependency order (including shared address entity rollup)
@@ -383,11 +394,20 @@ write_plan() {
     for mv_name in "${selected_mvs[@]}"; do
       quoted_mv="$(quote_ident "$mv_name")"
       printf 'REFRESH MATERIALIZED VIEW %s.%s;\n' "$quoted_schema" "$quoted_mv"
+      if [[ "$SKIP_ANALYZE" != "true" \
+          && "$mv_name" == "mv_admin_email_bad_email_flags" ]] \
+          && contains_item "mv_legacy_corps_data" "${selected_mvs[@]}"; then
+        printf 'ANALYZE %s.%s;\n' "$quoted_schema" "$quoted_mv"
+      fi
     done
 
     if [[ "$SKIP_ANALYZE" != "true" ]]; then
       printf '\n'
       for mv_name in "${selected_mvs[@]}"; do
+        if [[ "$mv_name" == "mv_admin_email_bad_email_flags" ]] \
+            && contains_item "mv_legacy_corps_data" "${selected_mvs[@]}"; then
+          continue
+        fi
         quoted_mv="$(quote_ident "$mv_name")"
         printf 'ANALYZE %s.%s;\n' "$quoted_schema" "$quoted_mv"
       done

--- a/data-tool/restore_extract.sh
+++ b/data-tool/restore_extract.sh
@@ -20,7 +20,7 @@ PGDATABASE="${PGDATABASE:-colin-mig-corps-test}"     # or ‑‑dbname
 ##############################################################################
 
 # -- Tables to restore ------------------------------------------------------------
-RESTORE=(corp_processing auth_processing auth_component_operation colin_tracking mig_group mig_batch mig_corp_batch mig_corp_account corps_with_third_party email_domain_groups bar_corps bad_emails exclude_corps)
+RESTORE=(corp_processing auth_processing auth_component_operation colin_tracking mig_group mig_batch mig_corp_batch mig_corp_account corps_with_third_party email_domain_groups bar_corps bad_emails exclude_corps excluded_emails excluded_email_domains excluded_email_domain_patterns)
 
 # -- Runtime options -----------------------------------------------------------
 DUMP="${DUMP}"

--- a/data-tool/scripts/README_COLIN_Corps_Extract.md
+++ b/data-tool/scripts/README_COLIN_Corps_Extract.md
@@ -129,6 +129,8 @@ Safety rules:
 - The generator **does not use `CASCADE`**.
 - The generator **fails** if an unexpected non-allowlisted view/materialized view depends on a COLIN-owned object.
 - `reset` mode currently supports only schema `public` because `colin_corps_extract_postgres_views_ddl` is not schema-qualified.
+- Base tables must already exist before resetting/recreating the derived view layer.
+- For DDL or MV-column definition changes, including materialized-view definition changes, run `reset_colin_extract_views.sh --mode reset --yes` or the equivalent derived-layer reset path before running code that references the changed MV layer.
 - For **data-only** changes, prefer `REFRESH MATERIALIZED VIEW` rather than drop/recreate.
 
 ---
@@ -193,15 +195,15 @@ Options:
 ```
 
 Refresh profiles:
-- `legacy`: refresh `mv_corp_event_filing_rollup`, then `mv_legacy_corps_data` (safe/default legacy-screening refresh; keeps rolling time-windowed counts current)
-- `legacy-direct`: refresh `mv_legacy_corps_data` only (advanced/leaf-only path when all upstream derived MVs are already current)
-- `event-filing`: alias of `legacy`; refresh `mv_corp_event_filing_rollup`, then `mv_legacy_corps_data`
-- `share`: refresh `mv_share_class_issue_flags`, plus the event/filing rollup, then `mv_legacy_corps_data`
-- `address`: refresh `mv_addr_issue_counts_by_entity`, then the legacy-only address screening chain: `mv_addr_quality_screening_by_corp`, then the event/filing rollup, then `mv_legacy_corps_data`
-- `address-full`: refresh `mv_addr_issue_counts_by_entity`, both address-quality layers, then the event/filing rollup, legacy MV, and corp issue reporting MVs
-- `party`: refresh the legacy-only `corp_party` screening chain: `mv_corps_with_officers`, `mv_corps_party_role_count`, `mv_addr_issue_counts_by_entity`, `mv_addr_quality_screening_by_corp`, then the event/filing rollup, then `mv_legacy_corps_data`
-- `party-full`: refresh the `corp_party` chain, `mv_addr_issue_counts_by_entity`, both address-quality layers, event/filing rollup, legacy MV, and corp issue reporting MVs
-- `admin-email`: refresh `mv_admin_email_count`, plus the event/filing rollup, then `mv_legacy_corps_data`
+- `legacy`: refresh `mv_corp_event_filing_rollup`, then `mv_admin_email_bad_email_flags`, then `mv_legacy_corps_data` (safe/default legacy-screening refresh; keeps rolling time-windowed counts and bad-email flags current)
+- `legacy-direct`: refresh `mv_legacy_corps_data` only (advanced/leaf-only path when all upstream sidecars/derived MVs are already current)
+- `event-filing`: alias of `legacy`; refresh `mv_corp_event_filing_rollup`, then `mv_admin_email_bad_email_flags`, then `mv_legacy_corps_data`
+- `share`: refresh `mv_share_class_issue_flags`, plus the event/filing rollup, then `mv_admin_email_bad_email_flags`, then `mv_legacy_corps_data`
+- `address`: refresh `mv_addr_issue_counts_by_entity`, then the legacy-only address screening chain: `mv_addr_quality_screening_by_corp`, then the event/filing rollup, then `mv_admin_email_bad_email_flags`, then `mv_legacy_corps_data`
+- `address-full`: refresh `mv_addr_issue_counts_by_entity`, both address-quality layers, then the event/filing rollup, `mv_admin_email_bad_email_flags`, legacy MV, and corp issue reporting MVs
+- `party`: refresh the legacy-only `corp_party` screening chain: `mv_corps_with_officers`, `mv_corps_party_role_count`, `mv_addr_issue_counts_by_entity`, `mv_addr_quality_screening_by_corp`, then the event/filing rollup, then `mv_admin_email_bad_email_flags`, then `mv_legacy_corps_data`
+- `party-full`: refresh the `corp_party` chain, `mv_addr_issue_counts_by_entity`, both address-quality layers, event/filing rollup, `mv_admin_email_bad_email_flags`, legacy MV, and corp issue reporting MVs
+- `admin-email`: refresh `mv_admin_email_count`, plus the event/filing rollup, then `mv_admin_email_bad_email_flags`, then `mv_legacy_corps_data`
 - `email-domain`: refresh `mv_admin_email_domain_count` only
 - `corp-issues`: refresh `mv_addr_issue_counts_by_entity`, `mv_addr_quality_by_corp`, `mv_corp_issue_flags`, then `mv_issue_counts_by_corp_type`
 - `all`: refresh the full COLIN MV layer in dependency order, including `mv_addr_issue_counts_by_entity`
@@ -232,9 +234,8 @@ Examples:
 Notes:
 - Use `reset_colin_extract_views.sh` only when the view/MV DDL itself has changed.
 - BAR data is static and should no longer be treated as a reason to refresh `mv_legacy_corps_data`.
-- Any profile that refreshes `mv_legacy_corps_data` now refreshes the event/filing rollup first, except `legacy-direct`.
-- `legacy` is the safe/default profile for legacy-screening data.
-- `legacy-direct` is an advanced/leaf-only path that assumes all upstream derived MVs are already current; otherwise `mv_legacy_corps_data` can be refreshed against stale inputs.
+- `legacy` is the safe/default profile for legacy-screening data, including refreshes after email exclusion table or `bad_emails` row edits.
+- `legacy-direct` is an advanced/leaf-only path that assumes all upstream sidecars/derived MVs, including `mv_admin_email_bad_email_flags`, are already current; otherwise `mv_legacy_corps_data` can be refreshed against stale inputs and stale bad-email flags.
 - `event-filing` is kept as an explicit alias of `legacy` for event/filing-driven refreshes.
 - Address-driven profiles now refresh `mv_addr_issue_counts_by_entity` first so the slim and full address-quality MVs share the same upstream aggregation.
 - `address` / `party` stop at the slim screening MV for legacy-only refreshes.

--- a/data-tool/scripts/colin_corps_extract_generate_view_drop.sql
+++ b/data-tool/scripts/colin_corps_extract_generate_view_drop.sql
@@ -44,6 +44,7 @@ VALUES
   ('mv_addr_quality_screening_by_corp', 'm'),
   ('mv_share_class_issue_flags', 'm'),
   ('mv_corp_event_filing_rollup', 'm'),
+  ('mv_admin_email_bad_email_flags', 'm'),
   ('mv_legacy_corps_data', 'm'),
   ('mv_corp_issue_flags', 'm'),
   ('mv_issue_counts_by_corp_type', 'm');

--- a/data-tool/scripts/colin_corps_extract_postgres_ddl
+++ b/data-tool/scripts/colin_corps_extract_postgres_ddl
@@ -38,6 +38,10 @@ create sequence if not exists bad_emails_id_seq;
 
 alter sequence bad_emails_id_seq owner to postgres;
 
+create sequence if not exists excluded_email_domain_patterns_id_seq;
+
+alter sequence excluded_email_domain_patterns_id_seq owner to postgres;
+
 create table if not exists address
 (
     addr_id                numeric(10)
@@ -1200,6 +1204,58 @@ CREATE TABLE IF NOT EXISTS bad_emails (
 
 alter table bad_emails
     owner to postgres;
+
+-- Preserve raw bad_emails.email uniqueness while also enforcing the normalized
+-- case/whitespace-insensitive uniqueness used by mv_legacy_corps_data.
+CREATE UNIQUE INDEX IF NOT EXISTS ux_bad_emails_email_normalized
+    ON bad_emails (lower(btrim(email)));
+
+CREATE TABLE IF NOT EXISTS excluded_emails (
+    email varchar(255) NOT NULL
+        CONSTRAINT chk_excluded_emails_email_not_blank
+            CHECK (lower(btrim(email)) <> ''),
+    notes text
+);
+
+alter table excluded_emails
+    owner to postgres;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_excluded_emails_email_normalized
+    ON excluded_emails (lower(btrim(email)));
+
+CREATE TABLE IF NOT EXISTS excluded_email_domains (
+    email_domain varchar(255) NOT NULL
+        CONSTRAINT chk_excluded_email_domains_domain_not_blank
+            CHECK (lower(btrim(email_domain)) <> ''),
+    notes text
+);
+
+alter table excluded_email_domains
+    owner to postgres;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_excluded_email_domains_domain_normalized
+    ON excluded_email_domains (lower(btrim(email_domain)));
+
+-- Exact-domain-scoped local-part exclusions. `email_domain` is matched exactly;
+-- `local_part_pattern` is a literal substring of the email local part. This is
+-- not partial-domain matching.
+CREATE TABLE IF NOT EXISTS excluded_email_domain_patterns (
+	id integer default nextval('excluded_email_domain_patterns_id_seq'::regclass) not null
+		constraint pk_excluded_email_domain_patterns primary key,
+    email_domain varchar(255) NOT NULL
+        CONSTRAINT chk_excluded_email_domain_patterns_domain_not_blank
+            CHECK (lower(btrim(email_domain)) <> ''),
+    local_part_pattern varchar(255) NOT NULL
+        CONSTRAINT chk_excluded_email_domain_patterns_pattern_not_blank
+            CHECK (lower(btrim(local_part_pattern)) <> ''),
+    notes text
+);
+
+alter table excluded_email_domain_patterns
+    owner to postgres;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_excluded_email_domain_patterns_normalized
+    ON excluded_email_domain_patterns (lower(btrim(email_domain)), lower(btrim(local_part_pattern)));
 
 CREATE TABLE IF NOT EXISTS exclude_corps (
     corp_num varchar(10) NOT NULL

--- a/data-tool/scripts/colin_corps_extract_postgres_views_ddl
+++ b/data-tool/scripts/colin_corps_extract_postgres_views_ddl
@@ -780,6 +780,35 @@ ALTER MATERIALIZED VIEW mv_corp_event_filing_rollup
     owner to postgres;
 
 
+CREATE MATERIALIZED VIEW mv_admin_email_bad_email_flags AS
+WITH normalized_admin_emails AS (
+  SELECT DISTINCT
+    lower(btrim(c.admin_email)) AS normalized_admin_email
+  FROM corporation c
+  WHERE c.admin_email IS NOT NULL
+    AND btrim(c.admin_email) <> ''
+),
+normalized_bad_emails AS (
+  SELECT DISTINCT
+    lower(btrim(be.email)) AS normalized_email
+  FROM bad_emails be
+)
+SELECT
+  nae.normalized_admin_email,
+  CAST((nbe.normalized_email IS NOT NULL) AS boolean) AS is_bad_email
+FROM normalized_admin_emails nae
+LEFT JOIN normalized_bad_emails nbe
+  ON nbe.normalized_email = nae.normalized_admin_email
+WITH NO DATA
+;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_mv_admin_email_bad_email_flags_normalized_email
+  ON mv_admin_email_bad_email_flags (normalized_admin_email);
+
+ALTER MATERIALIZED VIEW mv_admin_email_bad_email_flags
+    owner to postgres;
+
+
 CREATE MATERIALIZED VIEW mv_legacy_corps_data AS
 WITH cp_completed AS (
   /* One completed migration row per corp in prod */
@@ -832,12 +861,23 @@ SELECT COALESCE(edg.group_name, NULL) AS group_name,
         tblFe.email_domain,
         admin_email,
         CAST(email_used_count as integer) as email_used_count,
-        CAST(EXISTS (
-          SELECT 1
-          FROM bad_emails be
-          WHERE btrim(tblFe.admin_email) <> ''
-            AND lower(btrim(be.email)) = lower(btrim(tblFe.admin_email))
-        ) AS boolean) AS is_bad_email,
+        CAST(COALESCE(bad_email_flags.is_bad_email, false) AS boolean) AS is_bad_email,
+        CAST((excluded_email_match.email IS NOT NULL) AS boolean) AS is_email_excluded_by_address,
+        CAST((excluded_email_domain_match.email_domain IS NOT NULL) AS boolean) AS is_email_excluded_by_domain,
+        CAST((excluded_email_pattern_match.id IS NOT NULL) AS boolean) AS is_email_excluded_by_domain_pattern,
+        CAST((
+          excluded_email_match.email IS NOT NULL
+          OR excluded_email_domain_match.email_domain IS NOT NULL
+          OR excluded_email_pattern_match.id IS NOT NULL
+        ) AS boolean) AS is_email_excluded,
+        CASE
+          WHEN excluded_email_match.email IS NOT NULL THEN 'email=' || btrim(excluded_email_match.email)
+          WHEN excluded_email_domain_match.email_domain IS NOT NULL THEN 'email_domain=' || btrim(excluded_email_domain_match.email_domain)
+          WHEN excluded_email_pattern_match.id IS NOT NULL THEN
+            'email_domain=' || btrim(excluded_email_pattern_match.email_domain)
+            || '; local_part_pattern=' || btrim(excluded_email_pattern_match.local_part_pattern)
+          ELSE NULL
+        END AS email_exclusion_criteria,
         corp_num,
         corp_name,
         corp_type_cd,
@@ -900,7 +940,7 @@ SELECT COALESCE(edg.group_name, NULL) AS group_name,
         CAST(bar_account_has_mailing_address as boolean) as bar_account_has_mailing_address,
         ting_corps
 FROM (
-    SELECT DISTINCT
+    SELECT
            LOWER(SPLIT_PART(c.admin_email, '@', 2)) as email_domain,
            LOWER(c.admin_email) as admin_email,
            aec.email_count AS email_used_count,
@@ -1033,7 +1073,35 @@ LEFT JOIN mig_status ms USING (corp_num)
 LEFT JOIN mig_batch  mb ON mb.id = ms.mig_batch_id
 LEFT JOIN mig_group  mg ON mg.id = mb.mig_group_id
 LEFT JOIN email_domain_groups edg ON tblFe.email_domain = edg.email_domain
+LEFT JOIN mv_admin_email_bad_email_flags bad_email_flags
+  ON bad_email_flags.normalized_admin_email = lower(btrim(tblFe.admin_email))
 LEFT JOIN mv_share_class_issue_flags sif USING (corp_num)
+LEFT JOIN LATERAL (
+  SELECT ee.email
+  FROM excluded_emails ee
+  WHERE lower(btrim(tblFe.admin_email)) <> ''
+    AND lower(btrim(ee.email)) = lower(btrim(tblFe.admin_email))
+  LIMIT 1
+) excluded_email_match ON true
+LEFT JOIN LATERAL (
+  SELECT eed.email_domain
+  FROM excluded_email_domains eed
+  WHERE lower(btrim(tblFe.email_domain)) <> ''
+    AND lower(btrim(eed.email_domain)) = lower(btrim(tblFe.email_domain))
+  LIMIT 1
+) excluded_email_domain_match ON true
+-- `excluded_email_domain_patterns` matches an exact email domain plus a literal
+-- local-part substring; it does not perform partial-domain matching.
+LEFT JOIN LATERAL (
+  SELECT eedp.id, eedp.email_domain, eedp.local_part_pattern
+  FROM excluded_email_domain_patterns eedp
+  WHERE lower(btrim(tblFe.admin_email)) <> ''
+    AND lower(btrim(tblFe.email_domain)) <> ''
+    AND lower(btrim(eedp.email_domain)) = lower(btrim(tblFe.email_domain))
+    AND POSITION(lower(btrim(eedp.local_part_pattern)) IN lower(btrim(split_part(tblFe.admin_email, '@', 1)))) > 0
+  ORDER BY eedp.id
+  LIMIT 1
+) excluded_email_pattern_match ON true
 where 1=1
 WITH NO DATA
 ;
@@ -1463,6 +1531,8 @@ REFRESH MATERIALIZED VIEW mv_addr_quality_by_corp;
 REFRESH MATERIALIZED VIEW mv_addr_quality_screening_by_corp;
 REFRESH MATERIALIZED VIEW mv_share_class_issue_flags;
 REFRESH MATERIALIZED VIEW mv_corp_event_filing_rollup;
+REFRESH MATERIALIZED VIEW mv_admin_email_bad_email_flags;
+ANALYZE mv_admin_email_bad_email_flags;
 REFRESH MATERIALIZED VIEW mv_legacy_corps_data;
 REFRESH MATERIALIZED VIEW mv_corp_issue_flags;
 REFRESH MATERIALIZED VIEW mv_issue_counts_by_corp_type;


### PR DESCRIPTION
*Issue #:* /bcgov/entity/33867 /bcgov/entity/33957

## Summary

Adds manual email exclusion support for COLIN legacy corporation migration screening and improves `mv_legacy_corps_data` refresh behavior.

Can now exclude migration candidates by:

1. exact email address
2. exact email domain
3. exact-domain/local-part pattern

SAF fallout now uses the combined `is_email_excluded` flag, and bad-email detection is precomputed in a sidecar MV instead of repeatedly checked inside the legacy MV.

## Changes

- Added exclusion tables: `excluded_emails`, `excluded_email_domains`, `excluded_email_domain_patterns`.
- Added normalized uniqueness/indexes for `bad_emails` and the new exclusion tables.
- Added `mv_admin_email_bad_email_flags` to precompute bad-email status by normalized admin email.
- Updated `mv_legacy_corps_data` with:
  - `is_email_excluded`
  - `is_email_excluded_by_address`
  - `is_email_excluded_by_domain`
  - `is_email_excluded_by_domain_pattern`
  - `email_exclusion_criteria`
- Updated SAF fallout filtering to require `is_email_excluded = false`.
- Updated refresh/reset/backup/restore/docs so the new sidecar MV and exclusion policy tables are handled correctly.
- Removed redundant inner `tblFe SELECT DISTINCT` from the legacy MV query.

## Main field to use

Use `is_email_excluded` when filtering businesses for migration eligibility:

```sql
SELECT corp_num, corp_name, admin_email
FROM mv_legacy_corps_data
WHERE is_email_excluded = false;
```

For analysis/debugging, the component fields show why a row was excluded:

| Column | Meaning |
|---|---|
| `is_email_excluded` | Main combined exclusion flag. |
| `is_email_excluded_by_address` | Matched `excluded_emails`. |
| `is_email_excluded_by_domain` | Matched `excluded_email_domains`. |
| `is_email_excluded_by_domain_pattern` | Matched `excluded_email_domain_patterns`. |
| `email_exclusion_criteria` | Text description of the matched rule. |

## Exclusion examples

| Table | Example rule | Excludes | Does not exclude |
|---|---|---|---|
| `excluded_emails` | `email = bad.actor@example.com` | `bad.actor@example.com` | `bad.actor@other.com` |
| `excluded_email_domains` | `email_domain = example.com` | `anyone@example.com` | `anyone@mail.example.com` |
| `excluded_email_domain_patterns` | `email_domain = example.com`<br>`local_part_pattern = test` | `test123@example.com`<br>`my-test-user@example.com` | `test123@other.com`<br>`user@example.com` |

Pattern rules require **both** the domain and local-part pattern to match:

```text
my-test-user@example.com
│            │
│            └── domain exactly matches `example.com`
└── local part contains `test`
```

So `local_part_pattern = test` + `email_domain = example.com` matches `my-test-user@example.com`, but not `test-user@other.com` or `user@example.com`.


##  Performance gains from mv_legacy_corps_data tweaks

### 1. Bad-email sidecar optimization

`mv_legacy_corps_data` now joins precomputed `mv_admin_email_bad_email_flags` instead of repeatedly evaluating `bad_emails` in the legacy MV query path.

| Metric | Before | After | Result |
|---|---:|---:|---:|
| Raw EXPLAIN execution time | `645,375.981 ms` | `36,544.238 ms` | ~`17.7x` faster / `94.3%` lower |
| Output rows | `1,549,795` | `1,549,795` | unchanged |

**Readout:** same row output, materially lower execution time.

---

### 2. Redundant `tblFe SELECT DISTINCT` removal

Diagnostics showed the inner `tblFe SELECT DISTINCT` was not removing rows, so it was adding sort/unique work without changing cardinality.

| Metric | Before | After | Result |
|---|---:|---:|---:|
| Raw EXPLAIN execution time | `37,824.819 ms` | `29,842.095 ms` | ~`8.0s` faster / `21.1%` lower |
| Raw rows | `1,549,795` | `1,549,795` | unchanged |
| Distinct rows | `1,549,795` | `1,549,795` | unchanged |
| Rows removed by DISTINCT | `0` | n/a | DISTINCT was redundant |
| Duplicate `corp_num` | `0` | `0` | unchanged |



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
