### PR TITLE
33872 filing comment model change

### DIFF
--- a/python/common/business-registry-model/pyproject.toml
+++ b/python/common/business-registry-model/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "business-model"
-version = "3.3.31"
+version = "3.3.32"
 description = ""
 authors = [
     {name = "thor",email = "1042854+thorwolpert@users.noreply.github.com"}

--- a/python/common/business-registry-model/src/business_model/models/comment.py
+++ b/python/common/business-registry-model/src/business_model/models/comment.py
@@ -21,6 +21,7 @@ from sqlalchemy import event, func
 from sqlalchemy.orm import backref
 
 from business_model.exceptions import BusinessException
+from business_model.utils.base import BaseEnum, auto
 
 from .db import db
 from .user import User
@@ -31,11 +32,18 @@ class Comment(db.Model):
 
     This class does NOT have a continuum shadow as comments should not be edited.
     """
+    
+    class CommentType(BaseEnum):
+        """Render an Enum of the types of comments."""
+
+        FILING = auto()
+        STAFF = auto()
 
     __tablename__ = 'comments'
 
     id = db.Column(db.Integer, primary_key=True)
     comment = db.Column(db.String(4096))
+    comment_type = db.Column('comment_type', db.Enum(CommentType), nullable=False)
     timestamp = db.Column('timestamp', db.DateTime(timezone=True), default=func.now())
 
     # parent keys
@@ -60,6 +68,7 @@ class Comment(db.Model):
                 'id': self.id,
                 'submitterDisplayName': user.display_name if user else REDACTED_STAFF_SUBMITTER,
                 'comment': self.comment,
+                'commentType': self.comment_type.name,
                 'filingId': self.filing_id,
                 'businessId': self.business_id,
                 'timestamp': self.timestamp.isoformat() if self.timestamp else None

--- a/python/common/business-registry-model/src/business_model_migrations/versions/20260626_093349_bc62c64eeaab_.py
+++ b/python/common/business-registry-model/src/business_model_migrations/versions/20260626_093349_bc62c64eeaab_.py
@@ -5,8 +5,8 @@ Revises: b5ded56cab5b
 Create Date: 2026-06-26 09:33:49.399745
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.

--- a/python/common/business-registry-model/src/business_model_migrations/versions/20260626_093349_bc62c64eeaab_.py
+++ b/python/common/business-registry-model/src/business_model_migrations/versions/20260626_093349_bc62c64eeaab_.py
@@ -1,0 +1,42 @@
+"""empty message
+
+Revision ID: bc62c64eeaab
+Revises: b5ded56cab5b
+Create Date: 2026-06-26 09:33:49.399745
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'bc62c64eeaab'
+down_revision = 'b5ded56cab5b'
+branch_labels = None
+depends_on = None
+
+enum_name = "commenttype"
+enum_values = ["FILING", "STAFF"]
+user_role_enum = sa.Enum(*enum_values, name=enum_name)
+
+def upgrade():
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute(f"CREATE TYPE {enum_name} AS ENUM ({', '.join([f"'{v}'" for v in enum_values])})")
+
+    with op.batch_alter_table('comments', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('comment_type', user_role_enum, nullable=True))
+
+    op.execute("UPDATE comments SET comment_type = 'STAFF' WHERE comment_type IS NULL")
+
+    with op.batch_alter_table('comments', schema=None) as batch_op:
+        batch_op.alter_column('comment_type', existing_type=user_role_enum, nullable=False)
+
+
+def downgrade():
+    with op.batch_alter_table('comments', schema=None) as batch_op:
+        batch_op.drop_column('comment_type')
+
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute(f"DROP TYPE {enum_name}")

--- a/python/common/business-registry-model/tests/models/__init__.py
+++ b/python/common/business-registry-model/tests/models/__init__.py
@@ -303,7 +303,7 @@ def factory_epoch_filing(business, filing_date=FROZEN_DATETIME):
     return filing
 
 
-def factory_business_comment(business: Business = None, comment_text: str = 'some text', user: User = None):
+def factory_business_comment(business: Business = None, comment_text: str = 'some text', user: User = None, comment_type: Comment.CommentType = Comment.CommentType.STAFF):
     """Create a comment."""
     if not business:
         business = factory_business('CP1234567')
@@ -320,7 +320,11 @@ def factory_business_comment(business: Business = None, comment_text: str = 'som
 
 
 def factory_comment(
-        business: Business = None, filing: Filing = None, comment_text: str = 'some text', user: User = None):
+        business: Business = None,
+        filing: Filing = None,
+        comment_text: str = 'some text',
+        user: User = None,
+        comment_type: Comment.CommentType = Comment.CommentType.STAFF):
     """Create a comment."""
     if not business:
         business = factory_business('CP1234567')
@@ -334,6 +338,7 @@ def factory_comment(
     c.comment = comment_text
     if user:
         c.staff_id = user.id
+    c.comment_type = comment_type
     c.save()
 
     return c

--- a/python/common/business-registry-model/tests/models/__init__.py
+++ b/python/common/business-registry-model/tests/models/__init__.py
@@ -312,6 +312,7 @@ def factory_business_comment(business: Business = None, comment_text: str = 'som
     c.business_id = business.id
     c.timestamp = EPOCH_DATETIME
     c.comment = comment_text
+    c.comment_type = comment_type
     if user:
         c.staff_id = user.id
     c.save()

--- a/python/common/business-registry-model/tests/models/test_comments.py
+++ b/python/common/business-registry-model/tests/models/test_comments.py
@@ -33,6 +33,7 @@ def test_minimal_comment(session):
     """Assert that a minimal comment can be created."""
     comment = Comment()
     comment.comment = 'some words'
+    comment.comment_type = Comment.CommentType.STAFF
     comment.save()
 
     assert comment.id is not None
@@ -79,6 +80,7 @@ def test_filing_comment_dump_json(session):
                 'id': c.id,
                 'submitterDisplayName': 'Registry Staff',
                 'comment': 'a comment',
+                'commentType': 'STAFF',
                 'filingId': f.id,
                 'businessId': None,
                 'timestamp': now.isoformat()
@@ -109,6 +111,7 @@ def test_comment_save(session):
     comment = Comment()
     comment.timestamp = EPOCH_DATETIME
     comment.comment = 'a comment'
+    comment.comment_type = Comment.CommentType.STAFF
 
     assert not session.new
     assert not Session.object_session(comment)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33872

*Description of changes:*
- add comment type so that we can easily distinguish between staff filing comments and filing form comments
- will open a PR after this is merged for filer and api changes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
