### PR TITLE
34010 fix email_used_count issue

### DIFF
--- a/data-tool/refresh_colin_extract_views.sh
+++ b/data-tool/refresh_colin_extract_views.sh
@@ -66,33 +66,38 @@ Options:
   -h, --help                 show help
 
 Refresh profiles:
-  legacy        refresh mv_corp_event_filing_rollup, mv_admin_email_bad_email_flags,
-                then mv_legacy_corps_data
-                (safe default for legacy-screening data, including rolling two-year counts
-                and bad-email flag updates)
+  legacy        refresh mv_admin_email_count, mv_corp_event_filing_rollup,
+                mv_admin_email_bad_email_flags, then mv_legacy_corps_data
+                (safe default for legacy-screening data, including normalized email-used
+                counts, rolling two-year counts, and bad-email flag updates)
   legacy-direct refresh mv_legacy_corps_data only
-                (advanced/leaf-only path when all upstream sidecars/derived MVs are already current)
-  event-filing  alias of legacy; refresh mv_corp_event_filing_rollup,
-                mv_admin_email_bad_email_flags, then mv_legacy_corps_data
-  share         refresh mv_share_class_issue_flags, plus the event rollup,
-                mv_admin_email_bad_email_flags, then mv_legacy_corps_data
-  address       refresh the shared address entity rollup and the legacy-only
-                address screening chain: mv_addr_issue_counts_by_entity,
-                mv_addr_quality_screening_by_corp, then mv_corp_event_filing_rollup,
-                mv_admin_email_bad_email_flags, then mv_legacy_corps_data
-  address-full  refresh the shared address entity rollup, both address-quality
-                layers, the event rollup, mv_admin_email_bad_email_flags,
-                legacy MV, and corp issue reporting MVs
+                (advanced/leaf-only path when all upstream sidecars/derived MVs are already current and analyzed)
+  event-filing  alias of legacy; refresh mv_admin_email_count,
+                mv_corp_event_filing_rollup, mv_admin_email_bad_email_flags,
+                then mv_legacy_corps_data
+  share         refresh mv_admin_email_count, mv_share_class_issue_flags,
+                mv_corp_event_filing_rollup, mv_admin_email_bad_email_flags,
+                then mv_legacy_corps_data
+  address       refresh mv_admin_email_count, then the shared address entity
+                rollup and legacy-only address screening chain:
+                mv_addr_issue_counts_by_entity, mv_addr_quality_screening_by_corp,
+                mv_corp_event_filing_rollup, mv_admin_email_bad_email_flags,
+                then mv_legacy_corps_data
+  address-full  refresh mv_admin_email_count, the shared address entity rollup,
+                both address-quality layers, the event rollup,
+                mv_admin_email_bad_email_flags, legacy MV, and corp issue reporting MVs
   party         refresh the legacy-only corp_party screening chain plus the
-                shared address entity rollup: mv_corps_with_officers,
-                mv_corps_party_role_count, mv_addr_issue_counts_by_entity,
-                mv_addr_quality_screening_by_corp, then mv_corp_event_filing_rollup,
+                normalized email count and shared address entity rollup:
+                mv_corps_with_officers, mv_corps_party_role_count,
+                mv_admin_email_count, mv_addr_issue_counts_by_entity,
+                mv_addr_quality_screening_by_corp, mv_corp_event_filing_rollup,
                 mv_admin_email_bad_email_flags, then mv_legacy_corps_data
-  party-full    refresh the corp_party chain, shared address entity rollup,
-                both address-quality layers, event rollup, mv_admin_email_bad_email_flags,
-                legacy MV, and corp issue reporting MVs
+  party-full    refresh the corp_party chain, normalized email count, shared
+                address entity rollup, both address-quality layers, event rollup,
+                mv_admin_email_bad_email_flags, legacy MV, and corp issue reporting MVs
   admin-email   refresh mv_admin_email_count, plus the event rollup,
                 mv_admin_email_bad_email_flags, then mv_legacy_corps_data
+                (refreshes the normalized email-used count sidecar before legacy)
   email-domain  refresh mv_admin_email_domain_count only
   corp-issues   refresh mv_addr_issue_counts_by_entity, mv_addr_quality_by_corp,
                 mv_corp_issue_flags, then mv_issue_counts_by_corp_type
@@ -119,9 +124,9 @@ Examples:
     --db colin-mig-corps-test-subset
 
 Notes:
-  - Any safe profile that refreshes `mv_legacy_corps_data` now refreshes the event/filing rollup and `mv_admin_email_bad_email_flags` first, except `legacy-direct`.
-  - `legacy` is the safe/default profile for legacy-screening data, including manual `bad_emails` row edits.
-  - `legacy-direct` is an advanced/leaf-only path that assumes all upstream sidecars/derived MVs, including `mv_admin_email_bad_email_flags`, are already current; otherwise `mv_legacy_corps_data` can be refreshed against stale inputs.
+  - Any safe profile that refreshes `mv_legacy_corps_data` now refreshes `mv_admin_email_count`, the event/filing rollup, and `mv_admin_email_bad_email_flags` first, except `legacy-direct`.
+  - `legacy` is the safe/default profile for legacy-screening data, including normalized email-used count updates and manual `bad_emails` row edits.
+  - `legacy-direct` is an advanced/leaf-only path that assumes all upstream sidecars/derived MVs, including `mv_admin_email_count` and `mv_admin_email_bad_email_flags`, are already current and analyzed; otherwise `mv_legacy_corps_data` can be refreshed against stale inputs.
   - `event-filing` is kept as an explicit alias of `legacy` for event/filing-driven refreshes.
   - Address-driven profiles now refresh `mv_addr_issue_counts_by_entity` first so the slim and full address-quality MVs share the same upstream rollup.
   - `address` / `party` stop at the slim screening MV for legacy-only refreshes.
@@ -264,6 +269,7 @@ expand_target() {
   local target="$1"
   case "$target" in
     legacy|event-filing)
+      append_unique_mv mv_admin_email_count
       append_unique_mv mv_corp_event_filing_rollup
       append_unique_mv mv_admin_email_bad_email_flags
       append_unique_mv mv_legacy_corps_data
@@ -273,6 +279,7 @@ expand_target() {
       ;;
     share)
       append_unique_mv mv_share_class_issue_flags
+      append_unique_mv mv_admin_email_count
       append_unique_mv mv_corp_event_filing_rollup
       append_unique_mv mv_admin_email_bad_email_flags
       append_unique_mv mv_legacy_corps_data
@@ -280,6 +287,7 @@ expand_target() {
     address)
       append_unique_mv mv_addr_issue_counts_by_entity
       append_unique_mv mv_addr_quality_screening_by_corp
+      append_unique_mv mv_admin_email_count
       append_unique_mv mv_corp_event_filing_rollup
       append_unique_mv mv_admin_email_bad_email_flags
       append_unique_mv mv_legacy_corps_data
@@ -288,6 +296,7 @@ expand_target() {
       append_unique_mv mv_addr_issue_counts_by_entity
       append_unique_mv mv_addr_quality_by_corp
       append_unique_mv mv_addr_quality_screening_by_corp
+      append_unique_mv mv_admin_email_count
       append_unique_mv mv_corp_event_filing_rollup
       append_unique_mv mv_admin_email_bad_email_flags
       append_unique_mv mv_legacy_corps_data
@@ -299,6 +308,7 @@ expand_target() {
       append_unique_mv mv_corps_party_role_count
       append_unique_mv mv_addr_issue_counts_by_entity
       append_unique_mv mv_addr_quality_screening_by_corp
+      append_unique_mv mv_admin_email_count
       append_unique_mv mv_corp_event_filing_rollup
       append_unique_mv mv_admin_email_bad_email_flags
       append_unique_mv mv_legacy_corps_data
@@ -309,6 +319,7 @@ expand_target() {
       append_unique_mv mv_addr_issue_counts_by_entity
       append_unique_mv mv_addr_quality_by_corp
       append_unique_mv mv_addr_quality_screening_by_corp
+      append_unique_mv mv_admin_email_count
       append_unique_mv mv_corp_event_filing_rollup
       append_unique_mv mv_admin_email_bad_email_flags
       append_unique_mv mv_legacy_corps_data
@@ -366,14 +377,14 @@ resolve_targets() {
 print_targets() {
   cat <<'TARGETS'
 Available refresh profiles:
-  legacy        -> mv_corp_event_filing_rollup -> mv_admin_email_bad_email_flags -> mv_legacy_corps_data
-  legacy-direct -> mv_legacy_corps_data only (advanced/leaf-only path; assumes upstream sidecars/MVs are current)
+  legacy        -> mv_admin_email_count -> mv_corp_event_filing_rollup -> mv_admin_email_bad_email_flags -> mv_legacy_corps_data
+  legacy-direct -> mv_legacy_corps_data only (advanced/leaf-only path; assumes upstream sidecars/MVs are current and analyzed)
   event-filing  -> alias of legacy
-  share         -> mv_share_class_issue_flags -> mv_corp_event_filing_rollup -> mv_admin_email_bad_email_flags -> mv_legacy_corps_data
-  address       -> mv_addr_issue_counts_by_entity -> mv_addr_quality_screening_by_corp -> mv_corp_event_filing_rollup -> mv_admin_email_bad_email_flags -> mv_legacy_corps_data
-  address-full  -> mv_addr_issue_counts_by_entity -> mv_addr_quality_by_corp -> mv_addr_quality_screening_by_corp -> mv_corp_event_filing_rollup -> mv_admin_email_bad_email_flags -> mv_legacy_corps_data -> mv_corp_issue_flags -> mv_issue_counts_by_corp_type
-  party         -> mv_corps_with_officers -> mv_corps_party_role_count -> mv_addr_issue_counts_by_entity -> mv_addr_quality_screening_by_corp -> mv_corp_event_filing_rollup -> mv_admin_email_bad_email_flags -> mv_legacy_corps_data
-  party-full    -> mv_corps_with_officers -> mv_corps_party_role_count -> mv_addr_issue_counts_by_entity -> mv_addr_quality_by_corp -> mv_addr_quality_screening_by_corp -> mv_corp_event_filing_rollup -> mv_admin_email_bad_email_flags -> mv_legacy_corps_data -> mv_corp_issue_flags -> mv_issue_counts_by_corp_type
+  share         -> mv_admin_email_count -> mv_share_class_issue_flags -> mv_corp_event_filing_rollup -> mv_admin_email_bad_email_flags -> mv_legacy_corps_data
+  address       -> mv_admin_email_count -> mv_addr_issue_counts_by_entity -> mv_addr_quality_screening_by_corp -> mv_corp_event_filing_rollup -> mv_admin_email_bad_email_flags -> mv_legacy_corps_data
+  address-full  -> mv_admin_email_count -> mv_addr_issue_counts_by_entity -> mv_addr_quality_by_corp -> mv_addr_quality_screening_by_corp -> mv_corp_event_filing_rollup -> mv_admin_email_bad_email_flags -> mv_legacy_corps_data -> mv_corp_issue_flags -> mv_issue_counts_by_corp_type
+  party         -> mv_corps_with_officers -> mv_corps_party_role_count -> mv_admin_email_count -> mv_addr_issue_counts_by_entity -> mv_addr_quality_screening_by_corp -> mv_corp_event_filing_rollup -> mv_admin_email_bad_email_flags -> mv_legacy_corps_data
+  party-full    -> mv_corps_with_officers -> mv_corps_party_role_count -> mv_admin_email_count -> mv_addr_issue_counts_by_entity -> mv_addr_quality_by_corp -> mv_addr_quality_screening_by_corp -> mv_corp_event_filing_rollup -> mv_admin_email_bad_email_flags -> mv_legacy_corps_data -> mv_corp_issue_flags -> mv_issue_counts_by_corp_type
   admin-email   -> mv_admin_email_count -> mv_corp_event_filing_rollup -> mv_admin_email_bad_email_flags -> mv_legacy_corps_data
   email-domain  -> mv_admin_email_domain_count
   corp-issues   -> mv_addr_issue_counts_by_entity -> mv_addr_quality_by_corp -> mv_corp_issue_flags -> mv_issue_counts_by_corp_type
@@ -395,7 +406,7 @@ write_plan() {
       quoted_mv="$(quote_ident "$mv_name")"
       printf 'REFRESH MATERIALIZED VIEW %s.%s;\n' "$quoted_schema" "$quoted_mv"
       if [[ "$SKIP_ANALYZE" != "true" \
-          && "$mv_name" == "mv_admin_email_bad_email_flags" ]] \
+          && ( "$mv_name" == "mv_admin_email_count" || "$mv_name" == "mv_admin_email_bad_email_flags" ) ]] \
           && contains_item "mv_legacy_corps_data" "${selected_mvs[@]}"; then
         printf 'ANALYZE %s.%s;\n' "$quoted_schema" "$quoted_mv"
       fi
@@ -404,7 +415,7 @@ write_plan() {
     if [[ "$SKIP_ANALYZE" != "true" ]]; then
       printf '\n'
       for mv_name in "${selected_mvs[@]}"; do
-        if [[ "$mv_name" == "mv_admin_email_bad_email_flags" ]] \
+        if [[ ( "$mv_name" == "mv_admin_email_count" || "$mv_name" == "mv_admin_email_bad_email_flags" ) ]] \
             && contains_item "mv_legacy_corps_data" "${selected_mvs[@]}"; then
           continue
         fi

--- a/data-tool/scripts/README_COLIN_Corps_Extract.md
+++ b/data-tool/scripts/README_COLIN_Corps_Extract.md
@@ -170,7 +170,7 @@ pg_restore -l /tmp/colin-no-views-test.tar | grep -E 'VIEW|MATERIALIZED VIEW'
 
 ## Refreshing selected materialized views for data-only changes
 
-Use this when the **derived MV definitions have not changed** and you only need to rebuild the affected materialized views in dependency order.
+Use this when the **derived MV definitions have not changed** and you only need to rebuild the affected materialized views in dependency order. If a materialized-view definition changes, use the reset/recreate workflow instead of refresh-only.
 
 Files:
 - Wrapper: `data-tool/refresh_colin_extract_views.sh`
@@ -195,14 +195,14 @@ Options:
 ```
 
 Refresh profiles:
-- `legacy`: refresh `mv_corp_event_filing_rollup`, then `mv_admin_email_bad_email_flags`, then `mv_legacy_corps_data` (safe/default legacy-screening refresh; keeps rolling time-windowed counts and bad-email flags current)
-- `legacy-direct`: refresh `mv_legacy_corps_data` only (advanced/leaf-only path when all upstream sidecars/derived MVs are already current)
-- `event-filing`: alias of `legacy`; refresh `mv_corp_event_filing_rollup`, then `mv_admin_email_bad_email_flags`, then `mv_legacy_corps_data`
-- `share`: refresh `mv_share_class_issue_flags`, plus the event/filing rollup, then `mv_admin_email_bad_email_flags`, then `mv_legacy_corps_data`
-- `address`: refresh `mv_addr_issue_counts_by_entity`, then the legacy-only address screening chain: `mv_addr_quality_screening_by_corp`, then the event/filing rollup, then `mv_admin_email_bad_email_flags`, then `mv_legacy_corps_data`
-- `address-full`: refresh `mv_addr_issue_counts_by_entity`, both address-quality layers, then the event/filing rollup, `mv_admin_email_bad_email_flags`, legacy MV, and corp issue reporting MVs
-- `party`: refresh the legacy-only `corp_party` screening chain: `mv_corps_with_officers`, `mv_corps_party_role_count`, `mv_addr_issue_counts_by_entity`, `mv_addr_quality_screening_by_corp`, then the event/filing rollup, then `mv_admin_email_bad_email_flags`, then `mv_legacy_corps_data`
-- `party-full`: refresh the `corp_party` chain, `mv_addr_issue_counts_by_entity`, both address-quality layers, event/filing rollup, `mv_admin_email_bad_email_flags`, legacy MV, and corp issue reporting MVs
+- `legacy`: refresh `mv_admin_email_count`, then `mv_corp_event_filing_rollup`, then `mv_admin_email_bad_email_flags`, then `mv_legacy_corps_data` (safe/default legacy-screening refresh; keeps normalized email-used counts, rolling time-windowed counts, and bad-email flags current)
+- `legacy-direct`: refresh `mv_legacy_corps_data` only (advanced/leaf-only path when all upstream sidecars/derived MVs are already current and analyzed)
+- `event-filing`: alias of `legacy`; refresh `mv_admin_email_count`, then `mv_corp_event_filing_rollup`, then `mv_admin_email_bad_email_flags`, then `mv_legacy_corps_data`
+- `share`: refresh `mv_admin_email_count`, then `mv_share_class_issue_flags`, the event/filing rollup, `mv_admin_email_bad_email_flags`, then `mv_legacy_corps_data`
+- `address`: refresh `mv_admin_email_count`, then `mv_addr_issue_counts_by_entity`, the legacy-only address screening chain (`mv_addr_quality_screening_by_corp`), the event/filing rollup, `mv_admin_email_bad_email_flags`, then `mv_legacy_corps_data`
+- `address-full`: refresh `mv_admin_email_count`, then `mv_addr_issue_counts_by_entity`, both address-quality layers, the event/filing rollup, `mv_admin_email_bad_email_flags`, legacy MV, and corp issue reporting MVs
+- `party`: refresh the legacy-only `corp_party` screening chain, then normalized email count and address screening chain: `mv_corps_with_officers`, `mv_corps_party_role_count`, `mv_admin_email_count`, `mv_addr_issue_counts_by_entity`, `mv_addr_quality_screening_by_corp`, the event/filing rollup, `mv_admin_email_bad_email_flags`, then `mv_legacy_corps_data`
+- `party-full`: refresh the `corp_party` chain, `mv_admin_email_count`, `mv_addr_issue_counts_by_entity`, both address-quality layers, event/filing rollup, `mv_admin_email_bad_email_flags`, legacy MV, and corp issue reporting MVs
 - `admin-email`: refresh `mv_admin_email_count`, plus the event/filing rollup, then `mv_admin_email_bad_email_flags`, then `mv_legacy_corps_data`
 - `email-domain`: refresh `mv_admin_email_domain_count` only
 - `corp-issues`: refresh `mv_addr_issue_counts_by_entity`, `mv_addr_quality_by_corp`, `mv_corp_issue_flags`, then `mv_issue_counts_by_corp_type`
@@ -232,15 +232,17 @@ Examples:
 ```
 
 Notes:
-- Use `reset_colin_extract_views.sh` only when the view/MV DDL itself has changed.
+- Use `reset_colin_extract_views.sh` when the view/MV DDL itself has changed; refresh-only does not apply changed definitions.
+- `mv_legacy_corps_data.email_used_count` is based on normalized `lower(btrim(admin_email))` values from `mv_admin_email_count`, so case/space variants count as the same admin email.
 - BAR data is static and should no longer be treated as a reason to refresh `mv_legacy_corps_data`.
-- `legacy` is the safe/default profile for legacy-screening data, including refreshes after email exclusion table or `bad_emails` row edits.
-- `legacy-direct` is an advanced/leaf-only path that assumes all upstream sidecars/derived MVs, including `mv_admin_email_bad_email_flags`, are already current; otherwise `mv_legacy_corps_data` can be refreshed against stale inputs and stale bad-email flags.
+- `legacy` is the safe/default profile for legacy-screening data, including refreshes after normalized admin-email count changes, email exclusion table edits, or `bad_emails` row edits.
+- `legacy-direct` is an advanced/leaf-only path that assumes all upstream sidecars/derived MVs, including `mv_admin_email_count` and `mv_admin_email_bad_email_flags`, are already current and analyzed; otherwise `mv_legacy_corps_data` can be refreshed against stale inputs, stale email-used counts, and stale bad-email flags.
 - `event-filing` is kept as an explicit alias of `legacy` for event/filing-driven refreshes.
 - Address-driven profiles now refresh `mv_addr_issue_counts_by_entity` first so the slim and full address-quality MVs share the same upstream aggregation.
 - `address` / `party` stop at the slim screening MV for legacy-only refreshes.
 - `address-full` / `party-full` / `corp-issues` continue through `mv_addr_quality_by_corp` for full-wide address issue reporting.
 - The refresh helper assumes the materialized views already exist and now preflights the selected targets before generating/executing the plan.
+- Roll out normalized email-count definition changes by applying/recreating the derived MV definitions, refreshing/analyzing `mv_admin_email_count` before `mv_legacy_corps_data`, validating count and SAF eligibility deltas, and capturing a new refresh timing baseline.
 
 ---
 

--- a/data-tool/scripts/colin_corps_extract_postgres_views_ddl
+++ b/data-tool/scripts/colin_corps_extract_postgres_views_ddl
@@ -30,11 +30,17 @@ ALTER MATERIALIZED VIEW mv_corps_party_role_count
 
 
 CREATE MATERIALIZED VIEW mv_admin_email_count AS
-select admin_email, count(*) as email_count
-from corporation
-group by admin_email
+select CAST(lower(btrim(c.admin_email)) AS varchar(254)) AS normalized_admin_email,
+       count(*)                                             AS email_count
+from corporation c
+where c.admin_email IS NOT NULL
+  and btrim(c.admin_email) <> ''
+group by CAST(lower(btrim(c.admin_email)) AS varchar(254))
 WITH NO DATA
 ;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_mv_admin_email_count_normalized_email
+  ON mv_admin_email_count (normalized_admin_email);
 
 ALTER MATERIALIZED VIEW mv_admin_email_count
     owner to postgres;
@@ -1059,7 +1065,8 @@ FROM (
         AND cp.party_typ_cd = 'DIR'
       GROUP BY cp.corp_num
     ) dir_mail_loc ON dir_mail_loc.corp_num = c.corp_num
-    LEFT OUTER JOIN mv_admin_email_count aec ON c.admin_email = aec.admin_email
+    LEFT OUTER JOIN mv_admin_email_count aec
+      ON CAST(lower(btrim(c.admin_email)) AS varchar(254)) = aec.normalized_admin_email
     LEFT OUTER JOIN mv_addr_quality_screening_by_corp mvaqs ON c.corp_num = mvaqs.corp_num
     LEFT OUTER JOIN bar_corps bc ON c.corp_num = bc.identifier
     LEFT OUTER JOIN (
@@ -1525,6 +1532,7 @@ CREATE INDEX IF NOT EXISTS ix_legacy_recog_dts  ON mv_legacy_corps_data (recogni
 REFRESH MATERIALIZED VIEW mv_corps_with_officers;
 REFRESH MATERIALIZED VIEW mv_corps_party_role_count;
 REFRESH MATERIALIZED VIEW mv_admin_email_count;
+ANALYZE mv_admin_email_count;
 REFRESH MATERIALIZED VIEW mv_admin_email_domain_count;
 REFRESH MATERIALIZED VIEW mv_addr_issue_counts_by_entity;
 REFRESH MATERIALIZED VIEW mv_addr_quality_by_corp;
@@ -1539,7 +1547,6 @@ REFRESH MATERIALIZED VIEW mv_issue_counts_by_corp_type;
 
 ANALYZE mv_corps_with_officers;
 ANALYZE mv_corps_party_role_count;
-ANALYZE mv_admin_email_count;
 ANALYZE mv_admin_email_domain_count;
 ANALYZE mv_addr_issue_counts_by_entity;
 ANALYZE mv_addr_quality_by_corp;


### PR DESCRIPTION
*Issue #:* /bcgov/entity#34010

*Description of changes:*
- Updated mv_admin_email_count and mv_legacy_corps_data to use the same normalized email
- misc view refresh script updates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
