### PR TITLE
33788-show-uploaded-continuation-out-docs-to-clients

### DIFF
--- a/legal-api/src/legal_api/core/filing.py
+++ b/legal-api/src/legal_api/core/filing.py
@@ -639,8 +639,15 @@ class Filing:  # pylint: disable=too-many-public-methods
             for doc in additional:
                 documents["documents"][doc] = f"{base_url}{doc_url}/{doc}"
 
+            # continuationOut uploaded documents are visible to clients as well as staff
+            # (see https://github.com/bcgov/entity/issues/33788); all other static
+            # documents (e.g. continuationIn affidavit/authorization files) remain staff-only.
+            static_documents_visible = (
+                has_roles(jwt, [UserRoles.staff]) or
+                filing.storage.filing_type == Filing.FilingTypes.CONTINUATIONOUT.value
+            )
             if (
-                has_roles(jwt, [UserRoles.staff]) and
+                static_documents_visible and
                 (static_docs := FilingMeta.get_static_documents(filing.storage, f"{base_url}{doc_url}/static"))
             ):
                 documents["documents"]["staticDocuments"] = static_docs

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
@@ -1668,7 +1668,7 @@ def filer_action(filing_name, filing_json, meta_data, business):
 
 
 def test_continuation_out_uploaded_documents(app, session, client, jwt, monkeypatch, mock_drs_service):
-    """Assert that uploaded continuation out documents are returned as staff-only static documents."""
+    """Assert that uploaded continuation out documents are returned as static documents to staff."""
     identifier = 'BC7654321'
     entity_type = Business.LegalTypes.COMP.value
     business = factory_business(identifier, entity_type=entity_type)
@@ -1730,9 +1730,13 @@ def test_continuation_out_uploaded_documents(app, session, client, jwt, monkeypa
 
 
 @pytest.mark.parametrize('non_staff_role', [BASIC_USER, PUBLIC_USER])
-def test_continuation_out_uploaded_documents_not_returned_for_non_staff(non_staff_role, app, session, client, jwt,
-                                                                        monkeypatch, mock_drs_service):
-    """Assert that uploaded continuation out documents are returned to staff only, not other roles."""
+def test_continuation_out_uploaded_documents_returned_for_non_staff(non_staff_role, app, session, client, jwt,
+                                                                    monkeypatch, mock_drs_service):
+    """Assert that uploaded continuation out documents are returned to non-staff users as well as staff.
+
+    See https://github.com/bcgov/entity/issues/33788 - continuation out uploaded documents are
+    visible to clients, unlike other static documents which remain staff-only.
+    """
     identifier = 'BC7654321'
     entity_type = Business.LegalTypes.COMP.value
     business = factory_business(identifier, entity_type=entity_type)
@@ -1761,9 +1765,16 @@ def test_continuation_out_uploaded_documents_not_returned_for_non_staff(non_staf
     }
     filing.save()
 
-    # a non-staff user is authorized to view the business, but not the staff-only static documents
+    # a non-staff user authorized to view the business now also sees the continuation out uploaded documents
     expected_msg = {'documents': {
-        'receipt': f'{base_url}/api/v2/businesses/{identifier}/filings/1/documents/receipt'
+        'receipt': f'{base_url}/api/v2/businesses/{identifier}/filings/1/documents/receipt',
+        'staticDocuments': [
+            {
+                'name': file.get('fileName'),
+                'url': f'{base_url}/api/v2/businesses/{identifier}/filings/1/documents/static/{file.get("fileKey")}'
+            }
+            for file in uploaded_documents
+        ]
     }}
 
     account_id = '1'
@@ -1784,7 +1795,7 @@ def test_continuation_out_uploaded_documents_not_returned_for_non_staff(non_staf
     expected = json.loads(re.sub(r"/\d+/", "/", json.dumps(expected_msg)))
 
     assert rv.status_code == HTTPStatus.OK
-    assert 'staticDocuments' not in rv_data['documents']
+    assert 'staticDocuments' in rv_data['documents']
     assert rv_data == expected
 
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33788

*Description of changes:*
Show uploaded continuation out documents to clients in the filing history ledger.

*Testing:*
<pre>
1. Call the filing's documents endpoint (continuationOut filing, non-staff token):
curl -sS "http://127.0.0.1:5000/api/v2/businesses/BC0888001/filings/233929/documents" \
  -H "Authorization: Bearer $TOKEN" \
  -H "account-id: 3040" \
  -H "Accept: application/json" \
  -w "\nHTTP %{http_code}\n"

2. Response payload — staticDocuments now returned to non-staff:
{
  "documents": {
    "receipt": "/api/v2/businesses/BC0888001/filings/233929/documents/receipt",
    "staticDocuments": [
      {
        "name": "Test upload.pdf",
        "url": "/api/v2/businesses/BC0888001/filings/233929/documents/static/aaaaaaaa-1111-2222-3333-444444444444"
      }
    ]
  }
}
HTTP 200
</pre>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
