### PR TITLE
32956 bug fix for cont in review status email publish

### DIFF
--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
@@ -1218,7 +1218,7 @@ class ListFilingResource:  # pylint: disable=too-many-public-methods
 
         # emailer notification
         publish_to_queue(
-            data={"email": {"filingId": filing.id, "type": filing.filing_type, "option": review.status}},
+            data={"email": {"filingId": filing.id, "type": filing.filing_type, "option": review.status.name}},
             subject=current_app.config.get("BUSINESS_EMAILER_TOPIC"),
             identifier=business.identifier if business else None,
             event_type=None,

--- a/queue_services/business-emailer/src/business_emailer/email_processors/continuation_in_notification.py
+++ b/queue_services/business-emailer/src/business_emailer/email_processors/continuation_in_notification.py
@@ -82,7 +82,7 @@ def process(email_info: dict, token: str) -> dict:  # pylint: disable=too-many-l
 
     # compute Foreign Jurisdiction string as in report.py and business_document.py
     country_code = filing_data["foreignJurisdiction"]["country"]
-    region_code = filing_data["foreignJurisdiction"]["region"]
+    region_code = filing_data["foreignJurisdiction"].get("region")
     country = pycountry.countries.get(alpha_2=country_code)
     region = None
     if region_code and region_code.upper() != "FEDERAL":


### PR DESCRIPTION
*Issue #:* /bcgov/entity#32956

*Description of changes:*
- these review emails aren't working in prod (likely unnoticed as its a rare filing)
  - region may not be defined (regular users can't set it for international jurisdictions), was leading to exception in emailer
  - enum was getting published from the API as the number instead of the name (i.e. '1' instead of 'AWAITING_REVIEW')

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
