### PR TITLE
34021 - Use Legislation Datetime for Special Resolution Date Comparisons

### DIFF
--- a/legal-api/src/legal_api/services/filings/validations/special_resolution.py
+++ b/legal-api/src/legal_api/services/filings/validations/special_resolution.py
@@ -17,7 +17,7 @@ from typing import Final
 
 from flask_babel import _
 
-from business_common.utils.datetime import datetime
+from business_common.utils.legislation_datetime import LegislationDatetime
 from business_model.models import Business
 from legal_api.errors import Error
 from legal_api.services.utils import get_date, get_str
@@ -74,12 +74,14 @@ def validate_resolution_date(business: Business, filing_json: dict) -> list | No
         msg.append({"error": _("Resolution date is required."), "path": resolution_date_path})
         return msg
 
-    if resolution_date < business.founding_date.date():
+    founding_date_leg = LegislationDatetime.as_legislation_timezone(business.founding_date).date()
+
+    if resolution_date < founding_date_leg:
         msg.append({"error": _("Resolution date cannot be earlier than the incorporation date."),
                     "path": resolution_date_path})
         return msg
 
-    if resolution_date > datetime.utcnow().date():
+    if resolution_date > LegislationDatetime.datenow():
         msg.append({"error": _("Resolution date cannot be in the future."),
                     "path": resolution_date_path})
         return msg
@@ -99,7 +101,7 @@ def validate_signing_date(filing_json: dict, filing_type: str = "specialResoluti
         msg.append({"error": _("Signing date is required."), "path": signing_date_path})
         return msg
 
-    if signing_date > datetime.utcnow().date():
+    if signing_date > LegislationDatetime.datenow():
         msg.append({"error": _("Signing date cannot be in the future."),
                     "path": signing_date_path})
         return msg

--- a/legal-api/tests/unit/services/filings/validations/test_special_resolution.py
+++ b/legal-api/tests/unit/services/filings/validations/test_special_resolution.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Test suite to ensure Special Resolution is validated correctly."""
 import copy
-from datetime import datetime
+from datetime import datetime, timezone
 from http import HTTPStatus
 
 import pytest
@@ -27,7 +27,7 @@ from . import create_utc_future_date_str
 @pytest.mark.parametrize(
     'test_name, resolution, identifier, resolution_date, signing_date, signatory_given_name, signatory_family_name, business_founding_date, expected_code, expected_msg',
     [
-        ('SUCCESS', 'some resolution', 'CP1234567', '2021-01-10', '2021-01-10', 'jane', 'doe', '2010-01-10', None, None),
+        ('SUCCESS - resolution date before UTC founding date', 'some resolution', 'CP1234567', '2010-01-09', '2010-01-09', 'jane', 'doe', '2010-01-10', None, None),
         ('MISSING - resolution', None, 'CP1234567', '2021-01-10', '2021-01-10', 'jane', 'doe', '2010-01-10',
          HTTPStatus.BAD_REQUEST, 'Resolution must be provided.'),
         ('MISSING - resolution date', 'some resolution', 'CP1234567', None, '2021-01-10', 'jane', 'doe', '2010-01-10',
@@ -61,7 +61,10 @@ def test_validate(session, test_name, resolution, identifier, resolution_date, s
     """Assert that a SR can be validated."""
     # setup
     business = Business(identifier=identifier)
-    business.founding_date = datetime.strptime(business_founding_date, '%Y-%m-%d')
+    business.founding_date = datetime.strptime(
+        business_founding_date,
+        '%Y-%m-%d'
+    ).replace(tzinfo=timezone.utc)
 
     filing = copy.deepcopy(FILING_HEADER)
     filing['filing']['specialResolution'] = copy.deepcopy(SPECIAL_RESOLUTION)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#34021

*Description of changes:*
Special Resolution validation was comparing the resolution date against the business incorporation date using the raw UTC timestamp. Updated the Special Resolution validation logic to convert timestamps into the legislation timezone before comparing legal dates:
- Aligned with other implementations, see: https://github.com/bcgov/lear/blob/main/legal-api/src/legal_api/services/filings/validations/common_validations.py#L143

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
