### PR TITLE
34080 - Remove Active CCO Validation for Continuation Out Filing

### DIFF
--- a/legal-api/src/legal_api/services/filings/validations/continuation_out.py
+++ b/legal-api/src/legal_api/services/filings/validations/continuation_out.py
@@ -18,7 +18,7 @@ from typing import Final
 from flask_babel import _ as babel
 
 from business_common.utils.legislation_datetime import LegislationDatetime
-from business_model.models import Business, ConsentContinuationOut
+from business_model.models import Business
 from legal_api.errors import Error
 from legal_api.services import flags
 from legal_api.services.filings.validations.common_validations import (
@@ -41,20 +41,13 @@ def validate(business: Business, filing: dict) -> Error | None:
     msg = []
     filing_type = "continuationOut"
 
-    is_valid_co_date = True
-    is_valid_foreign_jurisdiction = True
 
     if err := validate_continuation_out_date(filing, filing_type):
         msg.extend(err)
-        is_valid_co_date = False
 
     if err := validate_foreign_jurisdiction(filing["filing"][filing_type]["foreignJurisdiction"],
                                             f"/filing/{filing_type}/foreignJurisdiction"):
         msg.extend(err)
-        is_valid_foreign_jurisdiction = False
-
-    if is_valid_co_date and is_valid_foreign_jurisdiction:
-        msg.extend(validate_active_cco(business, filing, filing_type))
 
     if court_order := filing.get("filing", {}).get(filing_type, {}).get("courtOrder", None):
         court_order_path: Final = f"/filing/{filing_type}/courtOrder"
@@ -65,34 +58,6 @@ def validate(business: Business, filing: dict) -> Error | None:
     if msg:
         return Error(HTTPStatus.BAD_REQUEST, msg)
     return None
-
-
-def validate_active_cco(business: Business, filing: dict, filing_type: str) -> list:
-    """Validate active consent continuation out."""
-    msg = []
-    continuation_out_date_str = filing["filing"][filing_type]["continuationOutDate"]
-    continuation_out_date = LegislationDatetime.as_legislation_timezone_from_date_str(continuation_out_date_str)
-
-    foreign_jurisdiction = filing["filing"][filing_type]["foreignJurisdiction"]
-    country_code = foreign_jurisdiction.get("country")
-    region = foreign_jurisdiction.get("region")
-
-    continuation_out_date_utc = LegislationDatetime.as_utc_timezone(continuation_out_date)
-    ccos = ConsentContinuationOut.get_active_cco(business.id, continuation_out_date_utc, country_code, region)
-
-    active_consent = False
-    # Make sure continuation_out_date is on or after consent filing effective date
-    for consent in ccos:
-        if continuation_out_date.date() >= \
-                LegislationDatetime.as_legislation_timezone(consent.filing.effective_date).date():
-            active_consent = True
-            break
-
-    if not active_consent:
-        msg.extend([{"error": "No active consent continuation out for this date and/or jurisdiction.",
-                    "path": f"/filing/{filing_type}/continuationOutDate"}])
-
-    return msg
 
 
 def validate_continuation_out_date(filing: dict, filing_type: str) -> list:

--- a/legal-api/tests/unit/services/filings/validations/test_continuation_out.py
+++ b/legal-api/tests/unit/services/filings/validations/test_continuation_out.py
@@ -29,7 +29,6 @@ from tests.unit.models import factory_business, factory_completed_filing, get_cc
 
 date_format = '%Y-%m-%d'
 legal_name = 'Test name request'
-validate_active_cco_path = 'legal_api.services.filings.validations.continuation_out.validate_active_cco'
 
 
 def _create_consent_continuation_out(business, foreign_jurisdiction, effective_date=datetime.utcnow()):
@@ -56,7 +55,7 @@ def _create_consent_continuation_out(business, foreign_jurisdiction, effective_d
     'test_name, expected_code, message',
     [
         ('FAIL_IN_FUTURE', HTTPStatus.BAD_REQUEST, 'Continuation out date must be today or past.'),
-        ('FAIL_NO_CCO', HTTPStatus.BAD_REQUEST, 'No active consent continuation out for this date and/or jurisdiction.'),
+        ('SUCCESS_NO_CCO', None, None),
         ('SUCCESS', None, None)
     ]
 )
@@ -77,7 +76,7 @@ def test_validate_continuation_out_date(session, test_name, expected_code, messa
     if test_name == 'FAIL_IN_FUTURE':
         filing['filing']['continuationOut']['continuationOutDate'] = \
             (LegislationDatetime.now() + datedelta.datedelta(days=1)).strftime(date_format)
-    elif test_name == 'FAIL_NO_CCO':
+    elif test_name == 'SUCCESS_NO_CCO':
         effective_date -= datedelta.datedelta(months=6, days=1)
 
     _create_consent_continuation_out(business,
@@ -86,7 +85,7 @@ def test_validate_continuation_out_date(session, test_name, expected_code, messa
     err = validate(business, filing)
 
     # validate outcomes
-    if test_name != 'SUCCESS':
+    if test_name == 'FAIL_IN_FUTURE':
         assert expected_code == err.code
         assert message == err.msg[0]['error']
     else:
@@ -127,7 +126,6 @@ def test_validate_foreign_jurisdiction(session, mocker, test_name, expected_code
         filing['filing']['continuationOut']['foreignJurisdiction']['country'] = 'US'
         filing['filing']['continuationOut']['foreignJurisdiction']['region'] = 'NONE'
 
-    mocker.patch(validate_active_cco_path, return_value=[])
     err = validate(business, filing)
 
     # validate outcomes
@@ -148,7 +146,6 @@ def test_valid_foreign_jurisdiction(session, mocker, monkeypatch):
     business = factory_business(identifier='BC1234567', entity_type='BC', founding_date=datetime.utcnow())
     filing = copy.deepcopy(FILING_HEADER)
     filing['filing']['header']['name'] = 'continuationOut'
-    mocker.patch(validate_active_cco_path, return_value=[])
 
     for country in pycountry.countries:
         filing['filing']['continuationOut'] = copy.deepcopy(CONTINUATION_OUT)
@@ -192,7 +189,6 @@ def test_continuation_out_court_order(session, mocker, test_status, file_number,
     else:
         del filing['filing']['continuationOut']['courtOrder']['fileNumber']
 
-    mocker.patch(validate_active_cco_path, return_value=[])
     err = validate(business, filing)
 
     # validate outcomes


### PR DESCRIPTION
*Issue #:* /bcgov/entity#34080

*Description of changes:*
- Remove validation that requires an active consent to continue out
- Update unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
