### PR TITLE
34022 move director mailing validation to schema

### DIFF
--- a/legal-api/src/legal_api/services/filings/validations/change_of_directors.py
+++ b/legal-api/src/legal_api/services/filings/validations/change_of_directors.py
@@ -203,13 +203,7 @@ def validate_directors_addresses(business: Business, cod: dict) -> list:
         for address_type in Address.JSON_ADDRESS_TYPES:
             address = director.get(address_type)
 
-            if not address:
-                if business.legal_type in Business.CORPS:
-                    msg.append({
-                        "error": f"missing {address_type}",
-                        "path": f"/filing/changeOfDirectors/directors/{idx}/{address_type}"
-                    })
-            elif address_type == Address.JSON_MAILING:
+            if address and address_type == Address.JSON_MAILING:
                 for field in mailing_required_fields:
                     if not address.get(field):
                         msg.append({

--- a/python/common/business-registry-model/poetry.lock
+++ b/python/common/business-registry-model/poetry.lock
@@ -1472,7 +1472,7 @@ rpds-py = ">=0.7.0"
 
 [[package]]
 name = "registry_schemas"
-version = "2.18.73"
+version = "2.18.74"
 description = "A short description of the project"
 optional = false
 python-versions = ">=3.6"
@@ -1489,9 +1489,9 @@ strict-rfc3339 = "*"
 
 [package.source]
 type = "git"
-url = "https://github.com/bcgov/business-schemas.git"
-reference = "2.18.73"
-resolved_reference = "e6999a46b6e38c52cc79f0e5a3c9fcbd0c473434"
+url = "https://github.com/mruff-aeq/business-schemas.git"
+reference = "34022-director-mailingaddress-required"
+resolved_reference = "341f16ddc16829aa57e323cca497a4008e5fe52f"
 
 [[package]]
 name = "requests"
@@ -2085,4 +2085,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<3.14"
-content-hash = "ec2f82cd063a03708cf9e5103b1de1002f0e75e06c995790c5cc6d53558e3a0e"
+content-hash = "04b7d2eee0556a8916e50420a9fa6e6a66816375b6411654b197a6be11619b87"

--- a/python/common/business-registry-model/pyproject.toml
+++ b/python/common/business-registry-model/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 requires-python = ">=3.13,<3.14"
 dependencies = [
     "sql-versioning @ git+https://github.com/bcgov/lear.git@main#subdirectory=python/common/sql-versioning-alt",
-    "registry-schemas @ git+https://github.com/bcgov/business-schemas.git@2.18.73",
+    "registry-schemas @ git+https://github.com/mruff-aeq/business-schemas.git@34022-director-mailingaddress-required",
     "flask-migrate (>=4.1.0,<5.0.0)",
     "pg8000 (>=1.31.2,<2.0.0)",
     "pydantic (>=2.10.6,<3.0.0)",


### PR DESCRIPTION
*Issue #:* /bcgov/entity#34022

*Description of changes:*
Removed the CORPS-only director mailingAddress presence check from legal-api since that validation now lives in the schema (directors.json requires mailingAddress); the deps temporarily reference my fork of business-schemas for pre-merge testing and will be pointed back to bcgov once the schema PR is merged and tagged.

*Testing*
<pre>
curl -sS -i -X POST \
  "http://127.0.0.1:5000/api/v2/businesses/CP0000019/filings?only_validate=true" \
  -H "Authorization: Bearer $TOKEN" \
  -H "x-apikey: KHGuiTxG52ejzFZi7wu4QyD8GdVGEMAz" \
  -H "account-id: 3040" \
  -H "Content-Type: application/json" \
  --data-binary @B_missing_mailing.json

Raw response:
HTTP/1.1 422 UNPROCESSABLE ENTITY
Content-Type: application/json
API: legal_api/3.1.0
SCHEMAS: registry_schemas/2.18.74
Connection: close
</pre>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
