### PR TITLE
33940 api completing party incorporation

### DIFF
--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -411,7 +411,7 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
         )
 
         if is_corp_incorp and incorp_compparty_stmnt_enabled:
-            if self._filing.submitter_roles in [UserRoles.staff]:
+            if self._filing.submitter_roles in [UserRoles.staff, UserRoles.system]:
                 filing["header"]["certifiedBy"] = self._filing.filing_json["filing"]["header"].get("certifiedBy")
             else:
                 filing["header"]["certifiedBy"] = self._filing.filing_submitter.display_name

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -411,10 +411,16 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
         )
 
         if is_corp_incorp and incorp_compparty_stmnt_enabled:
-            if self._filing.submitter_roles in [UserRoles.staff, UserRoles.system]:
+            # staff and API gateway users supply the completing party name via header certifiedBy;
+            # for API users the token resolves to the account name, not a user name, so it can't be
+            # sourced from the submitter (API users are identified by the jwt loginSource, not a role).
+            api_login_source = "API_GW"  # jwt loginSource of an API gateway user
+            submitter = self._filing.filing_submitter
+            if (self._filing.submitter_roles == UserRoles.staff
+                    or (submitter and submitter.login_source == api_login_source)):
                 filing["header"]["certifiedBy"] = self._filing.filing_json["filing"]["header"].get("certifiedBy")
             else:
-                filing["header"]["certifiedBy"] = self._filing.filing_submitter.display_name
+                filing["header"]["certifiedBy"] = submitter.display_name
 
             if not filing["header"]["certifiedBy"]:
                 raise BusinessException(

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -33,7 +33,7 @@ from business_common.utils.legislation_datetime import LegislationDatetime
 from business_model.models import Address, Business, PartyRole
 from legal_api.core.filing import Filing as CoreFiling
 from legal_api.errors import Error
-from legal_api.services import STAFF_ROLE, SYSTEM_ROLE, MinioService, colin, flags, namex
+from legal_api.services import STAFF_ROLE, MinioService, colin, flags, namex
 from legal_api.services.permissions import ListActionsPermissionsAllowed, PermissionService
 from legal_api.services.request_context import get_request_context
 from legal_api.services.utils import get_str
@@ -1299,14 +1299,14 @@ def validate_certified_by(filing_json: dict, filing_type: str, legal_type: str) 
     certified_by = filing_json["filing"]["header"].get("certifiedBy")
 
     if legal_type in Business.CORPS:
-        # completing party statement takes its name from certifiedBy for staff and API users
-        enabled_features: list[str] = flags.value("enable-new-feature", []) or []
+        # the completing party statement takes its name from certifiedBy for staff and API users,
+        # so certifiedBy is required for them on a corp incorporation application
+        api_login_source = "API_GW"  # jwt loginSource of an API gateway user
         current_user = getattr(request_ctx, "current_user", None) if has_request_context() else None
         if (filing_type == CoreFiling.FilingTypes.INCORPORATIONAPPLICATION
-                and "incorporationApplication-completingParty" in enabled_features
                 and current_user
                 and (jwt.validate_roles(current_user, [STAFF_ROLE])
-                     or jwt.validate_roles(current_user, [SYSTEM_ROLE]))):
+                     or current_user.get("loginSource") == api_login_source)):
             if not certified_by:
                 msg.append({
                     "error": "Certified by field is required.",

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -21,7 +21,8 @@ from http import HTTPStatus
 from typing import Final
 
 import pycountry
-from flask import current_app, g, request
+from flask import current_app, g, has_request_context, request
+from flask.globals import request_ctx
 from flask_babel import _
 from pypdf import PdfReader
 
@@ -32,7 +33,7 @@ from business_common.utils.legislation_datetime import LegislationDatetime
 from business_model.models import Address, Business, PartyRole
 from legal_api.core.filing import Filing as CoreFiling
 from legal_api.errors import Error
-from legal_api.services import MinioService, colin, flags, namex
+from legal_api.services import STAFF_ROLE, SYSTEM_ROLE, MinioService, colin, flags, namex
 from legal_api.services.permissions import ListActionsPermissionsAllowed, PermissionService
 from legal_api.services.request_context import get_request_context
 from legal_api.services.utils import get_str
@@ -1298,7 +1299,25 @@ def validate_certified_by(filing_json: dict, filing_type: str, legal_type: str) 
     certified_by = filing_json["filing"]["header"].get("certifiedBy")
 
     if legal_type in Business.CORPS:
-        return msg  # certifiedBy is not required for corporations
+        # completing party statement takes its name from certifiedBy for staff and API users
+        enabled_features: list[str] = flags.value("enable-new-feature", []) or []
+        current_user = getattr(request_ctx, "current_user", None) if has_request_context() else None
+        if (filing_type == CoreFiling.FilingTypes.INCORPORATIONAPPLICATION
+                and "incorporationApplication-completingParty" in enabled_features
+                and current_user
+                and (jwt.validate_roles(current_user, [STAFF_ROLE])
+                     or jwt.validate_roles(current_user, [SYSTEM_ROLE]))):
+            if not certified_by:
+                msg.append({
+                    "error": "Certified by field is required.",
+                    "path": "/filing/header/certifiedBy"
+                })
+            elif certified_by != certified_by.strip():
+                msg.append({
+                    "error": "Certified by field cannot start or end with whitespace.",
+                    "path": "/filing/header/certifiedBy"
+                })
+        return msg  # certifiedBy is not otherwise required for corporations
     is_cert_filing = filing_type in FILINGS_REQUIRING_CERTIFICATION
 
     is_client_correction = (

--- a/legal-api/tests/unit/reports/test_report.py
+++ b/legal-api/tests/unit/reports/test_report.py
@@ -576,12 +576,15 @@ def test_set_corp_flag(session, test_name, identifier, entity_type, expected_is_
         f'{test_name}: expected isCorp={expected_is_corp} for legalType={entity_type}'
 
 
-@pytest.mark.parametrize('test_name, submitter_role, expected_certified_by', [
-    ('staff_uses_header', 'staff', 'Header Name'),
-    ('api_user_uses_header', 'system', 'Header Name'),
+@pytest.mark.parametrize('test_name, submitter_role, login_source, expected_certified_by', [
+    ('staff_uses_header', 'staff', 'IDIR', 'Header Name'),
+    ('api_user_uses_header', None, 'API_GW', 'Header Name'),
+    ('public_user_uses_submitter', None, 'BCSC', 'Submitter Name'),
 ])
-def test_set_completing_party_header_certified_by(session, test_name, submitter_role, expected_certified_by):
-    """Staff and API (system) submitters use the header certifiedBy for the completing party statement."""
+def test_set_completing_party_header_certified_by(session, test_name, submitter_role,
+                                                  login_source, expected_certified_by):
+    """Staff and API users use the header certifiedBy; API users are identified by the jwt loginSource."""
+    from business_model.models import User
     from legal_api.services import flags
     from registry_schemas.example_data import INCORPORATION_FILING_TEMPLATE
 
@@ -594,7 +597,12 @@ def test_set_completing_party_header_certified_by(session, test_name, submitter_
         filing_type='incorporationApplication',
         template=template
     )
+    submitter = User()
+    submitter.firstname = 'Submitter'
+    submitter.lastname = 'Name'
+    submitter.login_source = login_source
     report._filing.submitter_roles = submitter_role
+    report._filing.filing_submitter = submitter
 
     filing = report._filing.filing_json['filing']
     filing['flags'] = {}

--- a/legal-api/tests/unit/reports/test_report.py
+++ b/legal-api/tests/unit/reports/test_report.py
@@ -576,6 +576,36 @@ def test_set_corp_flag(session, test_name, identifier, entity_type, expected_is_
         f'{test_name}: expected isCorp={expected_is_corp} for legalType={entity_type}'
 
 
+@pytest.mark.parametrize('test_name, submitter_role, expected_certified_by', [
+    ('staff_uses_header', 'staff', 'Header Name'),
+    ('api_user_uses_header', 'system', 'Header Name'),
+])
+def test_set_completing_party_header_certified_by(session, test_name, submitter_role, expected_certified_by):
+    """Staff and API (system) submitters use the header certifiedBy for the completing party statement."""
+    from legal_api.services import flags
+    from registry_schemas.example_data import INCORPORATION_FILING_TEMPLATE
+
+    template = copy.deepcopy(INCORPORATION_FILING_TEMPLATE)
+    template['filing']['header']['certifiedBy'] = 'Header Name'
+    report = create_report(
+        identifier='BC1234567',
+        entity_type='BEN',
+        report_type='incorporationApplication',
+        filing_type='incorporationApplication',
+        template=template
+    )
+    report._filing.submitter_roles = submitter_role
+
+    filing = report._filing.filing_json['filing']
+    filing['flags'] = {}
+
+    with patch.object(flags, 'value', return_value=['incorporationApplication-completingParty']):
+        report._set_completing_party(filing)
+
+    assert filing['flags']['incorporationApplication_completingParty'] is True
+    assert filing['header']['certifiedBy'] == expected_certified_by
+
+
 def _create_previous_liquidation_report(business):
     lr_filing_json = copy.deepcopy(FILING_HEADER)
     lr_filing_json['filing']['header']['name'] = 'changeOfLiquidators'

--- a/legal-api/tests/unit/services/filings/validations/test_common_validations.py
+++ b/legal-api/tests/unit/services/filings/validations/test_common_validations.py
@@ -603,6 +603,39 @@ def test_validate_certified_by_corps(session, legal_type, input_value, expected_
             assert errors[0]['error'] == 'Certified by field is required.'
         assert errors[0]['path'] == '/filing/header/certifiedBy'
 
+@pytest.mark.parametrize('test_name, roles, certified_by, expected_error', [
+    ('api_user_missing', ['system'], '', 'Certified by field is required.'),
+    ('api_user_whitespace', ['system'], ' John Doe ', 'Certified by field cannot start or end with whitespace.'),
+    ('api_user_valid', ['system'], 'John Doe', None),
+    ('staff_missing', ['staff'], '', 'Certified by field is required.'),
+    ('staff_valid', ['staff'], 'John Doe', None),
+    ('public_user_not_required', [], '', None),
+])
+def test_validate_certified_by_corps_completing_party_ff(app, session, test_name, roles,
+                                                         certified_by, expected_error):
+    """Corps IA under the completing party ff requires certifiedBy for staff and API users."""
+    filing = copy.deepcopy(FILING_HEADER)
+    filing['filing']['header']['certifiedBy'] = certified_by
+    filing['filing']['incorporationApplication'] = INCORPORATION
+
+    with (
+        patch.object(flags, 'value', return_value=['incorporationApplication-completingParty']),
+        patch('legal_api.services.filings.validations.common_validations.jwt.validate_roles',
+              side_effect=lambda user, required: bool(set(required) & set(roles))),
+        app.test_request_context()
+    ):
+        from flask.globals import request_ctx
+        request_ctx.current_user = {'sub': 'test-user'}
+        errors = validate_certified_by(filing, 'incorporationApplication', 'BEN')
+
+    if expected_error:
+        assert errors
+        assert errors[0]['error'] == expected_error
+        assert errors[0]['path'] == '/filing/header/certifiedBy'
+    else:
+        assert errors == []
+
+
 @pytest.mark.parametrize(
     'legal_type',
     [

--- a/legal-api/tests/unit/services/filings/validations/test_common_validations.py
+++ b/legal-api/tests/unit/services/filings/validations/test_common_validations.py
@@ -603,29 +603,28 @@ def test_validate_certified_by_corps(session, legal_type, input_value, expected_
             assert errors[0]['error'] == 'Certified by field is required.'
         assert errors[0]['path'] == '/filing/header/certifiedBy'
 
-@pytest.mark.parametrize('test_name, roles, certified_by, expected_error', [
-    ('api_user_missing', ['system'], '', 'Certified by field is required.'),
-    ('api_user_whitespace', ['system'], ' John Doe ', 'Certified by field cannot start or end with whitespace.'),
-    ('api_user_valid', ['system'], 'John Doe', None),
-    ('staff_missing', ['staff'], '', 'Certified by field is required.'),
-    ('staff_valid', ['staff'], 'John Doe', None),
-    ('public_user_not_required', [], '', None),
+@pytest.mark.parametrize('test_name, roles, login_source, certified_by, expected_error', [
+    ('api_user_missing', [], 'API_GW', '', 'Certified by field is required.'),
+    ('api_user_whitespace', [], 'API_GW', ' John Doe ', 'Certified by field cannot start or end with whitespace.'),
+    ('api_user_valid', [], 'API_GW', 'John Doe', None),
+    ('staff_missing', ['staff'], 'IDIR', '', 'Certified by field is required.'),
+    ('staff_valid', ['staff'], 'IDIR', 'John Doe', None),
+    ('public_user_not_required', [], 'BCSC', '', None),
 ])
-def test_validate_certified_by_corps_completing_party_ff(app, session, test_name, roles,
-                                                         certified_by, expected_error):
-    """Corps IA under the completing party ff requires certifiedBy for staff and API users."""
+def test_validate_certified_by_corps_completing_party(app, session, test_name, roles,
+                                                      login_source, certified_by, expected_error):
+    """Corps IA requires certifiedBy for staff and API users (API users identified by loginSource)."""
     filing = copy.deepcopy(FILING_HEADER)
     filing['filing']['header']['certifiedBy'] = certified_by
     filing['filing']['incorporationApplication'] = INCORPORATION
 
     with (
-        patch.object(flags, 'value', return_value=['incorporationApplication-completingParty']),
         patch('legal_api.services.filings.validations.common_validations.jwt.validate_roles',
               side_effect=lambda user, required: bool(set(required) & set(roles))),
         app.test_request_context()
     ):
         from flask.globals import request_ctx
-        request_ctx.current_user = {'sub': 'test-user'}
+        request_ctx.current_user = {'sub': 'test-user', 'loginSource': login_source}
         errors = validate_certified_by(filing, 'incorporationApplication', 'BEN')
 
     if expected_error:


### PR DESCRIPTION
lets *Issue #:* /bcgov/entity#33940

*Description of changes:*
Allows authorized API users to specify the completing party name on corp incorporation applications via header certifiedBy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
