### PR TITLE
34218 Emailer - firm name on filing notification bug fix

### DIFF
--- a/queue_services/business-emailer/src/business_emailer/email_processors/__init__.py
+++ b/queue_services/business-emailer/src/business_emailer/email_processors/__init__.py
@@ -316,5 +316,5 @@ def get_pdfs(  # noqa: PLR0913
     for pdf_type in extra_pdf_type_list:
         attach_order = _add_filing_document_pdf(pdfs, attach_order, pdf_type, token, business, filing, regenerate=regenerate)
     # add receipt
-    attach_order = _add_filing_document_pdf(pdfs, attach_order, 'receipt', token, business, filing, regenerate=regenerate)
+    attach_order = _add_filing_document_pdf(pdfs, attach_order, "receipt", token, business, filing, regenerate=regenerate)
     return pdfs

--- a/queue_services/business-emailer/src/business_emailer/email_processors/__init__.py
+++ b/queue_services/business-emailer/src/business_emailer/email_processors/__init__.py
@@ -231,7 +231,7 @@ def get_filing_document(business_identifier, filing_id, document_type, token, re
         f'/documents/{document_type}', headers=headers, params=params
     )
 
-    if document.status_code != HTTPStatus.OK:
+    if document.status_code not in [HTTPStatus.OK, HTTPStatus.CREATED]:
         current_app.logger.error("Failed to get %s pdf for filing: %s", document_type, filing_id)
         return None
     try:
@@ -299,56 +299,10 @@ def _add_filing_document_pdf(  # noqa: PLR0913
     return attach_order
 
 
-def _add_receipt_pdf(  # noqa: PLR0913
-    pdfs: list[dict],
-    attach_order: int,
-    token: str,
-    business: dict,
-    filing: Filing,
-    filing_date_time: str,
-    effective_date: str
-):
-    """Add the filing receipt pdf to the pdfs list."""
-    headers = {
-        "Accept": "application/pdf",
-        "Authorization": f"Bearer {token}"
-    }
-    if not (corp_name := business.get("legalName")):  # pylint: disable=superfluous-parens
-        legal_type = business.get("legalType")
-        corp_name = Business.BUSINESSES.get(legal_type, {}).get("numberedDescription")
-
-    receipt = requests.post(
-        f'{current_app.config.get("PAY_API_URL")}/{filing.payment_token}/receipts',
-        json={
-            "corpName": corp_name,
-            "filingDateTime": filing_date_time,
-            "effectiveDateTime": effective_date if effective_date != filing_date_time else "",
-            "filingIdentifier": str(filing.id),
-            "businessNumber": business.get("taxId", "")
-        },
-        headers=headers
-    )
-    if receipt.status_code != HTTPStatus.CREATED:
-        current_app.logger.error("Failed to get receipt pdf for filing: %s", filing.id)
-    else:
-        receipt_encoded = base64.b64encode(receipt.content)
-        pdfs.append(
-            {
-                "fileName": "Receipt.pdf",
-                "fileBytes": receipt_encoded.decode("utf-8"),
-                "fileUrl": "",
-                "attachOrder": str(attach_order)
-            }
-        )
-        return attach_order + 1
-
-
 def get_pdfs(  # noqa: PLR0913
     token: str,
     business: dict,
     filing: Filing,
-    filing_date_time: str,
-    effective_date: str,
     extra_pdf_type_list: list[str],
     filing_attachment_name: str | None,
     regenerate=False
@@ -362,5 +316,5 @@ def get_pdfs(  # noqa: PLR0913
     for pdf_type in extra_pdf_type_list:
         attach_order = _add_filing_document_pdf(pdfs, attach_order, pdf_type, token, business, filing, regenerate=regenerate)
     # add receipt
-    attach_order = _add_receipt_pdf(pdfs, attach_order, token, business, filing, filing_date_time, effective_date)
+    attach_order = _add_filing_document_pdf(pdfs, attach_order, 'receipt', token, business, filing, regenerate=regenerate)
     return pdfs

--- a/queue_services/business-emailer/src/business_emailer/email_processors/filing_notification.py
+++ b/queue_services/business-emailer/src/business_emailer/email_processors/filing_notification.py
@@ -152,7 +152,9 @@ def process(email_info: dict, token: str) -> dict | None:
         business_identifier = NOT_AVAILABLE
 
     show_effective_date = filing.is_future_effective
-    business_name = business.get("legalName") or NOT_AVAILABLE
+
+    # businessName is added for FIRMs when legalName is set to the proprietor name or list of partners
+    business_name = business.get("businessName") or business.get("legalName") or NOT_AVAILABLE
     filing_name_short = FILING_TITLE_SHORT.get(filing_type)
     legal_type_key = get_legal_type_key(legal_type)
     business_description = "Business"
@@ -173,7 +175,7 @@ def process(email_info: dict, token: str) -> dict | None:
     # attachments and future attachments
     full_attachments_list, extra_pdf_types = _get_attachments_and_extra_pdf_types(status, filing_type, filing, legal_type_key)
     filing_attachment_name = full_attachments_list[0] if full_attachments_list else None
-    pdfs = get_pdfs(token, business, filing, leg_tmz_filing_date, leg_tmz_effective_date, extra_pdf_types, filing_attachment_name)
+    pdfs = get_pdfs(token, business, filing, extra_pdf_types, filing_attachment_name)
 
     # render template with vars
     attachments_list = [pdf["fileName"].replace(".pdf", "") for pdf in pdfs]

--- a/queue_services/business-emailer/tests/unit/email_processors/test_filing_notification.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_filing_notification.py
@@ -82,8 +82,9 @@ def mock_filing_docs(m, config, identifier, filing, doc_contents, receipt=b'rece
             status_code=200,
         )
     if receipt is not None:
-        m.post(
-            f'{config.get("PAY_API_URL")}/{filing.payment_token}/receipts',
+        m.get(
+            f'{config.get("LEGAL_API_URL")}/businesses/{identifier}'
+            f'/filings/{filing.id}/documents/receipt',
             content=receipt,
             status_code=201,
         )
@@ -394,7 +395,7 @@ def test_maintenance_notification(app, session, mock_pdfs, mock_recipients, mock
         assert 'auth@email.com' in email['recipients']
         # party emails are pulled by get_recipients with the dissolution filing type
         assert mock_recipients.call_args[0][3] == 'dissolution'
-        assert email['content']['subject'] == f'{expected_legal_name} - Successful Dissolution'
+        assert email['content']['subject'] == f'{LEGAL_NAME} - Successful Dissolution'
     else:
         assert mock_recipients.call_args[0][3] is None
         assert not mock_auth_recipient.called
@@ -789,7 +790,7 @@ def test_firm_filing_subject(app, session, filing_type, expected_subject_suffix,
     email = process_filing(filing, filing_type, 'COMPLETED')
 
     assert email is not None
-    assert email['content']['subject'] == f'JANE A DOE - {expected_subject_suffix}'
+    assert email['content']['subject'] == f'test business - {expected_subject_suffix}'
 
 
 # ---------------------------------------------------------------------------
@@ -894,8 +895,8 @@ def test_correction_filing_attachments(session, config, mock_recipients, mock_us
 
 @pytest.mark.parametrize('orig_filing_type, legal_type, identifier, expected_header, expected_subject', [
     ('incorporationApplication', 'BC', 'BC1234567', 'You have successfully completed your correction with the BC Business Registry', 'test business - Successful Correction'),
-    ('registration', 'SP', 'FM1234567', 'You have successfully completed your correction with the BC Business Registry', 'JANE A DOE - Successful Correction'),
-    ('registration', 'GP', 'FM1234567', 'You have successfully completed your correction with the BC Business Registry', 'JANE A DOE - Successful Correction'),
+    ('registration', 'SP', 'FM1234567', 'You have successfully completed your correction with the BC Business Registry', 'test business - Successful Correction'),
+    ('registration', 'GP', 'FM1234567', 'You have successfully completed your correction with the BC Business Registry', 'test business - Successful Correction'),
     ('specialResolution', 'CP', 'CP1234567', 'You have successfully completed your correction with the BC Business Registry', 'test business - Successful Correction'),
 ])
 def test_correction_filing_header_and_subject(session, config, mock_pdfs, mock_recipients, mock_user_email,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#34218

*Description of changes:*
- use businessName as legalName when available (set to operating name firms)
- removed direct pay-api call for receipt in filing_notification flow (using same flow as regular documents via legal-api instead to ensure its using the same logic - i.e. firm name, dates, etc)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
