### PR TITLE
34199 Update delta restore script to support merging of specific table rows

### DIFF
--- a/data-tool/backup_extract_tables.sh
+++ b/data-tool/backup_extract_tables.sh
@@ -15,7 +15,7 @@ PGPORT="${PGPORT:-5432}"             # or ‑‑port
 PGUSER="${PGUSER:-postgres}"        # or ‑‑user
 PGDATABASE="${PGDATABASE:-colin-mig-corps-test}"     # or ‑‑dbname
 # Optional PostgreSQL client binary directory. Leave empty to use PATH.
-# Example: PG_BIN=/opt/homebrew/opt/postgresql@15/bin ./backup_extract_tables.sh
+# Example: PG_BIN=/path/to/postgresql/bin ./backup_extract_tables.sh
 PG_BIN="${PG_BIN:-}"
 # Supply the password *either* via a .pgpass file *or* one‑shot:
 #   PGPASSWORD=secret ./backup_extract_tables.sh

--- a/data-tool/delta_restore_extract.sh
+++ b/data-tool/delta_restore_extract.sh
@@ -6,6 +6,7 @@
 # optionally applies selected NEW/CHANGED rows.
 
 set -euo pipefail
+umask 077
 
 ##############################################################################
 # CONNECTION DEFAULTS
@@ -16,7 +17,7 @@ PGPORT="${PGPORT:-5432}"
 PGUSER="${PGUSER:-postgres}"
 PGDATABASE="${PGDATABASE:-colin-mig-corps-test}"
 # Optional PostgreSQL client binary directory. Leave empty to use PATH.
-# Example: PG_BIN=/opt/homebrew/opt/postgresql@15/bin ./delta_restore_extract.sh
+# Example: PG_BIN=/path/to/postgresql/bin ./delta_restore_extract.sh
 PG_BIN="${PG_BIN:-}"
 
 ##############################################################################
@@ -31,6 +32,7 @@ FUNCTIONS_SQL="$DELTA_DIR/10_functions.sql"
 SESSION_BEGIN_SQL="$DELTA_DIR/20_session_begin.sql"
 SESSION_END_SQL="$DELTA_DIR/21_session_end.sql"
 REWRITE_AWK="$DELTA_DIR/rewrite_copy_targets.awk"
+ALIGN_DETAILS_AWK="$DELTA_DIR/align_details.awk"
 REPAIR_SEQUENCES_SQL="$SCRIPT_DIR/scripts/restore/repair_sequences.sql"
 ACQUIRE_LOCK_SQL="$SCRIPT_DIR/scripts/subset/subset_pg_acquire_advisory_lock.sql"
 RELEASE_LOCK_SQL="$SCRIPT_DIR/scripts/subset/subset_pg_release_advisory_lock.sql"
@@ -44,6 +46,13 @@ EXCLUDE_CLASSES=""
 SELECTION_FILE=""
 ONLY_CORPS_FILE=""
 SAMPLE_SIZE="20"
+DETAILS_LIMIT="10000"
+SELECTOR_SUGGESTION_LIMIT="50"
+SELECTOR_SUGGESTION_LIMIT_MAX="100000"
+ALIGN_DETAILS="true"
+ALIGN_WIDTH="40"
+MANIFEST_DEFAULT="new,changed"
+DUMP_SHA256=""
 REPORT_BASE="$DEFAULT_REPORT_BASE"
 KEEP_ARTIFACTS="false"
 YES="false"
@@ -75,18 +84,26 @@ die5() { die_with_code 5 "$@"; }
 usage() {
   cat <<'USAGE'
 Usage:
-  delta_restore_extract.sh --dump <path> [--mode preview] [options]
+  delta_restore_extract.sh --dump <path> [--mode preview|apply|validate] [options]
   delta_restore_extract.sh --cleanup
 
 Options parsed now:
   --dump <path>                 pg_dump -Fc archive to stage (or DUMP env var)
-  --mode preview|apply          default: preview; apply requires --yes or confirmation
-  --tables all|<csv>            narrows default apply selection; staging/classification still use all preserved tables
-  --include-classes <csv>       override default apply classes when no --selection-file
-  --exclude-classes <csv>       remove classes from default apply selection when no --selection-file
-  --selection-file <path>       generated/edited selection.conf to apply
+  --mode preview|apply|validate default: preview; apply requires --yes or confirmation
+  --tables all|<csv>            hard selection scope; staging/classification still use all preserved tables
+  --include-classes <csv>       when supplied, limit selection to these classes
+  --exclude-classes <csv>       remove classes after selection-file/include processing
+  --selection-file <path>       generated/edited candidates, bounded by explicit table/class scope
   --only-corps <path>           restrict selected corp-bearing rows to listed corp identifiers
   --sample-size <n>             preview sample limit; default: 20
+  --details-limit <n>           detail rows per table/class; default: 10000
+  --selector-suggestion-limit <n>
+                                exact manifest suggestions per table/class; default: 50
+                                0 disables exact suggestions; maximum: 100000
+  --no-aligned-details          do not create fixed-width .txt detail companions
+  --align-width <n>             aligned detail cell width; default: 40, minimum: 6
+  --manifest-default <new,changed|none>
+                                generated selection default; default: new,changed
   --report-dir <dir>            base directory for run artifacts
   --keep-artifacts              retain delta schemas after successful apply
   --yes                         skip interactive apply confirmation
@@ -95,6 +112,16 @@ Options parsed now:
 
 Exit codes reserved by the plan:
   0 ok · 2 preflight/drift/corrupt dump · 3 advisory lock busy · 4 selection invalid · 5 apply verification failed
+
+Environment:
+  PGHOST, PGPORT, PGUSER, PGDATABASE, PGPASSWORD/.pgpass   libpq connection settings
+  PG_BIN=/path/to/postgresql/bin     optional PostgreSQL client-tools directory; unset or empty uses PATH
+  DUMP=<path>                        alternative to --dump
+  LOCK_TIMEOUT_SECONDS=30            advisory-lock wait before exit 3
+
+After run-directory initialization, each invocation prints its artifact directory on exit:
+  Artifacts: <run-dir>            (success)
+  Artifacts retained for inspection: <run-dir>   (failure)
 USAGE
 }
 
@@ -161,9 +188,16 @@ psql_delta_session_file() {
     "$PSQL_BIN" -X -q $(pg_conn_opts) -v ON_ERROR_STOP=1 "$@" \
       -f "$SESSION_BEGIN_SQL" -f "$payload" -f "$SESSION_END_SQL" > "$stdout_path"
   else
-    "$PSQL_BIN" -X -q $(pg_conn_opts) -v ON_ERROR_STOP=1 "$@" \
-      -f "$SESSION_BEGIN_SQL" -f "$payload" -f "$SESSION_END_SQL" \
-      > "$stdout_path" 2> >(tee "$stderr_path" >&2)
+    local status
+    if "$PSQL_BIN" -X -q $(pg_conn_opts) -v ON_ERROR_STOP=1 "$@" \
+         -f "$SESSION_BEGIN_SQL" -f "$payload" -f "$SESSION_END_SQL" \
+         > "$stdout_path" 2> "$stderr_path"; then
+      status=0
+    else
+      status=$?
+    fi
+    cat "$stderr_path" >&2
+    return "$status"
   fi
 }
 
@@ -187,7 +221,7 @@ parse_args() {
         shift 2
         ;;
       --mode)
-        [[ "$#" -ge 2 ]] || die "--mode requires preview or apply"
+        [[ "$#" -ge 2 ]] || die "--mode requires preview, apply, or validate"
         MODE="$2"
         shift 2
         ;;
@@ -221,6 +255,30 @@ parse_args() {
         SAMPLE_SIZE="$2"
         shift 2
         ;;
+      --details-limit)
+        [[ "$#" -ge 2 ]] || die "--details-limit requires a number"
+        DETAILS_LIMIT="$2"
+        shift 2
+        ;;
+      --selector-suggestion-limit)
+        [[ "$#" -ge 2 ]] || die "--selector-suggestion-limit requires a number"
+        SELECTOR_SUGGESTION_LIMIT="$2"
+        shift 2
+        ;;
+      --no-aligned-details)
+        ALIGN_DETAILS="false"
+        shift
+        ;;
+      --align-width)
+        [[ "$#" -ge 2 ]] || die "--align-width requires a number"
+        ALIGN_WIDTH="$2"
+        shift 2
+        ;;
+      --manifest-default)
+        [[ "$#" -ge 2 ]] || die "--manifest-default requires new,changed or none"
+        MANIFEST_DEFAULT="$2"
+        shift 2
+        ;;
       --report-dir)
         [[ "$#" -ge 2 ]] || die "--report-dir requires a directory"
         REPORT_BASE="$2"
@@ -249,13 +307,47 @@ parse_args() {
   done
 
   case "$MODE" in
-    preview|apply) ;;
-    *) die "--mode must be preview or apply" ;;
+    preview|apply|validate) ;;
+    *) die "--mode must be preview, apply, or validate" ;;
+  esac
+
+  case "$MANIFEST_DEFAULT" in
+    new,changed|none) ;;
+    *) die "--manifest-default must be new,changed or none" ;;
   esac
 
   case "$SAMPLE_SIZE" in
     ''|*[!0-9]*) die "--sample-size must be a non-negative integer" ;;
     *) ;;
+  esac
+  case "$DETAILS_LIMIT" in
+    ''|*[!0-9]*) die "--details-limit must be a non-negative integer" ;;
+    *) ;;
+  esac
+  case "$SELECTOR_SUGGESTION_LIMIT" in
+    ''|*[!0-9]*)
+      die "--selector-suggestion-limit must be a decimal integer from 0 to $SELECTOR_SUGGESTION_LIMIT_MAX"
+      ;;
+    *)
+      SELECTOR_SUGGESTION_LIMIT="${SELECTOR_SUGGESTION_LIMIT#"${SELECTOR_SUGGESTION_LIMIT%%[!0]*}"}"
+      [[ -n "$SELECTOR_SUGGESTION_LIMIT" ]] || SELECTOR_SUGGESTION_LIMIT="0"
+      if [[ "${#SELECTOR_SUGGESTION_LIMIT}" -gt "${#SELECTOR_SUGGESTION_LIMIT_MAX}" ]] \
+         || (( 10#$SELECTOR_SUGGESTION_LIMIT > SELECTOR_SUGGESTION_LIMIT_MAX )); then
+        die "--selector-suggestion-limit must be a decimal integer from 0 to $SELECTOR_SUGGESTION_LIMIT_MAX"
+      fi
+      ;;
+  esac
+  case "$ALIGN_WIDTH" in
+    ''|*[!0-9]*) die "--align-width must be a positive integer" ;;
+    *)
+      while [[ "$ALIGN_WIDTH" = 0* && "$ALIGN_WIDTH" != "0" ]]; do
+        ALIGN_WIDTH="${ALIGN_WIDTH#0}"
+      done
+      case "$ALIGN_WIDTH" in
+        0) die "--align-width must be a positive integer" ;;
+        [1-5]) ALIGN_WIDTH="6" ;;
+      esac
+      ;;
   esac
 }
 
@@ -266,6 +358,7 @@ validate_static_files() {
   [[ -f "$SESSION_BEGIN_SQL" ]] || die2 "missing session begin SQL: $SESSION_BEGIN_SQL"
   [[ -f "$SESSION_END_SQL" ]] || die2 "missing session end SQL: $SESSION_END_SQL"
   [[ -f "$REWRITE_AWK" ]] || die2 "missing COPY rewrite awk: $REWRITE_AWK"
+  [[ -f "$ALIGN_DETAILS_AWK" ]] || die2 "missing detail alignment awk: $ALIGN_DETAILS_AWK"
   [[ -f "$REPAIR_SEQUENCES_SQL" ]] || die2 "missing repair sequences SQL: $REPAIR_SEQUENCES_SQL"
   [[ -f "$ACQUIRE_LOCK_SQL" ]] || die2 "missing advisory lock acquire SQL: $ACQUIRE_LOCK_SQL"
   [[ -f "$RELEASE_LOCK_SQL" ]] || die2 "missing advisory lock release SQL: $RELEASE_LOCK_SQL"
@@ -429,6 +522,10 @@ record_metadata() {
 INSERT INTO delta_ctl.run_metadata(key, value) VALUES
   ('mode', $(sql_literal "$MODE")),
   ('dump_path', $(sql_literal "$DUMP")),
+  ('dump_sha256', $(sql_literal "$DUMP_SHA256")),
+  ('manifest_default', $(sql_literal "$MANIFEST_DEFAULT")),
+  ('selector_suggestion_limit', $(sql_literal "$SELECTOR_SUGGESTION_LIMIT")),
+  ('selection_file', $(sql_literal "$SELECTION_FILE")),
   ('run_dir', $(sql_literal "$RUN_DIR")),
   ('target_host', $(sql_literal "$PGHOST")),
   ('target_port', $(sql_literal "$PGPORT")),
@@ -450,20 +547,32 @@ SQL
   printf "✅  Cleanup complete.\n"
 }
 
+compute_dump_sha() {
+  [[ -n "$DUMP" ]] || die2 "--dump is required for preview/apply/validate mode"
+  [[ -r "$DUMP" ]] || die2 "dump is not readable: $DUMP"
+
+  local computed_sha
+  computed_sha="$(sha256_file "$DUMP")" || return $?
+  [[ -n "$computed_sha" ]] || die2 "could not compute dump sha256: $DUMP"
+  DUMP_SHA256="$computed_sha"
+  printf '%s\n' "$DUMP_SHA256" > "$RUN_DIR/dump.sha256"
+}
+
 verify_dump_and_manifest() {
-  [[ -n "$DUMP" ]] || die2 "--dump is required for preview/apply mode"
+  [[ -n "$DUMP" ]] || die2 "--dump is required for preview/apply/validate mode"
   [[ -r "$DUMP" ]] || die2 "dump is not readable: $DUMP"
 
   printf "🔎  Reading dump TOC …\n"
   "$PG_RESTORE_BIN" -l "$DUMP" > "$RUN_DIR/toc.list" || die2 "pg_restore could not read dump: $DUMP"
 
   local manifest expected_sha actual_sha
+  compute_dump_sha
   manifest="$DUMP.manifest.json"
   if [[ -f "$manifest" ]]; then
     cp "$manifest" "$RUN_DIR/dump.manifest.json"
     expected_sha="$(sed -n 's/.*"dump_sha256"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$manifest" | head -n 1)"
     if [[ -n "$expected_sha" ]]; then
-      actual_sha="$(sha256_file "$DUMP")"
+      actual_sha="$DUMP_SHA256"
       if [[ "$expected_sha" != "$actual_sha" ]]; then
         die2 "dump sha256 does not match manifest: expected $expected_sha, got $actual_sha"
       fi
@@ -713,6 +822,12 @@ add_stage_index() {
 create_stage_indexes() {
   : > "$RUN_DIR/create_stage_indexes.sql"
 
+  local table
+  while read -r table; do
+    [[ -n "$table" ]] || continue
+    add_stage_index "$table" "idx_delta_stage_${table}_drid" "_delta_row_id"
+  done < "$RUN_DIR/present_tables.txt"
+
   add_stage_index email_domain_groups idx_delta_stage_email_domain_groups_nk "email_domain"
   add_stage_index bad_emails idx_delta_stage_bad_emails_nk "lower(btrim(email))"
   add_stage_index excluded_emails idx_delta_stage_excluded_emails_nk "lower(btrim(email))"
@@ -838,6 +953,82 @@ SQL
     "$RUN_DIR/selection.conf" "$RUN_DIR/selection_manifest.err" -tA
 }
 
+write_selection_cookbook() {
+  printf "📖  Writing selection cookbook …\n"
+  cat > "$RUN_DIR/render_selection_cookbook.sql" <<'SQL'
+SELECT * FROM delta_ctl.render_selection_cookbook();
+SQL
+  psql_delta_session_file "$RUN_DIR/render_selection_cookbook.sql" \
+    "$RUN_DIR/selection_cookbook.txt" "$RUN_DIR/selection_cookbook.err" -tA
+}
+
+write_aligned_detail() {
+  local tsv_file="$1" total="$2" row_class="$3"
+  local txt_file="${tsv_file%.tsv}.txt"
+  local tmp_file="$txt_file.tmp"
+  local err_file="$txt_file.err"
+  local rendered truncated=""
+
+  [[ "$ALIGN_DETAILS" = "true" && -s "$tsv_file" ]] || return 0
+
+  if ! rendered="$(awk 'NR > 1 && $0 !~ /^#/ { count++ } END { print count + 0 }' "$tsv_file")"; then
+    printf "⚠️  Could not count detail rows for aligned companion: %s\n" "$tsv_file" \
+      | tee -a "$RUN_DIR/warnings.log" >&2 || true
+    return 0
+  fi
+  if grep -q '^# TRUNCATED at ' "$tsv_file" || [[ "$total" -gt "$DETAILS_LIMIT" ]]; then
+    truncated=" — TRUNCATED"
+  fi
+
+  if awk -v max_width="$ALIGN_WIDTH" -f "$ALIGN_DETAILS_AWK" "$tsv_file" "$tsv_file" \
+       > "$tmp_file" 2> "$err_file" \
+     && printf '# rendered %s of %s %s rows%s\n' \
+          "$rendered" "$total" "$row_class" "$truncated" >> "$tmp_file" \
+     && mv "$tmp_file" "$txt_file"; then
+    rm -f "$err_file"
+  else
+    [[ ! -s "$err_file" ]] || cat "$err_file" >&2
+    printf "⚠️  Could not create aligned detail companion for %s; canonical TSV retained.\n" "$tsv_file" \
+      | tee -a "$RUN_DIR/warnings.log" >&2 || true
+    rm -f "$tmp_file" "$err_file" "$txt_file"
+  fi
+  return 0
+}
+
+write_row_details() {
+  local table new_n changed_n blocked_n sql_file out_file rel
+  mkdir -p "$RUN_DIR/details"
+  : > "$RUN_DIR/detail_artifacts.txt"
+  while read -r table; do
+    [[ -n "$table" ]] || continue
+    new_n="$(awk -F '\t' -v t="$table" '$1 == t && $2 == "NEW" { print $3; exit }' "$RUN_DIR/class_counts.tsv")"
+    changed_n="$(awk -F '\t' -v t="$table" '$1 == t && ($2 == "CHANGED" || $2 == "CHANGED_LOCAL_NEWER") { n += $3 } END { print n + 0 }' "$RUN_DIR/class_counts.tsv")"
+    blocked_n="$(awk -F '\t' -v t="$table" '$1 == t && ($2 == "BLOCKED_FK" || $2 == "AMBIGUOUS_NK") { n += $3 } END { print n + 0 }' "$RUN_DIR/class_counts.tsv")"
+
+    if [[ "${new_n:-0}" -gt 0 ]]; then
+      rel="details/$table.new.tsv"; out_file="$RUN_DIR/$rel"; sql_file="$RUN_DIR/render_$table.new.sql"
+      printf "SELECT * FROM delta_ctl.render_new_rows_tsv(%s, %s);\n" "$(sql_literal "$table")" "$DETAILS_LIMIT" > "$sql_file"
+      psql_delta_session_file "$sql_file" "$out_file" "$RUN_DIR/render_$table.new.err" -tA
+      write_aligned_detail "$out_file" "$new_n" "NEW"
+      printf '%s\n' "$rel" >> "$RUN_DIR/detail_artifacts.txt"
+    fi
+    if [[ "$changed_n" -gt 0 ]]; then
+      rel="details/$table.changed.tsv"; out_file="$RUN_DIR/$rel"; sql_file="$RUN_DIR/render_$table.changed.sql"
+      printf "SELECT * FROM delta_ctl.render_changed_rows_tsv(%s, %s);\n" "$(sql_literal "$table")" "$DETAILS_LIMIT" > "$sql_file"
+      psql_delta_session_file "$sql_file" "$out_file" "$RUN_DIR/render_$table.changed.err" -tA
+      write_aligned_detail "$out_file" "$changed_n" "CHANGED"
+      printf '%s\n' "$rel" >> "$RUN_DIR/detail_artifacts.txt"
+    fi
+    if [[ "$blocked_n" -gt 0 ]]; then
+      rel="details/$table.blocked.tsv"; out_file="$RUN_DIR/$rel"; sql_file="$RUN_DIR/render_$table.blocked.sql"
+      printf "SELECT * FROM delta_ctl.render_blocked_rows_tsv(%s, %s);\n" "$(sql_literal "$table")" "$DETAILS_LIMIT" > "$sql_file"
+      psql_delta_session_file "$sql_file" "$out_file" "$RUN_DIR/render_$table.blocked.err" -tA
+      write_aligned_detail "$out_file" "$blocked_n" "BLOCKED"
+      printf '%s\n' "$rel" >> "$RUN_DIR/detail_artifacts.txt"
+    fi
+  done < "$RUN_DIR/present_tables.txt"
+}
+
 normalize_class_list() {
   local value="$1" out="$2"
   : > "$out"
@@ -856,15 +1047,55 @@ normalize_class_list() {
   ' > "$out" || return 4
 }
 
+scope_selection_file_input() {
+  [[ "$TABLES_ARG" != "all" || -n "$INCLUDE_CLASSES" || -n "$EXCLUDE_CLASSES" ]] || return 0
+
+  local requested="$RUN_DIR/requested_tables.txt"
+  local include_classes="$RUN_DIR/scope_include_classes.txt"
+  local exclude_classes="$RUN_DIR/scope_exclude_classes.txt"
+  local scoped="$RUN_DIR/selection_input.scoped.tsv"
+  local restrict_include="false"
+
+  [[ -r "$requested" ]] || die4 "requested table scope is unavailable; re-run preview"
+  if [[ -n "$INCLUDE_CLASSES" ]]; then
+    restrict_include="true"
+  fi
+  normalize_class_list "$INCLUDE_CLASSES" "$include_classes" || die4 "invalid --include-classes"
+  normalize_class_list "$EXCLUDE_CLASSES" "$exclude_classes" || die4 "invalid --exclude-classes"
+
+  awk -F '\t' \
+      -v requested="$requested" \
+      -v included="$include_classes" \
+      -v excluded="$exclude_classes" \
+      -v restrict_include="$restrict_include" '
+    BEGIN {
+      while ((getline value < requested) > 0) allowed_table[value] = 1
+      close(requested)
+      while ((getline value < included) > 0) allowed_class[value] = 1
+      close(included)
+      while ((getline value < excluded) > 0) denied_class[value] = 1
+      close(excluded)
+    }
+    ($1 in allowed_table) &&
+      (restrict_include != "true" || ($2 in allowed_class)) &&
+      !($2 in denied_class) { print $0 }
+  ' "$RUN_DIR/selection_input.tsv" > "$scoped" || die4 "could not enforce selection table/class scope"
+  mv "$scoped" "$RUN_DIR/selection_input.tsv"
+}
+
 build_selection_input() {
   local base_classes="$RUN_DIR/base_classes.txt"
   local exclude_classes="$RUN_DIR/exclude_classes.txt"
   local requested="$RUN_DIR/requested_tables.txt"
   : > "$RUN_DIR/selection_input.tsv"
+  : > "$RUN_DIR/row_selection_input.tsv"
+  : > "$RUN_DIR/selection_header.tsv"
 
   if [[ -n "$SELECTION_FILE" ]]; then
     [[ -r "$SELECTION_FILE" ]] || die4 "selection file is not readable: $SELECTION_FILE"
-    awk -v all_tables="$RUN_DIR/all_conf_tables.txt" '
+    awk -v all_tables="$RUN_DIR/all_conf_tables.txt" \
+        -v rowout="$RUN_DIR/row_selection_input.tsv" \
+        -v headerout="$RUN_DIR/selection_header.tsv" '
       function trim(s) { gsub(/^[[:space:]]+|[[:space:]]+$/, "", s); return s }
       function cls(s) {
         s = tolower(trim(s))
@@ -872,7 +1103,29 @@ build_selection_input() {
         if (s == "changed") return "CHANGED"
         if (s == "changed_local_newer" || s == "local_newer") return "CHANGED_LOCAL_NEWER"
         if (s == "") return ""
-        printf("invalid apply class in selection file: %s\n", s) > "/dev/stderr"; exit 4
+        fail("invalid apply class: " s)
+      }
+      function fail(message) {
+        printf("selection line %s: %s\n", NR, message) > "/dev/stderr"
+        failed = 1
+        exit 4
+      }
+      function decimal_le(a, b, aa, bb, k, ad, bd) {
+        aa = a; bb = b
+        sub(/^0+/, "", aa); sub(/^0+/, "", bb)
+        if (aa == "") aa = "0"; if (bb == "") bb = "0"
+        if (length(aa) != length(bb)) return length(aa) < length(bb)
+        for (k = 1; k <= length(aa); k++) {
+          ad = substr(aa, k, 1) + 0; bd = substr(bb, k, 1) + 0
+          if (ad != bd) return ad < bd
+        }
+        return 1
+      }
+      function copy_escape(s) {
+        gsub(/\\/, "\\\\", s)
+        gsub(/\t/, "\\t", s)
+        gsub(/\r/, "\\r", s)
+        return s
       }
       BEGIN {
         while ((getline t < all_tables) > 0) { valid[t] = 1; order[++n] = t }
@@ -880,15 +1133,98 @@ build_selection_input() {
         wildcard = "NEW,CHANGED"
       }
       {
-        sub(/[[:space:]]*#.*/, "", $0)
-        if ($0 !~ /^[[:space:]]*\[[^]]+\][[:space:]]*include=/) next
-        target = $0; sub(/^[[:space:]]*\[/, "", target); sub(/\].*/, "", target); target = trim(target)
-        includes = $0; sub(/^.*include=/, "", includes); includes = trim(includes)
+        raw = $0
+        sub(/\r$/, "", raw)
+        if (raw ~ /^[[:space:]]*#[[:space:]]*dump_sha256=/) {
+          if (dump_header_seen++) fail("duplicate dump_sha256 header")
+          value = raw
+          sub(/^[[:space:]]*#[[:space:]]*dump_sha256=/, "", value)
+          print "dump_sha256\t" trim(value) >> headerout
+        } else if (raw ~ /^[[:space:]]*#[[:space:]]*staged[[:space:]]+/) {
+          value = raw
+          sub(/^[[:space:]]*#[[:space:]]*staged[[:space:]]+/, "", value)
+          count = split(value, entries, /[[:space:]]+/)
+          for (i = 1; i <= count; i++) {
+            if (entries[i] == "") continue
+            eq = index(entries[i], "=")
+            if (eq <= 1 || eq == length(entries[i])) {
+              fail("staged binding must use table=<decimal count>: " entries[i])
+            }
+            staged_table = substr(entries[i], 1, eq - 1)
+            staged_count = substr(entries[i], eq + 1)
+            if (staged_count !~ /^[0-9]+$/) {
+              fail("staged count must be a non-negative decimal integer for " staged_table)
+            }
+            if (staged_header_seen[staged_table]++) {
+              fail("duplicate staged-count header for " staged_table)
+            }
+            print "staged\t" staged_table "\t" staged_count >> headerout
+          }
+        }
+
+        line = raw
+        sub(/[[:space:]]*#.*/, "", line)
+        line = trim(line)
+        if (line == "") next
+        if (line !~ /^\[[^]]+\]/) fail("invalid syntax")
+
+        target = line
+        sub(/^\[/, "", target); sub(/\].*/, "", target); target = trim(target)
+        rest = line; sub(/^\[[^]]+\]/, "", rest); rest = trim(rest)
+
+        if (rest ~ /^[a-z_]+[.]rows[[:space:]]+/) {
+          if (target == "*") fail("row selectors do not support [*]")
+          if (!valid[target]) fail("selection table is not preserved: " target)
+          rowclass = rest; sub(/[.]rows.*/, "", rowclass); rowclass = cls(rowclass)
+          tail = rest; sub(/^[a-z_]+[.]rows[[:space:]]+/, "", tail)
+          mode = tail; sub(/[[:space:]]*=.*/, "", mode); mode = tolower(trim(mode))
+          if (mode != "include" && mode != "exclude") fail("row selector mode must be include or exclude")
+          if (tail !~ /=/) fail("row selector is missing =")
+          payload = tail; sub(/^[^=]*=/, "", payload); payload = trim(payload)
+          colon = index(payload, ":")
+          if (colon < 2) fail("row selector must use id:, row:, or corp:")
+          kind = tolower(trim(substr(payload, 1, colon - 1)))
+          values = substr(payload, colon + 1)
+          if (kind != "id" && kind != "row" && kind != "corp") fail("unsupported row selector kind: " kind)
+          if (trim(values) == "") fail("row selector value list is empty")
+          value_count = split(values, vals, ",")
+          for (j = 1; j <= value_count; j++) {
+            value = trim(vals[j])
+            if (value == "") fail("row selector contains an empty value")
+            from = "\\N"; to = "\\N"; corp = "\\N"; is_range = "f"
+            if (kind == "corp") {
+              corp = copy_escape(value)
+            } else {
+              if (value !~ /^[0-9]+(-[0-9]+)?$/) fail(kind " selector must be a non-negative integer or range: " value)
+              dash = index(value, "-")
+              if (dash > 0) {
+                from = substr(value, 1, dash - 1); to = substr(value, dash + 1); is_range = "t"
+                if (!decimal_le(from, to)) fail("row selector range is inverted: " value)
+              } else {
+                from = value; to = value
+              }
+              if (!decimal_le(from, "9223372036854775807") || !decimal_le(to, "9223372036854775807")) {
+                fail(kind " selector exceeds bigint maximum: " value)
+              }
+            }
+            key = target SUBSEP rowclass SUBSEP mode SUBSEP kind SUBSEP value
+            if (selector_seen[key]++) {
+              printf("warning: selection line %s duplicates selector %s:%s\n", NR, kind, value) > "/dev/stderr"
+              continue
+            }
+            print target "\t" rowclass "\t" mode "\t" kind "\t" from "\t" to "\t" corp "\t" is_range "\t" NR >> rowout
+          }
+          next
+        }
+
+        if (rest !~ /^include[[:space:]]*=/) fail("expected include=classes or <class>.rows include|exclude=<kind>:<values>")
+        includes = rest; sub(/^include[[:space:]]*=/, "", includes); includes = trim(includes)
         if (target == "*") wildcard = includes
-        else if (!valid[target]) { printf("selection table is not preserved: %s\n", target) > "/dev/stderr"; exit 4 }
+        else if (!valid[target]) fail("selection table is not preserved: " target)
         else override[target] = includes
       }
       END {
+        if (failed) exit 4
         for (i = 1; i <= n; i++) {
           t = order[i]
           includes = (t in override) ? override[t] : wildcard
@@ -900,6 +1236,7 @@ build_selection_input() {
         }
       }
     ' "$SELECTION_FILE" > "$RUN_DIR/selection_input.tsv" || die4 "invalid selection file: $SELECTION_FILE"
+    scope_selection_file_input
     return 0
   fi
 
@@ -917,13 +1254,42 @@ build_selection_input() {
   done < "$requested"
 }
 
+verify_selection_binding() {
+  [[ -s "$RUN_DIR/row_selection_input.tsv" ]] || return 0
+  local bound_sha table expected actual
+  bound_sha="$(awk -F '\t' '$1 == "dump_sha256" { print $2; exit }' "$RUN_DIR/selection_header.tsv")"
+  [[ -n "$bound_sha" ]] || die4 "row-selector selection file is missing # dump_sha256=; re-run preview"
+  [[ "$bound_sha" = "$DUMP_SHA256" ]] || die4 "selection file was generated from a different dump (expected $DUMP_SHA256, found $bound_sha); re-run preview"
+
+  while read -r table; do
+    [[ -n "$table" ]] || continue
+    expected="$(awk -F '\t' -v t="$table" '$1 == "staged" && $2 == t { print $3; exit }' "$RUN_DIR/selection_header.tsv")"
+    actual="$(awk -F '\t' -v t="$table" '$1 == t && $2 == "STAGED" { print $3; exit }' "$RUN_DIR/stage_counts.tsv")"
+    [[ -n "$expected" ]] || die4 "row: selector for $table is missing its # staged $table=<count> binding"
+    [[ "$expected" = "${actual:-0}" ]] || die4 "staged row count for $table changed (selection=$expected current=${actual:-0}); re-run preview"
+  done < <(awk -F '\t' '$4 == "row" { print $1 }' "$RUN_DIR/row_selection_input.tsv" | sort -u)
+
+  psql_cmd "INSERT INTO delta_ctl.run_metadata(key, value) VALUES
+    ('selection_file', $(sql_literal "$SELECTION_FILE")),
+    ('selection_bound_sha256', $(sql_literal "$bound_sha"))
+    ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, created_at = now();" >/dev/null
+}
+
 load_selection_tables() {
   build_selection_input
-  psql_cmd "TRUNCATE delta_ctl.selection; TRUNCATE delta_ctl.only_corps;"
+  verify_selection_binding
+  psql_cmd "TRUNCATE delta_ctl.selection; TRUNCATE delta_ctl.row_selection; TRUNCATE delta_ctl.selection_diagnostics; TRUNCATE delta_ctl.only_corps;"
   if [[ -s "$RUN_DIR/selection_input.tsv" ]]; then
     "$PSQL_BIN" -X $(pg_conn_opts) -v ON_ERROR_STOP=1 \
       -c "COPY delta_ctl.selection(table_name, class) FROM STDIN" \
       < "$RUN_DIR/selection_input.tsv"
+  fi
+  if [[ -s "$RUN_DIR/row_selection_input.tsv" ]]; then
+    if ! "$PSQL_BIN" -X $(pg_conn_opts) -v ON_ERROR_STOP=1 \
+      -c "COPY delta_ctl.row_selection(table_name, class, mode, kind, value_from, value_to, corp_num, is_range, source_line) FROM STDIN" \
+      < "$RUN_DIR/row_selection_input.tsv"; then
+      die4 "failed to load row selectors; check selection values and line diagnostics"
+    fi
   fi
 
   if [[ -n "$ONLY_CORPS_FILE" ]]; then
@@ -940,10 +1306,29 @@ load_selection_tables() {
 prepare_apply_selection() {
   printf "🎯  Loading and stamping selection …\n"
   load_selection_tables
+  psql_cmd "SELECT delta_ctl.verify_row_selection();" > "$RUN_DIR/row_selection_validation.out"
+  "$PSQL_BIN" -X $(pg_conn_opts) -v ON_ERROR_STOP=1 -tA -F $'\t' > "$RUN_DIR/selection_diagnostics.tsv" <<'SQL'
+SELECT table_name, class, mode, kind, selector, source_line, COALESCE(matched::text, ''), problem
+FROM delta_ctl.selection_diagnostics
+ORDER BY source_line, table_name, class;
+SQL
+  if awk -F '\t' 'NF >= 8 && $8 != "" { found=1 } END { exit !found }' "$RUN_DIR/selection_diagnostics.tsv"; then
+    cat "$RUN_DIR/selection_diagnostics.tsv" >&2
+    die4 "row selection validation failed; see selection_diagnostics.tsv"
+  fi
   psql_cmd "SELECT delta_ctl.stamp_selection();"
   if ! psql_cmd "SELECT delta_ctl.validate_dependencies();" > "$RUN_DIR/selection_validation.out" 2> "$RUN_DIR/selection_validation.err"; then
     cat "$RUN_DIR/selection_validation.err" >&2
-    die4 "selection/dependency validation failed; inspect delta_ctl.dependency_violations"
+    die4 "selection/dependency validation failed"
+  fi
+  "$PSQL_BIN" -X $(pg_conn_opts) -v ON_ERROR_STOP=1 -tA -F $'\t' > "$RUN_DIR/dependency_violations.tsv" <<'SQL'
+SELECT child_table, parent_table, reason, row_count, COALESCE(sample_ids, '')
+FROM delta_ctl.dependency_violations
+ORDER BY child_table, parent_table;
+SQL
+  if [[ -s "$RUN_DIR/dependency_violations.tsv" ]]; then
+    cat "$RUN_DIR/dependency_violations.tsv" >&2
+    die4 "selection/dependency validation failed; see dependency_violations.tsv"
   fi
 
   "$PSQL_BIN" -X $(pg_conn_opts) -v ON_ERROR_STOP=1 -tA -F $'\t' > "$RUN_DIR/selected_counts.tsv" <<'SQL'
@@ -1033,6 +1418,7 @@ write_apply_summary() {
 
 write_preview_report() {
   local report="$RUN_DIR/preview.txt"
+  local detail aligned_detail table_name detail_class rendered total truncated aligned
   {
     printf "Delta restore preview\n"
     printf "=====================\n\n"
@@ -1042,10 +1428,57 @@ write_preview_report() {
     printf "Mode: %s\n" "$MODE"
     printf "Tables: %s\n" "$TABLES_ARG"
     printf "Sample size: %s\n" "$SAMPLE_SIZE"
+    printf "Details limit: %s\n" "$DETAILS_LIMIT"
     printf "Selection manifest: %s\n" "$RUN_DIR/selection.conf"
     if [[ -f "$RUN_DIR/dump.manifest.json" ]]; then
       printf "Manifest: %s\n" "$RUN_DIR/dump.manifest.json"
     fi
+    printf "\nDetail artifacts\n"
+    printf '%s\n' '----------------'
+    if [[ -s "$RUN_DIR/detail_artifacts.txt" ]]; then
+      while read -r detail; do
+        table_name="${detail#details/}"
+        table_name="${table_name%.*.tsv}"
+        rendered="$(awk 'NR > 1 && $0 !~ /^#/ { count++ } END { print count + 0 }' "$RUN_DIR/$detail")"
+        case "$detail" in
+          *.new.tsv)
+            detail_class="NEW"
+            total="$(awk -F '\t' -v t="$table_name" '$1 == t && $2 == "NEW" { n += $3 } END { print n + 0 }' "$RUN_DIR/class_counts.tsv")"
+            ;;
+          *.changed.tsv)
+            detail_class="CHANGED"
+            total="$(awk -F '\t' -v t="$table_name" '$1 == t && ($2 == "CHANGED" || $2 == "CHANGED_LOCAL_NEWER") { n += $3 } END { print n + 0 }' "$RUN_DIR/class_counts.tsv")"
+            ;;
+          *.blocked.tsv)
+            detail_class="BLOCKED"
+            total="$(awk -F '\t' -v t="$table_name" '$1 == t && ($2 == "BLOCKED_FK" || $2 == "AMBIGUOUS_NK") { n += $3 } END { print n + 0 }' "$RUN_DIR/class_counts.tsv")"
+            ;;
+        esac
+
+        truncated=""
+        if grep -q '^# TRUNCATED at ' "$RUN_DIR/$detail" || [[ "$total" -gt "$DETAILS_LIMIT" ]]; then
+          truncated=" (TRUNCATED)"
+        fi
+        aligned=""
+        aligned_detail="${detail%.tsv}.txt"
+        if [[ -f "$RUN_DIR/$aligned_detail" ]]; then
+          aligned=" · aligned: $aligned_detail"
+        fi
+        printf -- "- %s — %s of %s %s rows%s%s\n" \
+          "$detail" "$rendered" "$total" "$detail_class" "$truncated" "$aligned"
+      done < "$RUN_DIR/detail_artifacts.txt"
+    else
+      printf "(none)\n"
+    fi
+    cat <<'TIPS'
+
+Viewing tips
+------------
+Aligned text: open details/<table>.<class>.txt in any editor (turn off word wrap).
+Terminal:     column -s $'\t' -t < details/<table>.<class>.tsv | less -S
+SQL:          the delta_stage/delta_diff schemas remain installed after preview;
+              see "Querying the staged run directly" in README_delta_restore.md.
+TIPS
     if [[ -s "$RUN_DIR/drift_local_copy_permitted.tsv" ]]; then
       printf "\nSchema drift warnings\n"
       printf "---------------------\n"
@@ -1075,8 +1508,94 @@ run_preview_staging() {
   create_stage_indexes
   record_stage_counts
   run_preview_classification
+  write_row_details
   write_selection_manifest
+  write_selection_cookbook
   write_preview_report
+
+  printf '\nNext steps:\n'
+  printf '  1. Review %q\n' "$RUN_DIR/preview.txt"
+  printf '  2. cp %q my_selection.conf and edit it\n' "$RUN_DIR/selection.conf"
+  printf '  3. To validate: %q --dump %q --mode validate' "$0" "$DUMP"
+  [[ "$TABLES_ARG" = "all" ]] || printf ' --tables %q' "$TABLES_ARG"
+  [[ -z "$INCLUDE_CLASSES" ]] || printf ' --include-classes %q' "$INCLUDE_CLASSES"
+  [[ -z "$EXCLUDE_CLASSES" ]] || printf ' --exclude-classes %q' "$EXCLUDE_CLASSES"
+  printf ' --selection-file my_selection.conf'
+  [[ -z "$ONLY_CORPS_FILE" ]] || printf ' --only-corps %q' "$ONLY_CORPS_FILE"
+  printf '\n'
+}
+
+verify_resident_run() {
+  local resident_state resident_sha
+
+  if ! resident_state="$("$PSQL_BIN" -X $(pg_conn_opts) -qAt -v ON_ERROR_STOP=1 <<'SQL'
+SELECT CASE
+  WHEN to_regclass('delta_ctl.run_metadata') IS NULL THEN 'NO_RUN'
+  WHEN to_regclass('delta_ctl.run_counts') IS NULL
+    OR to_regclass('delta_ctl.table_config') IS NULL
+    OR to_regclass('delta_ctl.selection') IS NULL
+    OR to_regclass('delta_ctl.row_selection') IS NULL
+    OR to_regclass('delta_ctl.selection_diagnostics') IS NULL
+    OR to_regclass('delta_ctl.only_corps') IS NULL
+    OR to_regclass('delta_ctl.dependency_violations') IS NULL
+    OR NOT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = 'delta_stage')
+    OR NOT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = 'delta_map')
+    OR NOT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = 'delta_diff')
+    OR to_regprocedure('delta_ctl.verify_row_selection()') IS NULL
+    OR to_regprocedure('delta_ctl.stamp_selection()') IS NULL
+    OR to_regprocedure('delta_ctl.validate_dependencies()') IS NULL
+    OR to_regprocedure('delta_ctl.selected_counts()') IS NULL
+    THEN 'INCOMPLETE'
+  ELSE 'READY'
+END;
+SQL
+  )"; then
+    die2 "could not inspect resident delta run"
+  fi
+
+  case "$resident_state" in
+    NO_RUN|'') die2 "no resident delta run found; run --mode preview first" ;;
+    READY) ;;
+    *) die2 "resident delta run is incomplete; re-run preview" ;;
+  esac
+
+  compute_dump_sha
+  if ! resident_sha="$("$PSQL_BIN" -X $(pg_conn_opts) -qAt -v ON_ERROR_STOP=1 \
+      -c "SELECT value FROM delta_ctl.run_metadata WHERE key = 'dump_sha256'")"; then
+    die2 "could not read resident delta run metadata"
+  fi
+  [[ -n "$resident_sha" ]] || die2 "resident delta run has no dump sha256; re-run preview"
+  [[ "$resident_sha" = "$DUMP_SHA256" ]] \
+    || die2 "resident run was staged from a different dump; re-run preview"
+
+  if ! "$PSQL_BIN" -X $(pg_conn_opts) -v ON_ERROR_STOP=1 -tA -F $'\t' \
+      > "$RUN_DIR/stage_counts.tsv" <<'SQL'
+SELECT table_name, count_name, row_count
+FROM delta_ctl.run_counts
+WHERE count_name IN ('STAGED', 'SKIPPED_ABSENT')
+ORDER BY table_name, count_name;
+SQL
+  then
+    die2 "could not regenerate staged-count binding from resident run"
+  fi
+  [[ -s "$RUN_DIR/stage_counts.tsv" ]] \
+    || die2 "resident delta run has no staged-count metadata; re-run preview"
+}
+
+run_validate_mode() {
+  verify_resident_run
+  load_preserved_config
+  select_tables
+  prepare_apply_selection
+
+  printf "✅  Selection is valid.\n"
+  printf 'To apply: %q --dump %q --mode apply' "$0" "$DUMP"
+  [[ "$TABLES_ARG" = "all" ]] || printf ' --tables %q' "$TABLES_ARG"
+  [[ -z "$INCLUDE_CLASSES" ]] || printf ' --include-classes %q' "$INCLUDE_CLASSES"
+  [[ -z "$EXCLUDE_CLASSES" ]] || printf ' --exclude-classes %q' "$EXCLUDE_CLASSES"
+  [[ -z "$SELECTION_FILE" ]] || printf ' --selection-file %q' "$SELECTION_FILE"
+  [[ -z "$ONLY_CORPS_FILE" ]] || printf ' --only-corps %q' "$ONLY_CORPS_FILE"
+  printf ' --yes\n'
 }
 
 run_apply_mode() {
@@ -1090,7 +1609,9 @@ run_apply_mode() {
   create_stage_indexes
   record_stage_counts
   run_preview_classification
+  write_row_details
   write_selection_manifest
+  write_selection_cookbook
   prepare_apply_selection
   confirm_apply
   run_apply_transaction
@@ -1105,6 +1626,10 @@ run_apply_mode() {
 # MAIN
 ##############################################################################
 
+if [[ "${DELTA_RESTORE_SOURCE_ONLY:-false}" = "true" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
 parse_args "$@"
 validate_static_files
 init_run_dir
@@ -1117,8 +1642,8 @@ if [[ "$CLEANUP" = "true" ]]; then
   exit 0
 fi
 
-if [[ "$MODE" = "apply" ]]; then
-  run_apply_mode
-else
-  run_preview_staging
-fi
+case "$MODE" in
+  apply) run_apply_mode ;;
+  validate) run_validate_mode ;;
+  preview) run_preview_staging ;;
+esac

--- a/data-tool/restore_extract.sh
+++ b/data-tool/restore_extract.sh
@@ -16,7 +16,7 @@ PGPORT="${PGPORT:-5432}"             # or ‑‑port
 PGUSER="${PGUSER:-postgres}"        # or ‑‑user
 PGDATABASE="${PGDATABASE:-colin-mig-corps-test}"     # or ‑‑dbname
 # Optional PostgreSQL client binary directory. Leave empty to use PATH.
-# Example: PG_BIN=/opt/homebrew/opt/postgresql@15/bin ./restore_extract.sh
+# Example: PG_BIN=/path/to/postgresql/bin ./restore_extract.sh
 PG_BIN="${PG_BIN:-}"
 # Supply the password *either* via a .pgpass file *or* one‑shot:
 #   PGPASSWORD=secret ./restore_extract.sh

--- a/data-tool/scripts/README_COLIN_Corps_Extract.md
+++ b/data-tool/scripts/README_COLIN_Corps_Extract.md
@@ -74,11 +74,11 @@ The preserved migration/tracking/auth side-table list is centralized in `data-to
 
 - `data-tool/backup_extract_tables.sh` — creates a preserved-table dump and `<dump>.manifest.json` sidecar.
 - `data-tool/restore_extract.sh` — full preserved-table restore after an extract rebuild.
-- `data-tool/delta_restore_extract.sh` — preview/apply merge for preserved tables.
+- `data-tool/delta_restore_extract.sh` — preview/validate/apply merge for preserved tables.
 
-For the delta workflow, see [restore/README_delta_restore.md](restore/README_delta_restore.md). It documents preview/apply usage, class semantics, selection files, blocked-row remediation, cleanup, and test harness commands.
+For the delta workflow, see [restore/README_delta_restore.md](restore/README_delta_restore.md). It provides the golden path, a complete CLI/environment reference, and troubleshooting by exit code.
 
-`DELTA_MODE=true ./restore_extract.sh` has been removed by design. The full restore script now aborts with a pointer to `data-tool/delta_restore_extract.sh`; run explicit delta preview/apply commands instead.
+`DELTA_MODE=true ./restore_extract.sh` has been removed by design. The full restore script now aborts with a pointer to `data-tool/delta_restore_extract.sh`; run explicit delta preview, validate, and apply commands instead.
 
 Delta restore uses the same PostgreSQL advisory-lock SQL as the subset/full-refresh scripts. Avoid running migration flows or other non-cooperating writers against the target database during apply.
 

--- a/data-tool/scripts/colin_corps_extract_postgres_ddl
+++ b/data-tool/scripts/colin_corps_extract_postgres_ddl
@@ -1459,3 +1459,28 @@ CREATE INDEX IF NOT EXISTS ix_mig_batch_target_env_dates
 CREATE INDEX IF NOT EXISTS ix_event_corpnum_eventid_cover
 	ON event (corp_num, event_id)
 	INCLUDE (event_type_cd, event_timerstamp);
+
+-- Associate standalone ID sequences with their owning columns.
+-- This allows pg_get_serial_sequence() and delta ID reallocation to resolve them.
+ALTER SEQUENCE public.affiliation_processing_id_seq
+	OWNED BY public.affiliation_processing.id;
+ALTER SEQUENCE public.auth_processing_id_seq
+	OWNED BY public.auth_processing.id;
+ALTER SEQUENCE public.auth_component_operation_id_seq
+	OWNED BY public.auth_component_operation.id;
+ALTER SEQUENCE public.corp_processing_id_seq
+	OWNED BY public.corp_processing.id;
+ALTER SEQUENCE public.colin_tracking_id_seq
+	OWNED BY public.colin_tracking.id;
+ALTER SEQUENCE public.mig_group_id_seq
+	OWNED BY public.mig_group.id;
+ALTER SEQUENCE public.mig_batch_id_seq
+	OWNED BY public.mig_batch.id;
+ALTER SEQUENCE public.mig_corp_batch_id_seq
+	OWNED BY public.mig_corp_batch.id;
+ALTER SEQUENCE public.mig_corp_account_id_seq
+	OWNED BY public.mig_corp_account.id;
+ALTER SEQUENCE public.bad_emails_id_seq
+	OWNED BY public.bad_emails.id;
+ALTER SEQUENCE public.excluded_email_domain_patterns_id_seq
+	OWNED BY public.excluded_email_domain_patterns.id;

--- a/data-tool/scripts/restore/README_delta_restore.md
+++ b/data-tool/scripts/restore/README_delta_restore.md
@@ -1,26 +1,179 @@
 # Delta restore for preserved COLIN extract tables
 
-`data-tool/delta_restore_extract.sh` merges a preserved-table dump into an existing COLIN PostgreSQL extract database without truncating the preserved tables. It is the replacement for the old `DELTA_MODE=true` prototype in `restore_extract.sh`.
+`data-tool/delta_restore_extract.sh` merges a preserved-table dump into an existing COLIN PostgreSQL extract database without truncating preserved tables. Use it when a developer/local extract already has migration, tracking, or auth side-table data that must be reconciled with a newer preserved-table dump.
 
-Use it when a developer/local extract database already has migration/tracking/auth side-table data that should be reconciled with a newer preserved-table dump.
-
-## What it operates on
-
-The preserved table set and phase order are centralized in:
-
-```text
-data-tool/scripts/restore/preserved_tables.conf
-```
-
-The same file is consumed by:
+The preserved table set and phase order are centralized in `data-tool/scripts/restore/preserved_tables.conf`. The same file is consumed by:
 
 - `data-tool/backup_extract_tables.sh` — creates the preserved-table dump and sidecar manifest.
 - `data-tool/restore_extract.sh` — full restore path.
-- `data-tool/delta_restore_extract.sh` — delta preview/apply path.
+- `data-tool/delta_restore_extract.sh` — delta preview, validate, and apply path.
 
-## Connection defaults
+## Quick reference
 
-The script uses libpq environment variables:
+### Contents
+
+- [Golden path: merge a delta dump end to end](#golden-path-merge-a-delta-dump-end-to-end)
+- [Connection and environment](#connection-and-environment)
+- [Run directory artifacts](#run-directory-artifacts)
+- [Modes: preview, validate, apply](#modes-preview-validate-apply)
+- [Class semantics](#class-semantics)
+- [Selection manifest and cookbook](#selection-manifest-and-cookbook)
+  - [Row-selector grammar](#row-selector-grammar)
+  - [Binding and validation](#binding-and-validation)
+- [CLI and environment reference](#cli-and-environment-reference)
+- [Detail artifacts and viewing](#detail-artifacts-and-viewing)
+- [Querying the staged run directly](#querying-the-staged-run-directly)
+- [Troubleshooting by exit code](#troubleshooting-by-exit-code)
+- [Recovery, cleanup, and concurrency](#recovery-cleanup-and-concurrency)
+- [DELTA_MODE removal and restore_extract.sh delegation](#delta_mode-removal-and-restore_extractsh-delegation)
+- [Exit codes](#exit-codes)
+- [Tests](#tests)
+
+The five-command path, run from `data-tool/`, is:
+
+```bash
+# 1. Back up the preserved tables on the source.
+PGDATABASE=source_extract BACKUP_DIR=/tmp/preserved ./backup_extract_tables.sh
+
+# Export the target connection inherited by preview and its printed follow-up commands.
+export PGDATABASE=local_extract
+
+# 2. Preview against the target; keep the final "Artifacts:" path.
+DUMP=/tmp/preserved/keep_$(date +%F).dump; ./delta_restore_extract.sh --dump "$DUMP" --mode preview
+
+# 3. Set RUN to the printed path (example shown), then copy and edit the selection.
+RUN=scripts/generated/delta_restore/20260716_183022; cp "$RUN/selection.conf" my_selection.conf; vi my_selection.conf
+
+# 4. Validate the copy until this exits 0.
+./delta_restore_extract.sh --dump "$DUMP" --mode validate --selection-file my_selection.conf
+
+# 5. Paste the apply command printed by validate (shown here in full).
+./delta_restore_extract.sh --dump "$DUMP" --mode apply --selection-file my_selection.conf --yes
+```
+
+> After a run directory is initialized, the invocation prints `Artifacts: <run-dir>` on success or `Artifacts retained for inspection: <run-dir>` on failure. Parse/help failures before initialization do not print an artifact path. Capture the preview path as `RUN` for review and selection editing; validate and apply each print their own diagnostic run directory.
+
+## Golden path: merge a delta dump end to end
+
+This walkthrough supplies every command and handoff needed for a normal merge. Follow links only when you need additional detail.
+
+### Step 0: Prepare the target and connection
+
+The target extract database must already exist with the current `colin_corps_extract_postgres_ddl` applied. Stop migration flows and avoid other non-cooperating writers against the target while applying. Export the target's [libpq settings](#connection-and-environment), at minimum `PGDATABASE`; set `PG_BIN` explicitly if the PostgreSQL client tools are not available through `PATH`.
+
+Export the target connection so the preview command and its printed validate/apply follow-ups inherit the same database, then run the remaining commands from `data-tool/`:
+
+```bash
+export PGDATABASE=local_extract
+cd data-tool
+```
+
+### Step 1: Create the dump on the source
+
+```bash
+PGDATABASE=source_extract \
+BACKUP_DIR=/tmp/preserved \
+./backup_extract_tables.sh
+```
+
+By default this creates `keep_YYYY-MM-DD.dump` under `BACKUP_DIR` and prints:
+
+```text
+✅  Wrote <dump> and <dump>.manifest.json
+```
+
+Keep the dump and sidecar together. Preview computes the dump sha256 and verifies it against the sidecar manifest.
+
+### Step 2: Preview against the target
+
+Use the exact dump path printed in Step 1:
+
+```bash
+DUMP=/tmp/preserved/keep_YYYY-MM-DD.dump
+./delta_restore_extract.sh \
+  --dump "$DUMP" \
+  --mode preview
+```
+
+A successful run ends with a concrete path such as:
+
+```text
+Artifacts: scripts/generated/delta_restore/20260716_183022
+```
+
+Capture it:
+
+```bash
+RUN=scripts/generated/delta_restore/20260716_183022
+```
+
+`RUN` is the preview run directory used in Steps 3–4. The console also prints a ready-to-paste validate command for Step 5.
+
+### Step 3: Review the preview in order
+
+1. Read `$RUN/preview.txt` for class counts, per-table samples, and the detail index with rendered/total/truncation state.
+2. Read the blast-radius comment immediately after `[*]` in `$RUN/selection.conf` for the number of rows selected by default.
+3. For surprising counts, open `$RUN/details/<table>.<class>.txt`; its canonical `.tsv` is beside it.
+4. For large or targeted reviews, use the recipes in [Querying the staged run directly](#querying-the-staged-run-directly).
+
+### Step 4: Copy, then edit, the selection
+
+Do not edit the generated manifest in place:
+
+```bash
+cp "$RUN/selection.conf" my_selection.conf
+vi my_selection.conf
+```
+
+Copying keeps the generated manifest pristine for later diffing and keeps the run directory immutable. The copy retains the dump and staged-count binding headers required by validate/apply. The full grammar and 13 worked examples are in `$RUN/selection_cookbook.txt`. For `id:` selectors, use staged IDs from `selector_id`—never local-database IDs; see [Row-selector grammar](#row-selector-grammar).
+
+### Step 5: Validate; repeat until exit 0
+
+```bash
+./delta_restore_extract.sh \
+  --dump "$DUMP" \
+  --mode validate \
+  --selection-file my_selection.conf
+```
+
+Validate normally takes seconds because it reuses the resident preview instead of restaging. After each attempt, use that invocation's printed artifact path:
+
+- Exit `4`: read `selection_diagnostics.tsv` and `dependency_violations.tsv` in the new validate run directory, edit `my_selection.conf`, and retry.
+- Exit `2`: the resident preview is missing, incomplete, or stale; rerun Step 2 before retrying.
+
+On exit `0`, validate prints the exact apply command to paste, carrying forward the current selection and selector flags.
+
+### Step 6: Apply
+
+Paste validate's printed command. For the commands above it is equivalent to:
+
+```bash
+./delta_restore_extract.sh \
+  --dump "$DUMP" \
+  --mode apply \
+  --selection-file my_selection.conf \
+  --yes
+```
+
+Apply deliberately re-verifies the dump hash, restages, reclassifies, binds, stamps, and checks dependencies against current local data. A validate result that has become stale therefore cannot bypass the apply safety checks.
+
+### Step 7: Confirm
+
+Capture the successful apply's final `Artifacts: <apply-run-dir>` path and read `<apply-run-dir>/apply_summary.txt`. Confirm every row's `expected` count equals `affected`. The summary also records the touched tables; apply analyzes those tables and repairs their sequences. On success, the `delta_*` schemas are dropped unless `--keep-artifacts` was supplied.
+
+### Step 8: Clean up only when needed
+
+After diagnosing an abandoned preview or failed apply, drop the resident delta schemas:
+
+```bash
+PGDATABASE=local_extract ./delta_restore_extract.sh --cleanup
+```
+
+Cleanup does not remove any run directory.
+
+## Connection and environment
+
+The script passes these libpq settings to PostgreSQL tools. Export the target settings before preview so the printed validate/apply commands inherit the same connection:
 
 ```bash
 PGHOST=localhost
@@ -30,192 +183,437 @@ PGDATABASE=colin-mig-corps-test
 PGPASSWORD=...        # optional; or use .pgpass
 ```
 
-## Basic usage
+`PG_BIN` optionally names the directory containing PostgreSQL client tools. If it is unset or explicitly empty (`PG_BIN=""`), `psql`, `pg_restore`, and related clients are resolved through `PATH`. If it is nonempty, clients are resolved from that directory.
 
-Create a preserved-table dump from the source extract database:
+The default run-directory base is `data-tool/scripts/generated/delta_restore/`. `DUMP` can supply the archive path instead of `--dump`, and `LOCK_TIMEOUT_SECONDS` controls the advisory-lock wait. See the consolidated [CLI and environment reference](#cli-and-environment-reference) for all defaults.
 
-```bash
-cd data-tool
-PGDATABASE=source_extract \
-BACKUP_DIR=/tmp/preserved \
-./backup_extract_tables.sh
-```
+## Run directory artifacts
 
-Preview a merge into the target database:
+Artifacts are written under `data-tool/scripts/generated/delta_restore/<UTC timestamp>/` by default. The process sets `umask 077`, so new run directories and files default to modes 700 and 600.
 
-```bash
-cd data-tool
-PGDATABASE=local_extract \
-./delta_restore_extract.sh \
-  --dump /tmp/preserved/keep_YYYY-MM-DD.dump \
-  --mode preview
-```
+| Artifact | Purpose |
+| --- | --- |
+| `preview.txt` | Class samples plus an index of detail artifacts with rendered/total counts, truncation state, aligned paths, and viewing tips. |
+| `selection.conf` | Concise active v2 manifest. Binding headers protect row selectors; class-only v1 files remain supported. |
+| `selection_cookbook.txt` | Full selector grammar and 13 commented examples generated for the same run. |
+| `details/<table>.new.tsv` | Canonical staged selector, row ordinal, and public-column values for NEW rows. |
+| `details/<table>.changed.tsv` | Canonical local-to-dump changed-column records for CHANGED and CHANGED_LOCAL_NEWER rows. |
+| `details/<table>.blocked.tsv` | Canonical staged values, block class, and reason. |
+| `details/<table>.<class>.txt` | Derived fixed-width companion for double-click/editor review; never consumed by apply. |
+| `classification.out/.err` | Classification stdout and timing notices. |
+| `temp_stats.tsv` | Before/after PostgreSQL temp file and byte counters. |
+| `selection_diagnostics.tsv` | Selector match counts and any validation problem. |
+| `dependency_violations.tsv` | Selected-child/preserved-parent violations. |
+| `selected_counts.tsv` | Counts selected by table and class. |
+| `apply_transaction.err` | Apply transaction errors, including verification failures. |
+| `apply_summary.txt` | Successful apply's expected/affected counts and touched-table summary. |
 
-Apply selected rows after reviewing the preview:
+Preview samples replace LF, tab, CR, and ESC with visible markers (`␤`, `␉`, `␍`, `␛`) and sanitize other terminal controls. Review `preview.txt` first, then the selection blast radius, then table/class details. Every exit prints the applicable run-directory path; failure paths remain available for diagnosis.
 
-```bash
-cd data-tool
-PGDATABASE=local_extract \
-./delta_restore_extract.sh \
-  --dump /tmp/preserved/keep_YYYY-MM-DD.dump \
-  --mode apply \
-  --selection-file scripts/generated/delta_restore/<run>/selection.conf \
-  --yes
-```
-
-Clean up leftover delta schemas from an interrupted run:
-
-```bash
-cd data-tool
-PGDATABASE=local_extract ./delta_restore_extract.sh --cleanup
-```
-
-## Modes and artifacts
+## Modes: preview, validate, apply
 
 ### Preview mode
 
 Preview is the default. It:
 
-1. Verifies the dump and optional `<dump>.manifest.json` sha256.
+1. Computes the dump sha256 and verifies it against optional `<dump>.manifest.json` metadata.
 2. Filters the dump TOC to the preserved table list.
-3. Creates run-scoped schemas: `delta_stage`, `delta_map`, `delta_diff`, `delta_ctl`.
-4. Streams data into `delta_stage` with guarded COPY-target rewriting.
+3. Creates `delta_stage`, `delta_map`, `delta_diff`, and `delta_ctl`.
+4. Streams data into staging with guarded COPY-target rewriting.
 5. Runs schema-drift preflight.
-6. Classifies staged rows and builds ID maps. Preview classification and preview-report SQL run inside the delta session wrapper (`20_session_begin.sql` / `21_session_end.sql`), so they use the same high-work-memory settings as staging/apply.
-7. Writes:
-   - `preview.txt`
-   - `selection.conf`
-   - `classification.out` / `classification.err` with classification stdout and timing notices
-   - `temp_stats.tsv` with before/after `pg_stat_database` temp file/byte counters around classification
-   - `preview_lines.out` / `preview_lines.err` for preview report rendering
-   - count TSVs and diagnostic SQL/stdout/stderr files
+6. Classifies staged rows and builds ID maps.
+7. Writes the operator and diagnostic artifacts.
 
-Artifacts are written under:
+`--sample-size` controls only how many rows per class appear in the *Samples* section of `preview.txt` for each table. It does not cap detail files; `--details-limit` does that.
 
-```text
-data-tool/scripts/generated/delta_restore/<UTC timestamp>/
-```
+### Validate mode
+
+Validate is the fast selection-editing loop. It requires the same target database and dump used by a preceding preview whose delta schemas are still resident. It:
+
+1. Acquires the normal advisory lock.
+2. Confirms the resident control/diff objects are complete.
+3. Hashes `--dump` and compares it with the resident `dump_sha256`.
+4. Reconstructs staged-count bindings from `delta_ctl.run_counts`.
+5. Reuses the normal bind → verify → stamp → dependency-check → selected-count workflow.
+6. Writes diagnostics in a new run directory and prints a ready-to-paste apply command.
+
+Validate does **not** read the dump TOC, restage, reclassify, prompt, or modify public tables. Its transient selection/stamp state is replaced by the next preview or apply.
+
+A valid selection exits `0`. A missing or incomplete resident run, unreadable dump, or resident/dump sha mismatch is stale/preflight state and exits `2`; rerun preview. Lock contention exits `3`. Binding, selector, or dependency errors exit `4` and retain `selection_diagnostics.tsv` or `dependency_violations.tsv`.
+
+Validate is advisory rather than the correctness gate. Local public tables can change after preview without changing the dump sha, so validate can become optimistic. Apply intentionally repeats dump verification, staging, classification, binding, stamping, and dependency checks against current local data.
 
 ### Apply mode
 
-Apply mode re-runs staging/classification fresh, stamps the requested selection, validates dependencies, and applies selected rows in one `REPEATABLE READ` transaction. It then repairs sequences, analyzes touched tables, writes `apply_summary.txt`, and drops the delta schemas unless `--keep-artifacts` is supplied.
+Apply re-runs staging and classification fresh, stamps the requested selection, validates dependencies, and applies selected rows in one `REPEATABLE READ` transaction. It repairs sequences, analyzes touched tables, writes `apply_summary.txt`, and drops the delta schemas unless `--keep-artifacts` is supplied.
 
-Apply requires `--yes` or an interactive `yes` confirmation.
+Apply requires `--yes` or an interactive `yes` confirmation. Expected-versus-affected mismatches exit `5` and roll back the transaction.
+
+### Schema and run-directory lifecycle
+
+| After… | `delta_*` schemas | Run directory |
+| --- | --- | --- |
+| Preview success | Resident | Retained |
+| Preview failure | Absent, incomplete, or resident depending on the failure stage | Retained |
+| Validate success or exit `4` | Existing resident run remains; selection state is transient | Retained |
+| Validate exit `2` | Existing state is unchanged and may be absent, incomplete, stale, or for a different dump | Retained |
+| Apply success | Dropped unless `--keep-artifacts` | Retained |
+| Apply failure (exit `4` or `5`) | Resident; public DML is rolled back | Retained |
+| `--cleanup` | Dropped | Untouched |
 
 ## Class semantics
 
 | Class | Meaning | Applyable? |
 | --- | --- | --- |
-| `NEW` | Staged row has no safe local match. For ID tables, the map records whether the dump ID can be preserved or must be reallocated. | Yes, by default |
-| `CHANGED` | Staged row matched a local row by natural key/hash but payload differs. Dump wins on apply. | Yes, by default |
-| `CHANGED_LOCAL_NEWER` | Staged row matched local row but local `last_modified` is newer. | Only when explicitly included |
-| `UNCHANGED` | Staged and local row are equivalent for compared columns. | No |
-| `LOCAL_ONLY` | Local row has no staged match. Reported as a count only. | No |
-| `BLOCKED_FK` | Required external or preserved-parent FK cannot be safely resolved. | No |
-| `BLOCKED_PARENT` | Child row depends on a preserved parent that is blocked or ambiguous. | No |
-| `AMBIGUOUS_NK` | Natural key is duplicated on staged and/or local side for an unenforced-NK table. | No |
-| `SKIPPED_ABSENT` | Table is configured but absent from the dump. | No |
+| `NEW` | No safe local match. A staged ID may be preserved or reallocated. | Yes, by default |
+| `CHANGED` | Natural-key/hash match with a different payload; dump wins. | Yes, by default |
+| `CHANGED_LOCAL_NEWER` | Local `last_modified` is newer. | Only when explicitly included |
+| `UNCHANGED` | Staged and local compared values are equivalent. | No |
+| `LOCAL_ONLY` | Local row has no staged match; count-only diagnostic. | No |
+| `BLOCKED_FK` | Required external or preserved-parent FK cannot be resolved safely. | No |
+| `BLOCKED_PARENT` | Child depends on a blocked or ambiguous preserved parent. | No |
+| `AMBIGUOUS_NK` | Natural key is duplicated for an unenforced-NK table. | No |
+| `SKIPPED_ABSENT` | Configured table is absent from the dump. | No |
 
-Natural-key matching is hash-accelerated where possible, but still keeps the null-safe natural-key residual check. This preserves existing behavior, including matches where natural-key components are `NULL`, while allowing PostgreSQL to use hashable equality for large staged/local comparisons.
+Natural-key matching is hash-accelerated while retaining the null-safe residual check. `auth_component_operation` is append-only: novel hash-parent rows can be inserted, but changed updates are not applied.
 
-`auth_component_operation` is append-only: novel hash-parent rows can be inserted; changed updates are not applied. Its `LOCAL_ONLY` count is scoped to local component rows under staged `auth_processing` parents that mapped to existing local parents; unrelated local auth-processing parents are not included in that diagnostic count.
-
-During classification the database emits grep-friendly timing notices such as:
+Classification emits grep-friendly timing notices to the console and `classification.err`:
 
 ```text
 NOTICE: delta_restore table=auth_processing phase=classify_nk_table start
 NOTICE: delta_restore table=auth_processing phase=classify_nk_table done elapsed_ms=1234.567
 ```
 
-Preview mode tees these notices to the console and saves them in `classification.err`.
+## Selection manifest and cookbook
 
-## Selection grammar
-
-Preview writes a default `selection.conf` like:
+Preview writes a concise `selection.conf`. The generated shape is:
 
 ```text
-# classes: new | changed | changed_local_newer   (others are never applyable)
-[*] include=new,changed
-[corp_processing] include=new,changed # new=12 changed=4 changed_local_newer=1
-[bar_corps] include=                  # exclude this table entirely
+# delta-selection v2
+# dump_sha256=<sha256>
+# staged bad_emails=3 mig_group=128 ...
+# ...
+# ACTIVE SELECTION
+[*]          include=new,changed
+# Default selection ([*] new,changed) currently matches 97342 rows across 9 tables (new=96105 changed=1237).
+
+[mig_batch]  include=new,changed # new=3 changed=2 changed_local_newer=0 parents=mig_group
+# ...
+
+# Small NEW sets receive ready-to-uncomment suggestions:
+
+# [bad_emails] Exact NEW set: rows=14 singletons=4 ranges=3
+# [bad_emails] new.rows include=id:101-104,200-203
+#   Range counts: 101-104 (4 rows), 200-203 (4 rows)
+# [bad_emails] new.rows include=id:300-301
+#   Range counts: 300-301 (2 rows)
+
+# [bad_emails] new.rows include=id:401,500,700
+# [bad_emails] new.rows include=id:900
+
+# Small CHANGED sets receive ready-to-uncomment suggestions:
+
+# [mig_batch] Exact CHANGED set: rows=3 singletons=1 ranges=1
+# [mig_batch] changed.rows include=row:150-151
+#   Range counts: 150-151 (2 rows)
+
+# [mig_batch] changed.rows include=row:160
+
+# Large CHANGED sets receive a useful pointer rather than no guidance:
+# corp_processing has 4812 CHANGED rows; choose selector_id or corp values from:
+# details/corp_processing.changed.tsv
+# Example syntax:
+# [corp_processing] changed.rows include=id:100,200-210
+# [corp_processing] changed.rows include=corp:BC0000001,BC0000002
+
+# Full selector grammar and 13 worked examples: selection_cookbook.txt (this run dir)
 ```
 
-Precedence:
+Operator cues:
 
-1. `--selection-file <path>`
-2. `--include-classes` / `--exclude-classes`
-3. Default `new,changed`
+- The blast-radius comment immediately after `[*]` totals the default-selected NEW and CHANGED rows before any edit.
+- A per-table `parents=` suffix lists preserved parents. A selected NEW child whose preserved parent is also NEW requires that parent row to remain selected.
+- By default, sets of 1–50 NEW or CHANGED rows receive exact commented `id:` or `row:` suggestions; the limit is inclusive and applies independently to each table/class set. The summary reports total rows, isolated singleton values, and consecutive ranges (a range counts as one run, not as its number of rows).
+- Actual blank lines separate table blocks and, for mixed sets, separate the range selectors from singleton selectors. A range selector always remains directly adjacent to its `Range counts` comment.
+- Long categories wrap at a soft maximum of 120 characters. Every wrapped line repeats the complete `[table] class.rows include=kind:` prefix, no token is split, and an indivisible prefix-plus-token may exceed the soft maximum. Singleton lists producing more than eight selector lines receive another actual blank line after every four lines for visual grouping. There is no continuation syntax.
+- Repeated complete `include=` lines are unioned by the existing selector semantics. Uncomment every suggested line to select the entire summarized exact set; uncommenting only some lines deliberately selects only that subset.
+- Sets above the resolved limit receive a pointer to the corresponding canonical TSV and table-aware examples. Set `--selector-suggestion-limit 0` to make every positive NEW/CHANGED set use this generic guidance.
+- `CHANGED_LOCAL_NEWER` never receives ready-to-uncomment guidance because overwriting newer local values must stay deliberate.
+- `selection_cookbook.txt` holds the complete, commented grammar/examples; it is generated with the manifest so the two cannot drift.
 
-Examples:
+The three preview-output controls are independent: `--sample-size` affects only `preview.txt` samples, `--details-limit` caps detail TSV/TXT artifacts, and `--selector-suggestion-limit` controls only commented manifest assistance. A generic pointer can therefore refer to a detail file truncated by a lower `--details-limit`; the full staged data remains queryable. Changing the selector-suggestion limit never changes active selection or apply behavior.
+
+To generate a conservative manifest that selects nothing until explicitly edited:
 
 ```bash
-# Apply only NEW rows for all preserved tables.
-./delta_restore_extract.sh --dump keep.dump --mode apply --include-classes new --yes
-
-# Apply default classes except CHANGED rows.
-./delta_restore_extract.sh --dump keep.dump --mode apply --exclude-classes changed --yes
-
-# Only stamp corp-bearing rows for listed corps. Parent lookup tables are not restricted.
-./delta_restore_extract.sh --dump keep.dump --mode apply --only-corps corps.txt --yes
+./delta_restore_extract.sh \
+  --dump keep.dump \
+  --mode preview \
+  --manifest-default none
 ```
 
-`--tables a,b,c` narrows the default/CLI selection set. Staging and classification still run for the full preserved set so parent maps exist.
+This emits empty wildcard and per-table `include=` rules plus a zero-row blast-radius total. The default remains `new,changed` for compatibility.
 
-## Blocked-row remediation
+### Row-selector grammar
 
-If apply exits with code `4`, inspect the run artifacts and the database diagnostics before retrying:
+Class-only v1 files remain valid and do not require binding headers. Optional row lines use:
+
+```text
+[table] <class>.rows <include|exclude>=<kind>:<values>
+```
+
+- Classes are `new`, `changed`, or `changed_local_newer`; the class must also be enabled by a class line.
+- `id:` selects non-negative staged primary-key integers and inclusive ranges.
+- `row:` selects staging ordinals for PK-less tables with the same bigint grammar.
+- `corp:` selects exact identifiers on corp-bearing tables.
+- Multiple include lines union their matches; excludes subtract afterward.
+- With excludes only, the enabled class remains selected except for matching rows.
+- `--only-corps` is a final intersection and never widens selection.
+
+> **`id:` values are staged (dump) primary keys** — the `selector_id` column in `details/<table>.new.tsv` / `.changed.tsv` and the `id …` shown in preview samples. They are never local-database IDs. When a staged ID collides with an unrelated local row, apply allocates a fresh local ID; the selector still refers to the staged value you reviewed.
+
+Example:
+
+```text
+[*] include=new,changed
+[mig_batch] include=new,changed
+[mig_corp_account] include=new,changed
+[mig_corp_account] new.rows exclude=id:23
+[corp_processing] include=new,changed
+[corp_processing] changed.rows include=corp:BC0000001,BC0000002
+```
+
+### Binding and validation
+
+The dump sha256 is computed for every run. Any file containing a `.rows` line must retain the generated `# dump_sha256=` header. A `row:` selector also requires the generated staged-count binding for that table. Duplicate hash headers, duplicate table counts, non-decimal counts, and binding mismatches exit `4`.
+
+Every selector must match at least one classified row after the `--only-corps` intersection. Unsupported selector kinds, selectors on disabled classes, duplicate staged primary keys, zero matches, and scalar multi-matches exit `4` with line-numbered entries in `selection_diagnostics.tsv`. Parent dependency failures are written to `dependency_violations.tsv`, including up to ten child selector IDs.
+
+Use validate repeatedly while editing:
+
+```bash
+./delta_restore_extract.sh --dump keep.dump --mode validate \
+  --selection-file my_selection.conf
+```
+
+A selection file supplies the authored candidate set. Explicit CLI filters are then enforced as a hard ceiling:
+
+1. `--tables a,b,c` removes every candidate from other tables.
+2. A supplied `--include-classes` removes candidates outside those classes.
+3. `--exclude-classes` removes its classes after the include ceiling.
+4. Row selectors and `--only-corps` can narrow the remaining candidates but never widen them.
+
+With no selection file, the default candidate classes remain `new,changed` unless `--include-classes` changes them. With a selection file and no explicit table/class filters, the file retains its previous full authoring behavior. A generated `selection.conf` remains a full preserved-set review artifact, so after a filtered preview use the printed validate command: it carries the same filters, and validate/apply cannot re-enable file entries outside that scope. Staging and classification still use the full preserved set so parent maps exist.
+
+## CLI and environment reference
+
+### Flags
+
+| Flag | Argument | Default | Effect and details |
+| --- | --- | --- | --- |
+| `--dump` | `<path>` | `DUMP`; otherwise required | Uses the named `pg_dump -Fc` archive for preview, validate, or apply. |
+| `--mode` | `preview\|validate\|apply` | `preview` | Chooses staging/reporting, fast resident selection validation, or transactional apply; see [Modes](#modes-preview-validate-apply). |
+| `--tables` | `all\|<csv>` | `all` | Hard selection ceiling, including with `--selection-file`; staging and classification still use every preserved table so parent maps exist. |
+| `--include-classes` | `<csv>` | None | When supplied, limits candidates to these classes even with `--selection-file`; otherwise a file chooses its own classes. |
+| `--exclude-classes` | `<csv>` | None | Removes classes after selection-file/include processing and cannot widen selection. |
+| `--selection-file` | `<path>` | None | Supplies generated/edited candidates for validate or apply; explicit table/class filters remain a hard ceiling, and row selections retain their bindings. |
+| `--only-corps` | `<path>` | None | Intersects selected corp-bearing rows with identifiers from the file and never widens selection; parent lookup tables are not restricted. |
+| `--sample-size` | `<n>` | `20` | Sets rows per class in each table's `preview.txt` *Samples* section. It affects `preview.txt` only; the detail TSV/TXT row cap is `--details-limit`. |
+| `--details-limit` | `<n>` | `10000` | Caps rows per table/class detail artifact. Full totals remain in `preview.txt` and `TRUNCATED` markers identify capped output. |
+| `--selector-suggestion-limit` | `<n>` | `50` | Controls exact commented selector ranges independently for each NEW/CHANGED table-class set. Accepts decimal integers `0..100000` inclusive; `0` makes every positive set use generic TSV guidance. This is CLI-only and does not alter active selection. |
+| `--no-aligned-details` | — | Aligned `.txt` enabled | Suppresses derived fixed-width `.txt` companions; canonical TSVs are still written. |
+| `--align-width` | `<n>` | `40`; floor `6` | Sets the maximum aligned-detail cell width; values 1–5 are raised to 6. |
+| `--manifest-default` | `new,changed\|none` | `new,changed` | Chooses the generated manifest's active wildcard selection; see the [conservative manifest example](#selection-manifest-and-cookbook). |
+| `--report-dir` | `<dir>` | `data-tool/scripts/generated/delta_restore` | Changes the base directory under which the UTC timestamped run directory is created. |
+| `--keep-artifacts` | — | Off | Retains `delta_*` schemas after a successful apply; run-directory files are retained regardless. |
+| `--yes` | — | Off | Skips the interactive `yes` confirmation for apply. |
+| `--cleanup` | — | Off | Drops `delta_stage`, `delta_map`, `delta_diff`, and `delta_ctl`, then exits; run directories are untouched. |
+| `-h`, `--help` | — | — | Prints usage, flags, exit codes, environment settings, and artifact handoff lines. |
+
+### Environment variables
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `PGHOST` | `localhost` | PostgreSQL server host used by libpq clients. |
+| `PGPORT` | `5432` | PostgreSQL server port. |
+| `PGUSER` | `postgres` | PostgreSQL user. |
+| `PGDATABASE` | `colin-mig-corps-test` | Target database. |
+| `PGPASSWORD` / `.pgpass` | None | Optional libpq password source. Prefer `.pgpass` where appropriate. |
+| `PG_BIN` | Unset or empty (`PATH`) | Optional directory containing PostgreSQL client tools. A nonempty value resolves clients from that directory. |
+| `DUMP` | Empty | Alternative to `--dump`; the CLI flag replaces it. |
+| `LOCK_TIMEOUT_SECONDS` | `30` | Seconds to wait for the shared subset/full-refresh advisory lock before exit `3`. |
+
+## Detail artifacts and viewing
+
+Only interesting classes generate detail files; `UNCHANGED` and `LOCAL_ONLY` do not. The TSV is canonical and remains grep/awk/spreadsheet-importable. The `.txt` file is derived from it, is never parsed by validate/apply, and can be regenerated; if the two ever disagree, trust the TSV.
+
+The aligned companion preserves the TSV's visible COPY escapes rather than unescaping data. It uses a per-cell width of 40 by default, a minimum of 6, a two-space gutter, and a clipped `…` marker. Change the cap with `--align-width <n>` or disable companions with `--no-aligned-details`.
+
+Each aligned file ends with a footer such as:
+
+```text
+# rendered 812 of 812 CHANGED rows
+# rendered 10000 of 97105 NEW rows — TRUNCATED
+```
+
+Canonical truncated TSVs end with `# TRUNCATED at <n> rows`; `preview.txt` repeats rendered/total values and `(TRUNCATED)`. Values use COPY-style tab/newline/backslash escaping and are capped at 8 KiB. Rows are ordered by staged primary key and then staging ordinal. For PK-less CHANGED rows, local display uses the classification-time `ctid`.
+
+Viewing options:
+
+- Double-click/open `details/<table>.<class>.txt` in a text editor and turn off word wrap.
+- Use `column -s $'\t' -t < details/<table>.<class>.tsv | less -S`.
+- Import the canonical TSV into a spreadsheet.
+- Query the resident staged run directly for large or targeted reviews.
+
+## Querying the staged run directly
+
+Preview leaves the delta schemas installed. Run these recipes against the same target database before cleanup or a successful apply without `--keep-artifacts`.
+
+Filter NEW `corp_processing` rows by corporation prefix:
 
 ```sql
+SELECT s.*
+FROM delta_diff.corp_processing_class AS d
+JOIN delta_stage.corp_processing AS s USING (_delta_row_id)
+WHERE d.class = 'NEW'
+  AND s.corp_num LIKE 'BC08%'
+ORDER BY d.staged_pk NULLS LAST, d._delta_row_id;
+```
+
+List changed columns for one staged row:
+
+```sql
+SELECT d.staged_pk, d._delta_row_id, changed.column_name
+FROM delta_diff.corp_processing_class AS d
+CROSS JOIN LATERAL unnest(d.changed_cols) AS changed(column_name)
+WHERE d.class IN ('CHANGED', 'CHANGED_LOCAL_NEWER')
+  AND d.staged_pk = 881
+ORDER BY changed.column_name;
+```
+
+Count blocking reasons for one table:
+
+```sql
+SELECT d.class, d.block_reason, count(*) AS rows
+FROM delta_diff.corp_processing_class AS d
+WHERE d.class IN ('BLOCKED_FK', 'BLOCKED_PARENT', 'AMBIGUOUS_NK')
+GROUP BY d.class, d.block_reason
+ORDER BY d.class, rows DESC;
+```
+
+For cross-table totals, query `delta_ctl.run_counts`:
+
+```sql
+SELECT table_name, count_name, row_count
+FROM delta_ctl.run_counts
+WHERE count_name IN ('NEW', 'CHANGED', 'CHANGED_LOCAL_NEWER',
+                     'BLOCKED_FK', 'BLOCKED_PARENT', 'AMBIGUOUS_NK')
+ORDER BY table_name, count_name;
+```
+
+## Troubleshooting by exit code
+
+Use the final `Artifacts:` or `Artifacts retained for inspection:` line to find the run directory named below.
+
+### Exit 0: successful run
+
+**Symptom:** The command completed successfully.
+
+**Read:** For preview, read `preview.txt` and copy `selection.conf`. For validate, use the printed ready-to-paste apply command. For apply, read `apply_summary.txt` and confirm `expected` equals `affected`.
+
+**Next step:** Continue at the corresponding next step in the [Golden path](#golden-path-merge-a-delta-dump-end-to-end). No remediation is required.
+
+### Exit 2: preflight, drift, dump, or stale-preview failure
+
+**Symptom:** Preflight rejected schema drift, an unreadable/corrupt dump, a manifest sha mismatch, or validate found no complete resident preview matching the dump.
+
+**Read:** Start with console stderr and the retained run directory. Check `dump.sha256` and any copied `dump.manifest.json`, `toc.list`/TOC errors, `drift_dump_only.tsv`, and `drift_local_required.tsv` as applicable.
+
+**Remediation:** Fix the connection or input, apply the current DDL when the dump contains newer columns, regenerate the dump when it lacks required columns, or restore the matching dump/manifest pair. Then rerun preview; validate cannot repair stale or missing resident state.
+
+### Exit 3: advisory lock busy or unavailable
+
+**Symptom:** The shared subset/full-refresh advisory lock was not acquired within `LOCK_TIMEOUT_SECONDS`.
+
+**Read:** Read console stderr and `advisory_lock.err` in the retained run directory to distinguish contention from a connection/lock error.
+
+**Remediation:** Let the cooperating subset/full-refresh/delta operation finish, or investigate an unexpected holder before retrying. Increase `LOCK_TIMEOUT_SECONDS` only when a longer wait is appropriate; its default is 30 seconds.
+
+### Exit 4: invalid selection, binding, or dependency
+
+If validate or apply exits `4`, inspect the run artifacts and resident diagnostics:
+
+```sql
+SELECT * FROM delta_ctl.selection_diagnostics WHERE problem IS NOT NULL;
 SELECT * FROM delta_ctl.dependency_violations;
-SELECT table_name, count_name, row_count FROM delta_ctl.run_counts
+SELECT table_name, count_name, row_count
+FROM delta_ctl.run_counts
 WHERE count_name IN ('BLOCKED_FK', 'BLOCKED_PARENT', 'AMBIGUOUS_NK')
 ORDER BY table_name, count_name;
 ```
 
 Common remediations:
 
-- Include a required preserved parent class in `selection.conf`, or exclude the child class.
-- Load/refresh missing external `corporation` or `event` rows before applying.
-- Resolve duplicated natural keys in local data, or leave those rows unapplied.
+- Include the required preserved parent, or exclude the selected child.
+- Load/refresh missing external `corporation` or `event` rows.
+- Resolve duplicated natural keys locally, or leave ambiguous rows unapplied.
 - Regenerate the dump if a configured table was unintentionally absent.
+- Rerun preview if validate reports absent, incomplete, or stale resident state.
 
-## Recovery and cleanup
+The file equivalents are `selection_diagnostics.tsv`, `dependency_violations.tsv`, and `selected_counts.tsv` in the retained run directory. Edit the copied selection—not the generated `selection.conf`—then validate again.
 
-- Staging failures do not modify public tables.
-- Apply failures inside the transaction roll back all public-table DML.
-- Successful apply drops `delta_*` schemas unless `--keep-artifacts` is used.
-- Interrupted or retained runs can be cleaned with:
+### Exit 5: apply verification failed
 
-```bash
-./delta_restore_extract.sh --cleanup
+**Symptom:** `APPLY_VERIFICATION_FAILED` means an expected count differed from its affected count, or a selected NEW row had no allocated local ID. The transaction rolled back, so **no public data changed**; the `delta_*` schemas and run directory are retained.
+
+**Read:** Start with `apply_transaction.err`, which durably records the table/class and expected/affected counts. The failed transaction also rolls back its writes to `delta_ctl.apply_counts`, so that table is not a post-failure count diagnostic. For a missing-ID failure, use this read-only resident query, replacing `<table>` with the table named by the error:
+
+```sql
+-- disposition of every selected NEW row that would insert without an ID:
+SELECT s.id AS staged_id, d.class, d.selected, m.local_id, m.disposition
+FROM delta_stage.<table> s
+JOIN delta_diff.<table>_class d USING (_delta_row_id)
+LEFT JOIN delta_map.<table>_id_map m ON m.staged_id = s.id
+WHERE d.selected AND d.class = 'NEW' AND m.local_id IS NULL;
 ```
 
-## Advisory lock and concurrency
+**Remediation:** Do not hand-edit `delta_map` or staged rows. Capture the error and query output, run `--cleanup`, address the underlying cause, and rerun from preview. If `disposition = 'NEW_REALLOCATED'` with `local_id IS NULL`, verify the target table's ID sequence is discoverable through `pg_get_serial_sequence()`. The current DDL associates sequences with `ALTER SEQUENCE … OWNED BY`; databases created from older DDL may need that association applied.
 
-Delta restore uses the same PostgreSQL advisory-lock SQL as the subset/full-refresh scripts. This protects against cooperating maintenance scripts, but it does not stop unrelated app or migration-flow sessions. Avoid running migration flows against the target database during apply.
+## Recovery, cleanup, and concurrency
 
-## DELTA_MODE removal
+Use the [schema lifecycle table](#schema-and-run-directory-lifecycle) to determine whether resident state should exist. Staging failures do not modify public tables, and apply failures inside the transaction roll back all public-table DML. Run directories are retained regardless of schema cleanup.
 
-`DELTA_MODE=true ./restore_extract.sh` is intentionally unsupported. The full restore script aborts with a pointer to `data-tool/delta_restore_extract.sh` rather than running the old prototype branch or silently truncating. Use explicit preview/apply commands instead.
+Delta restore uses the same PostgreSQL advisory lock as the subset/full-refresh scripts. This protects against cooperating maintenance scripts, not unrelated application or migration-flow sessions. Avoid non-cooperating writers during apply.
+
+After capturing any diagnostics, clean up resident schemas with:
+
+```bash
+PGDATABASE=local_extract ./delta_restore_extract.sh --cleanup
+```
+
+## DELTA_MODE removal and restore_extract.sh delegation
+
+`DELTA_MODE=true ./restore_extract.sh` is intentionally unsupported and aborts with a pointer to `data-tool/delta_restore_extract.sh`. For CLI compatibility, `restore_extract.sh --delta <delta-arguments>` delegates directly to `delta_restore_extract.sh` after removing `--delta`. Prefer explicit preview, validate, and apply commands in operator runbooks.
 
 ## Exit codes
 
-| Code | Meaning |
+| Code | Meaning and troubleshooting |
 | --- | --- |
-| `0` | Success |
-| `2` | Preflight/schema drift/corrupt dump |
-| `3` | Advisory lock busy/unavailable |
-| `4` | Selection/dependency invalid |
-| `5` | Apply verification failed; transaction rolled back |
+| `0` | Preview/apply succeeded, or validate found the selection valid. [Next steps](#exit-0-successful-run). |
+| `2` | Preflight/schema drift/corrupt or unreadable dump; for validate, no complete matching resident preview. [Troubleshoot exit 2](#exit-2-preflight-drift-dump-or-stale-preview-failure). |
+| `3` | Advisory lock busy or unavailable. [Troubleshoot exit 3](#exit-3-advisory-lock-busy-or-unavailable). |
+| `4` | Selection binding, selector, or dependency invalid. [Troubleshoot exit 4](#exit-4-invalid-selection-binding-or-dependency). |
+| `5` | Apply verification failed; transaction rolled back. [Troubleshoot exit 5](#exit-5-apply-verification-failed). |
 
 ## Tests
 
-Run the lightweight harness from the repo root or `data-tool`:
+Run the broad harness from the repo root:
 
 ```bash
 make -C data-tool test-delta-restore
-# or
-data-tool/tests/delta_restore/run_tests.sh
+data-tool/tests/delta_restore/run_tests.sh --integration
 ```
 
-The harness always runs shell/AWK static checks. PostgreSQL-backed compile/smoke scenarios run only when local `createdb`, `dropdb`, `psql`, `pg_dump`, and `pg_restore` are available and reachable with the current libpq environment.
+The always-on static suite covers shell syntax, guarded COPY rewriting, aligned rendering and footer semantics, CLI validation, manifest plumbing, v1/v2 parsing, bindings, and the validate/apply orchestration boundary. PostgreSQL smoke tests cover classification, performance, selection stamping, diagnostics, dependencies, unchanged TSV renderers, manifest structure (T16), and the exact cookbook (T17). Integration covers backup → preview → valid/invalid validate without restaging → apply, private artifacts, real detail truncation/counts, and dump-hash rejection.
+
+PostgreSQL-backed checks are skipped only when the required local tools or server are unavailable. See `docs/plans/delta_restore_extract_test_plan.md` for the matrix and deferred manual checks.

--- a/data-tool/scripts/restore/delta/00_install.sql
+++ b/data-tool/scripts/restore/delta/00_install.sql
@@ -62,6 +62,35 @@ CREATE TABLE delta_ctl.selection (
   PRIMARY KEY (table_name, class)
 );
 
+CREATE TABLE delta_ctl.row_selection (
+  table_name text NOT NULL,
+  class text NOT NULL,
+  mode text NOT NULL CHECK (mode IN ('include', 'exclude')),
+  kind text NOT NULL CHECK (kind IN ('id', 'row', 'corp')),
+  value_from bigint,
+  value_to bigint,
+  corp_num text,
+  is_range boolean NOT NULL DEFAULT false,
+  source_line int NOT NULL,
+  CHECK (
+    (kind IN ('id', 'row') AND value_from IS NOT NULL AND value_to IS NOT NULL AND corp_num IS NULL)
+    OR (kind = 'corp' AND value_from IS NULL AND value_to IS NULL AND corp_num IS NOT NULL)
+  )
+);
+CREATE INDEX row_selection_lookup_idx
+  ON delta_ctl.row_selection (table_name, class, mode, kind);
+
+CREATE TABLE delta_ctl.selection_diagnostics (
+  table_name text,
+  class text,
+  mode text,
+  kind text,
+  selector text,
+  source_line int,
+  matched bigint,
+  problem text
+);
+
 CREATE TABLE delta_ctl.only_corps (
   corp_num text PRIMARY KEY
 );
@@ -70,7 +99,8 @@ CREATE TABLE delta_ctl.dependency_violations (
   child_table text NOT NULL,
   parent_table text NOT NULL,
   reason text NOT NULL,
-  row_count bigint NOT NULL
+  row_count bigint NOT NULL,
+  sample_ids text
 );
 
 CREATE TABLE delta_ctl.apply_counts (

--- a/data-tool/scripts/restore/delta/10_functions.sql
+++ b/data-tool/scripts/restore/delta/10_functions.sql
@@ -108,6 +108,18 @@ LANGUAGE sql
 IMMUTABLE PARALLEL SAFE
 AS $$ SELECT 'table' $$;
 
+CREATE OR REPLACE FUNCTION delta_ctl.class_header()
+RETURNS text
+LANGUAGE sql
+IMMUTABLE PARALLEL SAFE
+AS $$ SELECT 'class' $$;
+
+CREATE OR REPLACE FUNCTION delta_ctl.truncated_rows_marker(p_limit integer)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT format('# TRUNCATED at %s rows', p_limit) $$;
+
 CREATE OR REPLACE FUNCTION delta_ctl.parent_table_kind()
 RETURNS text
 LANGUAGE sql
@@ -1378,39 +1390,318 @@ LEFT JOIN delta_ctl.table_config tc ON tc.table_name = rc.table_name
 ORDER BY tc.load_phase ASC NULLS LAST, rc.table_name ASC, rc.count_name ASC;
 $$;
 
+CREATE OR REPLACE FUNCTION delta_ctl.tsv_escape(p_value text, p_max_len int DEFAULT 8192)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE PARALLEL SAFE
+AS $$
+SELECT CASE
+  WHEN p_value IS NULL THEN E'\\N'
+  ELSE regexp_replace(
+    replace(replace(replace(replace(replace(
+      CASE WHEN length(p_value) > GREATEST(p_max_len, 1)
+        THEN left(p_value, GREATEST(p_max_len, 1)) || '…[truncated]'
+        ELSE p_value END,
+      E'\\', E'\\\\'), E'\t', E'\\t'), E'\n', E'\\n'), E'\r', E'\\r'), chr(27), '␛'),
+    '[[:cntrl:]]', '�', 'g')
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION delta_ctl.display_text(p_value text, p_max_len int DEFAULT 60)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE PARALLEL SAFE
+AS $$
+DECLARE
+  v_value text;
+BEGIN
+  IF p_value IS NULL THEN
+    RETURN 'NULL';
+  END IF;
+  v_value := replace(replace(replace(replace(
+    p_value, E'\n', '␤'), E'\t', '␉'), E'\r', '␍'), chr(27), '␛');
+  v_value := regexp_replace(v_value, '[[:cntrl:]]', '�', 'g');
+  IF length(v_value) > GREATEST(p_max_len, 1) THEN
+    v_value := left(v_value, GREATEST(p_max_len, 1)) || '…';
+  END IF;
+  RETURN v_value;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION delta_ctl.display_value(p_row jsonb, p_col text, p_max_len int DEFAULT 60)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE PARALLEL SAFE
+AS $$
+BEGIN
+  IF p_row IS NULL OR NOT (p_row ? p_col) OR p_row -> p_col = 'null'::jsonb THEN
+    RETURN 'NULL';
+  END IF;
+  RETURN delta_ctl.display_text(COALESCE(p_row ->> p_col, ''), p_max_len);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION delta_ctl.display_columns(p_table text)
+RETURNS text[]
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_cfg delta_ctl.table_config%ROWTYPE;
+  v_cols text[];
+  v_expr text;
+  v_match text[];
+BEGIN
+  SELECT * INTO v_cfg FROM delta_ctl.table_config WHERE table_name = p_table;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'missing table_config row for %', p_table;
+  END IF;
+  IF array_length(v_cfg.nk_cols, 1) IS NOT NULL THEN
+    RETURN v_cfg.nk_cols;
+  END IF;
+  FOREACH v_expr IN ARRAY v_cfg.nk_stage_exprs LOOP
+    v_match := regexp_match(v_expr, '^s\\.([a-z_][a-z0-9_]*)$');
+    IF v_match IS NOT NULL AND NOT (v_match[1] = ANY(COALESCE(v_cols, '{}'))) THEN
+      v_cols := COALESCE(v_cols, '{}') || v_match[1];
+    END IF;
+  END LOOP;
+  IF array_length(v_cols, 1) IS NOT NULL THEN
+    RETURN v_cols;
+  END IF;
+  SELECT COALESCE(array_agg(attname ORDER BY attnum), '{}') INTO v_cols
+  FROM (
+    SELECT a.attname, a.attnum
+    FROM pg_attribute a
+    WHERE a.attrelid = delta_ctl.public_rel(p_table)::regclass
+      AND a.attnum > 0 AND NOT a.attisdropped
+      AND (v_cfg.pk_col IS NULL OR a.attname <> v_cfg.pk_col)
+    ORDER BY a.attnum
+    LIMIT 3
+  ) q;
+  RETURN v_cols;
+END;
+$$;
+
 CREATE OR REPLACE FUNCTION delta_ctl.render_samples(p_table text, p_class text, p_limit int DEFAULT 20)
 RETURNS SETOF text
 LANGUAGE plpgsql
 AS $$
 DECLARE
   r record;
+  v_cfg delta_ctl.table_config%ROWTYPE;
   v_sql text;
+  v_local_join text;
+  v_col text;
+  v_cols text[];
+  v_values text;
+  v_line text;
+  v_changed_count int;
   v_limit int := GREATEST(COALESCE(p_limit, 20), 0);
 BEGIN
   PERFORM delta_ctl.assert_table_name(p_table);
-  IF v_limit = 0 OR to_regclass(format('delta_diff.%I', delta_ctl.class_table_name(p_table))) IS NULL THEN
+  SELECT * INTO v_cfg FROM delta_ctl.table_config WHERE table_name = p_table;
+  IF v_limit = 0 OR NOT FOUND
+     OR to_regclass(format('delta_diff.%I', delta_ctl.class_table_name(p_table))) IS NULL THEN -- NOSONAR
     RETURN;
   END IF;
 
+  v_cols := delta_ctl.display_columns(p_table);
+  v_local_join := CASE
+    WHEN v_cfg.pk_col IS NULL THEN 'LEFT JOIN public.' || quote_ident(p_table) || ' l ON l.ctid = d.local_ctid'
+    ELSE format('LEFT JOIN public.%I l ON l.%I = d.local_pk', p_table, v_cfg.pk_col)
+  END;
   v_sql := format($fmt$
-    SELECT _delta_row_id, staged_pk, local_pk, class, changed_cols, block_reason, parent_pending
-    FROM delta_diff.%I
-    WHERE class = $1
-    ORDER BY _delta_row_id
+    SELECT d._delta_row_id, d.staged_pk, d.local_pk, d.changed_cols,
+           d.block_reason, d.parent_pending, to_jsonb(s) AS staged_json,
+           to_jsonb(l) AS local_json
+    FROM delta_diff.%I d
+    JOIN delta_stage.%I s ON s._delta_row_id = d._delta_row_id
+    %s
+    WHERE d.class = $1
+    ORDER BY d.staged_pk NULLS LAST, d._delta_row_id
     LIMIT $2
-  $fmt$, delta_ctl.class_table_name(p_table));
+  $fmt$, delta_ctl.class_table_name(p_table), p_table, v_local_join);
 
   FOR r IN EXECUTE v_sql USING p_class, v_limit LOOP
-    RETURN NEXT format('▸ staged row %s · staged id %s · local id %s%s%s',
+    v_values := '';
+    FOREACH v_col IN ARRAY v_cols LOOP
+      v_values := v_values || format(' · %s=%s', v_col,
+        delta_ctl.display_value(r.staged_json, v_col, 40));
+    END LOOP;
+    v_line := format('▸ %s%srow %s%s%s',
+      CASE WHEN v_cfg.pk_col IS NOT NULL THEN format('id %s · ', COALESCE(r.staged_pk::text, '—')) ELSE '' END,
+      '',
       r._delta_row_id,
-      COALESCE(r.staged_pk::text, '—'),
-      COALESCE(r.local_pk::text, '—'),
-      CASE WHEN r.parent_pending THEN ' · parent pending' ELSE '' END,
-      CASE WHEN r.block_reason IS NOT NULL THEN ' · ' || r.block_reason ELSE '' END);
-    IF r.changed_cols IS NOT NULL AND array_length(r.changed_cols, 1) IS NOT NULL THEN
-      RETURN NEXT format('    changed: %s', array_to_string(r.changed_cols, ', '));
+      v_values,
+      CASE WHEN r.parent_pending THEN ' · parent pending' ELSE '' END
+        || CASE WHEN r.block_reason IS NOT NULL
+             THEN ' · ' || delta_ctl.display_text(r.block_reason, 80) ELSE '' END);
+    IF length(v_line) > 220 THEN
+      v_line := left(v_line, 219) || '…';
+    END IF;
+    RETURN NEXT v_line;
+    IF r.changed_cols IS NOT NULL THEN
+      v_changed_count := 0;
+      FOREACH v_col IN ARRAY r.changed_cols LOOP
+        EXIT WHEN v_changed_count >= 5;
+        RETURN NEXT format('    changed %s: %s → %s', v_col,
+          delta_ctl.display_value(r.local_json, v_col, 60),
+          delta_ctl.display_value(r.staged_json, v_col, 60));
+        v_changed_count := v_changed_count + 1;
+      END LOOP;
     END IF;
   END LOOP;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION delta_ctl.render_new_rows_tsv(p_table text, p_limit int DEFAULT 10000)
+RETURNS SETOF text
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_cfg delta_ctl.table_config%ROWTYPE;
+  v_cols text[];
+  v_col text;
+  v_sql text;
+  v_line text;
+  r record;
+  v_limit int := GREATEST(COALESCE(p_limit, 10000), 0);
+BEGIN
+  PERFORM delta_ctl.assert_table_name(p_table);
+  SELECT * INTO v_cfg FROM delta_ctl.table_config WHERE table_name = p_table;
+  IF NOT FOUND OR NOT delta_ctl.stage_table_exists(p_table) THEN RETURN; END IF;
+  SELECT array_agg(a.attname ORDER BY a.attnum) INTO v_cols
+  FROM pg_attribute a
+  WHERE a.attrelid = delta_ctl.public_rel(p_table)::regclass
+    AND a.attnum > 0 AND NOT a.attisdropped;
+  RETURN NEXT 'selector_id' || E'\t' || 'delta_row_id' || E'\t' || array_to_string(v_cols, E'\t'); -- NOSONAR
+  v_sql := format($fmt$
+    SELECT d.staged_pk, d._delta_row_id, to_jsonb(s) AS staged_json
+    FROM delta_diff.%I d
+    JOIN delta_stage.%I s ON s._delta_row_id = d._delta_row_id
+    WHERE d.class = 'NEW'
+    ORDER BY d.staged_pk NULLS LAST, d._delta_row_id
+    LIMIT $1
+  $fmt$, delta_ctl.class_table_name(p_table), p_table);
+  FOR r IN EXECUTE v_sql USING v_limit LOOP
+    v_line := delta_ctl.tsv_escape(COALESCE(r.staged_pk, r._delta_row_id)::text)
+      || E'\t' || r._delta_row_id::text;
+    FOREACH v_col IN ARRAY v_cols LOOP
+      v_line := v_line || E'\t' || delta_ctl.tsv_escape(r.staged_json ->> v_col);
+    END LOOP;
+    RETURN NEXT v_line;
+  END LOOP;
+  IF (SELECT row_count FROM delta_ctl.run_counts
+      WHERE table_name = p_table AND count_name = 'NEW') > v_limit THEN
+    RETURN NEXT delta_ctl.truncated_rows_marker(v_limit);
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION delta_ctl.render_changed_rows_tsv(p_table text, p_limit int DEFAULT 10000)
+RETURNS SETOF text
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_cfg delta_ctl.table_config%ROWTYPE;
+  v_local_join text;
+  v_sql text;
+  v_col text;
+  r record;
+  v_limit int := GREATEST(COALESCE(p_limit, 10000), 0);
+BEGIN
+  PERFORM delta_ctl.assert_table_name(p_table);
+  SELECT * INTO v_cfg FROM delta_ctl.table_config WHERE table_name = p_table;
+  IF NOT FOUND OR NOT delta_ctl.stage_table_exists(p_table) THEN RETURN; END IF;
+  RETURN NEXT 'selector_id' || E'\t' || 'delta_row_id' || E'\t' || 'local_pk' -- NOSONAR
+    || E'\t' || delta_ctl.class_header() || E'\t' || 'column' || E'\t' || 'local_value' || E'\t' || 'dump_value';
+  v_local_join := CASE
+    WHEN v_cfg.pk_col IS NULL THEN format('JOIN public.%I l ON l.ctid = d.local_ctid', p_table)
+    ELSE format('JOIN public.%I l ON l.%I = d.local_pk', p_table, v_cfg.pk_col)
+  END;
+  v_sql := format($fmt$
+    WITH ranked AS (
+      SELECT d.staged_pk, d._delta_row_id, d.local_pk, d.class, d.changed_cols,
+             to_jsonb(s) AS staged_json, to_jsonb(l) AS local_json,
+             row_number() OVER (
+               PARTITION BY d.class ORDER BY d.staged_pk NULLS LAST, d._delta_row_id
+             ) AS class_row_number
+      FROM delta_diff.%I d
+      JOIN delta_stage.%I s ON s._delta_row_id = d._delta_row_id
+      %s
+      WHERE d.class IN ('CHANGED', 'CHANGED_LOCAL_NEWER')
+    )
+    SELECT staged_pk, _delta_row_id, local_pk, class, changed_cols, staged_json, local_json
+    FROM ranked
+    WHERE class_row_number <= $1
+    ORDER BY staged_pk NULLS LAST, _delta_row_id
+  $fmt$, delta_ctl.class_table_name(p_table), p_table, v_local_join);
+  FOR r IN EXECUTE v_sql USING v_limit LOOP
+    FOREACH v_col IN ARRAY COALESCE(r.changed_cols, '{}') LOOP
+      RETURN NEXT delta_ctl.tsv_escape(COALESCE(r.staged_pk, r._delta_row_id)::text)
+        || E'\t' || r._delta_row_id::text
+        || E'\t' || delta_ctl.tsv_escape(r.local_pk::text)
+        || E'\t' || r.class
+        || E'\t' || delta_ctl.tsv_escape(v_col)
+        || E'\t' || delta_ctl.tsv_escape(r.local_json ->> v_col)
+        || E'\t' || delta_ctl.tsv_escape(r.staged_json ->> v_col);
+    END LOOP;
+  END LOOP;
+  IF EXISTS (SELECT 1 FROM delta_ctl.run_counts
+      WHERE table_name = p_table AND count_name IN ('CHANGED', 'CHANGED_LOCAL_NEWER')
+        AND row_count > v_limit) THEN
+    RETURN NEXT delta_ctl.truncated_rows_marker(v_limit);
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION delta_ctl.render_blocked_rows_tsv(p_table text, p_limit int DEFAULT 10000)
+RETURNS SETOF text
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_cols text[];
+  v_col text;
+  v_sql text;
+  v_line text;
+  r record;
+  v_limit int := GREATEST(COALESCE(p_limit, 10000), 0);
+BEGIN
+  PERFORM delta_ctl.assert_table_name(p_table);
+  SELECT array_agg(a.attname ORDER BY a.attnum) INTO v_cols
+  FROM pg_attribute a
+  WHERE a.attrelid = delta_ctl.public_rel(p_table)::regclass
+    AND a.attnum > 0 AND NOT a.attisdropped;
+  RETURN NEXT 'selector_id' || E'\t' || 'delta_row_id' || E'\t' || delta_ctl.class_header()
+    || E'\t' || array_to_string(v_cols, E'\t') || E'\t' || 'block_reason';
+  v_sql := format($fmt$
+    WITH ranked AS (
+      SELECT d.staged_pk, d._delta_row_id, d.class, d.block_reason,
+             to_jsonb(s) AS staged_json,
+             row_number() OVER (
+               PARTITION BY d.class ORDER BY d.staged_pk NULLS LAST, d._delta_row_id
+             ) AS class_row_number
+      FROM delta_diff.%I d
+      JOIN delta_stage.%I s ON s._delta_row_id = d._delta_row_id
+      WHERE d.class IN ('BLOCKED_FK', 'AMBIGUOUS_NK')
+    )
+    SELECT staged_pk, _delta_row_id, class, block_reason, staged_json
+    FROM ranked
+    WHERE class_row_number <= $1
+    ORDER BY staged_pk NULLS LAST, _delta_row_id
+  $fmt$, delta_ctl.class_table_name(p_table), p_table);
+  FOR r IN EXECUTE v_sql USING v_limit LOOP
+    v_line := delta_ctl.tsv_escape(COALESCE(r.staged_pk, r._delta_row_id)::text)
+      || E'\t' || r._delta_row_id::text || E'\t' || r.class;
+    FOREACH v_col IN ARRAY v_cols LOOP
+      v_line := v_line || E'\t' || delta_ctl.tsv_escape(r.staged_json ->> v_col);
+    END LOOP;
+    RETURN NEXT v_line || E'\t' || delta_ctl.tsv_escape(r.block_reason);
+  END LOOP;
+  IF EXISTS (SELECT 1 FROM delta_ctl.run_counts
+      WHERE table_name = p_table AND count_name IN ('BLOCKED_FK', 'AMBIGUOUS_NK')
+        AND row_count > v_limit) THEN
+    RETURN NEXT delta_ctl.truncated_rows_marker(v_limit);
+  END IF;
 END;
 $$;
 
@@ -1492,7 +1783,7 @@ BEGIN
   END LOOP;
 
   RETURN NEXT '';
-  RETURN NEXT 'Selection: edit selection.conf or pass apply selection flags, then run --mode apply.';
+  RETURN NEXT 'Selection: copy and edit selection.conf, check it with --mode validate, then run --mode apply.';
 END;
 $$;
 
@@ -1502,23 +1793,438 @@ LANGUAGE plpgsql
 AS $$
 DECLARE
   t record;
+  c record;
+  v_sha text;
+  v_staged text;
+  v_manifest_default text;
+  v_selector_limit_raw text;
+  v_selector_limit_normalized text;
+  v_selector_limit_present boolean;
+  v_selector_suggestion_limit integer := 50;
+  v_selector_suggestion_limit_max constant integer := 100000;
+  v_default_include text;
+  v_default_new bigint := 0;
+  v_default_changed bigint := 0;
+  v_default_total bigint := 0;
+  v_default_tables bigint := 0;
+  v_range_tokens text[];
+  v_range_sizes bigint[];
+  v_singleton_tokens text[];
+  v_singleton_lines text[];
+  v_total_rows bigint;
+  v_singleton_count bigint;
+  v_range_count bigint;
+  v_id_col text;
+  v_primary_kind text;
+  v_example_values text;
+  v_invalid_ids boolean;
+  v_class_width integer;
+  v_selector_line_max constant integer := 120;
+  v_selector_prefix text;
+  v_selector_line text;
+  v_range_annotation text;
+  v_token text;
+  v_count_token text;
+  v_token_index integer;
+  v_singleton_line_index integer;
 BEGIN
-  RETURN NEXT '# classes: new | changed | changed_local_newer   (others are never applyable)';
-  RETURN NEXT '[*]                include=new,changed';
+  SELECT value INTO v_sha FROM delta_ctl.run_metadata WHERE key = 'dump_sha256';
+  SELECT COALESCE(
+           (SELECT value FROM delta_ctl.run_metadata WHERE key = 'manifest_default'),
+           'new,changed') -- NOSONAR
+    INTO v_manifest_default;
+  IF v_manifest_default NOT IN ('new,changed', 'none') THEN
+    RAISE EXCEPTION 'unsupported manifest_default metadata value: %', v_manifest_default;
+  END IF;
+
+  SELECT EXISTS (
+           SELECT 1 FROM delta_ctl.run_metadata WHERE key = 'selector_suggestion_limit'), -- NOSONAR
+         (SELECT value FROM delta_ctl.run_metadata WHERE key = 'selector_suggestion_limit')
+    INTO v_selector_limit_present, v_selector_limit_raw;
+  IF v_selector_limit_present THEN
+    IF v_selector_limit_raw IS NULL OR v_selector_limit_raw !~ '^[0-9]+$' THEN
+      RAISE EXCEPTION
+        'invalid selector_suggestion_limit metadata value: % (allowed range: 0..100000)', -- NOSONAR
+        COALESCE(v_selector_limit_raw, '<NULL>');
+    END IF;
+    v_selector_limit_normalized := COALESCE(
+      NULLIF(regexp_replace(v_selector_limit_raw, '^0+', ''), ''), '0');
+    IF length(v_selector_limit_normalized) > length(v_selector_suggestion_limit_max::text) THEN
+      RAISE EXCEPTION
+        'invalid selector_suggestion_limit metadata value: % (allowed range: 0..100000)', -- NOSONAR
+        v_selector_limit_raw;
+    END IF;
+    v_selector_suggestion_limit := v_selector_limit_normalized::integer;
+    IF v_selector_suggestion_limit > v_selector_suggestion_limit_max THEN
+      RAISE EXCEPTION
+        'invalid selector_suggestion_limit metadata value: % (allowed range: 0..100000)', -- NOSONAR
+        v_selector_limit_raw;
+    END IF;
+  END IF;
+
+  v_default_include := CASE WHEN v_manifest_default = 'none' THEN '' ELSE 'new,changed' END;
+
+  SELECT string_agg(format('%s=%s', tc.table_name, COALESCE(rc.row_count, 0)), ' ' ORDER BY tc.load_phase, tc.table_name)
+    INTO v_staged
+  FROM delta_ctl.table_config tc
+  LEFT JOIN delta_ctl.run_counts rc
+    ON rc.table_name = tc.table_name AND rc.count_name = 'STAGED';
+
+  SELECT GREATEST(3, COALESCE(max(length(tc.table_name) + 2), 3)) + 2
+    INTO v_class_width
+  FROM delta_ctl.table_config tc;
+
+  IF v_manifest_default = 'new,changed' THEN
+    SELECT COALESCE(sum(counts.new_n), 0),
+           COALESCE(sum(counts.changed_n), 0),
+           count(*) FILTER (WHERE counts.new_n + counts.changed_n > 0)
+      INTO v_default_new, v_default_changed, v_default_tables
+    FROM (
+      SELECT tc.table_name,
+             COALESCE(max(rc.row_count) FILTER (WHERE rc.count_name = 'NEW'), 0) AS new_n,
+             COALESCE(max(rc.row_count) FILTER (WHERE rc.count_name = 'CHANGED'), 0) AS changed_n
+      FROM delta_ctl.table_config tc
+      LEFT JOIN delta_ctl.run_counts rc ON rc.table_name = tc.table_name
+      GROUP BY tc.table_name
+    ) counts;
+    v_default_total := v_default_new + v_default_changed;
+  END IF;
+
+  RETURN NEXT '# delta-selection v2';
+  RETURN NEXT '# dump_sha256=' || COALESCE(v_sha, '');
+  RETURN NEXT '# staged ' || COALESCE(v_staged, '');
+  RETURN NEXT '#';
+  RETURN NEXT '# The two binding headers above tie row selectors to this reviewed preview.';
+  RETURN NEXT '# Keep them unchanged when uncommenting any .rows selector.';
+  RETURN NEXT '# Class-only selection files remain backward compatible and do not require bindings.';
+  RETURN NEXT '#';
+  RETURN NEXT '# ---------------------------------------------------------------------------'; -- NOSONAR
+  RETURN NEXT '# ACTIVE SELECTION';
+  RETURN NEXT '# Edit these lines to choose which classes are eligible for apply.';
+  RETURN NEXT '# ---------------------------------------------------------------------------'; -- NOSONAR
+  RETURN NEXT '#';
+  RETURN NEXT rpad('[*]', v_class_width, ' ') || 'include=' || v_default_include;
+  RETURN NEXT format(
+    '# Default selection ([*] %s) currently matches %s rows across %s tables (new=%s changed=%s).',
+    v_manifest_default, v_default_total, v_default_tables, v_default_new, v_default_changed);
+  RETURN NEXT '#';
 
   FOR t IN
     SELECT tc.table_name, tc.load_phase,
            COALESCE(max(rc.row_count) FILTER (WHERE rc.count_name = 'NEW'), 0) AS new_n,
            COALESCE(max(rc.row_count) FILTER (WHERE rc.count_name = 'CHANGED'), 0) AS changed_n,
-           COALESCE(max(rc.row_count) FILTER (WHERE rc.count_name = 'CHANGED_LOCAL_NEWER'), 0) AS local_newer_n
+           COALESCE(max(rc.row_count) FILTER (WHERE rc.count_name = 'CHANGED_LOCAL_NEWER'), 0) AS local_newer_n,
+           COALESCE((
+             SELECT string_agg(DISTINCT fk.parent_name, ',' ORDER BY fk.parent_name)
+             FROM jsonb_each_text(tc.fk_map) AS fk(child_col, parent_name)
+             WHERE fk.parent_name NOT LIKE 'external:%'
+           ), '') AS parents
     FROM delta_ctl.table_config tc
     LEFT JOIN delta_ctl.run_counts rc ON rc.table_name = tc.table_name
-    GROUP BY tc.table_name, tc.load_phase
+    GROUP BY tc.table_name, tc.load_phase, tc.fk_map
     ORDER BY tc.load_phase, tc.table_name
   LOOP
-    RETURN NEXT format('[%s] include=new,changed # new=%s changed=%s changed_local_newer=%s',
-      t.table_name, t.new_n, t.changed_n, t.local_newer_n);
+    RETURN NEXT rpad(format('[%s]', t.table_name), v_class_width, ' ')
+      || format('include=%s # new=%s changed=%s changed_local_newer=%s%s',
+        v_default_include, t.new_n, t.changed_n, t.local_newer_n,
+        CASE WHEN t.parents = '' THEN '' ELSE ' parents=' || t.parents END);
   END LOOP;
+
+  RETURN NEXT '#';
+  FOR c IN
+    SELECT class_name, selector_name
+    FROM (VALUES ('NEW', 'new'), ('CHANGED', 'changed')) AS classes(class_name, selector_name)
+  LOOP
+    RETURN NEXT format(
+      '# Small %s sets receive ready-to-uncomment suggestions:', c.class_name);
+    FOR t IN
+      SELECT tc.table_name, tc.load_phase, tc.pk_col
+      FROM delta_ctl.table_config tc
+      LEFT JOIN delta_ctl.run_counts rc ON rc.table_name = tc.table_name
+      GROUP BY tc.table_name, tc.load_phase, tc.pk_col
+      HAVING COALESCE(max(rc.row_count) FILTER (WHERE rc.count_name = c.class_name), 0)
+             BETWEEN 1 AND v_selector_suggestion_limit
+      ORDER BY tc.load_phase, tc.table_name
+    LOOP
+      IF delta_ctl.stage_table_exists(t.table_name) THEN
+        v_id_col := CASE WHEN t.pk_col IS NULL THEN '_delta_row_id' ELSE t.pk_col END;
+        EXECUTE format($fmt$
+          WITH source AS (
+            SELECT s.%I::numeric AS n
+            FROM delta_stage.%I s
+            JOIN delta_diff.%I d ON d._delta_row_id = s._delta_row_id
+            WHERE d.class = $1
+          ), ordered AS (
+            SELECT n, n - row_number() OVER (ORDER BY n)::numeric AS grp
+            FROM source
+          ), runs AS (
+            SELECT min(n) AS lo, max(n) AS hi, count(*)::bigint AS row_count
+            FROM ordered
+            GROUP BY grp
+          )
+          SELECT
+            COALESCE(
+              array_agg((lo::text || '-' || hi::text) ORDER BY lo)
+                FILTER (WHERE row_count > 1),
+              '{}'::text[]),
+            COALESCE(
+              array_agg(row_count ORDER BY lo)
+                FILTER (WHERE row_count > 1),
+              '{}'::bigint[]),
+            COALESCE(
+              array_agg(lo::text ORDER BY lo)
+                FILTER (WHERE row_count = 1),
+              '{}'::text[]),
+            COALESCE(sum(row_count), 0)::bigint,
+            count(*) FILTER (WHERE row_count = 1)::bigint,
+            count(*) FILTER (WHERE row_count > 1)::bigint,
+            EXISTS (SELECT 1 FROM source WHERE n < 0)
+          FROM runs
+        $fmt$, v_id_col, t.table_name, delta_ctl.class_table_name(t.table_name))
+        INTO v_range_tokens, v_range_sizes, v_singleton_tokens,
+             v_total_rows, v_singleton_count, v_range_count, v_invalid_ids
+        USING c.class_name;
+
+        -- An actual blank line separates each table block, including the first
+        -- block from its section heading.
+        RETURN NEXT '';
+        RETURN NEXT format(
+          '# [%s] Exact %s set: rows=%s singletons=%s ranges=%s',
+          t.table_name, c.class_name, v_total_rows, v_singleton_count, v_range_count);
+
+        IF v_invalid_ids THEN
+          RETURN NEXT format(
+            '# [%s] Exact %s selector unavailable for this small set.',
+            t.table_name, c.class_name);
+          RETURN NEXT format(
+            '#   Review details/%s.%s.tsv; negative id: values are outside the selector grammar.',
+            t.table_name, c.selector_name);
+        ELSE
+          v_selector_prefix := format(
+            '# [%s] %s.rows include=%s:',
+            t.table_name, c.selector_name,
+            CASE WHEN t.pk_col IS NULL THEN 'row' ELSE 'id' END);
+
+          IF cardinality(v_range_tokens) > 0 THEN
+            v_selector_line := v_selector_prefix;
+            v_range_annotation := '#   Range counts:'; -- NOSONAR
+            FOR v_token_index IN 1..cardinality(v_range_tokens) LOOP
+              v_token := v_range_tokens[v_token_index];
+              v_count_token := format(
+                '%s (%s rows)', v_token, v_range_sizes[v_token_index]);
+              IF v_selector_line <> v_selector_prefix
+                 AND (length(v_selector_line) + 1 + length(v_token) > v_selector_line_max
+                      OR length(v_range_annotation) + 2 + length(v_count_token)
+                           > v_selector_line_max) THEN
+                RETURN NEXT v_selector_line;
+                RETURN NEXT v_range_annotation;
+                v_selector_line := v_selector_prefix;
+                v_range_annotation := '#   Range counts:'; -- NOSONAR
+              END IF;
+              v_selector_line := v_selector_line
+                || CASE WHEN v_selector_line = v_selector_prefix THEN '' ELSE ',' END
+                || v_token;
+              v_range_annotation := v_range_annotation
+                || CASE WHEN v_range_annotation = '#   Range counts:' THEN ' ' ELSE ', ' END
+                || v_count_token;
+            END LOOP;
+            RETURN NEXT v_selector_line;
+            RETURN NEXT v_range_annotation;
+          END IF;
+
+          IF cardinality(v_singleton_tokens) > 0 THEN
+            -- Keep the range/count pair adjacent, then separate singleton IDs
+            -- with one actual blank line when both categories exist.
+            IF cardinality(v_range_tokens) > 0 THEN
+              RETURN NEXT '';
+            END IF;
+
+            -- Build singleton lines before emitting them so long lists can be
+            -- split into visual paragraphs after every four selector lines.
+            v_singleton_lines := '{}'::text[];
+            v_selector_line := v_selector_prefix;
+            FOREACH v_token IN ARRAY v_singleton_tokens LOOP
+              IF v_selector_line <> v_selector_prefix
+                 AND length(v_selector_line) + 1 + length(v_token) > v_selector_line_max THEN
+                v_singleton_lines := array_append(v_singleton_lines, v_selector_line);
+                v_selector_line := v_selector_prefix;
+              END IF;
+              v_selector_line := v_selector_line
+                || CASE WHEN v_selector_line = v_selector_prefix THEN '' ELSE ',' END
+                || v_token;
+            END LOOP;
+            v_singleton_lines := array_append(v_singleton_lines, v_selector_line);
+
+            FOR v_singleton_line_index IN 1..cardinality(v_singleton_lines) LOOP
+              IF cardinality(v_singleton_lines) > 8
+                 AND v_singleton_line_index > 1
+                 AND mod(v_singleton_line_index - 1, 4) = 0 THEN
+                RETURN NEXT '';
+              END IF;
+              RETURN NEXT v_singleton_lines[v_singleton_line_index];
+            END LOOP;
+          END IF;
+        END IF;
+      END IF;
+    END LOOP;
+    RETURN NEXT '#';
+  END LOOP;
+
+  FOR c IN
+    SELECT class_name, selector_name
+    FROM (VALUES ('NEW', 'new'), ('CHANGED', 'changed')) AS classes(class_name, selector_name)
+  LOOP
+    RETURN NEXT format(
+      '# Large %s sets receive a useful pointer rather than no guidance:', c.class_name);
+    FOR t IN
+      SELECT tc.table_name, tc.load_phase, tc.pk_col,
+             COALESCE(max(rc.row_count)
+               FILTER (WHERE rc.count_name = c.class_name), 0) AS class_n
+      FROM delta_ctl.table_config tc
+      LEFT JOIN delta_ctl.run_counts rc ON rc.table_name = tc.table_name
+      GROUP BY tc.table_name, tc.load_phase, tc.pk_col
+      HAVING COALESCE(max(rc.row_count)
+               FILTER (WHERE rc.count_name = c.class_name), 0) > v_selector_suggestion_limit
+      ORDER BY tc.load_phase, tc.table_name
+    LOOP
+      v_primary_kind := CASE WHEN t.pk_col IS NULL THEN 'row' ELSE 'id' END;
+      v_example_values := CASE WHEN t.pk_col IS NULL THEN '4,10-15' ELSE '100,200-210' END;
+      RETURN NEXT format(
+        '# %s has %s %s rows; choose selector_id%s from:',
+        t.table_name, t.class_n, c.class_name,
+        CASE
+          WHEN t.table_name = delta_ctl.auth_component_op_table() THEN ''
+          WHEN delta_ctl.corp_col_expr(t.table_name) IS NOT NULL
+            THEN ' or corp values'
+          ELSE ''
+        END);
+      RETURN NEXT format('# details/%s.%s.tsv', t.table_name, c.selector_name);
+      RETURN NEXT '# Example syntax:';
+      RETURN NEXT format('# [%s] %s.rows include=%s:%s',
+        t.table_name, c.selector_name, v_primary_kind, v_example_values);
+      IF delta_ctl.corp_col_expr(t.table_name) IS NOT NULL THEN
+        IF t.table_name = delta_ctl.auth_component_op_table() THEN
+          RETURN NEXT '# corp: selectors are also supported via the staged auth_processing parent:';
+        END IF;
+        RETURN NEXT format('# [%s] %s.rows include=corp:BC0000001,BC0000002',
+          t.table_name, c.selector_name);
+      END IF;
+      RETURN NEXT '#';
+    END LOOP;
+  END LOOP;
+
+  RETURN NEXT '# ---------------------------------------------------------------------------'; -- NOSONAR
+  RETURN NEXT '# Full selector grammar and 13 worked examples: selection_cookbook.txt (this run dir)';
+  RETURN NEXT '# ---------------------------------------------------------------------------'; -- NOSONAR
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION delta_ctl.render_selection_cookbook()
+RETURNS SETOF text
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN NEXT '# Classes: new | changed | changed_local_newer (other classes are never applyable).';
+  RETURN NEXT '# Selector kinds: id: for PK tables; row: for PK-less tables; corp: only where supported.';
+  RETURN NEXT '# Multiple includes union their matches; excludes subtract; --only-corps is a final intersection.';
+  RETURN NEXT '#';
+  RETURN NEXT '# ---------------------------------------------------------------------------'; -- NOSONAR
+  RETURN NEXT '# OPERATOR COOKBOOK';
+  RETURN NEXT '# Everything below is commented documentation. Copy or uncomment only the';
+  RETURN NEXT '# examples you intend to use. Row selectors never enable a class by themselves.';
+  RETURN NEXT '# ---------------------------------------------------------------------------'; -- NOSONAR
+  RETURN NEXT '#';
+  RETURN NEXT '# 1. Apply all NEW and CHANGED rows for a table:';
+  RETURN NEXT '#';
+  RETURN NEXT '# [mig_corp_batch] include=new,changed';
+  RETURN NEXT '#';
+  RETURN NEXT '# 2. Apply only NEW rows for a table:';
+  RETURN NEXT '#';
+  RETURN NEXT '# [mig_corp_batch] include=new';
+  RETURN NEXT '#';
+  RETURN NEXT '# 3. Apply only CHANGED rows for a table:';
+  RETURN NEXT '#';
+  RETURN NEXT '# [corp_processing] include=changed';
+  RETURN NEXT '#';
+  RETURN NEXT '# 4. Disable a table entirely:';
+  RETURN NEXT '#';
+  RETURN NEXT '# [mig_corp_batch] include=';
+  RETURN NEXT '#';
+  RETURN NEXT '# 5. Apply specific NEW rows by staged primary key.';
+  RETURN NEXT '#    Lists and inclusive ranges may be mixed:';
+  RETURN NEXT '#';
+  RETURN NEXT '# [mig_corp_batch] include=new,changed';
+  RETURN NEXT '# [mig_corp_batch] new.rows include=id:3067,7922,8241-8242';
+  RETURN NEXT '#';
+  RETURN NEXT '# 6. Apply every NEW row except specific IDs:';
+  RETURN NEXT '#';
+  RETURN NEXT '# [mig_corp_account] include=new,changed';
+  RETURN NEXT '# [mig_corp_account] new.rows exclude=id:23,100-105';
+  RETURN NEXT '#';
+  RETURN NEXT '# 7. Combine multiple includes, then subtract exclusions.';
+  RETURN NEXT '#    Include lines are unioned; exclude lines are applied afterward:';
+  RETURN NEXT '#';
+  RETURN NEXT '# [corp_processing] include=new,changed'; -- NOSONAR
+  RETURN NEXT '# [corp_processing] new.rows include=id:53946-53959';
+  RETURN NEXT '# [corp_processing] new.rows include=corp:BC0000001,BC0000002';
+  RETURN NEXT '# [corp_processing] new.rows exclude=id:53947,53952';
+  RETURN NEXT '#';
+  RETURN NEXT '# 8. Apply specific CHANGED rows:';
+  RETURN NEXT '#';
+  RETURN NEXT '# [corp_processing] include=new,changed'; -- NOSONAR
+  RETURN NEXT '# [corp_processing] changed.rows include=id:881,900-905';
+  RETURN NEXT '#';
+  RETURN NEXT '# 9. Apply CHANGED rows for selected corporations:';
+  RETURN NEXT '#';
+  RETURN NEXT '# [corp_processing] include=new,changed'; -- NOSONAR
+  RETURN NEXT '# [corp_processing] changed.rows include=corp:BC0000001,BC0000002';
+  RETURN NEXT '#';
+  RETURN NEXT '# 10. Explicitly opt into locally newer rows.';
+  RETURN NEXT '#     CAUTION: these may overwrite more recently modified local values:';
+  RETURN NEXT '#';
+  RETURN NEXT '# [corp_processing] include=new,changed,changed_local_newer';
+  RETURN NEXT '# [corp_processing] changed_local_newer.rows include=id:901';
+  RETURN NEXT '#';
+  RETURN NEXT '# 11. Select rows from a PK-less table using the staged row ordinal:';
+  RETURN NEXT '#';
+  RETURN NEXT '# [email_domain_groups] include=new';
+  RETURN NEXT '# [email_domain_groups] new.rows include=row:4,10-15';
+  RETURN NEXT '#';
+  RETURN NEXT '# 12. Parent dependency reminder:';
+  RETURN NEXT '#     A selected NEW child whose preserved parent is also NEW requires that';
+  RETURN NEXT '#     parent row to remain selected.';
+  RETURN NEXT '#';
+  RETURN NEXT '# [mig_batch] include=new';
+  RETURN NEXT '# [mig_batch] new.rows include=id:152';
+  RETURN NEXT '# [mig_corp_account] include=new';
+  RETURN NEXT '# [mig_corp_account] new.rows include=id:23643-23658';
+  RETURN NEXT '#';
+  RETURN NEXT '# 13. --only-corps is an additional global intersection:';
+  RETURN NEXT '#';
+  RETURN NEXT '# ./delta_restore_extract.sh ... ' || chr(92);
+  RETURN NEXT '#   --selection-file selection.conf ' || chr(92);
+  RETURN NEXT '#   --only-corps selected_corps.txt';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION delta_ctl.corp_col_expr(p_table text)
+RETURNS text
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  PERFORM delta_ctl.assert_table_name(p_table);
+  CASE p_table
+    WHEN delta_ctl.auth_component_op_table() THEN
+      IF delta_ctl.stage_table_exists(delta_ctl.auth_processing_table()) THEN
+        RETURN '(SELECT ap.corp_num::text FROM delta_stage.auth_processing ap WHERE ap.id = s.auth_processing_id LIMIT 1)';
+      END IF;
+      RETURN NULL;
+    WHEN 'corp_processing', 'colin_tracking', delta_ctl.auth_processing_table(),
+         'mig_corp_batch', 'mig_corp_account', 'exclude_corps', 'corps_with_third_party'
+      THEN RETURN 's.corp_num::text';
+    WHEN 'bar_corps' THEN RETURN 's.identifier::text';
+    ELSE RETURN NULL;
+  END CASE;
 END;
 $$;
 
@@ -1526,28 +2232,90 @@ CREATE OR REPLACE FUNCTION delta_ctl.selection_filter_expr(p_table text)
 RETURNS text
 LANGUAGE plpgsql
 AS $$
+DECLARE
+  v_corp text;
 BEGIN
-  PERFORM delta_ctl.assert_table_name(p_table);
+  PERFORM 1 FROM delta_ctl.only_corps LIMIT 1;
+  IF NOT FOUND THEN RETURN 'true'; END IF;
+  v_corp := delta_ctl.corp_col_expr(p_table);
+  IF v_corp IS NULL THEN RETURN 'true'; END IF;
+  RETURN format('EXISTS (SELECT 1 FROM delta_ctl.only_corps oc WHERE oc.corp_num = (%s))', v_corp);
+END;
+$$;
 
-  IF NOT EXISTS (SELECT 1 FROM delta_ctl.only_corps) THEN
-    RETURN 'true';
-  END IF;
+CREATE OR REPLACE FUNCTION delta_ctl.verify_row_selection()
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  r record;
+  v_cfg delta_ctl.table_config%ROWTYPE;
+  v_condition text;
+  v_corp text;
+  v_filter text;
+  v_matched bigint;
+  v_problem text;
+  v_dups boolean;
+BEGIN
+  TRUNCATE delta_ctl.selection_diagnostics;
+  FOR r IN
+    SELECT *, CASE WHEN kind = 'corp' THEN corp_num
+      WHEN is_range THEN value_from || '-' || value_to ELSE value_from::text END AS selector
+    FROM delta_ctl.row_selection
+    ORDER BY source_line, table_name, class, mode, kind, value_from, corp_num
+  LOOP
+    SELECT * INTO v_cfg FROM delta_ctl.table_config WHERE table_name = r.table_name;
+    v_problem := NULL;
+    v_matched := NULL;
+    IF NOT EXISTS (SELECT 1 FROM delta_ctl.selection s
+                   WHERE s.table_name = r.table_name AND s.class = r.class) THEN
+      v_problem := 'CLASS_NOT_INCLUDED';
+    ELSIF NOT delta_ctl.stage_table_exists(r.table_name)
+       OR to_regclass(format('delta_diff.%I', delta_ctl.class_table_name(r.table_name))) IS NULL THEN
+      v_matched := 0;
+      v_problem := 'NO_MATCH';
+    ELSIF r.kind = 'id' AND v_cfg.pk_col IS NULL THEN
+      v_problem := 'KIND_UNSUPPORTED';
+    ELSIF r.kind = 'corp' AND delta_ctl.corp_col_expr(r.table_name) IS NULL THEN
+      v_problem := 'KIND_UNSUPPORTED';
+    END IF;
 
-  CASE p_table
-    WHEN delta_ctl.auth_component_op_table()
-      THEN
-        IF delta_ctl.stage_table_exists(delta_ctl.auth_processing_table()) THEN
-          RETURN 'EXISTS (SELECT 1 FROM delta_stage.auth_processing ap JOIN delta_ctl.only_corps oc ON oc.corp_num = ap.corp_num::text WHERE ap.id = s.auth_processing_id)';
-        END IF;
-        RETURN delta_ctl.false_expr();
-    WHEN 'corp_processing', 'colin_tracking', delta_ctl.auth_processing_table(),
-         'mig_corp_batch', 'mig_corp_account', 'exclude_corps', 'corps_with_third_party'
-      THEN RETURN 'EXISTS (SELECT 1 FROM delta_ctl.only_corps oc WHERE oc.corp_num = s.corp_num::text)';
-    WHEN 'bar_corps'
-      THEN RETURN 'EXISTS (SELECT 1 FROM delta_ctl.only_corps oc WHERE oc.corp_num = s.identifier::text)';
-    ELSE
-      RETURN 'true';
-  END CASE;
+    IF v_problem IS NULL AND r.kind = 'id' THEN
+      EXECUTE format('SELECT EXISTS (SELECT 1 FROM delta_stage.%I GROUP BY %I HAVING count(*) > 1)',
+        r.table_name, v_cfg.pk_col) INTO v_dups;
+      IF v_dups THEN v_problem := 'DUP_STAGED_PK'; END IF;
+    END IF;
+
+    IF v_problem IS NULL THEN
+      IF r.kind = 'id' THEN
+        v_condition := format('s.%I::bigint BETWEEN $2 AND $3', v_cfg.pk_col);
+      ELSIF r.kind = 'row' THEN
+        v_condition := 's._delta_row_id BETWEEN $2 AND $3';
+      ELSE
+        v_corp := delta_ctl.corp_col_expr(r.table_name);
+        v_condition := format('(%s) = $4', v_corp);
+      END IF;
+      v_filter := delta_ctl.selection_filter_expr(r.table_name);
+      EXECUTE format($fmt$
+        SELECT count(*)
+        FROM delta_diff.%I d
+        JOIN delta_stage.%I s ON s._delta_row_id = d._delta_row_id
+        WHERE d.class = $1 AND (%s) AND (%s)
+      $fmt$, delta_ctl.class_table_name(r.table_name), r.table_name, v_condition, v_filter)
+      INTO v_matched USING r.class, r.value_from, r.value_to, r.corp_num;
+      IF v_matched = 0 THEN
+        v_problem := 'NO_MATCH';
+      ELSIF r.kind IN ('id', 'row') AND NOT r.is_range AND v_matched > 1 THEN
+        v_problem := 'SCALAR_MULTI_MATCH';
+      END IF;
+    END IF;
+
+    INSERT INTO delta_ctl.selection_diagnostics(
+      table_name, class, mode, kind, selector, source_line, matched, problem)
+    VALUES (r.table_name, r.class, r.mode, r.kind, r.selector,
+            r.source_line, v_matched, v_problem);
+  END LOOP;
+
 END;
 $$;
 
@@ -1558,9 +2326,15 @@ AS $$
 DECLARE
   r record;
   v_filter text;
+  v_corp text;
+  v_match text;
 BEGIN
+  PERFORM delta_ctl.verify_row_selection();
+  IF EXISTS (SELECT 1 FROM delta_ctl.selection_diagnostics WHERE problem IS NOT NULL) THEN
+    RAISE EXCEPTION 'SELECTION_INVALID: row selectors failed validation; query delta_ctl.selection_diagnostics';
+  END IF;
   FOR r IN
-    SELECT table_name
+    SELECT table_name, pk_col
     FROM delta_ctl.table_config
     WHERE delta_ctl.stage_table_exists(table_name)
     ORDER BY load_phase, table_name
@@ -1579,6 +2353,43 @@ BEGIN
         )
         AND (%s)
     $fmt$, delta_ctl.class_table_name(r.table_name), r.table_name, r.table_name, v_filter);
+
+    IF EXISTS (SELECT 1 FROM delta_ctl.row_selection rs WHERE rs.table_name = r.table_name) THEN
+      v_corp := delta_ctl.corp_col_expr(r.table_name);
+      v_match := '('
+        || CASE WHEN r.pk_col IS NULL THEN 'false'
+             ELSE format('(rs.kind = ''id'' AND s.%I::bigint BETWEEN rs.value_from AND rs.value_to)', r.pk_col) END
+        || ' OR (rs.kind = ''row'' AND s._delta_row_id BETWEEN rs.value_from AND rs.value_to)'
+        || CASE WHEN v_corp IS NULL THEN ''
+             ELSE format(' OR (rs.kind = ''corp'' AND (%s) = rs.corp_num)', v_corp) END
+        || ')';
+      EXECUTE format($fmt$
+        UPDATE delta_diff.%I d
+        SET selected = false
+        FROM delta_stage.%I s
+        WHERE d._delta_row_id = s._delta_row_id
+          AND d.selected
+          AND (
+            (
+              EXISTS (
+                SELECT 1 FROM delta_ctl.row_selection rs
+                WHERE rs.table_name = %L AND rs.class = d.class AND rs.mode = 'include'
+              )
+              AND NOT EXISTS (
+                SELECT 1 FROM delta_ctl.row_selection rs
+                WHERE rs.table_name = %L AND rs.class = d.class AND rs.mode = 'include'
+                  AND %s
+              )
+            )
+            OR EXISTS (
+              SELECT 1 FROM delta_ctl.row_selection rs
+              WHERE rs.table_name = %L AND rs.class = d.class AND rs.mode = 'exclude'
+                AND %s
+            )
+          )
+      $fmt$, delta_ctl.class_table_name(r.table_name), r.table_name,
+        r.table_name, r.table_name, v_match, r.table_name, v_match);
+    END IF;
   END LOOP;
 END;
 $$;
@@ -1612,6 +2423,7 @@ DECLARE
   p record;
   v_parent_pk text;
   v_count bigint;
+  v_sample_ids text;
 BEGIN
   TRUNCATE delta_ctl.dependency_violations;
 
@@ -1633,34 +2445,37 @@ BEGIN
       END IF;
 
       EXECUTE format($fmt$
-        SELECT count(*)
-        FROM delta_diff.%I cd
-        JOIN delta_stage.%I cs ON cs._delta_row_id = cd._delta_row_id
-        LEFT JOIN delta_stage.%I ps ON ps.%I = cs.%I
-        LEFT JOIN delta_diff.%I pd ON pd._delta_row_id = ps._delta_row_id
-        WHERE cd.selected
-          AND cs.%I IS NOT NULL
-          AND (
-            pd._delta_row_id IS NULL
-            OR pd.class IN ('BLOCKED_FK', 'AMBIGUOUS_NK', 'BLOCKED_PARENT')
-            OR (pd.class = 'NEW' AND NOT pd.selected)
-          )
+        WITH violations AS (
+          SELECT COALESCE(cd.staged_pk::text, cd._delta_row_id::text) AS sample_id
+          FROM delta_diff.%I cd
+          JOIN delta_stage.%I cs ON cs._delta_row_id = cd._delta_row_id
+          LEFT JOIN delta_stage.%I ps ON ps.%I = cs.%I
+          LEFT JOIN delta_diff.%I pd ON pd._delta_row_id = ps._delta_row_id
+          WHERE cd.selected
+            AND cs.%I IS NOT NULL
+            AND (
+              pd._delta_row_id IS NULL
+              OR pd.class IN ('BLOCKED_FK', 'AMBIGUOUS_NK', 'BLOCKED_PARENT')
+              OR (pd.class = 'NEW' AND NOT pd.selected)
+            )
+        )
+        SELECT count(*),
+               (SELECT string_agg(sample_id, ',' ORDER BY sample_id)
+                FROM (SELECT sample_id FROM violations ORDER BY sample_id LIMIT 10) q)
+        FROM violations
       $fmt$, delta_ctl.class_table_name(c.table_name), c.table_name, p.parent_table, v_parent_pk, p.fk_col,
             delta_ctl.class_table_name(p.parent_table), p.fk_col)
-      INTO v_count;
+      INTO v_count, v_sample_ids;
 
       IF v_count > 0 THEN
-        INSERT INTO delta_ctl.dependency_violations(child_table, parent_table, reason, row_count)
+        INSERT INTO delta_ctl.dependency_violations(child_table, parent_table, reason, row_count, sample_ids)
         VALUES (c.table_name, p.parent_table,
                 format('selected child rows require selected/non-blocked parent via %I', p.fk_col),
-                v_count);
+                v_count, v_sample_ids);
       END IF;
     END LOOP;
   END LOOP;
 
-  IF EXISTS (SELECT 1 FROM delta_ctl.dependency_violations) THEN
-    RAISE EXCEPTION 'SELECTION_INVALID: selected child rows have blocked, missing, or unselected NEW preserved parents. Query delta_ctl.dependency_violations for details.';
-  END IF;
 END;
 $$;
 
@@ -1892,6 +2707,9 @@ BEGIN
   PERFORM delta_ctl.run_preview_classification();
   PERFORM delta_ctl.stamp_selection();
   PERFORM delta_ctl.validate_dependencies();
+  IF EXISTS (SELECT 1 FROM delta_ctl.dependency_violations) THEN
+    RAISE EXCEPTION 'SELECTION_INVALID: selected child rows have blocked, missing, or unselected NEW preserved parents. Query delta_ctl.dependency_violations for details.';
+  END IF;
 
   TRUNCATE delta_ctl.apply_counts;
   TRUNCATE delta_ctl.touched_tables;
@@ -1923,7 +2741,7 @@ BEGIN
 
   RETURN NEXT 'Selected counts';
   RETURN NEXT '---------------';
-  RETURN NEXT format(c_summary_row_format, c_table_hdr, 'class', 'selected');
+  RETURN NEXT format(c_summary_row_format, c_table_hdr, delta_ctl.class_header(), 'selected');
   FOR r IN
     SELECT table_name, class, row_count, load_phase
     FROM delta_ctl.selected_counts()
@@ -1935,7 +2753,7 @@ BEGIN
   RETURN NEXT '';
   RETURN NEXT 'Affected counts';
   RETURN NEXT '---------------';
-  RETURN NEXT format('%-36s %-20s %-8s %10s %10s', c_table_hdr, 'class', 'action', 'expected', 'affected');
+  RETURN NEXT format('%-36s %-20s %-8s %10s %10s', c_table_hdr, delta_ctl.class_header(), 'action', 'expected', 'affected');
   FOR r IN
     SELECT table_name, class, action, expected_count, affected_count
     FROM delta_ctl.apply_counts

--- a/data-tool/scripts/restore/delta/align_details.awk
+++ b/data-tool/scripts/restore/delta/align_details.awk
@@ -1,0 +1,75 @@
+# Produce a fixed-width companion for a canonical detail TSV.
+#
+# Invoke with the same non-empty input path twice:
+#   awk -v max_width=40 -f align_details.awk details.tsv details.tsv
+#
+# The first pass measures column widths; the second pass renders the output.
+# Comment lines are not included in width calculations and pass through verbatim.
+
+BEGIN {
+  FS = "\t"
+  if (max_width == "" || max_width !~ /^[0-9]+$/ || max_width < 1) {
+    max_width = 40
+  }
+}
+
+NR == FNR {
+  if ($0 ~ /^#/) {
+    next
+  }
+
+  if (NF > column_count) {
+    column_count = NF
+  }
+  for (i = 1; i <= NF; i++) {
+    cell_width = length($i)
+    if (cell_width > max_width) {
+      cell_width = max_width
+    }
+    if (cell_width > widths[i]) {
+      widths[i] = cell_width
+    }
+  }
+  next
+}
+
+function clipped(value) {
+  if (length(value) <= max_width) {
+    return value
+  }
+  return substr(value, 1, max_width - 1) "…"
+}
+
+function dashes(count,    result, i) {
+  result = ""
+  for (i = 0; i < count; i++) {
+    result = result "-"
+  }
+  return result
+}
+
+function render_fields(underline,    result, value, i) {
+  result = ""
+  for (i = 1; i <= column_count; i++) {
+    value = underline ? dashes(widths[i]) : clipped(i <= NF ? $i : "")
+    if (i < column_count) {
+      result = result sprintf("%-" widths[i] "s", value) "  "
+    } else {
+      result = result value
+    }
+  }
+  print result
+}
+
+$0 ~ /^#/ {
+  print
+  next
+}
+
+{
+  render_fields(0)
+  if (!header_written) {
+    render_fields(1)
+    header_written = 1
+  }
+}

--- a/data-tool/tests/delta_restore/expected/t01_preview_patterns.txt
+++ b/data-tool/tests/delta_restore/expected/t01_preview_patterns.txt
@@ -1,4 +1,7 @@
 Delta restore preview
 Class counts
+Detail artifacts
+Viewing tips
+--mode validate
 UNCHANGED
 selection.conf

--- a/data-tool/tests/delta_restore/expected/t12_row_selection_assert.sql
+++ b/data-tool/tests/delta_restore/expected/t12_row_selection_assert.sql
@@ -1,0 +1,46 @@
+DO $$
+DECLARE
+  v_bad bigint;
+BEGIN
+  IF (SELECT count(*) FROM public.mig_batch WHERE id = 152) <> 1 THEN
+    RAISE EXCEPTION 'expected selected mig_batch parent id 152';
+  END IF;
+  IF (SELECT count(*) FROM public.mig_corp_account) <> 16
+     OR EXISTS (SELECT 1 FROM public.mig_corp_account WHERE id = 23) THEN
+    RAISE EXCEPTION 'mig_corp_account row exclusion failed';
+  END IF;
+  IF (SELECT count(*) FROM public.mig_corp_batch) <> 16
+     OR EXISTS (SELECT 1 FROM public.mig_corp_batch WHERE id > 3016) THEN
+    RAISE EXCEPTION 'mig_corp_batch range inclusion failed';
+  END IF;
+  IF (SELECT count(*) FROM public.corp_processing) <> 16
+     OR EXISTS (SELECT 1 FROM public.corp_processing WHERE id > 4016) THEN
+    RAISE EXCEPTION 'corp_processing range inclusion failed';
+  END IF;
+
+  SELECT count(*) INTO v_bad
+  FROM delta_ctl.apply_counts
+  WHERE expected_count <> affected_count;
+  IF v_bad <> 0 THEN
+    RAISE EXCEPTION 'expected apply expected_count = affected_count';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM delta_ctl.apply_counts
+    WHERE table_name = 'mig_batch' AND class = 'NEW'
+      AND expected_count = 1 AND affected_count = 1
+  ) OR NOT EXISTS (
+    SELECT 1 FROM delta_ctl.apply_counts
+    WHERE table_name = 'mig_corp_account' AND class = 'NEW'
+      AND expected_count = 16 AND affected_count = 16
+  ) OR NOT EXISTS (
+    SELECT 1 FROM delta_ctl.apply_counts
+    WHERE table_name = 'mig_corp_batch' AND class = 'NEW'
+      AND expected_count = 16 AND affected_count = 16
+  ) OR NOT EXISTS (
+    SELECT 1 FROM delta_ctl.apply_counts
+    WHERE table_name = 'corp_processing' AND class = 'NEW'
+      AND expected_count = 16 AND affected_count = 16
+  ) THEN
+    RAISE EXCEPTION 'missing expected 1/16/16/16 apply counts';
+  END IF;
+END $$;

--- a/data-tool/tests/delta_restore/expected/t13_selector_diagnostics_assert.sql
+++ b/data-tool/tests/delta_restore/expected/t13_selector_diagnostics_assert.sql
@@ -1,0 +1,39 @@
+DO $$
+BEGIN
+  IF (SELECT count(*) FROM delta_ctl.selection_diagnostics WHERE problem = 'KIND_UNSUPPORTED') <> 2 THEN
+    RAISE EXCEPTION 'expected two KIND_UNSUPPORTED diagnostics';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM delta_ctl.selection_diagnostics
+                 WHERE source_line = 12 AND problem = 'CLASS_NOT_INCLUDED') THEN
+    RAISE EXCEPTION 'expected CLASS_NOT_INCLUDED diagnostic';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM delta_ctl.selection_diagnostics
+                 WHERE source_line = 13 AND problem = 'NO_MATCH' AND matched = 0) THEN -- NOSONAR
+    RAISE EXCEPTION 'expected NO_MATCH diagnostic';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM delta_ctl.selection_diagnostics
+                 WHERE source_line = 14 AND problem = 'NO_MATCH' AND matched = 0) THEN
+    RAISE EXCEPTION 'expected --only-corps to reduce selector to NO_MATCH';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM delta_ctl.selection_diagnostics
+                 WHERE source_line = 15 AND problem IS NULL AND matched = 1) THEN
+    RAISE EXCEPTION 'expected parent-derived auth component corp selector match';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM delta_ctl.selection_diagnostics
+                 WHERE source_line = 16 AND problem IS NULL AND matched = 1) THEN
+    RAISE EXCEPTION 'expected PK-less row selector match';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM delta_ctl.selection_diagnostics
+                 WHERE source_line = 17 AND problem = 'NO_MATCH' AND matched = 0) THEN
+    RAISE EXCEPTION 'expected absent staged table to produce NO_MATCH';
+  END IF;
+
+  DELETE FROM delta_ctl.row_selection WHERE source_line NOT IN (15, 16);
+  PERFORM delta_ctl.stamp_selection();
+  IF NOT EXISTS (SELECT 1 FROM delta_diff.auth_component_operation_class WHERE selected) THEN
+    RAISE EXCEPTION 'expected parent-derived auth component corp selector to stamp row';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM delta_diff.email_domain_groups_class WHERE selected) THEN
+    RAISE EXCEPTION 'expected PK-less row selector to stamp row';
+  END IF;
+END $$;

--- a/data-tool/tests/delta_restore/expected/t14_parent_dependency_rows_assert.sql
+++ b/data-tool/tests/delta_restore/expected/t14_parent_dependency_rows_assert.sql
@@ -1,0 +1,17 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM delta_ctl.dependency_violations
+    WHERE child_table = 'mig_batch' AND parent_table = 'mig_group'
+      AND row_count = 1 AND sample_ids = '200'
+  ) THEN
+    RAISE EXCEPTION 'expected dependency violation with child sample id 200';
+  END IF;
+  UPDATE delta_diff.mig_group_class
+  SET selected = true
+  WHERE staged_pk = 100;
+  PERFORM delta_ctl.validate_dependencies();
+  IF EXISTS (SELECT 1 FROM delta_ctl.dependency_violations) THEN
+    RAISE EXCEPTION 'expected dependency validation to pass after selecting parent';
+  END IF;
+END $$;

--- a/data-tool/tests/delta_restore/expected/t15_details_assert.sql
+++ b/data-tool/tests/delta_restore/expected/t15_details_assert.sql
@@ -1,0 +1,81 @@
+DO $$
+DECLARE
+  v_new text;
+  v_changed text;
+  v_blocked text;
+  v_samples text;
+  v_control text;
+BEGIN
+  SELECT delta_ctl.display_value(
+           jsonb_build_object('value', E'line\nnext\tcell\rreturn' || chr(27) || 'escape' || chr(1) || 'control'),
+           'value', 200)
+    INTO v_control;
+  IF position(chr(13) in v_control) > 0
+     OR position(chr(27) in v_control) > 0
+     OR position(chr(1) in v_control) > 0
+     OR v_control NOT LIKE '%␤%'
+     OR v_control NOT LIKE '%␉%'
+     OR v_control NOT LIKE '%␍%'
+     OR v_control NOT LIKE '%␛%'
+     OR v_control NOT LIKE '%�%' THEN
+    RAISE EXCEPTION 'preview display value retained controls or omitted visible markers: %', v_control;
+  END IF;
+
+  SELECT string_agg(line, E'\n') INTO v_new
+  FROM delta_ctl.render_new_rows_tsv('bad_emails', 1) line; -- NOSONAR
+  IF v_new NOT LIKE '%selector_id%' OR v_new NOT LIKE '%# TRUNCATED at 1 rows%'
+     OR position(E'tab\\tline\\nnext\\rreturn\\\\slash' in v_new) = 0 THEN
+    RAISE EXCEPTION 'NEW detail output missing header, escaping, or truncation: %', v_new;
+  END IF;
+
+  SELECT string_agg(line, E'\n') INTO v_changed
+  FROM delta_ctl.render_changed_rows_tsv('bad_emails', 10) line;
+  IF v_changed NOT LIKE '%local old%' OR v_changed NOT LIKE '%dump new%'
+     OR v_changed NOT LIKE '%notes%' THEN
+    RAISE EXCEPTION 'CHANGED detail output missing old-to-new values: %', v_changed;
+  END IF;
+
+  UPDATE delta_diff.bad_emails_class
+  SET class = 'BLOCKED_FK',
+      block_reason = E'missing\tparent\nrow\rreturn' || chr(27) || 'escape' || chr(1) || 'control'
+  WHERE staged_pk = 3;
+  SELECT string_agg(line, E'\n') INTO v_blocked
+  FROM delta_ctl.render_blocked_rows_tsv('bad_emails', 10) line;
+  IF v_blocked NOT LIKE '%newer@example.test%'
+     OR position(E'missing\\tparent\\nrow\\rreturn' in v_blocked) = 0
+     OR position(chr(27) in v_blocked) > 0
+     OR position(chr(1) in v_blocked) > 0
+     OR v_blocked NOT LIKE '%␛%'
+     OR v_blocked NOT LIKE '%�%' THEN
+    RAISE EXCEPTION 'BLOCKED detail output missing escaping/sanitization: %', v_blocked;
+  END IF;
+
+  SELECT string_agg(line, E'\n') INTO v_control
+  FROM delta_ctl.render_samples('bad_emails', 'BLOCKED_FK', 10) line;
+  IF position(chr(13) in v_control) > 0
+     OR position(chr(27) in v_control) > 0
+     OR position(chr(1) in v_control) > 0
+     OR v_control NOT LIKE '%␍%'
+     OR v_control NOT LIKE '%␛%'
+     OR v_control NOT LIKE '%�%' THEN
+    RAISE EXCEPTION 'preview block reason retained controls or omitted visible markers: %', v_control;
+  END IF;
+
+  SELECT string_agg(line, E'\n') INTO v_samples
+  FROM delta_ctl.render_samples('bad_emails', 'CHANGED', 10) line; -- NOSONAR
+  IF v_samples NOT LIKE '%email=changed@example.test%'
+     OR v_samples NOT LIKE '%changed notes: local old → dump new%' THEN
+    RAISE EXCEPTION 'enriched sample output missing values/diff: %', v_samples;
+  END IF;
+
+  UPDATE delta_stage.bad_emails SET notes = repeat('x', 300) WHERE id = 1;
+  UPDATE delta_diff.bad_emails_class
+  SET changed_cols = ARRAY['email', 'notes', 'extra_1', 'extra_2', 'extra_3', 'extra_4']
+  WHERE staged_pk = 1;
+  IF (SELECT count(*) FROM delta_ctl.render_samples('bad_emails', 'CHANGED', 10)) <> 6 THEN
+    RAISE EXCEPTION 'expected one sample line plus at most five changed-column lines';
+  END IF;
+  IF (SELECT max(length(line)) FROM delta_ctl.render_samples('bad_emails', 'CHANGED', 10) line) > 220 THEN
+    RAISE EXCEPTION 'expected preview sample lines to be capped at 220 characters';
+  END IF;
+END $$;

--- a/data-tool/tests/delta_restore/expected/t16_selection_manifest_assert.sql
+++ b/data-tool/tests/delta_restore/expected/t16_selection_manifest_assert.sql
@@ -1,0 +1,603 @@
+DO $$
+DECLARE
+  v_lines text[];
+  v_none_lines text[];
+  v_variant_lines text[];
+  v_manifest text;
+  v_error text;
+  v_invalid_value text;
+  v_binding_headers integer;
+  v_active_count integer;
+  v_include_min integer;
+  v_include_max integer;
+  v_active integer;
+  v_wildcard integer;
+  v_small_new integer;
+  v_small_changed integer;
+  v_large_new integer;
+  v_large_changed integer;
+  v_pointer integer;
+  v_pos integer;
+  v_generic_count integer;
+  v_range_line_count integer;
+  v_singleton_line_count integer;
+  v_last_range integer;
+  v_first_singleton integer;
+  v_singleton_ordinals bigint[];
+  v_singleton_ordinal_index integer;
+  v_exact_count bigint;
+  v_exact_distinct bigint;
+  v_missing_count bigint;
+  v_extra_count bigint;
+  c_range_counts_pattern constant text := '#   Range counts:%';
+  c_boundary_selector_pattern constant text :=
+    '# [selector_limit_boundary] new.rows include=id:%';
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM delta_ctl.run_metadata WHERE key = 'selector_suggestion_limit' -- NOSONAR
+  ) THEN
+    RAISE EXCEPTION 'selector limit fixture must begin without metadata to test fallback';
+  END IF;
+
+  SELECT array_agg(line ORDER BY ord), string_agg(line, E'\n' ORDER BY ord)
+    INTO v_lines, v_manifest
+  FROM delta_ctl.render_selection_manifest() WITH ORDINALITY AS manifest(line, ord);
+
+  IF v_lines[1] <> '# delta-selection v2'
+     OR v_lines[2] <> '# dump_sha256=manifest-test-sha'
+     OR v_lines[3] <> '# staged bad_emails=5 selector_limit_boundary=51 mig_batch=5 mig_group=51 bar_corps=52 corp_processing=106 auth_component_operation=54' THEN
+    RAISE EXCEPTION 'v2 binding headers were not emitted first or exactly: %', v_manifest;
+  END IF;
+
+  SELECT count(*) INTO v_binding_headers
+  FROM unnest(v_lines) line
+  WHERE line ~ '^# (dump_sha256=|staged )';
+  IF v_binding_headers <> 2 THEN
+    RAISE EXCEPTION 'documentation was mistaken for a binding header: %', v_manifest;
+  END IF;
+
+  v_active := array_position(v_lines, '# ACTIVE SELECTION');
+  v_small_new := array_position(
+    v_lines, '# Small NEW sets receive ready-to-uncomment suggestions:'); -- NOSONAR
+  v_small_changed := array_position(
+    v_lines, '# Small CHANGED sets receive ready-to-uncomment suggestions:'); -- NOSONAR
+  v_large_new := array_position(
+    v_lines, '# Large NEW sets receive a useful pointer rather than no guidance:');
+  v_large_changed := array_position(
+    v_lines, '# Large CHANGED sets receive a useful pointer rather than no guidance:');
+  v_pointer := array_position(
+    v_lines,
+    '# Full selector grammar and 13 worked examples: selection_cookbook.txt (this run dir)');
+  IF v_active IS NULL OR v_small_new IS NULL OR v_small_changed IS NULL
+     OR v_large_new IS NULL OR v_large_changed IS NULL OR v_pointer IS NULL
+     OR NOT (v_active < v_small_new
+             AND v_small_new < v_small_changed
+             AND v_small_changed < v_large_new
+             AND v_large_new < v_large_changed
+             AND v_large_changed < v_pointer) THEN
+    RAISE EXCEPTION 'manifest section order is wrong: %', v_manifest;
+  END IF;
+  IF v_lines[v_pointer - 1] <> '# ---------------------------------------------------------------------------'
+     OR v_lines[v_pointer + 1] <> '# ---------------------------------------------------------------------------' THEN
+    RAISE EXCEPTION 'cookbook pointer block does not match the approved shape: %', v_manifest;
+  END IF;
+  IF array_position(v_lines, '# OPERATOR COOKBOOK') IS NOT NULL
+     OR array_position(v_lines, '# 1. Apply all NEW and CHANGED rows for a table:') IS NOT NULL
+     OR array_position(
+          v_lines,
+          '# Classes: new | changed | changed_local_newer (other classes are never applyable).')
+        IS NOT NULL THEN
+    RAISE EXCEPTION 'manifest still embeds cookbook or grammar reference text: %', v_manifest;
+  END IF;
+
+  SELECT count(*), min(strpos(line, 'include=')), max(strpos(line, 'include='))
+    INTO v_active_count, v_include_min, v_include_max
+  FROM unnest(v_lines) line
+  WHERE line ~ '^\[[^]]+\][[:space:]]+include=';
+  IF v_active_count <> 8 OR v_include_min <> v_include_max THEN
+    RAISE EXCEPTION
+      'wildcard/per-table active lines are missing or misaligned: count=% min=% max=% manifest=%',
+      v_active_count, v_include_min, v_include_max, v_manifest;
+  END IF;
+
+  SELECT ord INTO v_wildcard
+  FROM unnest(v_lines) WITH ORDINALITY AS u(line, ord)
+  WHERE line LIKE '[*]%' LIMIT 1;
+  IF v_lines[v_wildcard] !~ '^\[\*\][[:space:]]+include=new,changed$'
+     OR v_lines[v_wildcard + 1] <>
+       '# Default selection ([*] new,changed) currently matches 323 rows across 7 tables (new=266 changed=57).' THEN
+    RAISE EXCEPTION 'default wildcard or blast-radius total changed: %', v_manifest;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM unnest(v_lines) line
+    WHERE line ~ '^\[mig_batch\][[:space:]]+include=new,changed # new=3 changed=2 changed_local_newer=0 parents=mig_group$'
+  ) THEN
+    RAISE EXCEPTION 'mig_batch active line lacks its preserved parent annotation: %', v_manifest;
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM unnest(v_lines) line
+    WHERE line ~ '^\[corp_processing\][[:space:]]+include=new,changed # new=53 changed=53 changed_local_newer=0 parents=mig_batch$'
+  ) THEN
+    RAISE EXCEPTION 'corp_processing active line lacks its preserved parent annotation: %', v_manifest;
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM unnest(v_lines) line
+    WHERE line LIKE '[mig_batch]%' AND line LIKE '%external:%'
+  ) THEN
+    RAISE EXCEPTION 'external FK leaked into parent annotations: %', v_manifest;
+  END IF;
+
+  -- Every exact table block begins after an actual blank line. Mixed PK and
+  -- PK-less sets also keep range/count pairs adjacent and place one actual blank
+  -- line before their separate singleton selectors.
+  IF EXISTS (
+    SELECT 1
+    FROM unnest(v_lines) WITH ORDINALITY AS rendered(line, ord)
+    WHERE line ~ '^# \[[^]]+\] Exact (NEW|CHANGED) set:'
+      AND (ord < 3
+           OR v_lines[(ord - 1)::integer] <> ''
+           OR v_lines[(ord - 2)::integer] = '')
+  ) THEN
+    RAISE EXCEPTION 'an exact table block lacks its leading blank line: %', v_manifest;
+  END IF;
+
+  v_pos := array_position(
+    v_lines, '# [bad_emails] Exact NEW set: rows=3 singletons=1 ranges=1');
+  IF v_pos IS NULL
+     OR v_lines[v_pos + 1] <> '# [bad_emails] new.rows include=id:2-3'
+     OR v_lines[v_pos + 2] <> '#   Range counts: 2-3 (2 rows)'
+     OR v_lines[v_pos + 3] <> ''
+     OR v_lines[v_pos + 4] <> '# [bad_emails] new.rows include=id:5' THEN
+    RAISE EXCEPTION 'mixed PK NEW exact guidance has the wrong layout: %', v_manifest;
+  END IF;
+  v_pos := array_position(
+    v_lines, '# [mig_batch] Exact NEW set: rows=3 singletons=1 ranges=1');
+  IF v_pos IS NULL
+     OR v_lines[v_pos + 1] <> '# [mig_batch] new.rows include=row:4-5'
+     OR v_lines[v_pos + 2] <> '#   Range counts: 4-5 (2 rows)'
+     OR v_lines[v_pos + 3] <> ''
+     OR v_lines[v_pos + 4] <> '# [mig_batch] new.rows include=row:8' THEN
+    RAISE EXCEPTION 'mixed PK-less NEW exact guidance has the wrong layout: %', v_manifest;
+  END IF;
+  v_pos := array_position(
+    v_lines, '# [bad_emails] Exact CHANGED set: rows=2 singletons=2 ranges=0');
+  IF v_pos IS NULL
+     OR v_lines[v_pos + 1] <> '# [bad_emails] changed.rows include=id:7,9'
+     OR v_lines[v_pos + 2] LIKE c_range_counts_pattern THEN
+    RAISE EXCEPTION 'singleton-only CHANGED exact guidance has the wrong layout: %', v_manifest;
+  END IF;
+  v_pos := array_position(
+    v_lines, '# [mig_batch] Exact CHANGED set: rows=2 singletons=0 ranges=1');
+  IF v_pos IS NULL
+     OR v_lines[v_pos + 1] <> '# [mig_batch] changed.rows include=row:10-11'
+     OR v_lines[v_pos + 2] <> '#   Range counts: 10-11 (2 rows)' THEN
+    RAISE EXCEPTION 'range-only PK-less CHANGED guidance has the wrong layout: %', v_manifest;
+  END IF;
+
+  -- The inclusive default boundary remains exact and forces both categories to wrap.
+  IF array_position(
+       v_lines,
+       '# [selector_limit_boundary] Exact NEW set: rows=50 singletons=40 ranges=5')
+       IS NULL THEN
+    RAISE EXCEPTION '50-row exact summary is missing: %', v_manifest;
+  END IF;
+  SELECT
+    count(*) FILTER (WHERE line LIKE '%-%'),
+    count(*) FILTER (WHERE line NOT LIKE '%-%'),
+    max(ord) FILTER (WHERE line LIKE '%-%'),
+    min(ord) FILTER (WHERE line NOT LIKE '%-%')
+    INTO v_range_line_count, v_singleton_line_count, v_last_range, v_first_singleton
+  FROM unnest(v_lines) WITH ORDINALITY AS rendered(line, ord)
+  WHERE line LIKE c_boundary_selector_pattern;
+  IF v_range_line_count <= 1 OR v_singleton_line_count <= 8
+     OR v_last_range >= v_first_singleton
+     OR v_lines[v_first_singleton - 1] <> ''
+     OR v_lines[v_first_singleton - 2] NOT LIKE c_range_counts_pattern THEN
+    RAISE EXCEPTION
+      'boundary selectors did not wrap with all ranges before singletons: ranges=% singletons=% manifest=%',
+      v_range_line_count, v_singleton_line_count, v_manifest;
+  END IF;
+
+  -- Long singleton lists form visual paragraphs of four selector lines. There
+  -- is exactly one actual blank line before selector lines 5, 9, 13, and so on.
+  SELECT array_agg(ord ORDER BY ord)
+    INTO v_singleton_ordinals
+  FROM unnest(v_lines) WITH ORDINALITY AS rendered(line, ord)
+  WHERE line LIKE c_boundary_selector_pattern
+    AND line NOT LIKE '%-%';
+  FOR v_singleton_ordinal_index IN 2..cardinality(v_singleton_ordinals) LOOP
+    IF v_singleton_ordinals[v_singleton_ordinal_index]
+         - v_singleton_ordinals[v_singleton_ordinal_index - 1]
+       <> (CASE WHEN mod(v_singleton_ordinal_index - 1, 4) = 0 THEN 2 ELSE 1 END) THEN
+      RAISE EXCEPTION
+        'long singleton selector paragraphs do not break every four lines: ordinals=% manifest=%',
+        v_singleton_ordinals, v_manifest;
+    END IF;
+  END LOOP;
+
+  -- Every wrapped line is a complete selector. Categories never mix, and the soft
+  -- 120-character cap is exceeded only for one indivisible selector token.
+  IF EXISTS (
+    SELECT 1
+    FROM unnest(v_lines) line
+    WHERE line ~ '^# \[[^]]+\] (new|changed)\.rows include=(id|row):'
+      AND length(line) > 120
+      AND cardinality(string_to_array(
+            regexp_replace(line, '^.*include=(id|row):', ''), ',')) <> 1
+  ) OR EXISTS (
+    SELECT 1 FROM unnest(v_lines) line
+    WHERE line LIKE c_range_counts_pattern AND length(line) > 120
+  ) OR EXISTS (
+    SELECT 1
+    FROM unnest(v_lines) line
+    CROSS JOIN LATERAL unnest(string_to_array(
+      split_part(line, 'include=id:', 2), ',')) AS token -- NOSONAR
+    WHERE line LIKE c_boundary_selector_pattern
+    GROUP BY line
+    HAVING bool_or(position('-' in token) > 0)
+       AND bool_or(position('-' in token) = 0)
+  ) OR EXISTS (
+    SELECT 1 FROM unnest(v_lines) line
+    WHERE right(line, 1) = E'\\'
+       OR line ~ '^#[[:space:]]+include=(id|row):'
+  ) THEN
+    RAISE EXCEPTION 'wrapped selector grammar, category separation, or line cap failed: %',
+      v_manifest;
+  END IF;
+
+  -- Each wrapped range line is followed immediately by the annotation derived
+  -- from exactly that line's tokens, in the same order.
+  IF EXISTS (
+    SELECT 1
+    FROM unnest(v_lines) WITH ORDINALITY AS rendered(line, ord)
+    CROSS JOIN LATERAL (
+      SELECT '#   Range counts: ' ||
+             string_agg(
+               token || ' (' ||
+               (split_part(token, '-', 2)::bigint
+                - split_part(token, '-', 1)::bigint + 1)::text ||
+               ' rows)',
+               ', ' ORDER BY token_ord) AS expected
+      FROM unnest(string_to_array(
+        split_part(rendered.line, 'include=id:', 2), ','))
+        WITH ORDINALITY AS range_token(token, token_ord)
+    ) annotation
+    WHERE rendered.line LIKE '# [selector_limit_boundary] new.rows include=id:%-%'
+      AND v_lines[(rendered.ord + 1)::integer] <> annotation.expected
+  ) THEN
+    RAISE EXCEPTION 'a wrapped range annotation is absent or mismatched: %', v_manifest;
+  END IF;
+
+  -- Expanding every repeated line must reconstruct the classified exact set once:
+  -- no omissions, extras, or duplicated tokens across chunks.
+  WITH selector_lines AS (
+    SELECT split_part(line, 'include=id:', 2) AS payload
+    FROM unnest(v_lines) line
+    WHERE line LIKE c_boundary_selector_pattern
+  ), tokens AS (
+    SELECT token
+    FROM selector_lines
+    CROSS JOIN LATERAL unnest(string_to_array(payload, ',')) AS parsed(token)
+  ), expanded AS (
+    SELECT expanded_id AS id
+    FROM tokens
+    CROSS JOIN LATERAL generate_series(
+      split_part(token, '-', 1)::bigint,
+      CASE WHEN position('-' in token) > 0
+           THEN split_part(token, '-', 2)::bigint
+           ELSE token::bigint
+      END
+    ) AS ids(expanded_id)
+  ), source AS (
+    SELECT s.id
+    FROM delta_stage.selector_limit_boundary s
+    JOIN delta_diff.selector_limit_boundary_class d
+      ON d._delta_row_id = s._delta_row_id
+    WHERE d.class = 'NEW'
+  )
+  SELECT
+    (SELECT count(*) FROM expanded),
+    (SELECT count(DISTINCT id) FROM expanded),
+    (SELECT count(*) FROM (SELECT id FROM source EXCEPT SELECT id FROM expanded) q),
+    (SELECT count(*) FROM (SELECT id FROM expanded EXCEPT SELECT id FROM source) q)
+    INTO v_exact_count, v_exact_distinct, v_missing_count, v_extra_count;
+  IF v_exact_count <> 50 OR v_exact_distinct <> 50
+     OR v_missing_count <> 0 OR v_extra_count <> 0 THEN
+    RAISE EXCEPTION
+      'repeated selector lines do not union to the original exact set: count=% distinct=% missing=% extra=% manifest=%',
+      v_exact_count, v_exact_distinct, v_missing_count, v_extra_count, v_manifest;
+  END IF;
+
+  -- The paragraph threshold is strict: exactly eight singleton lines remain
+  -- contiguous, while nine lines break immediately before lines 5 and 9.
+  UPDATE delta_stage.selector_limit_boundary
+  SET id = 4000000000000000000::bigint + _delta_row_id * 2;
+  UPDATE delta_diff.selector_limit_boundary_class
+  SET class = CASE WHEN _delta_row_id <= 24 THEN 'NEW' ELSE 'UNCHANGED' END; -- NOSONAR
+  UPDATE delta_ctl.run_counts
+  SET row_count = 24
+  WHERE table_name = 'selector_limit_boundary' AND count_name = 'NEW'; -- NOSONAR
+  SELECT array_agg(line ORDER BY ord)
+    INTO v_variant_lines
+  FROM delta_ctl.render_selection_manifest() WITH ORDINALITY AS manifest(line, ord);
+  SELECT array_agg(ord ORDER BY ord)
+    INTO v_singleton_ordinals
+  FROM unnest(v_variant_lines) WITH ORDINALITY AS rendered(line, ord)
+  WHERE line LIKE c_boundary_selector_pattern;
+  IF cardinality(v_singleton_ordinals) <> 8 OR EXISTS (
+    SELECT 1
+    FROM generate_subscripts(v_singleton_ordinals, 1) AS indexes(i)
+    WHERE i > 1
+      AND v_singleton_ordinals[i] - v_singleton_ordinals[i - 1] <> 1
+  ) THEN
+    RAISE EXCEPTION 'exactly eight singleton lines received paragraph spacing: ordinals=% manifest=%',
+      v_singleton_ordinals, array_to_string(v_variant_lines, E'\n');
+  END IF;
+
+  UPDATE delta_diff.selector_limit_boundary_class
+  SET class = CASE WHEN _delta_row_id <= 27 THEN 'NEW' ELSE 'UNCHANGED' END;
+  UPDATE delta_ctl.run_counts
+  SET row_count = 27
+  WHERE table_name = 'selector_limit_boundary' AND count_name = 'NEW'; -- NOSONAR
+  SELECT array_agg(line ORDER BY ord)
+    INTO v_variant_lines
+  FROM delta_ctl.render_selection_manifest() WITH ORDINALITY AS manifest(line, ord);
+  SELECT array_agg(ord ORDER BY ord)
+    INTO v_singleton_ordinals
+  FROM unnest(v_variant_lines) WITH ORDINALITY AS rendered(line, ord)
+  WHERE line LIKE c_boundary_selector_pattern;
+  IF cardinality(v_singleton_ordinals) <> 9 OR EXISTS (
+    SELECT 1
+    FROM generate_subscripts(v_singleton_ordinals, 1) AS indexes(i)
+    WHERE i > 1
+      AND v_singleton_ordinals[i] - v_singleton_ordinals[i - 1]
+          <> (CASE WHEN mod(i - 1, 4) = 0 THEN 2 ELSE 1 END)
+  ) THEN
+    RAISE EXCEPTION 'nine singleton lines lack paragraph spacing before lines 5 and 9: ordinals=% manifest=%',
+      v_singleton_ordinals, array_to_string(v_variant_lines, E'\n');
+  END IF;
+
+  -- Restore the inclusive 50-row fixture for all subsequent limit variants.
+  UPDATE delta_stage.selector_limit_boundary
+  SET id = CASE
+             WHEN _delta_row_id <= 10 THEN
+               100000000000000::bigint
+               + ((_delta_row_id - 1) / 2) * 3
+               + ((_delta_row_id - 1) % 2)
+             WHEN _delta_row_id <= 50 THEN
+               2000000000000000000::bigint + (_delta_row_id - 11) * 2
+             ELSE 3000000000000000000::bigint
+           END;
+  UPDATE delta_diff.selector_limit_boundary_class
+  SET class = CASE WHEN _delta_row_id <= 50 THEN 'NEW' ELSE 'UNCHANGED' END;
+  UPDATE delta_ctl.run_counts
+  SET row_count = 50
+  WHERE table_name = 'selector_limit_boundary' AND count_name = 'NEW'; -- NOSONAR
+
+  IF EXISTS (
+    SELECT 1 FROM unnest(v_lines) line
+    WHERE line LIKE '# [%] changed_local_newer.rows include=%'
+  ) THEN
+    RAISE EXCEPTION 'CHANGED_LOCAL_NEWER received unsafe ready-to-uncomment guidance: %', v_manifest;
+  END IF;
+
+  v_pos := array_position(
+    v_lines, '# corp_processing has 53 CHANGED rows; choose selector_id or corp values from:');
+  IF v_pos IS NULL
+     OR v_lines[v_pos + 1] <> '# details/corp_processing.changed.tsv'
+     OR v_lines[v_pos + 2] <> '# Example syntax:'
+     OR v_lines[v_pos + 3] <> '# [corp_processing] changed.rows include=id:100,200-210'
+     OR v_lines[v_pos + 4] <> '# [corp_processing] changed.rows include=corp:BC0000001,BC0000002'
+     OR v_lines[v_pos + 5] <> '#' THEN
+    RAISE EXCEPTION 'large CHANGED guidance does not match the approved shape: %', v_manifest;
+  END IF;
+  IF NOT (v_large_changed < v_pos AND v_pos < v_pointer) THEN
+    RAISE EXCEPTION 'large CHANGED guidance is not in its grouped section: %', v_manifest;
+  END IF;
+
+  v_pos := array_position(
+    v_lines, '# auth_component_operation has 54 NEW rows; choose selector_id from:');
+  IF v_pos IS NULL
+     OR v_lines[v_pos + 1] <> '# details/auth_component_operation.new.tsv'
+     OR v_lines[v_pos + 3] <> '# [auth_component_operation] new.rows include=id:100,200-210'
+     OR v_lines[v_pos + 4] <>
+       '# corp: selectors are also supported via the staged auth_processing parent:'
+     OR v_lines[v_pos + 5] <>
+       '# [auth_component_operation] new.rows include=corp:BC0000001,BC0000002' THEN
+    RAISE EXCEPTION 'large NEW auth guidance lost its parent-derived corp caveat: %', v_manifest;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM unnest(v_lines) line
+    WHERE line NOT LIKE '#%' AND line LIKE '%.rows %'
+  ) THEN
+    RAISE EXCEPTION 'rendered manifest contains an uncommented row selector: %', v_manifest;
+  END IF;
+
+  -- Negative values still receive a summary but suppress every exact selector.
+  UPDATE delta_stage.bad_emails SET id = -2 WHERE _delta_row_id = 1;
+  SELECT array_agg(line ORDER BY ord)
+    INTO v_variant_lines
+  FROM delta_ctl.render_selection_manifest() WITH ORDINALITY AS manifest(line, ord);
+  IF array_position(
+       v_variant_lines,
+       '# [bad_emails] Exact NEW set: rows=3 singletons=3 ranges=0') IS NULL
+     OR array_position(
+       v_variant_lines,
+       '# [bad_emails] Exact NEW selector unavailable for this small set.') IS NULL
+     OR array_position(
+       v_variant_lines,
+       '#   Review details/bad_emails.new.tsv; negative id: values are outside the selector grammar.')
+       IS NULL
+     OR EXISTS (
+       SELECT 1 FROM unnest(v_variant_lines) line
+       WHERE line LIKE '# [bad_emails] new.rows include=id:%'
+     ) THEN
+    RAISE EXCEPTION 'negative selector fallback is incomplete or unsafe: %',
+      array_to_string(v_variant_lines, E'\n');
+  END IF;
+  UPDATE delta_stage.bad_emails SET id = 2 WHERE _delta_row_id = 1;
+
+  -- A singleton suggestion has no redundant range-count comment.
+  UPDATE delta_diff.bad_emails_class
+  SET class = 'UNCHANGED'
+  WHERE _delta_row_id = 5;
+  UPDATE delta_ctl.run_counts
+  SET row_count = 1
+  WHERE table_name = 'bad_emails' AND count_name = 'CHANGED'; -- NOSONAR
+  SELECT array_agg(line ORDER BY ord)
+    INTO v_variant_lines
+  FROM delta_ctl.render_selection_manifest() WITH ORDINALITY AS manifest(line, ord);
+  v_pos := array_position(
+    v_variant_lines,
+    '# [bad_emails] Exact CHANGED set: rows=1 singletons=1 ranges=0');
+  IF v_pos IS NULL
+     OR v_variant_lines[v_pos + 1] <> '# [bad_emails] changed.rows include=id:7'
+     OR v_variant_lines[v_pos + 2] LIKE c_range_counts_pattern THEN
+    RAISE EXCEPTION 'singleton suggestion received range-count guidance: %',
+      array_to_string(v_variant_lines, E'\n');
+  END IF;
+  UPDATE delta_diff.bad_emails_class
+  SET class = 'CHANGED'
+  WHERE _delta_row_id = 5;
+  UPDATE delta_ctl.run_counts
+  SET row_count = 2
+  WHERE table_name = 'bad_emails' AND count_name = 'CHANGED'; -- NOSONAR
+
+  -- Missing selector-limit metadata falls back to 50: 50 is exact, 51 is generic.
+  UPDATE delta_diff.selector_limit_boundary_class
+  SET class = 'NEW'
+  WHERE _delta_row_id = 51;
+  UPDATE delta_ctl.run_counts
+  SET row_count = 51
+  WHERE table_name = 'selector_limit_boundary' AND count_name = 'NEW'; -- NOSONAR
+  SELECT array_agg(line ORDER BY ord)
+    INTO v_variant_lines
+  FROM delta_ctl.render_selection_manifest() WITH ORDINALITY AS manifest(line, ord);
+  v_small_new := array_position(
+    v_variant_lines, '# Small NEW sets receive ready-to-uncomment suggestions:');
+  v_small_changed := array_position(
+    v_variant_lines, '# Small CHANGED sets receive ready-to-uncomment suggestions:');
+  IF EXISTS (
+       SELECT 1
+       FROM unnest(v_variant_lines) WITH ORDINALITY AS rendered(line, ord)
+       WHERE ord > v_small_new AND ord < v_small_changed
+         AND (line LIKE '# [selector_limit_boundary] Exact NEW set:%'
+              OR line LIKE c_boundary_selector_pattern)
+     )
+     OR array_position(
+       v_variant_lines,
+       '# selector_limit_boundary has 51 NEW rows; choose selector_id from:') IS NULL THEN
+    RAISE EXCEPTION 'missing selector-limit metadata did not use the 50/51 boundary: %',
+      array_to_string(v_variant_lines, E'\n');
+  END IF;
+
+  -- A custom limit applies to both complementary renderer branches.
+  INSERT INTO delta_ctl.run_metadata(key, value)
+  VALUES ('selector_suggestion_limit', '2')
+  ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value;
+  SELECT array_agg(line ORDER BY ord)
+    INTO v_variant_lines
+  FROM delta_ctl.render_selection_manifest() WITH ORDINALITY AS manifest(line, ord);
+  v_small_new := array_position(
+    v_variant_lines, '# Small NEW sets receive ready-to-uncomment suggestions:');
+  v_small_changed := array_position(
+    v_variant_lines, '# Small CHANGED sets receive ready-to-uncomment suggestions:');
+  IF array_position(
+       v_variant_lines,
+       '# [bad_emails] Exact CHANGED set: rows=2 singletons=2 ranges=0') IS NULL
+     OR array_position(v_variant_lines, '# [bad_emails] changed.rows include=id:7,9') IS NULL
+     OR EXISTS (
+       SELECT 1
+       FROM unnest(v_variant_lines) WITH ORDINALITY AS rendered(line, ord)
+       WHERE ord > v_small_new AND ord < v_small_changed
+         AND (line LIKE '# [bad_emails] Exact NEW set:%'
+              OR line LIKE '# [bad_emails] new.rows include=id:%')
+     )
+     OR array_position(
+       v_variant_lines, '# bad_emails has 3 NEW rows; choose selector_id from:') IS NULL THEN
+    RAISE EXCEPTION 'custom selector limit did not preserve exact N and generic N+1: %',
+      array_to_string(v_variant_lines, E'\n');
+  END IF;
+
+  -- Zero disables every exact suggestion while retaining generic guidance.
+  UPDATE delta_ctl.run_metadata
+  SET value = '0'
+  WHERE key = 'selector_suggestion_limit';
+  SELECT array_agg(line ORDER BY ord)
+    INTO v_variant_lines
+  FROM delta_ctl.render_selection_manifest() WITH ORDINALITY AS manifest(line, ord);
+  v_small_new := array_position(
+    v_variant_lines, '# Small NEW sets receive ready-to-uncomment suggestions:');
+  v_large_new := array_position(
+    v_variant_lines, '# Large NEW sets receive a useful pointer rather than no guidance:');
+  IF v_small_new IS NULL OR v_large_new IS NULL OR EXISTS (
+    SELECT 1
+    FROM unnest(v_variant_lines) WITH ORDINALITY AS rendered(line, ord)
+    WHERE ord > v_small_new AND ord < v_large_new
+      AND (line ~ '^# \[[^]]+\] (new|changed)\.rows include=(id|row):'
+           OR line ~ '^# \[[^]]+\] Exact (NEW|CHANGED) set:'
+           OR line ~ '^# \[[^]]+\] Exact (NEW|CHANGED) selector unavailable')
+  ) THEN
+    RAISE EXCEPTION 'zero selector limit still emitted exact selector assistance: %',
+      array_to_string(v_variant_lines, E'\n');
+  END IF;
+  SELECT count(*) INTO v_generic_count
+  FROM unnest(v_variant_lines) line
+  WHERE line ~ '^# [a-z0-9_]+ has [0-9]+ (NEW|CHANGED) rows; choose selector_id';
+  IF v_generic_count <> 10 THEN
+    RAISE EXCEPTION 'zero selector limit did not make every positive set generic: count=% manifest=%',
+      v_generic_count, array_to_string(v_variant_lines, E'\n');
+  END IF;
+
+  -- Present malformed metadata fails clearly; only absence receives the fallback.
+  FOREACH v_invalid_value IN ARRAY ARRAY['bogus', '-1', '100001', NULL]::text[] LOOP
+    UPDATE delta_ctl.run_metadata
+    SET value = v_invalid_value
+    WHERE key = 'selector_suggestion_limit';
+    v_error := NULL;
+    BEGIN
+      PERFORM delta_ctl.render_selection_manifest();
+    EXCEPTION WHEN OTHERS THEN
+      v_error := SQLERRM;
+    END;
+    IF v_error IS NULL
+       OR position('invalid selector_suggestion_limit metadata value:' in v_error) = 0
+       OR position('allowed range: 0..100000' in v_error) = 0 THEN
+      RAISE EXCEPTION 'invalid selector metadata % did not fail clearly: %',
+        COALESCE(v_invalid_value, '<NULL>'), COALESCE(v_error, '<no error>');
+    END IF;
+  END LOOP;
+  DELETE FROM delta_ctl.run_metadata WHERE key = 'selector_suggestion_limit';
+
+  UPDATE delta_ctl.run_metadata SET value = 'none' WHERE key = 'manifest_default';
+  SELECT array_agg(line ORDER BY ord)
+    INTO v_none_lines
+  FROM delta_ctl.render_selection_manifest() WITH ORDINALITY AS manifest(line, ord);
+
+  SELECT ord INTO v_wildcard
+  FROM unnest(v_none_lines) WITH ORDINALITY AS u(line, ord)
+  WHERE line LIKE '[*]%' LIMIT 1;
+  IF v_none_lines[v_wildcard] !~ '^\[\*\][[:space:]]+include=$'
+     OR v_none_lines[v_wildcard + 1] <>
+       '# Default selection ([*] none) currently matches 0 rows across 0 tables (new=0 changed=0).'
+     OR EXISTS (
+       SELECT 1 FROM unnest(v_none_lines) line
+       WHERE line NOT LIKE '#%' AND line ~ 'include=(new|changed)'
+     ) THEN
+    RAISE EXCEPTION '--manifest-default none did not produce an empty active selection: %',
+      array_to_string(v_none_lines, E'\n');
+  END IF;
+
+  DELETE FROM delta_ctl.run_metadata WHERE key = 'manifest_default';
+  SELECT array_agg(line ORDER BY ord)
+    INTO v_none_lines
+  FROM delta_ctl.render_selection_manifest() WITH ORDINALITY AS manifest(line, ord);
+  IF NOT EXISTS (
+    SELECT 1 FROM unnest(v_none_lines) line
+    WHERE line ~ '^\[\*\][[:space:]]+include=new,changed$'
+  ) THEN
+    RAISE EXCEPTION 'missing manifest_default metadata did not preserve the historical default';
+  END IF;
+END $$;

--- a/data-tool/tests/delta_restore/expected/t17_selection_cookbook_assert.sql
+++ b/data-tool/tests/delta_restore/expected/t17_selection_cookbook_assert.sql
@@ -1,0 +1,105 @@
+DO $$
+DECLARE
+  v_actual text[];
+  c_corp_processing_include constant text := '# [corp_processing] include=new,changed';
+  v_expected text[] := ARRAY[
+    '# Classes: new | changed | changed_local_newer (other classes are never applyable).',
+    '# Selector kinds: id: for PK tables; row: for PK-less tables; corp: only where supported.',
+    '# Multiple includes union their matches; excludes subtract; --only-corps is a final intersection.',
+    '#',
+    '# ---------------------------------------------------------------------------',
+    '# OPERATOR COOKBOOK',
+    '# Everything below is commented documentation. Copy or uncomment only the',
+    '# examples you intend to use. Row selectors never enable a class by themselves.',
+    '# ---------------------------------------------------------------------------',
+    '#',
+    '# 1. Apply all NEW and CHANGED rows for a table:',
+    '#',
+    '# [mig_corp_batch] include=new,changed',
+    '#',
+    '# 2. Apply only NEW rows for a table:',
+    '#',
+    '# [mig_corp_batch] include=new',
+    '#',
+    '# 3. Apply only CHANGED rows for a table:',
+    '#',
+    '# [corp_processing] include=changed',
+    '#',
+    '# 4. Disable a table entirely:',
+    '#',
+    '# [mig_corp_batch] include=',
+    '#',
+    '# 5. Apply specific NEW rows by staged primary key.',
+    '#    Lists and inclusive ranges may be mixed:',
+    '#',
+    '# [mig_corp_batch] include=new,changed',
+    '# [mig_corp_batch] new.rows include=id:3067,7922,8241-8242',
+    '#',
+    '# 6. Apply every NEW row except specific IDs:',
+    '#',
+    '# [mig_corp_account] include=new,changed',
+    '# [mig_corp_account] new.rows exclude=id:23,100-105',
+    '#',
+    '# 7. Combine multiple includes, then subtract exclusions.',
+    '#    Include lines are unioned; exclude lines are applied afterward:',
+    '#',
+    c_corp_processing_include,
+    '# [corp_processing] new.rows include=id:53946-53959',
+    '# [corp_processing] new.rows include=corp:BC0000001,BC0000002',
+    '# [corp_processing] new.rows exclude=id:53947,53952',
+    '#',
+    '# 8. Apply specific CHANGED rows:',
+    '#',
+    c_corp_processing_include,
+    '# [corp_processing] changed.rows include=id:881,900-905',
+    '#',
+    '# 9. Apply CHANGED rows for selected corporations:',
+    '#',
+    c_corp_processing_include,
+    '# [corp_processing] changed.rows include=corp:BC0000001,BC0000002',
+    '#',
+    '# 10. Explicitly opt into locally newer rows.',
+    '#     CAUTION: these may overwrite more recently modified local values:',
+    '#',
+    '# [corp_processing] include=new,changed,changed_local_newer',
+    '# [corp_processing] changed_local_newer.rows include=id:901',
+    '#',
+    '# 11. Select rows from a PK-less table using the staged row ordinal:',
+    '#',
+    '# [email_domain_groups] include=new',
+    '# [email_domain_groups] new.rows include=row:4,10-15',
+    '#',
+    '# 12. Parent dependency reminder:',
+    '#     A selected NEW child whose preserved parent is also NEW requires that',
+    '#     parent row to remain selected.',
+    '#',
+    '# [mig_batch] include=new',
+    '# [mig_batch] new.rows include=id:152',
+    '# [mig_corp_account] include=new',
+    '# [mig_corp_account] new.rows include=id:23643-23658',
+    '#',
+    '# 13. --only-corps is an additional global intersection:',
+    '#',
+    '# ./delta_restore_extract.sh ... ' || chr(92),
+    '#   --selection-file selection.conf ' || chr(92),
+    '#   --only-corps selected_corps.txt'
+  ];
+  v_line_no integer;
+BEGIN
+  SELECT array_agg(line ORDER BY ord)
+    INTO v_actual
+  FROM delta_ctl.render_selection_cookbook() WITH ORDINALITY AS cookbook(line, ord);
+
+  IF v_actual IS DISTINCT FROM v_expected THEN
+    FOR v_line_no IN 1..GREATEST(
+      COALESCE(array_length(v_expected, 1), 0),
+      COALESCE(array_length(v_actual, 1), 0))
+    LOOP
+      IF v_expected[v_line_no] IS DISTINCT FROM v_actual[v_line_no] THEN
+        RAISE EXCEPTION 'selection cookbook differs at line %: expected=% actual=%',
+          v_line_no, v_expected[v_line_no], v_actual[v_line_no];
+      END IF;
+    END LOOP;
+    RAISE EXCEPTION 'selection cookbook array metadata differs despite equal lines';
+  END IF;
+END $$;

--- a/data-tool/tests/delta_restore/fixtures/t12_row_selection.sql
+++ b/data-tool/tests/delta_restore/fixtures/t12_row_selection.sql
@@ -1,0 +1,71 @@
+-- End-to-end row selection apply: 1 parent plus 16/16/16 selected children.
+TRUNCATE delta_ctl.table_config, delta_ctl.run_counts, delta_ctl.selection,
+  delta_ctl.row_selection, delta_ctl.selection_diagnostics, delta_ctl.apply_counts,
+  delta_ctl.touched_tables, delta_ctl.dependency_violations;
+DROP SCHEMA delta_stage CASCADE;
+DROP SCHEMA delta_map CASCADE;
+DROP SCHEMA delta_diff CASCADE;
+CREATE SCHEMA delta_stage;
+CREATE SCHEMA delta_map;
+CREATE SCHEMA delta_diff;
+TRUNCATE public.mig_group, public.mig_batch, public.mig_corp_account,
+  public.mig_corp_batch, public.corp_processing, public.corporation RESTART IDENTITY;
+
+CREATE UNLOGGED TABLE delta_stage.mig_group (LIKE public.mig_group INCLUDING DEFAULTS);
+ALTER TABLE delta_stage.mig_group ADD COLUMN _delta_row_id bigint GENERATED ALWAYS AS IDENTITY;
+CREATE UNLOGGED TABLE delta_stage.mig_batch (LIKE public.mig_batch INCLUDING DEFAULTS);
+ALTER TABLE delta_stage.mig_batch ADD COLUMN _delta_row_id bigint GENERATED ALWAYS AS IDENTITY;
+CREATE UNLOGGED TABLE delta_stage.mig_corp_account (LIKE public.mig_corp_account INCLUDING DEFAULTS);
+ALTER TABLE delta_stage.mig_corp_account ADD COLUMN _delta_row_id bigint GENERATED ALWAYS AS IDENTITY;
+CREATE UNLOGGED TABLE delta_stage.mig_corp_batch (LIKE public.mig_corp_batch INCLUDING DEFAULTS);
+ALTER TABLE delta_stage.mig_corp_batch ADD COLUMN _delta_row_id bigint GENERATED ALWAYS AS IDENTITY;
+CREATE UNLOGGED TABLE delta_stage.corp_processing (LIKE public.corp_processing INCLUDING DEFAULTS);
+ALTER TABLE delta_stage.corp_processing ADD COLUMN _delta_row_id bigint GENERATED ALWAYS AS IDENTITY;
+
+INSERT INTO delta_ctl.table_config(table_name, load_phase)
+VALUES ('mig_group', 20), ('mig_batch', 30), ('mig_corp_batch', 40), -- NOSONAR
+       ('mig_corp_account', 50), ('corp_processing', 60); -- NOSONAR
+SELECT delta_ctl.complete_table_config();
+
+INSERT INTO public.mig_group(id, name, target_environment, source_db)
+VALUES (1, 'existing-group', 'dev', 'COLIN');
+INSERT INTO delta_stage.mig_group(id, name, target_environment, source_db)
+VALUES (1, 'existing-group', 'dev', 'COLIN');
+INSERT INTO delta_stage.mig_batch(id, mig_group_id, name, target_environment)
+VALUES (152, 1, 'selected-parent', 'dev');
+
+INSERT INTO delta_stage.mig_corp_account(id, corp_num, target_environment, account_id, mig_batch_id)
+SELECT id, 'BC' || lpad(id::text, 7, '0'), 'dev', 'acct-' || id, 152
+FROM (SELECT 23 AS id UNION ALL SELECT generate_series(23643, 23658)) q;
+
+INSERT INTO delta_stage.mig_corp_batch(id, mig_batch_id, corp_num)
+SELECT id, 152, 'MB' || lpad(id::text, 7, '0') FROM generate_series(3001, 3020) id;
+
+INSERT INTO public.corporation(corp_num)
+SELECT 'CP' || lpad(id::text, 7, '0') FROM generate_series(4001, 4032) id;
+INSERT INTO delta_stage.corp_processing(
+  id, corp_num, flow_name, environment, mig_batch_id, processed_status, last_modified)
+SELECT id, 'CP' || lpad(id::text, 7, '0'), 'flow-' || id, 'dev', 152, 'READY', now()
+FROM generate_series(4001, 4032) id;
+
+SELECT delta_ctl.run_preview_classification();
+INSERT INTO delta_ctl.selection(table_name, class)
+SELECT table_name, 'NEW' FROM delta_ctl.table_config; -- NOSONAR
+INSERT INTO delta_ctl.selection(table_name, class)
+SELECT table_name, 'CHANGED' FROM delta_ctl.table_config;
+
+DO $$
+DECLARE
+  c_include_mode constant text := 'include';
+BEGIN
+  INSERT INTO delta_ctl.row_selection(
+    table_name, class, mode, kind, value_from, value_to, corp_num, is_range, source_line)
+  VALUES
+    ('mig_corp_account', 'NEW', 'exclude', 'id', 23, 23, NULL, false, 1),
+    ('mig_corp_batch', 'NEW', c_include_mode, 'id', 3001, 3017, NULL, true, 2),
+    ('mig_corp_batch', 'NEW', 'exclude', 'id', 3017, 3017, NULL, false, 3),
+    ('corp_processing', 'NEW', c_include_mode, 'id', 4001, 4015, NULL, true, 4),
+    ('corp_processing', 'NEW', c_include_mode, 'corp', NULL, NULL, 'CP0004016', false, 5);
+END $$;
+
+SELECT delta_ctl.run_apply();

--- a/data-tool/tests/delta_restore/fixtures/t13_selector_diagnostics.sql
+++ b/data-tool/tests/delta_restore/fixtures/t13_selector_diagnostics.sql
@@ -1,0 +1,64 @@
+-- Semantic selector diagnostics: unsupported kinds, class gate, and zero match.
+TRUNCATE delta_ctl.table_config, delta_ctl.run_counts, delta_ctl.selection,
+  delta_ctl.row_selection, delta_ctl.selection_diagnostics, delta_ctl.apply_counts,
+  delta_ctl.touched_tables, delta_ctl.dependency_violations;
+DROP SCHEMA delta_stage CASCADE; DROP SCHEMA delta_map CASCADE; DROP SCHEMA delta_diff CASCADE;
+CREATE SCHEMA delta_stage; CREATE SCHEMA delta_map; CREATE SCHEMA delta_diff;
+
+CREATE UNLOGGED TABLE delta_stage.bar_corps (LIKE public.bar_corps INCLUDING DEFAULTS);
+ALTER TABLE delta_stage.bar_corps ADD COLUMN _delta_row_id bigint GENERATED ALWAYS AS IDENTITY;
+CREATE UNLOGGED TABLE delta_stage.mig_group (LIKE public.mig_group INCLUDING DEFAULTS);
+ALTER TABLE delta_stage.mig_group ADD COLUMN _delta_row_id bigint GENERATED ALWAYS AS IDENTITY;
+CREATE UNLOGGED TABLE delta_stage.bad_emails (LIKE public.bad_emails INCLUDING DEFAULTS);
+ALTER TABLE delta_stage.bad_emails ADD COLUMN _delta_row_id bigint GENERATED ALWAYS AS IDENTITY;
+CREATE UNLOGGED TABLE delta_stage.auth_processing (LIKE public.auth_processing INCLUDING DEFAULTS);
+ALTER TABLE delta_stage.auth_processing ADD COLUMN _delta_row_id bigint GENERATED ALWAYS AS IDENTITY;
+CREATE UNLOGGED TABLE delta_stage.auth_component_operation (LIKE public.auth_component_operation INCLUDING DEFAULTS);
+ALTER TABLE delta_stage.auth_component_operation ADD COLUMN _delta_row_id bigint GENERATED ALWAYS AS IDENTITY;
+CREATE UNLOGGED TABLE delta_stage.email_domain_groups (LIKE public.email_domain_groups INCLUDING DEFAULTS);
+ALTER TABLE delta_stage.email_domain_groups ADD COLUMN _delta_row_id bigint GENERATED ALWAYS AS IDENTITY;
+
+INSERT INTO delta_ctl.table_config(table_name, load_phase)
+VALUES ('bar_corps', 10), ('mig_group', 20), ('bad_emails', 30), -- NOSONAR
+       ('auth_processing', 40), ('auth_component_operation', 50), -- NOSONAR
+       ('email_domain_groups', 60), ('excluded_emails', 70); -- NOSONAR
+SELECT delta_ctl.complete_table_config();
+SELECT delta_ctl.create_class_table('bar_corps');
+SELECT delta_ctl.create_class_table('mig_group');
+SELECT delta_ctl.create_class_table('bad_emails');
+SELECT delta_ctl.create_class_table('auth_processing');
+SELECT delta_ctl.create_class_table('auth_component_operation');
+SELECT delta_ctl.create_class_table('email_domain_groups');
+
+INSERT INTO delta_stage.bar_corps(identifier, notes) VALUES ('BC1', 'x');
+INSERT INTO delta_stage.mig_group(id, name, target_environment, source_db) VALUES (1, 'g', 'dev', 'C');
+INSERT INTO delta_stage.bad_emails(id, email, notes) VALUES (1, 'a@example.test', 'x');
+INSERT INTO delta_stage.auth_processing(id, corp_num) VALUES (50, 'BCOK');
+INSERT INTO delta_stage.auth_component_operation(id, auth_processing_id, component_name)
+VALUES (60, 50, 'component');
+INSERT INTO delta_stage.email_domain_groups(email_domain, group_name)
+VALUES ('example.test', 'test-group');
+INSERT INTO delta_diff.bar_corps_class(_delta_row_id, class) VALUES (1, 'NEW');
+INSERT INTO delta_diff.mig_group_class(_delta_row_id, staged_pk, class) VALUES (1, 1, 'NEW');
+INSERT INTO delta_diff.bad_emails_class(_delta_row_id, staged_pk, class) VALUES (1, 1, 'NEW');
+INSERT INTO delta_diff.auth_processing_class(_delta_row_id, staged_pk, class) VALUES (1, 50, 'NEW');
+INSERT INTO delta_diff.auth_component_operation_class(_delta_row_id, staged_pk, class) VALUES (1, 60, 'NEW');
+INSERT INTO delta_diff.email_domain_groups_class(_delta_row_id, class) VALUES (1, 'NEW');
+
+INSERT INTO delta_ctl.selection(table_name, class)
+VALUES ('bar_corps', 'NEW'), ('mig_group', 'NEW'), ('bad_emails', 'NEW'),
+       ('auth_processing', 'NEW'), ('auth_component_operation', 'NEW'),
+       ('email_domain_groups', 'NEW'), ('excluded_emails', 'NEW');
+INSERT INTO delta_ctl.only_corps(corp_num) VALUES ('BCOK');
+INSERT INTO delta_ctl.row_selection(
+  table_name, class, mode, kind, value_from, value_to, corp_num, is_range, source_line)
+VALUES
+ ('bar_corps', 'NEW', 'include', 'id', 1, 1, NULL, false, 10), -- NOSONAR
+ ('mig_group', 'NEW', 'include', 'corp', NULL, NULL, 'BC1', false, 11),
+ ('bad_emails', 'CHANGED', 'include', 'id', 1, 1, NULL, false, 12),
+ ('bad_emails', 'NEW', 'include', 'id', 999, 999, NULL, false, 13),
+ ('bar_corps', 'NEW', 'include', 'corp', NULL, NULL, 'BC1', false, 14),
+ ('auth_component_operation', 'NEW', 'include', 'corp', NULL, NULL, 'BCOK', false, 15),
+ ('email_domain_groups', 'NEW', 'include', 'row', 1, 1, NULL, false, 16),
+ ('excluded_emails', 'NEW', 'include', 'row', 1, 1, NULL, false, 17);
+SELECT delta_ctl.verify_row_selection();

--- a/data-tool/tests/delta_restore/fixtures/t14_parent_dependency_rows.sql
+++ b/data-tool/tests/delta_restore/fixtures/t14_parent_dependency_rows.sql
@@ -1,0 +1,22 @@
+-- Selected child with excluded NEW parent produces persisted sample_ids.
+TRUNCATE delta_ctl.table_config, delta_ctl.run_counts, delta_ctl.selection,
+  delta_ctl.row_selection, delta_ctl.selection_diagnostics, delta_ctl.apply_counts,
+  delta_ctl.touched_tables, delta_ctl.dependency_violations;
+DROP SCHEMA delta_stage CASCADE; DROP SCHEMA delta_map CASCADE; DROP SCHEMA delta_diff CASCADE;
+CREATE SCHEMA delta_stage; CREATE SCHEMA delta_map; CREATE SCHEMA delta_diff;
+
+CREATE UNLOGGED TABLE delta_stage.mig_group (LIKE public.mig_group INCLUDING DEFAULTS);
+ALTER TABLE delta_stage.mig_group ADD COLUMN _delta_row_id bigint GENERATED ALWAYS AS IDENTITY;
+CREATE UNLOGGED TABLE delta_stage.mig_batch (LIKE public.mig_batch INCLUDING DEFAULTS);
+ALTER TABLE delta_stage.mig_batch ADD COLUMN _delta_row_id bigint GENERATED ALWAYS AS IDENTITY;
+INSERT INTO delta_ctl.table_config(table_name, load_phase) VALUES ('mig_group', 20), ('mig_batch', 30);
+SELECT delta_ctl.complete_table_config();
+SELECT delta_ctl.create_class_table('mig_group');
+SELECT delta_ctl.create_class_table('mig_batch');
+INSERT INTO delta_stage.mig_group(id, name) VALUES (100, 'parent');
+INSERT INTO delta_stage.mig_batch(id, mig_group_id, name) VALUES (200, 100, 'child');
+INSERT INTO delta_diff.mig_group_class(_delta_row_id, staged_pk, class, selected)
+VALUES (1, 100, 'NEW', false);
+INSERT INTO delta_diff.mig_batch_class(_delta_row_id, staged_pk, class, selected)
+VALUES (1, 200, 'NEW', true);
+SELECT delta_ctl.validate_dependencies();

--- a/data-tool/tests/delta_restore/fixtures/t15_details.sql
+++ b/data-tool/tests/delta_restore/fixtures/t15_details.sql
@@ -1,0 +1,18 @@
+-- Value rendering, old-to-new diffs, escaping, and detail truncation.
+TRUNCATE delta_ctl.table_config, delta_ctl.run_counts, delta_ctl.selection,
+  delta_ctl.row_selection, delta_ctl.selection_diagnostics, delta_ctl.apply_counts,
+  delta_ctl.touched_tables, delta_ctl.dependency_violations;
+DROP SCHEMA delta_stage CASCADE; DROP SCHEMA delta_map CASCADE; DROP SCHEMA delta_diff CASCADE;
+CREATE SCHEMA delta_stage; CREATE SCHEMA delta_map; CREATE SCHEMA delta_diff;
+TRUNCATE public.bad_emails RESTART IDENTITY;
+
+CREATE UNLOGGED TABLE delta_stage.bad_emails (LIKE public.bad_emails INCLUDING DEFAULTS);
+ALTER TABLE delta_stage.bad_emails ADD COLUMN _delta_row_id bigint GENERATED ALWAYS AS IDENTITY;
+INSERT INTO delta_ctl.table_config(table_name, load_phase) VALUES ('bad_emails', 10);
+SELECT delta_ctl.complete_table_config();
+INSERT INTO public.bad_emails(id, email, notes) VALUES (1, 'changed@example.test', 'local old');
+INSERT INTO delta_stage.bad_emails(id, email, notes) VALUES
+  (1, 'changed@example.test', 'dump new'),
+  (2, 'new@example.test', E'tab\tline\nnext\rreturn\\slash'),
+  (3, 'newer@example.test', 'third');
+SELECT delta_ctl.run_preview_classification();

--- a/data-tool/tests/delta_restore/fixtures/t16_selection_manifest.sql
+++ b/data-tool/tests/delta_restore/fixtures/t16_selection_manifest.sql
@@ -1,0 +1,95 @@
+-- Selection manifest structure, default behavior, dependencies, and selector assistance.
+TRUNCATE delta_ctl.table_config, delta_ctl.run_metadata, delta_ctl.run_counts,
+  delta_ctl.selection, delta_ctl.row_selection, delta_ctl.selection_diagnostics;
+DROP SCHEMA delta_stage CASCADE; DROP SCHEMA delta_map CASCADE; DROP SCHEMA delta_diff CASCADE;
+CREATE SCHEMA delta_stage; CREATE SCHEMA delta_map; CREATE SCHEMA delta_diff;
+
+INSERT INTO delta_ctl.run_metadata(key, value) VALUES
+  ('dump_sha256', 'manifest-test-sha'),
+  ('manifest_default', 'new,changed');
+INSERT INTO delta_ctl.table_config(table_name, load_phase, pk_col, fk_map) VALUES
+  ('bad_emails', 10, 'id', '{}'::jsonb), -- NOSONAR
+  ('selector_limit_boundary', 12, 'id', '{}'::jsonb), -- NOSONAR
+  ('mig_batch', 15, NULL, -- NOSONAR
+    '{"mig_group_id":"mig_group","external_id":"external:other.id"}'::jsonb),
+  ('mig_group', 20, 'id', '{}'::jsonb), -- NOSONAR
+  ('bar_corps', 30, NULL, '{}'::jsonb), -- NOSONAR
+  ('corp_processing', 40, 'id', -- NOSONAR
+    '{"mig_batch_id":"mig_batch","corp_num":"external:corporation.corp_num"}'::jsonb),
+  ('auth_component_operation', 45, 'id', -- NOSONAR
+    '{"auth_processing_id":"auth_processing"}'::jsonb);
+
+CREATE TABLE delta_stage.bad_emails (
+  id bigint,
+  _delta_row_id bigint
+);
+CREATE TABLE delta_diff.bad_emails_class (
+  _delta_row_id bigint,
+  class text
+);
+INSERT INTO delta_stage.bad_emails(id, _delta_row_id) VALUES
+  (2, 1), (3, 2), (5, 3), (7, 4), (9, 5);
+INSERT INTO delta_diff.bad_emails_class(_delta_row_id, class) VALUES
+  (1, 'NEW'), (2, 'NEW'), (3, 'NEW'), (4, 'CHANGED'), (5, 'CHANGED'); -- NOSONAR
+
+CREATE TABLE delta_stage.selector_limit_boundary (
+  id bigint,
+  _delta_row_id bigint
+);
+CREATE TABLE delta_diff.selector_limit_boundary_class (
+  _delta_row_id bigint,
+  class text
+);
+INSERT INTO delta_stage.selector_limit_boundary(id, _delta_row_id)
+SELECT CASE
+         -- Five separated two-value runs force wrapped range/count pairs.
+         WHEN n <= 10 THEN
+           100000000000000::bigint + ((n - 1) / 2) * 3 + ((n - 1) % 2)
+         -- Forty long, separated values force more than eight singleton lines
+         -- and therefore exercise four-line visual paragraph breaks.
+         WHEN n <= 50 THEN
+           2000000000000000000::bigint + (n - 11) * 2
+         ELSE 3000000000000000000::bigint
+       END,
+       n
+FROM generate_series(1, 51) AS ids(n);
+INSERT INTO delta_diff.selector_limit_boundary_class(_delta_row_id, class)
+SELECT n, CASE WHEN n <= 50 THEN 'NEW' ELSE 'UNCHANGED' END
+FROM generate_series(1, 51) AS ids(n);
+
+CREATE TABLE delta_stage.mig_batch (
+  _delta_row_id bigint
+);
+CREATE TABLE delta_diff.mig_batch_class (
+  _delta_row_id bigint,
+  class text
+);
+INSERT INTO delta_stage.mig_batch(_delta_row_id) VALUES (4), (5), (8), (10), (11);
+INSERT INTO delta_diff.mig_batch_class(_delta_row_id, class) VALUES
+  (4, 'NEW'), (5, 'NEW'), (8, 'NEW'), (10, 'CHANGED'), (11, 'CHANGED');
+
+-- auth_component_operation supports corp: through this staged parent, not its own TSV columns.
+CREATE TABLE delta_stage.auth_processing (
+  id bigint,
+  corp_num text,
+  _delta_row_id bigint
+);
+
+INSERT INTO delta_ctl.run_counts(table_name, count_name, row_count) VALUES
+  ('bad_emails', 'STAGED', 5), -- NOSONAR
+  ('bad_emails', 'NEW', 3),
+  ('bad_emails', 'CHANGED', 2),
+  ('selector_limit_boundary', 'STAGED', 51),
+  ('selector_limit_boundary', 'NEW', 50),
+  ('mig_batch', 'STAGED', 5),
+  ('mig_batch', 'NEW', 3),
+  ('mig_batch', 'CHANGED', 2),
+  ('mig_group', 'STAGED', 51),
+  ('mig_group', 'NEW', 51),
+  ('bar_corps', 'STAGED', 52),
+  ('bar_corps', 'NEW', 52),
+  ('corp_processing', 'STAGED', 106),
+  ('corp_processing', 'NEW', 53),
+  ('corp_processing', 'CHANGED', 53),
+  ('auth_component_operation', 'STAGED', 54),
+  ('auth_component_operation', 'NEW', 54);

--- a/data-tool/tests/delta_restore/fixtures/t17_selection_cookbook.sql
+++ b/data-tool/tests/delta_restore/fixtures/t17_selection_cookbook.sql
@@ -1,0 +1,2 @@
+-- The selection cookbook is a static grammar reference and must not depend on run state.
+TRUNCATE delta_ctl.run_metadata, delta_ctl.run_counts;

--- a/data-tool/tests/delta_restore/run_tests.sh
+++ b/data-tool/tests/delta_restore/run_tests.sh
@@ -32,7 +32,7 @@ usage() {
 Usage: run_tests.sh [--integration] [--static-only] [--keep-dbs] [-h|--help]
 
 Checks:
-  static       Shell syntax and guarded COPY-header AWK happy/failure paths.
+  static       Shell syntax plus guarded COPY-header and detail-alignment AWK paths.
   sql-smoke    If local Postgres tooling is available: compile/install delta SQL
                and run a focused preserved-parent BLOCKED_FK smoke fixture.
   integration  Optional: create source/local throwaway DBs with minimal DDL,
@@ -102,6 +102,16 @@ require_file() {
   return 0
 }
 
+path_mode() {
+  local path="$1"
+  if stat -f '%Lp' "$path" >/dev/null 2>&1; then
+    stat -f '%Lp' "$path"
+  else
+    stat -c '%a' "$path"
+  fi
+  return 0
+}
+
 run_static_checks() {
   log '== static checks =='
   local ok=true
@@ -118,7 +128,72 @@ run_static_checks() {
     fi
   done
 
-  local awk_tmp expected sidecar out err
+  local delta_usage
+  delta_usage="$(
+    unset PG_BIN
+    DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+    usage
+  )"
+  if grep -q '^Environment:$' <<<"$delta_usage" \
+     && grep -Fq 'PG_BIN=/path/to/postgresql/bin' <<<"$delta_usage" \
+     && grep -Fq 'optional PostgreSQL client-tools directory; unset or empty uses PATH' <<<"$delta_usage" \
+     && ! grep -Fq '/opt/homebrew/opt/postgresql@15/bin/' <<<"$delta_usage" \
+     && grep -q 'LOCK_TIMEOUT_SECONDS=30' <<<"$delta_usage" \
+     && grep -q '^After run-directory initialization, each invocation prints its artifact directory on exit:$' <<<"$delta_usage" \
+     && grep -q 'Artifacts retained for inspection: <run-dir>' <<<"$delta_usage"; then
+    pass 'delta restore help documents portable PG_BIN, lock timeout, and artifact handoff'
+  else
+    fail 'delta restore environment/artifact help contract'
+    ok=false
+  fi
+
+  if (
+    unset PG_BIN
+    DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+    [[ -z "$PG_BIN" ]]
+    [[ "$(pg_tool psql)" = "psql" ]]
+    [[ "$PSQL_BIN" = "psql" ]]
+    [[ "$PG_RESTORE_BIN" = "pg_restore" ]]
+  ) && (
+    PG_BIN=""
+    export PG_BIN
+    DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+    [[ -z "$PG_BIN" ]]
+    [[ "$(pg_tool psql)" = "psql" ]]
+    [[ "$PSQL_BIN" = "psql" ]]
+    [[ "$PG_RESTORE_BIN" = "pg_restore" ]]
+  ) && (
+    PG_BIN="/custom/postgresql/bin/"
+    export PG_BIN
+    DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+    [[ "$PG_BIN" = "/custom/postgresql/bin/" ]]
+    [[ "$(pg_tool psql)" = "/custom/postgresql/bin/psql" ]]
+    [[ "$PSQL_BIN" = "/custom/postgresql/bin/psql" ]]
+    [[ "$PG_RESTORE_BIN" = "/custom/postgresql/bin/pg_restore" ]]
+  ); then
+    pass 'delta PG_BIN resolver handles unset, empty, and explicit directory states'
+  else
+    fail 'delta PG_BIN resolver behavior'
+    ok=false
+  fi
+
+  local private_tmp
+  private_tmp="$TMP_BASE/private_artifacts"
+  if (
+    umask 022
+    DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+    mkdir -p "$private_tmp/run"
+    : > "$private_tmp/run/artifact.txt"
+    [[ "$(path_mode "$private_tmp/run")" = "700" ]]
+    [[ "$(path_mode "$private_tmp/run/artifact.txt")" = "600" ]]
+  ); then
+    pass 'delta restore artifacts default to private directory/file permissions'
+  else
+    fail 'delta restore private artifact permissions'
+    ok=false
+  fi
+
+  local awk_tmp expected sidecar out err aligned expected_aligned canonical
   awk_tmp="$TMP_BASE/awk"
   mkdir -p "$awk_tmp"
   expected="$awk_tmp/expected.txt"
@@ -160,6 +235,443 @@ SQL
   else
     fail 'AWK rewrite failure path produced unclear error'
     ok=false
+  fi
+
+  cat > "$awk_tmp/details.tsv" <<'TSV'
+id	name	note
+1	Ada	short
+22	Longer	1234567890
+# TRUNCATED at 2 rows
+TSV
+  cat > "$awk_tmp/details.expected.txt" <<'TXT'
+id  name    note
+--  ------  --------
+1   Ada     short
+22  Longer  1234567…
+# TRUNCATED at 2 rows
+TXT
+  aligned="$awk_tmp/details.txt"
+  expected_aligned="$awk_tmp/details.expected.txt"
+  canonical="$awk_tmp/details.canonical.tsv"
+  cp "$awk_tmp/details.tsv" "$canonical"
+  if awk -v max_width=8 -f "$DATA_TOOL_DIR/scripts/restore/delta/align_details.awk" \
+       "$awk_tmp/details.tsv" "$awk_tmp/details.tsv" > "$aligned" \
+     && cmp -s "$expected_aligned" "$aligned" \
+     && awk -v max_width=8 -f "$DATA_TOOL_DIR/scripts/restore/delta/align_details.awk" \
+          "$awk_tmp/details.tsv" "$awk_tmp/details.tsv" | cmp -s "$expected_aligned" -; then
+    pass 'detail aligner pads columns, clips cells, preserves sentinel, and is deterministic'
+  else
+    fail 'detail aligner formatting contract'
+    ok=false
+  fi
+
+  : > "$awk_tmp/empty.tsv"
+  if awk -f "$DATA_TOOL_DIR/scripts/restore/delta/align_details.awk" \
+       "$awk_tmp/empty.tsv" "$awk_tmp/empty.tsv" > "$aligned" \
+     && [[ ! -s "$aligned" ]]; then
+    pass 'detail aligner produces no output for empty input'
+  else
+    fail 'detail aligner empty-input contract'
+    ok=false
+  fi
+
+  if (
+    DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+    parse_args --mode validate --no-aligned-details --align-width 3 --manifest-default none
+    [[ "$MODE" = "validate" ]]
+    [[ "$ALIGN_DETAILS" = "false" && "$ALIGN_WIDTH" = "6" ]]
+    [[ "$MANIFEST_DEFAULT" = "none" ]]
+  ); then
+    pass 'validate mode, aligned-detail, and manifest-default CLI controls parse valid values'
+  else
+    fail 'validate mode, aligned-detail, or manifest-default CLI control parsing'
+    ok=false
+  fi
+
+  if (
+    DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+    [[ "$SELECTOR_SUGGESTION_LIMIT" = "50" ]]
+    parse_args --selector-suggestion-limit 0
+    [[ "$SELECTOR_SUGGESTION_LIMIT" = "0" ]]
+    parse_args --selector-suggestion-limit 37
+    [[ "$SELECTOR_SUGGESTION_LIMIT" = "37" ]]
+    parse_args --selector-suggestion-limit 00007
+    [[ "$SELECTOR_SUGGESTION_LIMIT" = "7" ]]
+    parse_args --selector-suggestion-limit 100000
+    [[ "$SELECTOR_SUGGESTION_LIMIT" = "100000" ]]
+  ); then
+    pass 'selector-suggestion-limit accepts default, zero, custom, canonical, and maximum values'
+  else
+    fail 'selector-suggestion-limit valid-value parsing or canonicalization'
+    ok=false
+  fi
+
+  selector_limit_rejections=true
+  for invalid_limit in -1 text +1 1.5 100001 999999999999999999999999999999; do
+    if (
+      DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+      parse_args --selector-suggestion-limit "$invalid_limit"
+    ) >/dev/null 2>&1; then
+      selector_limit_rejections=false
+    fi
+  done
+  if (
+    DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+    parse_args --selector-suggestion-limit
+  ) >/dev/null 2>&1; then
+    selector_limit_rejections=false
+  fi
+  if [[ "$selector_limit_rejections" = "true" ]]; then
+    pass 'selector-suggestion-limit rejects negative, malformed, above-cap, huge, and missing values'
+  else
+    fail 'selector-suggestion-limit accepted an invalid value'
+    ok=false
+  fi
+
+  if (
+    DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+    help_text="$(usage)"
+    [[ "$help_text" = *'--selector-suggestion-limit <n>'* ]]
+    [[ "$help_text" = *'exact manifest suggestions per table/class; default: 50'* ]]
+    [[ "$help_text" = *'0 disables exact suggestions; maximum: 100000'* ]]
+  ); then
+    pass 'selector-suggestion-limit help documents scope, default, zero, and maximum'
+  else
+    fail 'selector-suggestion-limit help contract'
+    ok=false
+  fi
+
+  (
+    DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+    parse_args --mode verify
+  ) >/dev/null 2>&1
+  if [[ "$?" -ne 0 ]]; then
+    pass 'mode CLI rejects unsupported values while accepting validate'
+  else
+    fail 'mode CLI accepted an unsupported value'
+    ok=false
+  fi
+  (
+    DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+    parse_args --align-width 0
+  ) >/dev/null 2>&1
+  if [[ "$?" -ne 0 ]]; then
+    pass 'aligned-detail CLI rejects a zero width'
+  else
+    fail 'aligned-detail CLI accepted a zero width'
+    ok=false
+  fi
+  (
+    DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+    parse_args --manifest-default changed
+  ) >/dev/null 2>&1
+  if [[ "$?" -ne 0 ]]; then
+    pass 'manifest-default CLI rejects unsupported defaults'
+  else
+    fail 'manifest-default CLI accepted an unsupported default'
+    ok=false
+  fi
+  printf 'resident dump fixture\n' > "$awk_tmp/resident.dump"
+  if (
+    DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+    RUN_DIR="$awk_tmp"
+    DUMP="$awk_tmp/resident.dump"
+    DUMP_SHA256=""
+    compute_dump_sha
+    [[ -n "$DUMP_SHA256" ]]
+    [[ "$DUMP_SHA256" = "$(sha256_file "$DUMP")" ]]
+    [[ "$(cat "$RUN_DIR/dump.sha256")" = "$DUMP_SHA256" ]]
+  ); then
+    pass 'dump sha helper safely sets the shared hash and writes its binding artifact'
+  else
+    fail 'dump sha helper shared-state contract'
+    ok=false
+  fi
+
+  if (
+    DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+    apply_body="$(declare -f run_apply_mode)"
+    [[ "$apply_body" = *'verify_dump_and_manifest'* ]]
+    [[ "$apply_body" = *'filter_toc'* ]]
+    [[ "$apply_body" = *'install_control_schemas'* ]]
+    [[ "$apply_body" = *'stream_stage_data'* ]]
+    [[ "$apply_body" = *'run_preview_classification'* ]]
+    [[ "$apply_body" = *'prepare_apply_selection'* ]]
+  ); then
+    pass 'apply retains full dump verification, restaging, and reclassification posture'
+  else
+    fail 'apply full-restage posture changed'
+    ok=false
+  fi
+
+  if (
+    DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+    validate_body="$(declare -f run_validate_mode)"
+    [[ "$validate_body" = *'verify_resident_run'* ]]
+    [[ "$validate_body" = *'load_preserved_config'* ]]
+    [[ "$validate_body" = *'select_tables'* ]]
+    [[ "$validate_body" = *'prepare_apply_selection'* ]]
+    [[ "$validate_body" != *'filter_toc'* ]]
+    [[ "$validate_body" != *'install_control_schemas'* ]]
+    [[ "$validate_body" != *'stream_stage_data'* ]]
+    [[ "$validate_body" != *'run_preview_classification'* ]]
+  ); then
+    pass 'validate reuses resident selection preparation without staging or classification'
+  else
+    fail 'validate resident-only dispatch contract'
+    ok=false
+  fi
+
+  if (
+    DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+    RUN_DIR="$awk_tmp"
+    MODE="preview"
+    DUMP="/tmp/manifest-default.dump"
+    DUMP_SHA256="manifest-default-sha"
+    MANIFEST_DEFAULT="none"
+    psql_file() { :; return 0; }
+    record_metadata
+    grep -Fq "('manifest_default', 'none')" "$RUN_DIR/metadata.sql"
+    grep -Fq "('selector_suggestion_limit', '50')" "$RUN_DIR/metadata.sql"
+  ); then
+    pass 'manifest and default selector limits are persisted into run metadata for SQL rendering'
+  else
+    fail 'manifest-default or selector-limit run metadata plumbing'
+    ok=false
+  fi
+
+  if (
+    DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+    parse_args --selector-suggestion-limit 00000
+    RUN_DIR="$awk_tmp"
+    MODE="preview"
+    DUMP="/tmp/selector-limit.dump"
+    DUMP_SHA256="selector-limit-sha"
+    psql_file() { :; return 0; }
+    record_metadata
+    grep -Fq "('selector_suggestion_limit', '0')" "$RUN_DIR/metadata.sql"
+  ); then
+    pass 'canonical custom selector limit is persisted into run metadata'
+  else
+    fail 'custom selector-limit metadata plumbing'
+    ok=false
+  fi
+
+  if (
+    DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+    manifest_body="$(declare -f write_selection_manifest)"
+    [[ "$manifest_body" = *'SELECT * FROM delta_ctl.render_selection_manifest();'* ]]
+    [[ "$manifest_body" != *'$SELECTOR_SUGGESTION_LIMIT'* ]]
+  ); then
+    pass 'selection manifest keeps the zero-argument SQL renderer invocation'
+  else
+    fail 'selection manifest renderer invocation changed signature or gained shell interpolation'
+    ok=false
+  fi
+
+  if (
+    DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+    RUN_DIR="$awk_tmp"
+    ALIGN_DETAILS="true"
+    ALIGN_WIDTH="8"
+    write_aligned_detail "$awk_tmp/details.tsv" "10" "NEW"
+    cmp -s "$canonical" "$awk_tmp/details.tsv"
+    grep -q '^# rendered 2 of 10 NEW rows — TRUNCATED$' "$awk_tmp/details.txt"
+  ); then
+    pass 'aligned companion preserves TSV bytes and appends rendered/total footer'
+  else
+    fail 'aligned companion TSV preservation and footer semantics'
+    ok=false
+  fi
+
+  rm -f "$awk_tmp/details.txt"
+  if (
+    DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+    RUN_DIR="$awk_tmp"
+    ALIGN_DETAILS="false"
+    write_aligned_detail "$awk_tmp/details.tsv" "10" "NEW"
+    [[ ! -e "$awk_tmp/details.txt" ]]
+  ); then
+    pass 'aligned companion generation can be disabled'
+  else
+    fail 'aligned companion disable control'
+    ok=false
+  fi
+
+  local parser_tmp="$TMP_BASE/selection_parser"
+  mkdir -p "$parser_tmp"
+  printf 'bad_emails\nbar_corps\n' > "$parser_tmp/all_conf_tables.txt"
+  cat > "$parser_tmp/happy.conf" <<'CONF'
+# delta-selection v2
+# dump_sha256=abc123
+# staged bad_emails=3 bar_corps=2
+# Operator cookbook (all examples remain comments)
+#   Class override: [<table>] include=new,changed
+#   Disable a table: [<table>] include=
+# [bad_emails] 51 NEW rows: review details/bad_emails.new.tsv; supported selectors: id:
+[*] include=new,changed
+[bad_emails] new.rows include=id:1-3,8,9007199254740993,9223372036854775807
+[bar_corps] changed.rows exclude=corp:BC0000001,BC\N
+CONF
+  if (
+    DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+    RUN_DIR="$parser_tmp"; SELECTION_FILE="$parser_tmp/happy.conf"
+    build_selection_input
+    grep -q $'bad_emails\tNEW\tinclude\tid\t1\t3\t\\N\tt' "$RUN_DIR/row_selection_input.tsv"
+    grep -q $'bad_emails\tNEW\tinclude\tid\t9223372036854775807\t9223372036854775807' "$RUN_DIR/row_selection_input.tsv"
+    grep -q $'bar_corps\tCHANGED\texclude\tcorp\t\\N\t\\N\tBC0000001' "$RUN_DIR/row_selection_input.tsv"
+    awk -F '\t' '$4 == "corp" && $7 == "BC\\\\N" { found=1 } END { exit !found }' "$RUN_DIR/row_selection_input.tsv"
+    grep -q $'dump_sha256\tabc123' "$RUN_DIR/selection_header.tsv"
+    [[ "$(wc -l < "$RUN_DIR/selection_header.tsv" | tr -d ' ')" = "3" ]]
+    ! grep -q '<table>\|51 NEW rows' "$RUN_DIR/selection_input.tsv" "$RUN_DIR/row_selection_input.tsv"
+  ); then
+    pass 'selection parser accepts v2 selectors/bindings and ignores generated cookbook comments'
+  else
+    fail 'selection parser v2 happy path and cookbook comment compatibility'
+    ok=false
+  fi
+
+  printf 'bad_emails\n' > "$parser_tmp/requested_tables.txt"
+  printf 'bad_emails\tNEW\n' > "$parser_tmp/scoped.expected.tsv"
+  if (
+    DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+    RUN_DIR="$parser_tmp"
+    SELECTION_FILE="$parser_tmp/happy.conf"
+    TABLES_ARG="bad_emails"
+    INCLUDE_CLASSES="new,changed"
+    EXCLUDE_CLASSES="changed"
+    build_selection_input
+    cmp -s "$RUN_DIR/scoped.expected.tsv" "$RUN_DIR/selection_input.tsv"
+  ); then
+    pass 'selection file candidates are bounded by explicit table/include/exclude scope'
+  else
+    fail 'selection file table/class scope ceiling'
+    ok=false
+  fi
+
+  cat > "$parser_tmp/duplicate_sha.conf" <<'CONF'
+# dump_sha256=abc123
+# dump_sha256=abc123
+[*] include=new
+CONF
+  cat > "$parser_tmp/duplicate_staged.conf" <<'CONF'
+# staged bad_emails=3
+# staged bar_corps=2 bad_emails=3
+[*] include=new
+CONF
+  cat > "$parser_tmp/nondecimal_staged.conf" <<'CONF'
+# staged bad_emails=three
+[*] include=new
+CONF
+  local bad_header expected_error parser_status
+  for bad_header in duplicate_sha duplicate_staged nondecimal_staged; do
+    case "$bad_header" in
+      duplicate_sha) expected_error='duplicate dump_sha256 header' ;;
+      duplicate_staged) expected_error='duplicate staged-count header' ;;
+      nondecimal_staged) expected_error='staged count must be decimal' ;;
+      *) expected_error='unexpected parser fixture' ;;
+    esac
+    (
+      DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+      RUN_DIR="$parser_tmp"; SELECTION_FILE="$parser_tmp/$bad_header.conf"
+      build_selection_input
+    ) >/dev/null 2>&1
+    parser_status=$?
+    if [[ "$parser_status" -eq 4 ]]; then
+      pass "selection parser rejects $expected_error with exit 4"
+    else
+      fail "selection parser $expected_error expected exit 4, got $parser_status"
+      ok=false
+    fi
+  done
+
+  cat > "$parser_tmp/inverted.conf" <<'CONF'
+[*] include=new
+[bad_emails] new.rows include=id:9-3
+CONF
+  if (
+    DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+    RUN_DIR="$parser_tmp"; SELECTION_FILE="$parser_tmp/inverted.conf"
+    build_selection_input
+  ) >/dev/null 2>&1; then
+    fail 'selection parser rejects inverted ranges'
+    ok=false
+  else
+    pass 'selection parser rejects inverted ranges'
+  fi
+
+  cat > "$parser_tmp/bad_kind.conf" <<'CONF'
+[*] include=new
+[bad_emails] new.rows include=pk:1
+CONF
+  if (
+    DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+    RUN_DIR="$parser_tmp"; SELECTION_FILE="$parser_tmp/bad_kind.conf"
+    build_selection_input
+  ) >/dev/null 2>&1; then
+    fail 'selection parser rejects unsupported selector kinds'
+    ok=false
+  else
+    pass 'selection parser rejects unsupported selector kinds'
+  fi
+
+  cat > "$parser_tmp/bigint_overflow.conf" <<'CONF'
+[*] include=new
+[bad_emails] new.rows include=id:9223372036854775808
+CONF
+  if (
+    DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+    RUN_DIR="$parser_tmp"; SELECTION_FILE="$parser_tmp/bigint_overflow.conf"
+    build_selection_input
+  ) >/dev/null 2>&1; then
+    fail 'selection parser rejects integers above bigint maximum'
+    ok=false
+  else
+    pass 'selection parser rejects integers above bigint maximum'
+  fi
+
+  cat > "$parser_tmp/v1.conf" <<'CONF'
+[*] include=new,changed
+[bar_corps] include=
+CONF
+  if (
+    DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+    RUN_DIR="$parser_tmp"; SELECTION_FILE="$parser_tmp/v1.conf"
+    build_selection_input
+    [[ ! -s "$RUN_DIR/row_selection_input.tsv" ]]
+    grep -q $'bad_emails\tNEW' "$RUN_DIR/selection_input.tsv"
+  ); then
+    pass 'selection parser preserves class-only v1 compatibility'
+  else
+    fail 'selection parser class-only v1 compatibility'
+    ok=false
+  fi
+
+  if (
+    DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+    RUN_DIR="$parser_tmp"; DUMP_SHA256="current"
+    printf 'bad_emails\tNEW\tinclude\tid\t1\t1\t\\N\tf\t1\n' > "$RUN_DIR/row_selection_input.tsv"
+    printf 'dump_sha256\tdifferent\n' > "$RUN_DIR/selection_header.tsv"
+    verify_selection_binding
+  ) >/dev/null 2>&1; then
+    fail 'selection binding rejects a different dump hash'
+    ok=false
+  else
+    pass 'selection binding rejects a different dump hash'
+  fi
+
+  if (
+    DELTA_RESTORE_SOURCE_ONLY=true source "$DATA_TOOL_DIR/delta_restore_extract.sh"
+    RUN_DIR="$parser_tmp"; DUMP_SHA256="current"
+    printf 'bar_corps\tNEW\tinclude\trow\t1\t1\t\\N\tf\t1\n' > "$RUN_DIR/row_selection_input.tsv"
+    printf 'dump_sha256\tcurrent\nstaged\tbar_corps\t9\n' > "$RUN_DIR/selection_header.tsv"
+    printf 'bar_corps\tSTAGED\t8\n' > "$RUN_DIR/stage_counts.tsv"
+    verify_selection_binding
+  ) >/dev/null 2>&1; then
+    fail 'row selector binding rejects a changed staged count'
+    ok=false
+  else
+    pass 'row selector binding rejects a changed staged count'
   fi
 
   [[ "$ok" = "true" ]]
@@ -236,7 +748,19 @@ run_sql_smoke() {
        -f "$FIXTURES_DIR/t10_auth_component_local_only.sql" \
        -f "$EXPECTED_DIR/t10_auth_component_local_only_assert.sql" \
        -f "$FIXTURES_DIR/t11_nk_hash_join_perf.sql" \
-       -f "$EXPECTED_DIR/t11_nk_hash_join_perf_assert.sql" >/dev/null; then
+       -f "$EXPECTED_DIR/t11_nk_hash_join_perf_assert.sql" \
+       -f "$FIXTURES_DIR/t12_row_selection.sql" \
+       -f "$EXPECTED_DIR/t12_row_selection_assert.sql" \
+       -f "$FIXTURES_DIR/t13_selector_diagnostics.sql" \
+       -f "$EXPECTED_DIR/t13_selector_diagnostics_assert.sql" \
+       -f "$FIXTURES_DIR/t14_parent_dependency_rows.sql" \
+       -f "$EXPECTED_DIR/t14_parent_dependency_rows_assert.sql" \
+       -f "$FIXTURES_DIR/t15_details.sql" \
+       -f "$EXPECTED_DIR/t15_details_assert.sql" \
+       -f "$FIXTURES_DIR/t16_selection_manifest.sql" \
+       -f "$EXPECTED_DIR/t16_selection_manifest_assert.sql" \
+       -f "$FIXTURES_DIR/t17_selection_cookbook.sql" \
+       -f "$EXPECTED_DIR/t17_selection_cookbook_assert.sql" >/dev/null; then
     pass 'SQL compile + classification performance smoke'
   else
     fail 'SQL compile + classification performance smoke'
@@ -262,9 +786,20 @@ run_optional_integration() {
   fi
 
   local src="delta_rt_src_$$" local_db="delta_rt_local_$$" dump_dir report_base dump preview_run apply_run
+  local scope_dump scope_preview hint_dir hint_only_corps preview_stdout validate_command apply_command
+  local hint_validate_stdout hint_validate_run hint_validate_status hint_validate_counts
+  local hint_apply_stdout hint_apply_run hint_apply_status hint_apply_counts
   dump_dir="$TMP_BASE/dumps"
   report_base="$TMP_BASE/reports"
-  mkdir -p "$dump_dir" "$report_base"
+  hint_dir="$TMP_BASE/preview-hint"
+  hint_only_corps="$hint_dir/only-corps.txt"
+  preview_stdout="$hint_dir/preview.out"
+  hint_validate_stdout="$hint_dir/validate.out"
+  hint_validate_counts="$hint_dir/validate-selected-counts.tsv"
+  hint_apply_stdout="$hint_dir/apply.out"
+  hint_apply_counts="$hint_dir/apply-selected-counts.tsv"
+  mkdir -p "$dump_dir" "$report_base" "$hint_dir"
+  printf 'BC0000001\n' > "$hint_only_corps"
   dump="$dump_dir/keep.dump"
 
   create_db "$src" || { skip "integration: could not create $src"; return 0; }
@@ -280,7 +815,8 @@ run_optional_integration() {
     return 1
   fi
 
-  if (cd "$DATA_TOOL_DIR" && PG_BIN="$PG_BIN" PGDATABASE="$local_db" ./delta_restore_extract.sh --dump "$dump" --mode preview --report-dir "$report_base" >/dev/null); then
+  if (cd "$DATA_TOOL_DIR" && PG_BIN="$PG_BIN" PGDATABASE="$local_db" ./delta_restore_extract.sh \
+      --dump "$dump" --mode preview --report-dir "$report_base" >/dev/null); then
     preview_run="$(latest_run_dir "$report_base")"
     pass 'integration: preview completed'
   else
@@ -288,10 +824,22 @@ run_optional_integration() {
     return 1
   fi
 
+  if [[ "$(path_mode "$preview_run")" = "700" ]] \
+     && [[ "$(path_mode "$preview_run/preview.txt")" = "600" ]] \
+     && [[ "$(path_mode "$preview_run/selection.conf")" = "600" ]] \
+     && [[ "$(path_mode "$preview_run/selection_cookbook.txt")" = "600" ]] \
+     && grep -q '^# OPERATOR COOKBOOK$' "$preview_run/selection_cookbook.txt" \
+     && grep -q 'selection_cookbook.txt (this run dir)' "$preview_run/selection.conf"; then
+    pass 'integration: preview selection artifacts are private and cookbook is split from manifest'
+  else
+    fail 'integration: preview artifact permissions'
+    return 1
+  fi
+
   local pattern missing=false
   while read -r pattern; do
     [[ -n "$pattern" ]] || continue
-    if ! grep -q "$pattern" "$preview_run/preview.txt"; then
+    if ! grep -q -- "$pattern" "$preview_run/preview.txt"; then
       printf >&2 'missing preview pattern: %s\n' "$pattern"
       missing=true
     fi
@@ -311,10 +859,214 @@ run_optional_integration() {
     return 1
   fi
 
-  if grep -q 'Apply summary' "$apply_run/apply_summary.txt" && grep -q 'Affected counts' "$apply_run/apply_summary.txt"; then
-    pass 'integration: apply summary contains expected sections'
+  if grep -q 'Apply summary' "$apply_run/apply_summary.txt" \
+     && grep -q 'Affected counts' "$apply_run/apply_summary.txt" \
+     && [[ -f "$apply_run/selection_cookbook.txt" ]] \
+     && grep -q '^# OPERATOR COOKBOOK$' "$apply_run/selection_cookbook.txt"; then
+    pass 'integration: apply summary and selection cookbook contain expected sections'
   else
-    fail 'integration: apply summary expected sections'
+    fail 'integration: apply summary or selection cookbook expected sections'
+    return 1
+  fi
+
+  scope_dump="$dump_dir/scoped-selection.dump"
+  psql_db "$src" -c "UPDATE bad_emails SET notes = 'source-changed' WHERE id = 1;
+    INSERT INTO bad_emails(id, email, notes) VALUES (201, 'scope-in@example.test', 'inside');
+    INSERT INTO excluded_emails(email, notes) VALUES ('scope-out@example.test', 'outside');" >/dev/null || {
+      fail 'integration: seed scoped selectable rows'; return 1;
+    }
+  if (cd "$DATA_TOOL_DIR" && PG_BIN="$PG_BIN" PGDATABASE="$src" BACKUP_DIR="$dump_dir" DUMP="$scope_dump" ./backup_extract_tables.sh >/dev/null); then
+    pass 'integration: scoped-selection dump created'
+  else
+    fail 'integration: scoped-selection dump creation'
+    return 1
+  fi
+  if (cd "$hint_dir" && PG_BIN="$PG_BIN" PGDATABASE="$local_db" "$DATA_TOOL_DIR/delta_restore_extract.sh" \
+      --dump "$scope_dump" --mode preview --tables bad_emails \
+      --include-classes new,changed --exclude-classes changed \
+      --only-corps "$hint_only_corps" --report-dir "$report_base" > "$preview_stdout" 2>&1); then
+    scope_preview="$(latest_run_dir "$report_base")"
+    pass 'integration: scoped preview completed with selectable rows inside and outside scope'
+  else
+    fail 'integration: scoped preview'
+    return 1
+  fi
+
+  cp "$scope_preview/selection.conf" "$hint_dir/my_selection.conf"
+  validate_command="$(sed -n 's/^  3[.] To validate: //p' "$preview_stdout" | tail -n 1)"
+  (cd "$hint_dir" && PG_BIN="$PG_BIN" PGDATABASE="$local_db" bash -c "$validate_command" \
+    > "$hint_validate_stdout" 2>&1)
+  hint_validate_status=$?
+  hint_validate_run="$(sed -n 's/^Artifacts: //p' "$hint_validate_stdout" | tail -n 1)"
+  if [[ -f "$hint_validate_run/selected_counts.tsv" ]]; then
+    cp "$hint_validate_run/selected_counts.tsv" "$hint_validate_counts"
+  fi
+  case "$hint_validate_run" in
+    "$DATA_TOOL_DIR/scripts/generated/delta_restore/"*) rm -rf -- "$hint_validate_run" ;;
+    *) ;;
+  esac
+  if [[ "$hint_validate_status" -eq 0 ]] \
+     && grep -q '^  3[.] To validate:' "$preview_stdout" \
+     && grep -Fq -- '--tables bad_emails' <<<"$validate_command" \
+     && grep -Fq -- '--include-classes new\,changed' <<<"$validate_command" \
+     && grep -Fq -- '--exclude-classes changed' <<<"$validate_command" \
+     && grep -Fq -- "--only-corps $hint_only_corps" <<<"$validate_command" \
+     && grep -q 'Selection is valid' "$hint_validate_stdout" \
+     && awk -F '\t' 'NR == 1 && $1 == "bad_emails" && $2 == "NEW" && $3 == "1" { ok=1 }
+          END { exit !(NR == 1 && ok) }' "$hint_validate_counts"; then
+    pass 'integration: printed validate command enforces table/class scope in actual selected counts'
+  else
+    fail "integration: printed scoped validate expected one bad_emails NEW row, got status $hint_validate_status"
+    return 1
+  fi
+
+  apply_command="$(sed -n 's/^To apply: //p' "$hint_validate_stdout" | tail -n 1)"
+  (cd "$hint_dir" && PG_BIN="$PG_BIN" PGDATABASE="$local_db" bash -c "$apply_command" \
+    > "$hint_apply_stdout" 2>&1)
+  hint_apply_status=$?
+  hint_apply_run="$(sed -n 's/^Artifacts: //p' "$hint_apply_stdout" | tail -n 1)"
+  if [[ -f "$hint_apply_run/selected_counts.tsv" ]]; then
+    cp "$hint_apply_run/selected_counts.tsv" "$hint_apply_counts"
+  fi
+  if [[ -f "$hint_apply_run/apply_summary.txt" ]]; then
+    cp "$hint_apply_run/apply_summary.txt" "$hint_dir/scoped-apply-summary.txt"
+  fi
+  case "$hint_apply_run" in
+    "$DATA_TOOL_DIR/scripts/generated/delta_restore/"*) rm -rf -- "$hint_apply_run" ;;
+    *) ;;
+  esac
+  if [[ "$hint_apply_status" -eq 0 ]] \
+     && grep -Fq -- '--tables bad_emails' <<<"$apply_command" \
+     && grep -Fq -- '--include-classes new\,changed' <<<"$apply_command" \
+     && grep -Fq -- '--exclude-classes changed' <<<"$apply_command" \
+     && grep -Fq -- "--only-corps $hint_only_corps" <<<"$apply_command" \
+     && awk -F '\t' 'NR == 1 && $1 == "bad_emails" && $2 == "NEW" && $3 == "1" { ok=1 }
+          END { exit !(NR == 1 && ok) }' "$hint_apply_counts" \
+     && [[ "$(psql_db "$local_db" -qAt -c "SELECT count(*) FROM bad_emails WHERE id = 201")" = "1" ]] \
+     && [[ "$(psql_db "$local_db" -qAt -c "SELECT notes FROM bad_emails WHERE id = 1")" = "seed" ]] \
+     && [[ "$(psql_db "$local_db" -qAt -c "SELECT count(*) FROM excluded_emails WHERE email = 'scope-out@example.test'")" = "0" ]] \
+     && grep -Eq 'bad_emails[[:space:]]+NEW[[:space:]]+INSERT[[:space:]]+1[[:space:]]+1' "$hint_dir/scoped-apply-summary.txt"; then
+    pass 'integration: printed apply command cannot select or modify rows outside explicit table/class scope'
+  else
+    fail "integration: printed scoped apply expected only one bad_emails NEW row, got status $hint_apply_status"
+    return 1
+  fi
+
+  psql_db "$local_db" -c "UPDATE bad_emails SET notes = 'source-changed' WHERE id = 1;
+    INSERT INTO excluded_emails(email, notes) VALUES ('scope-out@example.test', 'outside');" >/dev/null || {
+      fail 'integration: synchronize rows after scoped safety assertions'; return 1;
+    }
+
+  local row_dump="$dump_dir/row-selection.dump" row_preview row_validate bad_validate_run row_apply
+  local row_selection bad_selector_selection bad_selection validate_status mismatch_status
+  psql_db "$src" -c "INSERT INTO bad_emails(id, email, notes) VALUES
+    (101, 'row101@example.test', 'one'),
+    (102, 'row102@example.test', 'two'),
+    (103, 'row103@example.test', 'three');" >/dev/null || {
+      fail 'integration: seed row-selection source rows'; return 1;
+    }
+  if (cd "$DATA_TOOL_DIR" && PG_BIN="$PG_BIN" PGDATABASE="$src" BACKUP_DIR="$dump_dir" DUMP="$row_dump" ./backup_extract_tables.sh >/dev/null); then
+    pass 'integration: row-selection dump created'
+  else
+    fail 'integration: row-selection dump creation'
+    return 1
+  fi
+  if (cd "$DATA_TOOL_DIR" && PG_BIN="$PG_BIN" PGDATABASE="$local_db" ./delta_restore_extract.sh --dump "$row_dump" --mode preview --report-dir "$report_base" --details-limit 2 >/dev/null); then
+    row_preview="$(latest_run_dir "$report_base")"
+    pass 'integration: row-selection preview completed'
+  else
+    fail 'integration: row-selection preview'
+    return 1
+  fi
+  if [[ -f "$row_preview/details/bad_emails.new.tsv" ]] &&
+     grep -q 'row101@example.test' "$row_preview/details/bad_emails.new.tsv"; then
+    pass 'integration: NEW detail artifact contains staged row values'
+  else
+    fail 'integration: NEW detail artifact'
+    return 1
+  fi
+  if [[ -f "$row_preview/details/bad_emails.new.txt" ]] \
+     && [[ "$(path_mode "$row_preview/details/bad_emails.new.txt")" = "600" ]] \
+     && grep -q '^# rendered 2 of 3 NEW rows — TRUNCATED$' "$row_preview/details/bad_emails.new.txt" \
+     && grep -q '^# TRUNCATED at 2 rows$' "$row_preview/details/bad_emails.new.tsv" \
+     && grep -Fq -- '- details/bad_emails.new.tsv — 2 of 3 NEW rows (TRUNCATED) · aligned: details/bad_emails.new.txt' "$row_preview/preview.txt"; then
+    pass 'integration: truncated aligned NEW detail has private mode, footer, and preview counts'
+  else
+    fail 'integration: truncated aligned NEW detail and preview count enrichment'
+    return 1
+  fi
+
+  row_selection="$TMP_BASE/row-selection.conf"
+  cp "$row_preview/selection.conf" "$row_selection"
+  printf '\n[bad_emails] new.rows include=id:101-102\n' >> "$row_selection"
+
+  (cd "$DATA_TOOL_DIR" && PG_BIN="$PG_BIN" PGDATABASE="$local_db" ./delta_restore_extract.sh \
+    --dump "$row_dump" --mode validate --selection-file "$row_selection" \
+    --report-dir "$report_base" > "$TMP_BASE/validate.out" 2>&1)
+  validate_status=$?
+  row_validate="$(latest_run_dir "$report_base")"
+  if [[ "$validate_status" -eq 0 ]] \
+     && grep -q 'Selection is valid' "$TMP_BASE/validate.out" \
+     && grep -q $'bad_emails\tNEW\t2\t' "$row_validate/selected_counts.tsv"; then
+    pass 'integration: resident selection validate exits 0 with expected selected counts'
+  else
+    fail "integration: resident selection validate expected exit 0, got $validate_status"
+    return 1
+  fi
+  if [[ -s "$row_validate/stage_counts.tsv" ]] \
+     && [[ ! -e "$row_validate/toc.list" ]] \
+     && [[ ! -e "$row_validate/stage_counts.sql" ]] \
+     && [[ ! -e "$row_validate/create_stage_shells.sql" ]] \
+     && [[ ! -e "$row_validate/preview_classification.sql" ]]; then
+    pass 'integration: validate regenerates staged counts without TOC read, staging, or classification'
+  else
+    fail 'integration: validate performed or failed to exclude restaging work'
+    return 1
+  fi
+
+  bad_selector_selection="$TMP_BASE/row-selection-invalid-selector.conf"
+  cp "$row_selection" "$bad_selector_selection"
+  printf '[bad_emails] new.rows include=id:999999\n' >> "$bad_selector_selection"
+  (cd "$DATA_TOOL_DIR" && PG_BIN="$PG_BIN" PGDATABASE="$local_db" ./delta_restore_extract.sh \
+    --dump "$row_dump" --mode validate --selection-file "$bad_selector_selection" \
+    --report-dir "$report_base" > "$TMP_BASE/validate-invalid.out" 2>&1)
+  validate_status=$?
+  bad_validate_run="$(latest_run_dir "$report_base")"
+  if [[ "$validate_status" -eq 4 ]] \
+     && grep -Fq $'bad_emails\tNEW\tinclude\tid\t999999\t' "$bad_validate_run/selection_diagnostics.tsv" \
+     && grep -Fq $'\tNO_MATCH' "$bad_validate_run/selection_diagnostics.tsv" \
+     && [[ ! -e "$bad_validate_run/toc.list" ]] \
+     && [[ ! -e "$bad_validate_run/preview_classification.sql" ]]; then
+    pass 'integration: invalid resident selector exits 4 with diagnostics and no restaging'
+  else
+    fail "integration: invalid resident selector expected exit 4, got $validate_status"
+    return 1
+  fi
+
+  if (cd "$DATA_TOOL_DIR" && PG_BIN="$PG_BIN" PGDATABASE="$local_db" ./delta_restore_extract.sh --dump "$row_dump" --mode apply --selection-file "$row_selection" --report-dir "$report_base" --yes --keep-artifacts >/dev/null); then
+    row_apply="$(latest_run_dir "$report_base")"
+    pass 'integration: row-selector apply completed'
+  else
+    fail 'integration: row-selector apply'
+    return 1
+  fi
+  if [[ "$(psql_db "$local_db" -qAt -c "SELECT count(*) FROM bad_emails WHERE id IN (101,102)")" = "2" ]] &&
+     [[ "$(psql_db "$local_db" -qAt -c "SELECT count(*) FROM bad_emails WHERE id = 103")" = "0" ]] &&
+     grep -Eq 'bad_emails[[:space:]]+NEW[[:space:]]+INSERT[[:space:]]+2[[:space:]]+2' "$row_apply/apply_summary.txt"; then
+    pass 'integration: row selectors applied 2 rows and skipped 1 with expected=affected'
+  else
+    fail 'integration: row-selector applied/skipped row assertions'
+    return 1
+  fi
+
+  bad_selection="$TMP_BASE/row-selection-bad-sha.conf"
+  sed 's/^# dump_sha256=.*/# dump_sha256=0000/' "$row_selection" > "$bad_selection"
+  (cd "$DATA_TOOL_DIR" && PG_BIN="$PG_BIN" PGDATABASE="$local_db" ./delta_restore_extract.sh --dump "$row_dump" --mode apply --selection-file "$bad_selection" --report-dir "$report_base" --yes --keep-artifacts >/dev/null 2>&1)
+  mismatch_status=$?
+  if [[ "$mismatch_status" -eq 4 ]]; then
+    pass 'integration: row-selector dump hash mismatch exits 4'
+  else
+    fail "integration: row-selector hash mismatch expected exit 4, got $mismatch_status"
     return 1
   fi
 }
@@ -323,6 +1075,7 @@ main() {
   require_file "$DATA_TOOL_DIR/delta_restore_extract.sh" || return 1
   require_file "$DATA_TOOL_DIR/scripts/restore/delta/10_functions.sql" || return 1
   require_file "$DATA_TOOL_DIR/scripts/restore/delta/rewrite_copy_targets.awk" || return 1
+  require_file "$DATA_TOOL_DIR/scripts/restore/delta/align_details.awk" || return 1
 
   run_static_checks || true
   run_sql_smoke || true


### PR DESCRIPTION
*Issue #:* /bcgov/entity#34199

## What changed

`delta_restore_extract.sh` now supports a safer **preview → inspect → select → validate → apply** workflow:

- Preview writes row-level `.tsv` details, readable fixed-width `.txt` companions, a concise `selection.conf`, and a generated selector cookbook.
- Operators can narrow NEW/CHANGED rows by staged `id`, staging `row`, or `corp` (including ranges and exclusions).
- New `--mode validate` quickly checks the edited selection against the resident preview before apply.

### Quick example

```bash
# Preview, then keep the printed artifact directory.
DUMP=/tmp/preserved/keep_2026-07-16.dump
./delta_restore_extract.sh --dump "$DUMP" --mode preview
RUN=scripts/generated/delta_restore/20260716_183022

# Review the blast radius and readable row details.
less "$RUN/preview.txt"
less -S "$RUN/details/corp_processing.changed.txt"

# Copy the bound manifest; do not edit the generated original.
cp "$RUN/selection.conf" my_selection.conf
```

Keep the generated binding headers, then narrow the selection using values reviewed in the detail artifacts:

```ini
[*] include=
[corp_processing] include=changed
[corp_processing] changed.rows include=corp:BC0000001,BC0000002
[bad_emails] include=new
[bad_emails] new.rows include=id:101-104,200
```

```bash
# Validate until exit 0, then paste the apply command it prints.
./delta_restore_extract.sh --dump "$DUMP" --mode validate \
  --selection-file my_selection.conf

./delta_restore_extract.sh --dump "$DUMP" --mode apply \
  --selection-file my_selection.conf --yes
```

> `id:` means the staged/dump `selector_id`, not a local database ID. Selector errors and dependency failures are written to the validate run's `selection_diagnostics.tsv` and `dependency_violations.tsv`.

## Review notes

- Default selection remains `new,changed`; use `--manifest-default none` for opt-in-only manifests.
- `--sample-size`, `--details-limit`, and `--selector-suggestion-limit` independently control preview samples, detail files, and manifest suggestions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
