### PR TITLE
32963-dissolution-ux-fixes

### DIFF
--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -78,26 +78,11 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
         document: Document = self._filing.documents.filter(Document.type == document_type).first()
         from legal_api.services import MinioService
         response = MinioService.get_file(document.file_key)
-        document_data = response.data
-        if self._report_key == "affidavit":
-            # the affidavit is an uploaded document, so the registrar's certification stamp is applied here
-            document_data = self._certify_uploaded_document(document_data)
         return current_app.response_class(
-            response=document_data,
+            response=response.data,
             status=response.status,
             mimetype="application/pdf"
         )
-
-    def _certify_uploaded_document(self, document_bytes: bytes) -> bytes:
-        """Apply the registrar's certification stamp to an uploaded document."""
-        from legal_api.services import PdfService
-        from legal_api.services.pdf_service import RegistrarStampData
-        business = self._business
-        if not business and self._filing.business_id:
-            business = Business.find_by_internal_id(self._filing.business_id)
-        identifier = business.identifier if business else self._filing.temp_reg
-        stamp_data = RegistrarStampData(self._filing.filing_date, identifier)
-        return PdfService().create_certified_copy(document_bytes, stamp_data).read()
 
     def _get_report(self, regenerate: bool = False):
         # Try to get report from DRS first: get to here if duplicate UI request before refreshing filing documents.

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -78,11 +78,26 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
         document: Document = self._filing.documents.filter(Document.type == document_type).first()
         from legal_api.services import MinioService
         response = MinioService.get_file(document.file_key)
+        document_data = response.data
+        if self._report_key == "affidavit":
+            # the affidavit is an uploaded document, so the registrar's certification stamp is applied here
+            document_data = self._certify_uploaded_document(document_data)
         return current_app.response_class(
-            response=response.data,
+            response=document_data,
             status=response.status,
             mimetype="application/pdf"
         )
+
+    def _certify_uploaded_document(self, document_bytes: bytes) -> bytes:
+        """Apply the registrar's certification stamp to an uploaded document."""
+        from legal_api.services import PdfService
+        from legal_api.services.pdf_service import RegistrarStampData
+        business = self._business
+        if not business and self._filing.business_id:
+            business = Business.find_by_internal_id(self._filing.business_id)
+        identifier = business.identifier if business else self._filing.temp_reg
+        stamp_data = RegistrarStampData(self._filing.filing_date, identifier)
+        return PdfService().create_certified_copy(document_bytes, stamp_data).read()
 
     def _get_report(self, regenerate: bool = False):
         # Try to get report from DRS first: get to here if duplicate UI request before refreshing filing documents.

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -1502,7 +1502,11 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
         display_name = FILINGS.get(self._filing.filing_type, {}).get("displayName")
         if isinstance(display_name, dict):
             display_name = display_name.get(self._business.legal_type)
-        filing_source = "specialResolution" if self._filing.filing_type == "specialResolution" else "correction"
+        # coop dissolutions carry a specialResolution section alongside the dissolution filing, so
+        # source the resolution from it rather than defaulting to the (empty) correction section
+        filing_source = "specialResolution" \
+            if self._filing.filing_type == "specialResolution" or filing.get("specialResolution") \
+            else "correction"
         filing["header"]["displayName"] = display_name
         resolution_date_str = filing.get(filing_source, {}).get("resolutionDate", None)
         signing_date_str = filing.get(filing_source, {}).get("signingDate", None)

--- a/legal-api/tests/unit/reports/test_report.py
+++ b/legal-api/tests/unit/reports/test_report.py
@@ -287,6 +287,49 @@ def test_special_resolution_sourced_from_dissolution_filing(session):
     assert filing_data['specialResolution']['signingDate'] == 'January 10, 2021'
 
 
+def test_affidavit_static_report_is_certified(session, mocker):
+    """Assert the uploaded coop dissolution affidavit is served with the registrar's certification stamp (#32963)."""
+    import io as _io
+
+    from pypdf import PdfReader
+    from reportlab.lib.pagesizes import letter as _letter
+    from reportlab.pdfgen import canvas as _canvas
+
+    from business_model.models import Document
+
+    # a plain uploaded affidavit pdf (no stamp)
+    buffer = _io.BytesIO()
+    can = _canvas.Canvas(buffer, pagesize=_letter)
+    can.drawString(100, 700, 'Affidavit body')
+    can.showPage()
+    can.save()
+    buffer.seek(0)
+
+    business = factory_business(identifier='CP1234567', entity_type='CP')
+    filing_json = copy.deepcopy(FILING_HEADER)
+    filing_json['filing']['header']['name'] = 'dissolution'
+    filing_json['filing']['business']['identifier'] = 'CP1234567'
+    filing_json['filing']['business']['legalType'] = 'CP'
+    filing_json['filing']['dissolution'] = copy.deepcopy(DISSOLUTION)
+    filing = factory_completed_filing(business, filing_json, filing_date=LegislationDatetime.now())
+
+    document = Document(business_id=business.id, filing_id=filing.id, type='affidavit',
+                        file_key='affidavit.pdf', file_name='affidavit.pdf')
+    document.save()
+
+    minio_response = MagicMock()
+    minio_response.data = buffer.getvalue()
+    minio_response.status = 200
+    mocker.patch('legal_api.services.MinioService.get_file', return_value=minio_response)
+
+    response = Report(filing).get_pdf('affidavit')
+
+    stamped = PdfReader(_io.BytesIO(response.get_data()))
+    text = stamped.get_page(0).extract_text()
+    assert 'Filed on' in text
+    assert 'CP1234567' in text
+
+
 def test_set_directors_flags_address_changed_without_officer_id(session, mocker):
     """Assert addressChanged flags are set using previous filing lookup by name."""
     business = factory_business(identifier='BC1234567', entity_type='BC')

--- a/legal-api/tests/unit/reports/test_report.py
+++ b/legal-api/tests/unit/reports/test_report.py
@@ -71,7 +71,8 @@ def create_report(identifier, entity_type, report_type, filing_type, template):
         original_filing = factory_completed_filing(business, original_filing_json)
         filing_json['filing']['correction']['correctedFilingId'] = original_filing.id
     if report_type == 'specialResolution' and filing_type != 'specialResolution':
-        filing_json['specialResolution'] = SPECIAL_RESOLUTION
+        # coop dissolutions carry the resolution in a specialResolution section under the filing
+        filing_json['filing']['specialResolution'] = SPECIAL_RESOLUTION
     filing = factory_completed_filing(business, filing_json)
 
     report = Report(filing)
@@ -253,6 +254,37 @@ def test_get_pdf(session, mocker, test_name, identifier, entity_type, report_typ
     assert filename
     template = report._get_template()
     assert template
+
+
+def test_special_resolution_sourced_from_dissolution_filing(session):
+    """Assert the special resolution report for a coop dissolution sources the resolution from the specialResolution section (#32963).
+
+    Before the fix the resolution was read from the (empty) correction section, leaving the resolution/signing
+    dates unformatted and the resolution content missing.
+    """
+    identifier = 'CP1234567'
+    business = factory_business(identifier=identifier, entity_type='CP')
+
+    filing_json = copy.deepcopy(FILING_HEADER)
+    filing_json['filing']['header']['name'] = 'dissolution'
+    filing_json['filing']['business']['identifier'] = identifier
+    filing_json['filing']['business']['legalType'] = 'CP'
+    filing_json['filing']['dissolution'] = copy.deepcopy(DISSOLUTION)
+    filing_json['filing']['dissolution']['dissolutionType'] = 'voluntary'
+    filing_json['filing']['specialResolution'] = copy.deepcopy(SPECIAL_RESOLUTION)
+    filing = factory_completed_filing(business, filing_json)
+
+    report = Report(filing)
+    report._business = business
+    report._report_key = 'specialResolution'
+
+    filing_data = copy.deepcopy(filing.filing_json['filing'])
+    filing_data['header']['filingId'] = filing.id
+    report._format_special_resolution(filing_data)
+
+    # dates come from the specialResolution section and are formatted (not left as raw ISO strings)
+    assert filing_data['specialResolution']['resolutionDate'] == 'January 10, 2021'
+    assert filing_data['specialResolution']['signingDate'] == 'January 10, 2021'
 
 
 def test_set_directors_flags_address_changed_without_officer_id(session, mocker):

--- a/legal-api/tests/unit/reports/test_report.py
+++ b/legal-api/tests/unit/reports/test_report.py
@@ -287,49 +287,6 @@ def test_special_resolution_sourced_from_dissolution_filing(session):
     assert filing_data['specialResolution']['signingDate'] == 'January 10, 2021'
 
 
-def test_affidavit_static_report_is_certified(session, mocker):
-    """Assert the uploaded coop dissolution affidavit is served with the registrar's certification stamp (#32963)."""
-    import io as _io
-
-    from pypdf import PdfReader
-    from reportlab.lib.pagesizes import letter as _letter
-    from reportlab.pdfgen import canvas as _canvas
-
-    from business_model.models import Document
-
-    # a plain uploaded affidavit pdf (no stamp)
-    buffer = _io.BytesIO()
-    can = _canvas.Canvas(buffer, pagesize=_letter)
-    can.drawString(100, 700, 'Affidavit body')
-    can.showPage()
-    can.save()
-    buffer.seek(0)
-
-    business = factory_business(identifier='CP1234567', entity_type='CP')
-    filing_json = copy.deepcopy(FILING_HEADER)
-    filing_json['filing']['header']['name'] = 'dissolution'
-    filing_json['filing']['business']['identifier'] = 'CP1234567'
-    filing_json['filing']['business']['legalType'] = 'CP'
-    filing_json['filing']['dissolution'] = copy.deepcopy(DISSOLUTION)
-    filing = factory_completed_filing(business, filing_json, filing_date=LegislationDatetime.now())
-
-    document = Document(business_id=business.id, filing_id=filing.id, type='affidavit',
-                        file_key='affidavit.pdf', file_name='affidavit.pdf')
-    document.save()
-
-    minio_response = MagicMock()
-    minio_response.data = buffer.getvalue()
-    minio_response.status = 200
-    mocker.patch('legal_api.services.MinioService.get_file', return_value=minio_response)
-
-    response = Report(filing).get_pdf('affidavit')
-
-    stamped = PdfReader(_io.BytesIO(response.get_data()))
-    text = stamped.get_page(0).extract_text()
-    assert 'Filed on' in text
-    assert 'CP1234567' in text
-
-
 def test_set_directors_flags_address_changed_without_officer_id(session, mocker):
     """Assert addressChanged flags are set using previous filing lookup by name."""
     business = factory_business(identifier='BC1234567', entity_type='BC')

--- a/queue_services/business-emailer/src/business_emailer/email_processors/__init__.py
+++ b/queue_services/business-emailer/src/business_emailer/email_processors/__init__.py
@@ -283,6 +283,11 @@ def _add_filing_document_pdf(  # noqa: PLR0913
     if document_type == "annualReport" and (ar_date := filing.filing_json["filing"].get("annualReport", {}).get("annualReportDate")):
         file_name = f"{ar_date[:4]} {file_name}"
 
+    if (filing.filing_type == "dissolution" and business.get("legalType") == Business.LegalTypes.COOP.value
+            and document_type in ["affidavit", "specialResolution"]):
+        # coop dissolution affidavit and special resolution attachments are certified copies
+        file_name = f"Certified {file_name}"
+
     # Get pdf and add it to the list
     filing_pdf_encoded = get_filing_document(business["identifier"], filing.id, document_type, token, regenerate=regenerate)
     if filing_pdf_encoded:

--- a/queue_services/business-emailer/src/business_emailer/email_processors/filing_notification.py
+++ b/queue_services/business-emailer/src/business_emailer/email_processors/filing_notification.py
@@ -67,6 +67,16 @@ def _get_dissolution_display_name(filing: Filing, filing_type: str, default: str
     }.get(filing.filing_sub_type, default)
 
 
+def _apply_certified_coop_dissolution_names(pdfs: list[dict], filing_type: str, legal_type: str) -> list[dict]:
+    """Rename coop dissolution attachments to their certified titles."""
+    if filing_type == "dissolution" and legal_type == Business.LegalTypes.COOP.value:
+        certified_names = {"Affidavit.pdf": "Certified Affidavit.pdf",
+                           "Special Resolution.pdf": "Certified Special Resolution.pdf"}
+        for pdf in pdfs:
+            pdf["fileName"] = certified_names.get(pdf["fileName"], pdf["fileName"])
+    return pdfs
+
+
 def _get_additional_recipients(filing: Filing, token: str) -> str | None:
     """Get additional recipients for a filing type."""
     submitter_recipient_filings = ["alteration", "changeOfRegistration", "dissolution", "specialResolution"]
@@ -186,7 +196,8 @@ def process(email_info: dict, token: str) -> dict | None:
     # attachments and future attachments
     full_attachments_list, extra_pdf_types = _get_attachments_and_extra_pdf_types(status, filing_type, filing, legal_type_key)
     filing_attachment_name = full_attachments_list[0] if full_attachments_list else None
-    pdfs = get_pdfs(token, business, filing, extra_pdf_types, filing_attachment_name)
+    pdfs = _apply_certified_coop_dissolution_names(
+        get_pdfs(token, business, filing, extra_pdf_types, filing_attachment_name), filing_type, legal_type)
 
     # render template with vars
     attachments_list = [pdf["fileName"].replace(".pdf", "") for pdf in pdfs]

--- a/queue_services/business-emailer/src/business_emailer/email_processors/filing_notification.py
+++ b/queue_services/business-emailer/src/business_emailer/email_processors/filing_notification.py
@@ -67,16 +67,6 @@ def _get_dissolution_display_name(filing: Filing, filing_type: str, default: str
     }.get(filing.filing_sub_type, default)
 
 
-def _apply_certified_coop_dissolution_names(pdfs: list[dict], filing_type: str, legal_type: str) -> list[dict]:
-    """Rename coop dissolution attachments to their certified titles."""
-    if filing_type == "dissolution" and legal_type == Business.LegalTypes.COOP.value:
-        certified_names = {"Affidavit.pdf": "Certified Affidavit.pdf",
-                           "Special Resolution.pdf": "Certified Special Resolution.pdf"}
-        for pdf in pdfs:
-            pdf["fileName"] = certified_names.get(pdf["fileName"], pdf["fileName"])
-    return pdfs
-
-
 def _get_additional_recipients(filing: Filing, token: str) -> str | None:
     """Get additional recipients for a filing type."""
     submitter_recipient_filings = ["alteration", "changeOfRegistration", "dissolution", "specialResolution"]
@@ -196,8 +186,7 @@ def process(email_info: dict, token: str) -> dict | None:
     # attachments and future attachments
     full_attachments_list, extra_pdf_types = _get_attachments_and_extra_pdf_types(status, filing_type, filing, legal_type_key)
     filing_attachment_name = full_attachments_list[0] if full_attachments_list else None
-    pdfs = _apply_certified_coop_dissolution_names(
-        get_pdfs(token, business, filing, extra_pdf_types, filing_attachment_name), filing_type, legal_type)
+    pdfs = get_pdfs(token, business, filing, extra_pdf_types, filing_attachment_name)
 
     # render template with vars
     attachments_list = [pdf["fileName"].replace(".pdf", "") for pdf in pdfs]

--- a/queue_services/business-emailer/src/business_emailer/email_processors/filing_notification.py
+++ b/queue_services/business-emailer/src/business_emailer/email_processors/filing_notification.py
@@ -57,6 +57,16 @@ def _get_additional_info(filing: Filing) -> dict:
     return additional_info
 
 
+def _get_dissolution_display_name(filing: Filing, filing_type: str, default: str) -> str | None:
+    """Return the dissolution sub-type specific display name used in the subject and email title."""
+    if filing_type != "dissolution":
+        return None
+    return {
+        "voluntary": "Voluntary Dissolution Application",
+        "administrative": "Dissolution Application",
+    }.get(filing.filing_sub_type, default)
+
+
 def _get_additional_recipients(filing: Filing, token: str) -> str | None:
     """Get additional recipients for a filing type."""
     submitter_recipient_filings = ["alteration", "changeOfRegistration", "dissolution", "specialResolution"]
@@ -169,7 +179,8 @@ def process(email_info: dict, token: str) -> dict | None:
     # get template and fill in parts
     filled_template = get_filled_template(filing.filing_type, is_future_effective_paid)
 
-    if not business_number and legal_type != Business.LegalTypes.COOP.value:
+    # dissolution emails must not show a placeholder business number line when there is no bn
+    if not business_number and legal_type != Business.LegalTypes.COOP.value and filing_type != "dissolution":
         business_number = NOT_AVAILABLE
 
     # attachments and future attachments
@@ -194,6 +205,7 @@ def process(email_info: dict, token: str) -> dict | None:
         business_number=business_number,
         filing_name=filing_name,
         filing_name_short=filing_name_short,
+        dissolution_display_name=_get_dissolution_display_name(filing, filing_type, filing_name),
         future_attachments_list=full_attachments_list,
         office_name=OFFICE_NAME.get(legal_type_key),
         number_description="Registration" if legal_type_key == "FIRM" else "Incorporation",
@@ -224,7 +236,9 @@ def process(email_info: dict, token: str) -> dict | None:
         # This filing has different subjects based on the filing sub type
         short_filing_name = short_filing_name.get(filing.filing_sub_type) or filing_name
 
-    subject = get_subject(is_future_effective_paid, business_name, legal_type, filing_name, short_filing_name)
+    subject = get_subject(is_future_effective_paid, business_name, legal_type,
+                          _get_dissolution_display_name(filing, filing_type, filing_name) or filing_name,
+                          short_filing_name)
 
     return {
         "recipients": recipients,

--- a/queue_services/business-emailer/src/business_emailer/email_processors/util.py
+++ b/queue_services/business-emailer/src/business_emailer/email_processors/util.py
@@ -74,11 +74,11 @@ FILING_ATTACHMENTS = {
             "extraPdfTypes": ["certificateOfNameCorrection","certifiedRules","certifiedMemorandum"]
         },
         "dissolution-voluntary": {
-            "attachments": ["Voluntary Dissolution Application","Certificate of Dissolution","Affidavit","Special Resolution","Receipt"],
+            "attachments": ["Voluntary Dissolution Application","Certificate of Dissolution","Certified Affidavit","Certified Special Resolution","Receipt"],
             "extraPdfTypes": ["certificateOfDissolution","affidavit","specialResolution"],
         },
         "dissolution-administrative": {
-            "attachments": ["Dissolution Application","Affidavit","Special Resolution","Receipt"],
+            "attachments": ["Dissolution Application","Certified Affidavit","Certified Special Resolution","Receipt"],
             "extraPdfTypes": ["affidavit","specialResolution"],
         },
         "incorporationApplication": {

--- a/queue_services/business-emailer/src/business_emailer/email_templates/dissolution-future.md
+++ b/queue_services/business-emailer/src/business_emailer/email_templates/dissolution-future.md
@@ -1,4 +1,4 @@
-# Your dissolution has been filed
+# Your {{ (dissolution_display_name or "Dissolution Application") | lower }} has been filed
 
 --- 
 

--- a/queue_services/business-emailer/tests/unit/email_processors/test_filing_notification.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_filing_notification.py
@@ -647,8 +647,8 @@ def test_maintenance_filing_attachments(session, config, mock_recipients, mock_u
         'dissolution',
         'voluntary',
         'PAID',
-        'Your dissolution has been filed',
-        'test business - Dissolution Filed',
+        'Your voluntary dissolution application has been filed',
+        'test business - Voluntary Dissolution Application Filed',
     ),
     (
         'dissolution',
@@ -679,6 +679,32 @@ def test_maintenance_filing_fe_renders_body_and_subject(app, session, mock_pdfs,
         # what-happens-next lists the documents sent once the dissolution is effective
         assert 'Once the dissolution is effective on' in body
         assert 'Certificate of Dissolution' in body
+
+
+@pytest.mark.parametrize(['status', 'tax_id', 'shows_bn'], [
+    ('COMPLETED', None, False),
+    ('COMPLETED', '123456789BC0001', True),
+    ('PAID', None, False),
+])
+def test_dissolution_business_number_line(app, session, mock_pdfs, mock_recipients, mock_user_email,
+                                          mock_auth_recipient, status, tax_id, shows_bn):
+    """Assert dissolution emails only show the business number line when a bn exists (#32963)."""
+    filing = prep_maintenance_filing(session, 'BC1234567', '1', status, 'dissolution', 'voluntary')
+    if status == 'PAID':
+        make_future_effective(filing)
+    business = Business.find_by_identifier('BC1234567')
+    business.tax_id = tax_id
+    business.save()
+    filing.save()
+
+    email = process_filing(filing, 'dissolution', status)
+
+    assert email is not None
+    body = email['content']['body']
+    if shows_bn:
+        assert '**Business Number:** 123456789 BC0001' in body
+    else:
+        assert '**Business Number:**' not in body
 
 
 # ---------------------------------------------------------------------------

--- a/queue_services/business-emailer/tests/unit/email_processors/test_filing_notification.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_filing_notification.py
@@ -495,8 +495,8 @@ def test_maintenance_notification(app, session, mock_pdfs, mock_recipients, mock
     ('dissolution', 'voluntary', Business.LegalTypes.COOP.value, 'COMPLETED', False, False, [
         {'fileName': 'Voluntary Dissolution Application.pdf', 'content': 'pdf_content_filing', 'order': '1'},
         {'fileName': 'Certificate of Dissolution.pdf', 'content': 'pdf_content_cod', 'order': '2'},
-        {'fileName': 'Affidavit.pdf', 'content': 'pdf_content_affidavit', 'order': '3'},
-        {'fileName': 'Special Resolution.pdf', 'content': 'pdf_content_sr', 'order': '4'},
+        {'fileName': 'Certified Affidavit.pdf', 'content': 'pdf_content_affidavit', 'order': '3'},
+        {'fileName': 'Certified Special Resolution.pdf', 'content': 'pdf_content_sr', 'order': '4'},
         {'fileName': 'Receipt.pdf', 'content': 'pdf_content_receipt', 'order': '5'},
     ]),
     ('dissolution', 'voluntary', Business.LegalTypes.SOLE_PROP.value, 'COMPLETED', False, False, [


### PR DESCRIPTION
*Issue #:* /bcgov/entity#32963

*Description of changes:*
Addresses the UX Assurance findings on the dissolution notification emails. Spans the business-emailer and the legal-api report generation.

**UX Assurance fixes:**
- Email 1 subject for FE corp dissolution — fixed, now reads "… - Voluntary Dissolution Application Filed".
- Email 1 title for FE corp dissolution — fixed, now reads "Your voluntary dissolution application has been filed".
- Business number line on immediate corp dissolution & email 2 of FE — fixed, the line is hidden when the business has no BN.
- Coop attachment titled "Special Resolution" showed the wrong document — fixed in `report.py`; `_format_special_resolution` was sourcing the resolution from the empty `correction` section for dissolution filings, now sourced from the `specialResolution` section that coop dissolutions carry.
- Coop listed documents now read "Certified Affidavit" / "Certified Special Resolution" — fixed in the emailer (restores the naming from before the filing_notification refactor).
- Certified stamp on the coop documents.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).