### PR TITLE
34349 - update to remove court oder columns from filings table

### DIFF
--- a/data-tool/flows/tombstone/tombstone_base_data.py
+++ b/data-tool/flows/tombstone/tombstone_base_data.py
@@ -204,9 +204,7 @@ FILING = {
         'submitter_id': None,
         'withdrawn_filing_id': None,
         # others
-        'submitter_roles': None,
-        'court_order_file_number' : None,  # optional
-        'court_order_effect_of_order' : None,  # optional
+        'submitter_roles': None
     },
     'jurisdiction': None,  # optional
     'amalgamations': None,  # optional

--- a/data-tool/flows/tombstone/tombstone_utils.py
+++ b/data-tool/flows/tombstone/tombstone_utils.py
@@ -503,9 +503,7 @@ def format_filings_data(data: dict, config=None) -> dict:
             'paper_only': paper_only,
             'status': status,
             'submitter_id': user_id,  # will be updated to real user_id when loading data into db
-            'submitter_roles': 'staff' if x.get('u_role_typ_cd') and x['u_role_typ_cd'].lower() == 'staff' else None,
-            'court_order_file_number' : x['court_order_num'],
-            'court_order_effect_of_order' : 'planOfArrangement' if x['arrangement_ind'] == True else None,
+            'submitter_roles': 'staff' if x.get('u_role_typ_cd') and x['u_role_typ_cd'].lower() == 'staff' else None
         }
 
         # conversion still need to populate create-new-business info


### PR DESCRIPTION
*Issue #:* /bcgov/entity#34349

*Description of changes:*

Remove referenced columns from tombstone pipeline so that dry runs do not fail
        `court_order_file_number`
        `court_order_effect_of_order`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
