### PR TITLE
EXPERIMENT - Update refresh script to test least privilege access

### DIFF
--- a/data-tool/flows/refresh_extract_subset_flow.py
+++ b/data-tool/flows/refresh_extract_subset_flow.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import os
 from pathlib import Path
@@ -160,6 +162,7 @@ def run_cprd_subset_extract_generator(
     include_cp: bool = False,
     target_connection: str = _DEFAULT_TARGET_CONNECTION,
     prefix_numeric_bc: bool = False,
+    pg_cast_mode: str = 'install',
 ) -> subprocess.CompletedProcess:
     """
     Generate Commands
@@ -180,6 +183,8 @@ def run_cprd_subset_extract_generator(
         str(threads),
         '--pg-disable-method',
         pg_disable_method,
+        '--pg-cast-mode',
+        pg_cast_mode,
     ]
     argv.extend(['--target-connection', target_connection])
     if pg_fastload:
@@ -252,7 +257,8 @@ def extract_pull_flow(
     reset_extract_postgres: bool = True,
     include_cp: bool = False,
     target_connection: str = _DEFAULT_TARGET_CONNECTION,
-    delta_scope: str = 'batch'
+    delta_scope: str = 'batch',
+    pg_cast_mode: str = 'install',
 ) -> None:
     """
     Generate files
@@ -305,6 +311,7 @@ def extract_pull_flow(
             pg_fastload=pg_fastload,
             include_cp=include_cp,
             pg_disable_method=pg_disable_method,
+            pg_cast_mode=pg_cast_mode,
             out=out,
             target_connection=target_connection,
             prefix_numeric_bc=(mode=='refresh'),
@@ -345,7 +352,8 @@ if __name__ == '__main__':
     p.add_argument('--threads', type=int, default=4, help='DBSchemaCLI transfer threads')
     p.add_argument('--pg-fastload', action='store_true', help='Enable Postgres fast-load')
     p.add_argument('--include-cp', action='store_true', help='Include corp type CP in subset extract queries')
-    p.add_argument('--pg-disable-method', default='table_triggers', choices=('table_triggers', 'replica_role'))
+    p.add_argument('--pg-disable-method', default='table_triggers', choices=('table_triggers', 'replica_role', 'drop_constraints'))
+    p.add_argument('--pg-cast-mode', default='install', choices=('install', 'verify'))
     p.add_argument('--out', default='data-tool/scripts/subset/generated/subset_refresh.sql', help='Output path for generated master script.')
     p.add_argument('--run-dbschemacli', action='store_false')
     p.add_argument('--refresh-views', action='store_false')

--- a/data-tool/scripts/README_COLIN_Corps_Extract.md
+++ b/data-tool/scripts/README_COLIN_Corps_Extract.md
@@ -74,6 +74,175 @@ Notes:
 
 ---
 
+## Running without superuser
+
+The supported restricted path uses one owner identity for the extract database and all
+objects in `public`. During a load, `drop_constraints` temporarily removes every
+foreign key in `public`, so suppression applies to all DbSchemaCLI writer sessions.
+The constraints are restored afterward as `NOT VALID`. The database must be quiesced
+during the drop/load/restore window. Any user-defined triggers added outside this
+repository are **not** disabled by this method and will continue to fire.
+
+### One-time bootstrap vs. steady-state privileges
+
+| Phase | PostgreSQL privileges / ownership | Oracle privileges |
+|---|---|---|
+| One-time DBA bootstrap | Superuser creates or adopts the login and database, transfers database and `public` schema ownership, and installs the `varchar -> boolean` and `bpchar -> boolean` casts. Repeat the cast install whenever the database is dropped/recreated. | None. |
+| DDL installation | The restricted role owns the database and `public` schema and applies both DDL files itself, thereby owning all extract tables, sequences, views, materialized views, functions, and procedures. | None. |
+| Steady-state load/refresh | `LOGIN` plus object ownership. The role does **not** need `SUPERUSER`, `CREATEDB`, or `CREATEROLE`, and no additional grantable PostgreSQL privileges are required. | Existing source login plus `SELECT` on every COLIN source object used by the full/subset queries. See the privilege audit in `docs/plans/nonsuperuser_refresh_plan.md`. |
+
+Optional privileges are not part of the supported path: `pg_signal_backend` is needed
+only to terminate other users' sessions, and PostgreSQL 15+
+`GRANT SET ON PARAMETER session_replication_role` is relevant only to the legacy
+`replica_role` method. Neither is needed with `drop_constraints`, and restricted
+runs must not drop/recreate their database.
+
+If policy separates login and ownership, a non-login owner role granted to the login
+is equivalent, but both runtime connection mechanisms must receive the same membership
+and must be tested for owner checks.
+
+### Provision in this order
+
+Use a PostgreSQL superuser from a maintenance database. The bootstrap file is
+idempotent where PostgreSQL permits and deliberately does not contain a password;
+configure authentication through the deployment's approved secret mechanism.
+
+1. **Create/adopt the role and database, then transfer the database and schema:**
+
+   ```bash
+   psql -X -v ON_ERROR_STOP=1 -h <host> -p <port> -U <dba> -d postgres \
+     -v role=colin_extract -v dbname=colin_extract \
+     -f <lear-repo-base-path>/data-tool/scripts/bootstrap/colin_extract_restricted_bootstrap.sql
+   ```
+
+2. **Apply the base DDL and then the derived view/MV DDL as that restricted role:**
+
+   ```bash
+   psql -X -v ON_ERROR_STOP=1 -h <host> -p <port> -U colin_extract -d colin_extract \
+     -f <lear-repo-base-path>/data-tool/scripts/colin_corps_extract_postgres_ddl
+   psql -X -v ON_ERROR_STOP=1 -h <host> -p <port> -U colin_extract -d colin_extract \
+     -f <lear-repo-base-path>/data-tool/scripts/colin_corps_extract_postgres_views_ddl
+   ```
+
+3. **Install the database-scoped casts once as a superuser:**
+
+   ```bash
+   psql -X -v ON_ERROR_STOP=1 -h <host> -p <port> -U <dba> -d colin_extract \
+     -f <lear-repo-base-path>/data-tool/scripts/subset/subset_pg_boolean_casts.sql
+   ```
+
+   The installer is self-contained and technically may run any time after database
+   creation. Running it after the role-owned DDL makes the ownership boundary explicit:
+   the DBA owns the cast helper functions/casts, and restricted runs only verify them.
+   A missing bootstrap fails before transfer at
+   `subset_pg_boolean_casts_verify.sql`.
+
+4. **Run the full or subset workflow with the restricted identity.** The full
+   refresh needs no boolean casts because it temporarily converts the affected columns
+   to integers. Register `cprd_pg` with the restricted role and run the existing
+   `transfer_cprd_corps.sql`; it now uses the FK drop/restore procedures automatically.
+
+   For a subset load/refresh, generate with both restricted modes:
+
+   ```bash
+   python <lear-repo-base-path>/data-tool/scripts/generate_cprd_subset_extract.py \
+     --corp-file <corp-id-file> \
+     --mode refresh \
+     --pg-disable-method drop_constraints \
+     --pg-cast-mode verify \
+     --out <lear-repo-base-path>/data-tool/scripts/_generated/subset_refresh.sql
+   ```
+
+   For the flow entry point, pass the same privilege modes and explicitly disable its
+   database reset:
+
+   ```bash
+   python <lear-repo-base-path>/data-tool/flows/refresh_extract_subset_flow.py \
+     --mode refresh \
+     --pg-disable-method drop_constraints \
+     --pg-cast-mode verify \
+     --reset-extract-postgres
+   ```
+
+   **Flag inversion warning:** `--reset-extract-postgres` is implemented with
+   `action='store_false'`; passing it disables reset, while omitting it enables the
+   destructive drop/create path. Restricted runs must pass it. The
+   `--run-dbschemacli` and `--refresh-views` flags have the same inverted behavior:
+   passing either flag disables that action, so omit them when the flow should execute
+   DbSchemaCLI and refresh views.
+
+### Runtime identity requirement
+
+The flow's psql/SQLAlchemy connections use the `DATABASE_*_COLIN_MIGR`
+credentials, while DbSchemaCLI uses the registered target connection
+(`cprd_pg`, `cprd_pg_subset`, or `--target-connection`). Both must authenticate
+as the same restricted owner identity; otherwise one half of the run can fail owner
+checks even if the other succeeds. Confirm the DbSchemaCLI registration and environment
+together before the first run. A direct generator diagnostic run may add
+`--pg-debug-session-probes` to print `current_user` for the generated master/nested
+sessions; the ownership model still requires the separately opened transfer writers
+to use the same identity.
+
+### Existing extract databases
+
+Before the edited full-refresh script or a subset run using `drop_constraints`, an
+existing database created from older DDL needs the FK module installed once by its
+object-owning restricted role:
+
+```bash
+psql -X -v ON_ERROR_STOP=1 -h <host> -p <port> -U colin_extract -d <existing-db> \
+  -f <lear-repo-base-path>/data-tool/scripts/colin_fk_constraint_updates.sql
+```
+
+Also install the boolean casts as the DBA if they are absent, then use
+`--pg-cast-mode verify`. If the existing extract objects are still owned by
+`postgres`, grants alone are insufficient: have the DBA transfer the complete
+extract object set to the restricted owner or, preferably, provision a fresh database
+with the ordered procedure above. Do not reapply the full base DDL over a populated
+database merely to obtain the FK module.
+
+Dropping/recreating a restricted database is a DBA re-provisioning event: rerun the
+bootstrap, reapply both DDLs as the restricted owner, and reinstall the casts as the
+DBA. For load mode, target a pre-provisioned empty database and keep the flow reset
+disabled.
+
+### `NOT VALID`, trigger, and recovery caveats
+
+Restored foreign keys enforce all new writes but do not scan existing rows.
+`pg_constraint.convalidated` remains false, and `psql \d` reports `NOT VALID`.
+This is intentional because the extract can contain known legacy exceptions, including
+amalgamating-corporation references outside the extracted cohort. Do not run blanket
+`VALIDATE CONSTRAINT`; validate only a specifically understood constraint when its
+data is known to be clean.
+
+The FK procedures must be invoked as top-level autocommit `CALL` statements, not
+inside an explicit transaction. If a run fails in the suppression window:
+
+1. Stop other writers and reconnect as the same restricted owner. A disconnected
+   DbSchemaCLI session releases its session advisory lock.
+2. Restore every captured constraint (safe to repeat; a second call is a no-op):
+
+   ```sql
+   CALL public.colin_fk_restore_all(NULL);
+   ```
+
+3. For an interrupted full refresh, re-run the reverse
+   `ALTER COLUMN ... TYPE boolean USING ...::boolean` statements if any indicator
+   columns were left as integers.
+4. Confirm `public.colin_dropped_fks` is empty, repair any reported restore error, and
+   rerun the extract. A failed restore retains its helper row, so the same `CALL` can
+   resume without catalog surgery.
+
+### Performance validation status
+
+The manual comparison of the standard Oracle corp list under superuser
+`table_triggers` versus restricted `drop_constraints` is **deferred** because it
+requires Oracle and DbSchemaCLI access. No timing result is claimed here. When those
+external dependencies are available, record both runs with the same corp list,
+PostgreSQL target class, DbSchemaCLI version/thread count, and fast-load settings.
+
+---
+
 ## Preserved-table backup, full restore, and delta restore
 
 The preserved migration/tracking/auth side-table list is centralized in `data-tool/scripts/restore/preserved_tables.conf` and is shared by:
@@ -359,7 +528,7 @@ Generated scripts (gitignored by default):
    - `--include-cp` affects the **subset workflow only**. Full refresh (`transfer_cprd_corps.sql`) and downstream reservation flows still use the historical corp-type cohort unless updated separately.
    Optional performance flags:
    - Add `--pg-fastload` to enable Postgres session settings for faster bulk writes (templates `subset_pg_fastload_begin.sql` / `subset_pg_fastload_end.sql`).
-   - `--pg-disable-method` currently accepts only `table_triggers` and `replica_role`.
+   - `--pg-disable-method` accepts `table_triggers`, `replica_role`, and `drop_constraints`; use `drop_constraints` for the restricted-owner path, which restores foreign keys as `NOT VALID`.
    - The actual generator default is `table_triggers`, not `replica_role`.
    - In refresh mode, preserved rows in `corp_processing`, `auth_processing`, `affiliation_processing`, and `colin_tracking` still reference `corporation` / `event`, so FK enforcement must stay suppressed across delete/reload. The generator now adds refresh-only trigger suppression for those preserved FK-owning tables when `--pg-disable-method table_triggers` is used.
    - Subset load/refresh scripts acquire a session-level Postgres advisory lock at the start and release it at the end. The same lock key is used by the full refresh script.

--- a/data-tool/scripts/bootstrap/colin_extract_restricted_bootstrap.sql
+++ b/data-tool/scripts/bootstrap/colin_extract_restricted_bootstrap.sql
@@ -1,0 +1,118 @@
+\set ON_ERROR_STOP on
+
+/*
+One-time DBA provisioning for a restricted COLIN extract owner.
+
+Run from a maintenance database as a PostgreSQL superuser:
+
+  psql -X -v ON_ERROR_STOP=1 -d postgres \
+    -v role=colin_extract -v dbname=colin_extract \
+    -f data-tool/scripts/bootstrap/colin_extract_restricted_bootstrap.sql
+
+This file intentionally does not accept or store a password. Configure LOGIN
+authentication with the deployment's approved secret-management process.
+
+After this file succeeds:
+  1. connect as the restricted role and apply
+     colin_corps_extract_postgres_ddl, then
+     colin_corps_extract_postgres_views_ddl;
+  2. reconnect as a superuser and install
+     ../subset/subset_pg_boolean_casts.sql once in this database.
+
+The cast installer is separate so the extract objects remain owned by the
+restricted role while the pg_catalog casts and their conversion functions are
+owned by the bootstrap superuser.
+*/
+
+\if :{?role}
+\else
+  \echo 'ERROR: required psql variable "role" is missing (use -v role=...)'
+  \quit 3
+\endif
+
+\if :{?dbname}
+\else
+  \echo 'ERROR: required psql variable "dbname" is missing (use -v dbname=...)'
+  \quit 3
+\endif
+
+SELECT rolsuper AS bootstrap_is_superuser
+FROM pg_catalog.pg_roles
+WHERE rolname = current_user
+\gset
+
+\if :bootstrap_is_superuser
+\else
+  \echo 'ERROR: this bootstrap must be run by a PostgreSQL superuser'
+  \quit 3
+\endif
+
+-- Never mutate the bootstrap identity or silently de-privilege an existing
+-- administrative role because of a mistyped -v role=... value.
+SELECT NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_roles
+    WHERE rolname = :'role'
+      AND (
+          rolname = current_user
+          OR rolsuper
+          OR rolcreatedb
+          OR rolcreaterole
+          OR rolreplication
+          OR rolbypassrls
+      )
+) AS target_role_is_safe
+\gset
+
+\if :target_role_is_safe
+\else
+  \echo 'ERROR: target role is the bootstrap identity or already has privileged attributes'
+  \quit 3
+\endif
+
+-- CREATE ROLE has no IF NOT EXISTS form. \gexec makes this rerunnable.
+SELECT pg_catalog.format(
+    'CREATE ROLE %I LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS',
+    :'role'
+)
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_roles
+    WHERE rolname = :'role'
+)
+\gexec
+
+-- Normalize an existing bootstrap role to the intended steady-state attributes.
+ALTER ROLE :"role"
+    LOGIN
+    NOSUPERUSER
+    NOCREATEDB
+    NOCREATEROLE
+    NOREPLICATION
+    NOBYPASSRLS;
+
+-- CREATE DATABASE also has no IF NOT EXISTS form and cannot run in a transaction.
+SELECT pg_catalog.format(
+    'CREATE DATABASE %I OWNER %I TEMPLATE template0',
+    :'dbname',
+    :'role'
+)
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_database
+    WHERE datname = :'dbname'
+)
+\gexec
+
+-- Existing empty databases can be adopted by rerunning this bootstrap.
+ALTER DATABASE :"dbname" OWNER TO :"role";
+
+\connect :dbname
+
+-- The role must own public before it applies either DDL, so every created
+-- table, sequence, view, materialized view, function, and procedure is role-owned.
+ALTER SCHEMA public OWNER TO :"role";
+
+\echo 'Restricted role/database/schema provisioning complete.'
+\echo 'Next: apply both COLIN DDL files as the restricted role.'
+\echo 'Then: install subset/subset_pg_boolean_casts.sql in this DB as superuser.'

--- a/data-tool/scripts/colin_corps_extract_postgres_ddl
+++ b/data-tool/scripts/colin_corps_extract_postgres_ddl
@@ -1,46 +1,24 @@
 create sequence affiliation_processing_id_seq;
 
-alter sequence affiliation_processing_id_seq owner to postgres;
-
 create sequence if not exists auth_processing_id_seq;
-
-alter sequence auth_processing_id_seq owner to postgres;
 
 create sequence if not exists auth_component_operation_id_seq;
 
-alter sequence auth_component_operation_id_seq owner to postgres;
-
 create sequence corp_processing_id_seq;
-
-alter sequence corp_processing_id_seq owner to postgres;
 
 create sequence colin_tracking_id_seq;
 
-alter sequence colin_tracking_id_seq owner to postgres;
-
 create sequence mig_group_id_seq;
-
-alter sequence mig_group_id_seq owner to postgres;
 
 create sequence mig_batch_id_seq;
 
-alter sequence mig_batch_id_seq owner to postgres;
-
 create sequence mig_corp_batch_id_seq;
-
-alter sequence mig_corp_batch_id_seq owner to postgres;
 
 create sequence if not exists mig_corp_account_id_seq;
 
-alter sequence mig_corp_account_id_seq owner to postgres;
-
 create sequence if not exists bad_emails_id_seq;
 
-alter sequence bad_emails_id_seq owner to postgres;
-
 create sequence if not exists excluded_email_domain_patterns_id_seq;
-
-alter sequence excluded_email_domain_patterns_id_seq owner to postgres;
 
 create table if not exists address
 (
@@ -71,9 +49,6 @@ create table if not exists address
     route_service_no       varchar(4)
 );
 
-alter table address
-    owner to postgres;
-
 create table if not exists subset_address_stage
 (
     addr_id         numeric(10),
@@ -86,18 +61,12 @@ create table if not exists subset_address_stage
     city            varchar(40)
 );
 
-alter table subset_address_stage
-    owner to postgres;
-
 create table if not exists subset_excluded_corps
 (
     corp_num varchar(10)
         constraint pk_subset_excluded_corps
             primary key
 );
-
-alter table subset_excluded_corps
-    owner to postgres;
 
 create table if not exists subset_excluded_events
 (
@@ -106,18 +75,12 @@ create table if not exists subset_excluded_events
             primary key
 );
 
-alter table subset_excluded_events
-    owner to postgres;
-
 create table if not exists subset_excluded_corp_parties
 (
     corp_party_id numeric(9)
         constraint pk_subset_excluded_corp_parties
             primary key
 );
-
-alter table subset_excluded_corp_parties
-    owner to postgres;
 
 create table if not exists corporation
 (
@@ -137,9 +100,6 @@ create table if not exists corporation
     last_ar_reminder_year numeric(4)
 );
 
-alter table corporation
-    owner to postgres;
-
 create index if not exists idx_corporation_corp_type_cd
     on corporation (corp_type_cd);
 
@@ -155,9 +115,6 @@ create table if not exists event
     event_timerstamp timestamp with time zone,
     trigger_dts      timestamp with time zone
 );
-
-alter table event
-    owner to postgres;
 
 create index if not exists idx_event_event_type_cd
     on event (event_type_cd);
@@ -185,9 +142,6 @@ create table if not exists filing
     court_order_num    varchar(255)
 );
 
-alter table filing
-    owner to postgres;
-
 create index if not exists idx_filing_filing_type_cd
     on filing (filing_type_cd);
 
@@ -205,9 +159,6 @@ create table if not exists filing_user
     bcol_acct_num  integer,
     role_typ_cd    varchar(30)
 );
-
-alter table filing_user
-    owner to postgres;
 
 create table if not exists jurisdiction
 (
@@ -228,9 +179,6 @@ create table if not exists jurisdiction
 
 comment on table jurisdiction is 'new table \n\nThis table does hold continued in company former home jurisdiction information, and XPRO company home jurisdiction information. which will not be going over to the new system quite yet.\n\nevery "Continued In" has one and only one row with a corp_num starting with a C';
 
-alter table jurisdiction
-    owner to postgres;
-
 create table if not exists ledger_text
 (
     event_id        numeric(9)
@@ -240,9 +188,6 @@ create table if not exists ledger_text
     user_id         varchar(32),
     ledger_text_dts timestamp with time zone
 );
-
-alter table ledger_text
-    owner to postgres;
 
 create table if not exists notification
 (
@@ -263,9 +208,6 @@ create table if not exists notification
 
 comment on table notification is 'new table\n\n2,999,121 rows.  recipient of filing outputs for 35 different filing types\n\nIts not displayed on the ledger anywhere. I found this info regarding the EVENT_ID and notifications. - COLIN updates the Notification table with the notification method details';
 
-alter table notification
-    owner to postgres;
-
 create table if not exists notification_resend
 (
     event_id        numeric(9) not null
@@ -284,9 +226,6 @@ create table if not exists notification_resend
 );
 
 comment on table notification_resend is 'new table\n\nThis is displayed in the ledger when a staff member has resent a document to the client after the original filing.  It appears in the notification information on the original filing';
-
-alter table notification_resend
-    owner to postgres;
 
 create table if not exists office
 (
@@ -308,9 +247,6 @@ create table if not exists office
             references address (addr_id)
 );
 
-alter table office
-    owner to postgres;
-
 create table if not exists resolution
 (
     corp_num             varchar(10) not null
@@ -325,9 +261,6 @@ create table if not exists resolution
         constraint fk_resolution_event_0
             references event (event_id)
 );
-
-alter table resolution
-    owner to postgres;
 
 create table if not exists share_struct
 (
@@ -345,9 +278,6 @@ create table if not exists share_struct
 );
 
 comment on table share_struct is 'new table\n\n972,136 rows, right padded with blanks, select id from businesses where identifier=:corp_num';
-
-alter table share_struct
-    owner to postgres;
 
 create table if not exists share_struct_cls
 (
@@ -369,9 +299,6 @@ create table if not exists share_struct_cls
 );
 
 comment on table share_struct_cls is 'new table\n\n3,441,652 rows, right padded with blanks, select id from businesses where identifier=:corp_num';
-
-alter table share_struct_cls
-    owner to postgres;
 
 create table if not exists submitting_party
 (
@@ -411,9 +338,6 @@ comment on column submitting_party.notify_last_nme is '2846 different from last_
 
 comment on column submitting_party.phone_number is 'all for PICKUP, does the new application have pickup?';
 
-alter table submitting_party
-    owner to postgres;
-
 create table if not exists affiliation_processing
 (
     id               integer                  default nextval('affiliation_processing_id_seq'::regclass) not null
@@ -436,9 +360,6 @@ create table if not exists affiliation_processing
         unique (account_id, corp_num, environment)
 );
 
-alter table affiliation_processing
-    owner to postgres;
-
 create table if not exists business_description
 (
     corp_num            varchar(10)
@@ -455,9 +376,6 @@ create table if not exists business_description
     description         varchar(300)
 );
 
-alter table business_description
-    owner to postgres;
-
 create table if not exists completing_party
 (
     event_id          numeric(9) not null
@@ -473,9 +391,6 @@ create table if not exists completing_party
 );
 
 comment on table completing_party is 'new table\n\ncompleting_party table only used for incorporations.  parties.party_type=person.  party_roles.role= incorporator';
-
-alter table completing_party
-    owner to postgres;
 
 create table if not exists cont_out
 (
@@ -494,9 +409,6 @@ create table if not exists cont_out
 
 comment on table cont_out is 'new table\n\nWhen a BC company continues out to another jurisdiction, the information is saved here, and it shows on the corporate summary';
 
-alter table cont_out
-    owner to postgres;
-
 create table if not exists conv_event
 (
     event_id         numeric(9) not null
@@ -513,9 +425,6 @@ create table if not exists conv_event
 
 comment on table conv_event is 'new table \n\n1,243,749 rows, 15 have a filing, pre-COLIN ARs are a different format and maybe use this? Exclusively used by event_typ_cd CONV*';
 
-alter table conv_event
-    owner to postgres;
-
 create table if not exists conv_ledger
 (
     event_id         numeric(9) not null
@@ -528,18 +437,12 @@ create table if not exists conv_ledger
 
 comment on table conv_ledger is 'new table\n\n"4,072,795 rows, event is FILE except for 5, filing is always CONVL, 4 rows after March 26, 2004\nCOLIN ledger displays:\nledger_title_txt\nevent.event_timestmp\nledger_desc and filing.effective_dt and filing_user"\n\nthis is the ledger_text table prior to March 26, 2004.  filing_typ_cd =''CONVL'' may be best way to detect this';
 
-alter table conv_ledger
-    owner to postgres;
-
 create table if not exists carsfile
 (
     documtid   varchar(8) not null,
     filedate         date,
     regiracf         varchar(8)
 );
-
-alter table carsfile
-    owner to postgres;
 
 create table if not exists carsbox
 (
@@ -549,18 +452,12 @@ create table if not exists carsbox
     boxrracf         varchar(8)
 );
 
-alter table carsbox
-    owner to postgres;
-
 create table if not exists carsrept
 (
     documtid   varchar(8) not null,
     docutype    varchar(4),
     compnumb    varchar(7)
 );
-
-alter table carsrept
-    owner to postgres;
 
 create table if not exists carindiv
 (
@@ -580,9 +477,6 @@ create table if not exists carindiv
     dircaddr04	varchar(40)
 );
 
-alter table carindiv
-    owner to postgres;
-
 create table if not exists corp_comments
 (
     comment_dts        timestamp with time zone,
@@ -596,9 +490,6 @@ create table if not exists corp_comments
     middle_nme         varchar(20),
     accession_comments varchar(2000)
 );
-
-alter table corp_comments
-    owner to postgres;
 
 create table if not exists corp_flag
 (
@@ -615,9 +506,6 @@ create table if not exists corp_flag
 );
 
 comment on table corp_flag is 'new table\n\n114,405 businesses have 29 different flags (mostly societies)\n\nsome flags are for societies, some for XPROs, and some are set on BC companies by staff';
-
-alter table corp_flag
-    owner to postgres;
 
 create table if not exists corp_involved_amalgamating
 (
@@ -640,9 +528,6 @@ create table if not exists corp_involved_amalgamating
 
 comment on table corp_involved_amalgamating is 'new table\n\nused for almagmations\n\nselect all where TED is a BC Corp, 37 will not be be BC Corps';
 
-alter table corp_involved_amalgamating
-    owner to postgres;
-
 create table if not exists corp_name
 (
     corp_num         varchar(10)
@@ -657,9 +542,6 @@ create table if not exists corp_name
             references event (event_id),
     corp_name        varchar(150)
 );
-
-alter table corp_name
-    owner to postgres;
 
 create table if not exists corp_party
 (
@@ -695,9 +577,6 @@ create table if not exists corp_party
     corr_typ_cd            char,
     office_notification_dt timestamp with time zone
 );
-
-alter table corp_party
-    owner to postgres;
 
 create index if not exists idx_corp_party_party_typ_cd
     on corp_party (party_typ_cd);
@@ -737,9 +616,6 @@ comment on column corp_party_relationship.corp_party_id is 'This column is used 
 
 comment on column corp_party_relationship.relationship_typ_cd is 'Court ordered person, Heir, Shareholder, officer, director';
 
-alter table corp_party_relationship
-    owner to postgres;
-
 create table if not exists mig_group
 (
     id          integer default nextval('mig_group_id_seq'::regclass) not null
@@ -751,9 +627,6 @@ create table if not exists mig_group
     create_date timestamp with time zone default CURRENT_TIMESTAMP not null,
     notes       varchar(600)
 );
-
-alter table mig_group
-    owner to postgres;
 
 create index if not exists idx_mig_group_delta_nk
     on mig_group (name, target_environment, source_db);
@@ -776,9 +649,6 @@ create table if not exists mig_batch
     target_environment varchar(25)
 );
 
-alter table mig_batch
-    owner to postgres;
-
 create index if not exists idx_mig_batch_delta_nk
     on mig_batch (mig_group_id, name, target_environment);
 
@@ -793,9 +663,6 @@ create table if not exists mig_corp_batch
     corp_num     varchar(10) not null,
     notes            varchar(600)
 );
-
-alter table mig_corp_batch
-    owner to postgres;
 
 create index if not exists idx_mig_corp_batch_delta_nk
     on mig_corp_batch (mig_batch_id, corp_num);
@@ -812,9 +679,6 @@ create table if not exists mig_corp_account
         constraint fk_mig_corp_account_mig_batch
             references mig_batch
 );
-
-alter table mig_corp_account
-    owner to postgres;
 
 create index if not exists idx_mig_corp_account_delta_nk
     on mig_corp_account (corp_num, target_environment, account_id, mig_batch_id);
@@ -852,9 +716,6 @@ create table if not exists corp_processing
     constraint unq_corp_processing
         unique (corp_num, flow_name, environment)
 );
-
-alter table corp_processing
-    owner to postgres;
 
 create index if not exists idx_corp_processing_processed_status
     on corp_processing (processed_status);
@@ -918,8 +779,6 @@ create table if not exists auth_processing
 	)
 );
 
-alter table auth_processing owner to postgres;
-
 create index if not exists idx_auth_processing_claim_batch
 	on auth_processing (environment, flow_name, flow_run_id, processed_status, claimed_at);
 
@@ -958,8 +817,6 @@ create table if not exists auth_component_operation
 	create_date         timestamp with time zone default current_timestamp not null
 );
 
-alter table auth_component_operation owner to postgres;
-
 create index if not exists idx_auth_component_operation_auth_processing_id
 	on auth_component_operation (auth_processing_id);
 
@@ -982,9 +839,6 @@ create table if not exists corp_restriction
 
 comment on table corp_restriction is 'new table\n\n726,574 rows, pre-existing company provisions';
 
-alter table corp_restriction
-    owner to postgres;
-
 create table if not exists corp_state
 (
     corp_num       varchar(10)
@@ -1000,9 +854,6 @@ create table if not exists corp_state
     op_state_type_cd varchar(3)
 );
 
-alter table corp_state
-    owner to postgres;
-
 create table if not exists correction
 (
     event_id            numeric(9)  not null
@@ -1016,9 +867,6 @@ create table if not exists correction
 
 comment on table correction is 'new table\n\nAny correction filings completed appear to have this kind of entry, which includes BC Companyies, and the details show on the filing history on the ledger.';
 
-alter table correction
-    owner to postgres;
-
 create table if not exists offices_held
 (
     corp_party_id  numeric(9) not null
@@ -1030,9 +878,6 @@ create table if not exists offices_held
 comment on table offices_held is 'new table\n\nBoth BC companies and XPROs can input officers, secretaries, etc information in their annual reports';
 
 comment on column offices_held.officer_typ_cd is '9 values:  secretary, president, treasurer etc.';
-
-alter table offices_held
-    owner to postgres;
 
 create table if not exists party_notification
 (
@@ -1052,9 +897,6 @@ create table if not exists party_notification
     phone_number    varchar(20)
 );
 
-alter table party_notification
-    owner to postgres;
-
 create table if not exists share_series
 (
     corp_num       varchar(10) not null,
@@ -1073,9 +915,6 @@ create table if not exists share_series
 
 comment on table share_series is 'new table\n\n55,484 rows, right padded with blanks, select id from businesses where identifier=:corp_num';
 
-alter table share_series
-    owner to postgres;
-
 create table if not exists corp_involved_cont_in
 (
     event_id numeric(9)  not null
@@ -1088,9 +927,6 @@ create table if not exists corp_involved_cont_in
 
 comment on table corp_involved_cont_in is 'new table\n\n"Optionally, a ""Continuation In"" causes an existing xpro in CPRD to become ""Historical Continued In"".\nSearching the xpro shows the Continue In corp_num, date, and status.\nSearching the Continued In corp shows the xpro corp_num and name on the certificate and the Corporate Summary."';
 
-alter table corp_involved_cont_in
-    owner to postgres;
-
 create table if not exists payment
 (
     event_id numeric(9)  not null
@@ -1099,9 +935,6 @@ create table if not exists payment
     payment_typ_cd varchar(4) not null,
     cc_holder_nme varchar(80)
 );
-
-alter table payment
-    owner to postgres;
 
 
 create table if not exists colin_tracking
@@ -1127,9 +960,6 @@ create table if not exists colin_tracking
     constraint unq_colin_tracking unique (corp_num, flow_name, environment)
 );
 
-alter table colin_tracking
-    owner to postgres;
-
 create index if not exists idx_colin_tracking_claim_batch
 	on colin_tracking (environment, flow_name, flow_run_id, processed_status, claimed_at);
 
@@ -1139,18 +969,12 @@ create index if not exists idx_colin_tracking_flow_env_status
 create table if not exists colin_extract_version (
     extracted_at timestamp with time zone not null default current_timestamp
 );
-alter table colin_tracking
-    owner to postgres;
-
 create table if not exists corps_with_third_party
 (
     corp_num     text,
     vendor       text,
     vendor_count integer
 );
-
-alter table corps_with_third_party
-    owner to postgres;
 
 create index if not exists idx_corps_with_third_party_delta_nk
     on corps_with_third_party (corp_num, vendor);
@@ -1166,9 +990,6 @@ create table if not exists bar_corps
     bar_account_has_mailing_address boolean not null default false
 );
 
-alter table bar_corps
-    owner to postgres;
-
 create index if not exists idx_bar_corps_delta_nk
     on bar_corps (identifier);
 
@@ -1182,9 +1003,6 @@ as
 $$
 select btrim(t) = ''
 $$;
-
-alter function is_blank
-    owner to postgres;
 
 
 -- helper to count significant decimal places (ignoring trailing zeros)
@@ -1201,17 +1019,11 @@ select case
 end
 $$;
 
-alter function significant_decimal_places
-    owner to postgres;
-
 
 CREATE TABLE IF NOT EXISTS email_domain_groups (
     email_domain VARCHAR(255) PRIMARY KEY,
     group_name VARCHAR(100) NOT NULL
 );
-
-alter table email_domain_groups
-    owner to postgres;
 
 CREATE TABLE IF NOT EXISTS bad_emails (
 	id integer default nextval('bad_emails_id_seq'::regclass) not null
@@ -1219,9 +1031,6 @@ CREATE TABLE IF NOT EXISTS bad_emails (
     email varchar(255) NOT NULL UNIQUE,
     notes text
 );
-
-alter table bad_emails
-    owner to postgres;
 
 -- Preserve raw bad_emails.email uniqueness while also enforcing the normalized
 -- case/whitespace-insensitive uniqueness used by mv_legacy_corps_data.
@@ -1235,9 +1044,6 @@ CREATE TABLE IF NOT EXISTS excluded_emails (
     notes text
 );
 
-alter table excluded_emails
-    owner to postgres;
-
 CREATE UNIQUE INDEX IF NOT EXISTS ux_excluded_emails_email_normalized
     ON excluded_emails (lower(btrim(email)));
 
@@ -1247,9 +1053,6 @@ CREATE TABLE IF NOT EXISTS excluded_email_domains (
             CHECK (lower(btrim(email_domain)) <> ''),
     notes text
 );
-
-alter table excluded_email_domains
-    owner to postgres;
 
 CREATE UNIQUE INDEX IF NOT EXISTS ux_excluded_email_domains_domain_normalized
     ON excluded_email_domains (lower(btrim(email_domain)));
@@ -1269,9 +1072,6 @@ CREATE TABLE IF NOT EXISTS excluded_email_domain_patterns (
     notes text
 );
 
-alter table excluded_email_domain_patterns
-    owner to postgres;
-
 CREATE UNIQUE INDEX IF NOT EXISTS ux_excluded_email_domain_patterns_normalized
     ON excluded_email_domain_patterns (lower(btrim(email_domain)), lower(btrim(local_part_pattern)));
 
@@ -1280,9 +1080,6 @@ CREATE TABLE IF NOT EXISTS exclude_corps (
         CONSTRAINT pk_exclude_corps PRIMARY KEY,
     notes text
 );
-
-alter table exclude_corps
-    owner to postgres;
 
 CREATE INDEX if not exists ix_conv_event_event_id ON conv_event (event_id);
 
@@ -1484,6 +1281,10 @@ ALTER SEQUENCE public.bad_emails_id_seq
 	OWNED BY public.bad_emails.id;
 ALTER SEQUENCE public.excluded_email_domain_patterns_id_seq
 	OWNED BY public.excluded_email_domain_patterns.id;
+
+-- FK constraint suppression module (psql-only include; see header of the
+-- included file). DbSchemaCLI/SQLAlchemy must NOT be pointed at this DDL.
+\ir colin_fk_constraint_updates.sql
 
 -- Address-transpose routine module (psql-only include; see header of the
 -- included file). DbSchemaCLI/SQLAlchemy must NOT be pointed at this DDL.

--- a/data-tool/scripts/colin_corps_extract_postgres_views_ddl
+++ b/data-tool/scripts/colin_corps_extract_postgres_views_ddl
@@ -11,9 +11,6 @@ where 1 = 1
 WITH NO DATA
 ;
 
-ALTER MATERIALIZED VIEW mv_corps_with_officers
-    owner to postgres;
-
 
 CREATE MATERIALIZED VIEW mv_corps_party_role_count AS
 select c.corp_num, cp.party_typ_cd, count(cp.party_typ_cd) as party_typ_count
@@ -24,9 +21,6 @@ where 1 = 1
 group by c.corp_num, cp.party_typ_cd
 WITH NO DATA
 ;
-
-ALTER MATERIALIZED VIEW mv_corps_party_role_count
-    owner to postgres;
 
 
 CREATE MATERIALIZED VIEW mv_admin_email_count AS
@@ -42,9 +36,6 @@ WITH NO DATA
 CREATE UNIQUE INDEX IF NOT EXISTS ux_mv_admin_email_count_normalized_email
   ON mv_admin_email_count (normalized_admin_email);
 
-ALTER MATERIALIZED VIEW mv_admin_email_count
-    owner to postgres;
-
 
 CREATE MATERIALIZED VIEW mv_admin_email_domain_count AS
 select LOWER(SPLIT_PART(c.admin_email, '@', 2)) as email_domain,
@@ -54,9 +45,6 @@ group by LOWER(SPLIT_PART(c.admin_email, '@', 2))
 order by domain_count desc
 WITH NO DATA
 ;
-
-ALTER MATERIALIZED VIEW mv_admin_email_domain_count
-    owner to postgres;
 
 
 create view v_addr_links as
@@ -95,9 +83,6 @@ from current_party
 union all
 select *
 from current_office;
-
-ALTER VIEW v_addr_links
-    owner to postgres;
 
 create or replace view v_addr_issues as
 with link_rows as (
@@ -195,9 +180,6 @@ select
   not rf.any_bad as is_healthy
 from row_flags rf;
 
-ALTER VIEW v_addr_issues
-    owner to postgres;
-
 
 /* Shared per-corp/entity-type address issue counts reused by both the
    slim screening MV and the wide/full address-quality MV. */
@@ -226,9 +208,6 @@ WITH NO DATA
 
 CREATE UNIQUE INDEX IF NOT EXISTS ux_mv_addr_issue_counts_by_entity
   ON mv_addr_issue_counts_by_entity (corp_num, entity_kind, entity_type);
-
-ALTER MATERIALIZED VIEW mv_addr_issue_counts_by_entity
-    owner to postgres;
 
 
 create materialized view mv_addr_quality_by_corp as
@@ -598,9 +577,6 @@ WITH NO DATA
 
 create unique index on mv_addr_quality_by_corp (corp_num);
 
-ALTER MATERIALIZED VIEW mv_addr_quality_by_corp
-    owner to postgres;
-
 
 CREATE MATERIALIZED VIEW mv_addr_quality_screening_by_corp AS
 WITH
@@ -632,9 +608,6 @@ WITH NO DATA
 
 CREATE UNIQUE INDEX IF NOT EXISTS ux_mv_addr_quality_screening_by_corp_corpnum
   ON mv_addr_quality_screening_by_corp (corp_num);
-
-ALTER MATERIALIZED VIEW mv_addr_quality_screening_by_corp
-    owner to postgres;
 
 /* ---------------------------------------------------------------------
    Share class eligibility issue flags (1 row per corp_num)
@@ -680,9 +653,6 @@ WITH NO DATA
 
 CREATE UNIQUE INDEX IF NOT EXISTS ux_mv_share_class_issue_flags_corpnum
   ON mv_share_class_issue_flags (corp_num);
-
-ALTER MATERIALIZED VIEW mv_share_class_issue_flags
-    owner to postgres;
 
 
 CREATE MATERIALIZED VIEW mv_corp_event_filing_rollup AS
@@ -782,9 +752,6 @@ WITH NO DATA
 CREATE UNIQUE INDEX IF NOT EXISTS ux_mv_corp_event_filing_rollup_corpnum
   ON mv_corp_event_filing_rollup (corp_num);
 
-ALTER MATERIALIZED VIEW mv_corp_event_filing_rollup
-    owner to postgres;
-
 
 CREATE MATERIALIZED VIEW mv_admin_email_bad_email_flags AS
 WITH normalized_admin_emails AS (
@@ -810,9 +777,6 @@ WITH NO DATA
 
 CREATE UNIQUE INDEX IF NOT EXISTS ux_mv_admin_email_bad_email_flags_normalized_email
   ON mv_admin_email_bad_email_flags (normalized_admin_email);
-
-ALTER MATERIALIZED VIEW mv_admin_email_bad_email_flags
-    owner to postgres;
 
 
 CREATE MATERIALIZED VIEW mv_legacy_corps_data AS
@@ -1113,9 +1077,6 @@ where 1=1
 WITH NO DATA
 ;
 
-ALTER MATERIALIZED VIEW mv_legacy_corps_data
-    owner to postgres;
-
 CREATE OR REPLACE VIEW v_business_state AS
 SELECT cs.corp_num,
        CASE cs.op_state_type_cd
@@ -1125,9 +1086,6 @@ SELECT cs.corp_num,
        END AS business_state
 FROM corp_state cs
 WHERE cs.end_event_id IS NULL;
-
-ALTER VIEW v_business_state
-    owner to postgres;
 
 CREATE OR REPLACE VIEW v_auth_component_operation_audit AS
 SELECT
@@ -1175,9 +1133,6 @@ SELECT
 FROM auth_component_operation aco
 JOIN auth_processing ap ON ap.id = aco.auth_processing_id
 LEFT JOIN corporation c ON c.corp_num = aco.corp_num;
-
-ALTER VIEW v_auth_component_operation_audit
-    owner to postgres;
 
 CREATE MATERIALIZED VIEW mv_corp_issue_flags AS
 SELECT
@@ -1378,9 +1333,6 @@ CREATE UNIQUE INDEX IF NOT EXISTS ux_mv_corp_issue_flags_corp
 CREATE INDEX IF NOT EXISTS ix_mv_corp_issue_flags_state_type
   ON mv_corp_issue_flags (business_state, corp_type_cd);
 
-ALTER MATERIALIZED VIEW mv_corp_issue_flags
-    owner to postgres;
-
 CREATE OR REPLACE VIEW v_corp_issue_flags_long AS
 WITH base AS (
   SELECT f.*, lcd.group_name, lcd.recognition_dts
@@ -1493,9 +1445,6 @@ UNION ALL SELECT corp_num, business_state, corp_type_cd, group_name, recognition
 UNION ALL SELECT corp_num, business_state, corp_type_cd, group_name, recognition_dts, 'office','DS','Missing addr1',    office_ds_missing_addr1,    has_office_ds_link, has_office_ds_real FROM base
 ;
 
-ALTER VIEW v_corp_issue_flags_long
-    owner to postgres;
-
 CREATE MATERIALIZED VIEW mv_issue_counts_by_corp_type AS
 SELECT
   business_state,
@@ -1518,9 +1467,6 @@ WITH NO DATA
 CREATE INDEX IF NOT EXISTS ix_mv_issue_counts_by_corp_type
   ON mv_issue_counts_by_corp_type (corp_type_cd, business_state);
 ;
-
-ALTER MATERIALIZED VIEW mv_issue_counts_by_corp_type
-    owner to postgres;
 
 CREATE UNIQUE INDEX IF NOT EXISTS ux_legacy_corps_data_corpnum ON mv_legacy_corps_data (corp_num);
 

--- a/data-tool/scripts/colin_fk_constraint_updates.sql
+++ b/data-tool/scripts/colin_fk_constraint_updates.sql
@@ -1,0 +1,146 @@
+/*
+FK constraint suppression for COLIN extract refreshes.
+
+This module is included from colin_corps_extract_postgres_ddl with psql's
+\ir command. Apply the base DDL with psql; do not point DbSchemaCLI or
+SQLAlchemy directly at that DDL.
+
+The procedures intentionally COMMIT after each constraint change. They must
+therefore be invoked by a top-level CALL outside an explicit transaction.
+The helper table makes interrupted drops and restores resumable.
+*/
+
+CREATE TABLE IF NOT EXISTS public.colin_dropped_fks
+(
+    table_schema name        NOT NULL,
+    table_name   name        NOT NULL,
+    conname      name        NOT NULL,
+    condef       text        NOT NULL,
+    dropped_at   timestamptz NOT NULL DEFAULT current_timestamp,
+    CONSTRAINT pk_colin_dropped_fks
+        PRIMARY KEY (table_schema, table_name, conname)
+);
+
+CREATE OR REPLACE PROCEDURE public.colin_fk_drop_all(
+    OUT dropped_count bigint
+)
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+    fk record;
+    constraint_definition text;
+BEGIN
+    dropped_count := 0;
+
+    FOR fk IN
+        SELECT
+            constraint_row.oid AS constraint_oid,
+            namespace.nspname AS table_schema,
+            relation.relname AS table_name,
+            constraint_row.conname
+        FROM pg_catalog.pg_constraint AS constraint_row
+        JOIN pg_catalog.pg_class AS relation
+          ON relation.oid = constraint_row.conrelid
+        JOIN pg_catalog.pg_namespace AS namespace
+          ON namespace.oid = relation.relnamespace
+        LEFT JOIN public.colin_dropped_fks AS dropped
+          ON dropped.table_schema = namespace.nspname
+         AND dropped.table_name = relation.relname
+         AND dropped.conname = constraint_row.conname
+        WHERE constraint_row.contype = 'f'
+          AND relation.relkind = 'r'
+          AND namespace.nspname = 'public'
+          AND dropped.conname IS NULL
+        ORDER BY namespace.nspname, relation.relname, constraint_row.conname
+    LOOP
+        -- Force pg_get_constraintdef() to schema-qualify every non-catalog
+        -- relation, independent of the caller's search_path. SET LOCAL is
+        -- intentionally repeated because each loop iteration commits.
+        PERFORM pg_catalog.set_config('search_path', 'pg_catalog', true);
+        constraint_definition := pg_catalog.pg_get_constraintdef(fk.constraint_oid);
+
+        INSERT INTO public.colin_dropped_fks (
+            table_schema,
+            table_name,
+            conname,
+            condef
+        )
+        VALUES (
+            fk.table_schema,
+            fk.table_name,
+            fk.conname,
+            constraint_definition
+        );
+
+        EXECUTE pg_catalog.format(
+            'ALTER TABLE %I.%I DROP CONSTRAINT %I',
+            fk.table_schema,
+            fk.table_name,
+            fk.conname
+        );
+
+        dropped_count := dropped_count + 1;
+        COMMIT;
+    END LOOP;
+END;
+$$;
+
+CREATE OR REPLACE PROCEDURE public.colin_fk_restore_all(
+    OUT restored_count bigint
+)
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+    fk record;
+    constraint_definition text;
+BEGIN
+    restored_count := 0;
+
+    FOR fk IN
+        SELECT
+            table_schema,
+            table_name,
+            conname,
+            condef
+        FROM public.colin_dropped_fks
+        ORDER BY table_schema, table_name, conname
+    LOOP
+        -- New captures contain qualified relation names. Keep public on a
+        -- controlled path as backward-compatible recovery for helper rows
+        -- captured by an earlier module version with unqualified names.
+        PERFORM pg_catalog.set_config('search_path', 'pg_catalog, public', true);
+
+        constraint_definition := pg_catalog.rtrim(fk.condef);
+        IF constraint_definition !~* '[[:space:]]+NOT[[:space:]]+VALID[[:space:]]*$' THEN
+            constraint_definition := constraint_definition || ' NOT VALID';
+        END IF;
+
+        EXECUTE pg_catalog.format(
+            'ALTER TABLE %I.%I ADD CONSTRAINT %I %s',
+            fk.table_schema,
+            fk.table_name,
+            fk.conname,
+            constraint_definition
+        );
+
+        DELETE FROM public.colin_dropped_fks
+        WHERE table_schema = fk.table_schema
+          AND table_name = fk.table_name
+          AND conname = fk.conname;
+
+        restored_count := restored_count + 1;
+        COMMIT;
+    END LOOP;
+END;
+$$;
+
+COMMENT ON TABLE public.colin_dropped_fks IS
+'Foreign key definitions captured while a COLIN extract refresh is in progress.';
+
+COMMENT ON PROCEDURE public.colin_fk_drop_all() IS
+'Captures and drops every foreign key on ordinary tables in public, committing each drop for resumability.';
+
+COMMENT ON PROCEDURE public.colin_fk_restore_all() IS
+'Restores captured foreign keys as NOT VALID constraints, committing and removing each saved definition on success.';

--- a/data-tool/scripts/generate_cprd_subset_extract.py
+++ b/data-tool/scripts/generate_cprd_subset_extract.py
@@ -60,6 +60,12 @@ class cfg_OracleInStrategy(str, Enum):
 class cfg_PgDisableMethod(str, Enum):
     TABLE_TRIGGERS = "table_triggers"  # ALTER TABLE ... DISABLE/ENABLE TRIGGER ALL (default)
     REPLICA_ROLE = "replica_role"      # SET session_replication_role=replica|origin (superuser only)
+    DROP_CONSTRAINTS = "drop_constraints"  # Drop/re-add public FKs via owner-invoked procedures
+
+
+class cfg_PgCastMode(str, Enum):
+    INSTALL = "install"
+    VERIFY = "verify"
 
 
 @dataclass(frozen=True)
@@ -78,6 +84,7 @@ class cfg_GenerationConfig:
 
     pg_fastload: bool
     pg_disable_method: cfg_PgDisableMethod
+    pg_cast_mode: cfg_PgCastMode
     pg_debug_session_probes: bool
 
     oracle_in_strategy: cfg_OracleInStrategy
@@ -117,7 +124,10 @@ class tmpl_TemplateBundle:
     pg_cleanup_orphan_children: tmpl_TemplateSpec
     disable_triggers: tmpl_TemplateSpec
     enable_triggers: tmpl_TemplateSpec
+    pg_fk_drop: tmpl_TemplateSpec
+    pg_fk_restore: tmpl_TemplateSpec
     pg_boolean_casts: tmpl_TemplateSpec
+    pg_boolean_casts_verify: tmpl_TemplateSpec
     pg_fastload_begin: tmpl_TemplateSpec
     pg_fastload_end: tmpl_TemplateSpec
     pg_purge_bcomps_excluded: tmpl_TemplateSpec
@@ -328,9 +338,21 @@ def tmpl_default_bundle(repo_root: Path) -> tmpl_TemplateBundle:
         name="subset_enable_triggers",
         path=subset_dir / "subset_enable_triggers.sql",
     )
+    pg_fk_drop = tmpl_TemplateSpec(
+        name="subset_pg_fk_drop",
+        path=subset_dir / "subset_pg_fk_drop.sql",
+    )
+    pg_fk_restore = tmpl_TemplateSpec(
+        name="subset_pg_fk_restore",
+        path=subset_dir / "subset_pg_fk_restore.sql",
+    )
     pg_boolean_casts = tmpl_TemplateSpec(
         name="subset_pg_boolean_casts",
         path=subset_dir / "subset_pg_boolean_casts.sql",
+    )
+    pg_boolean_casts_verify = tmpl_TemplateSpec(
+        name="subset_pg_boolean_casts_verify",
+        path=subset_dir / "subset_pg_boolean_casts_verify.sql",
     )
     pg_fastload_begin = tmpl_TemplateSpec(
         name="subset_pg_fastload_begin",
@@ -372,7 +394,10 @@ def tmpl_default_bundle(repo_root: Path) -> tmpl_TemplateBundle:
         pg_cleanup_orphan_children=pg_cleanup_orphan_children,
         disable_triggers=disable_triggers,
         enable_triggers=enable_triggers,
+        pg_fk_drop=pg_fk_drop,
+        pg_fk_restore=pg_fk_restore,
         pg_boolean_casts=pg_boolean_casts,
+        pg_boolean_casts_verify=pg_boolean_casts_verify,
         pg_fastload_begin=pg_fastload_begin,
         pg_fastload_end=pg_fastload_end,
         pg_purge_bcomps_excluded=pg_purge_bcomps_excluded,
@@ -562,6 +587,20 @@ def gen_write_chunk_files(
     return out_paths
 
 
+def _gen_emit_pg_casts(lines: List[str], *, cfg: cfg_GenerationConfig, templates: tmpl_TemplateBundle) -> None:
+    lines.append("-- Postgres helper: allow VARCHAR/BPCHAR -> BOOLEAN assignment (DbSchemaCLI boolean inserts)")
+    if cfg.pg_cast_mode == cfg_PgCastMode.INSTALL:
+        lines.append(f"execute {templates.pg_boolean_casts.path.as_posix()}")
+        lines.append("-- Fail-fast: verify varchar/bpchar -> boolean casts exist")
+        lines.append("select 't'::varchar::boolean;")
+        lines.append("select 'f'::bpchar::boolean;")
+    elif cfg.pg_cast_mode == cfg_PgCastMode.VERIFY:
+        lines.append(f"execute {templates.pg_boolean_casts_verify.path.as_posix()}")
+    else:
+        raise SystemExit(f"Unsupported pg_cast_mode: {cfg.pg_cast_mode}")
+    lines.append("")
+
+
 def _gen_emit_pg_disable_begin(lines: List[str], *, cfg: cfg_GenerationConfig, templates: tmpl_TemplateBundle) -> None:
     if cfg.pg_disable_method == cfg_PgDisableMethod.TABLE_TRIGGERS:
         lines.append(f"execute {templates.disable_triggers.path.as_posix()}")
@@ -576,6 +615,11 @@ def _gen_emit_pg_disable_begin(lines: List[str], *, cfg: cfg_GenerationConfig, t
     if cfg.pg_disable_method == cfg_PgDisableMethod.REPLICA_ROLE:
         lines.append("-- Disable triggers / FK checks for this session (requires superuser privileges).")
         lines.append("SET session_replication_role = replica;")
+        lines.append("")
+        return
+
+    if cfg.pg_disable_method == cfg_PgDisableMethod.DROP_CONSTRAINTS:
+        lines.append(f"execute {templates.pg_fk_drop.path.as_posix()}")
         lines.append("")
         return
 
@@ -599,6 +643,11 @@ def _gen_emit_pg_disable_end(lines: List[str], *, cfg: cfg_GenerationConfig, tem
         lines.append("")
         return
 
+    if cfg.pg_disable_method == cfg_PgDisableMethod.DROP_CONSTRAINTS:
+        lines.append(f"execute {templates.pg_fk_restore.path.as_posix()}")
+        lines.append("")
+        return
+
     raise SystemExit(f"Unsupported pg_disable_method: {cfg.pg_disable_method}")
 
 
@@ -609,6 +658,8 @@ def _gen_emit_refresh_fk_note(lines: List[str], *, cfg: cfg_GenerationConfig) ->
     lines.append("-- Refresh mode preserves processing/tracking rows while deleting and reloading corporation/event rows.")
     if cfg.pg_disable_method == cfg_PgDisableMethod.TABLE_TRIGGERS:
         lines.append("-- table_triggers mode adds refresh-only trigger suppression for the preserved FK-owning tables too.")
+    elif cfg.pg_disable_method == cfg_PgDisableMethod.DROP_CONSTRAINTS:
+        lines.append("-- drop_constraints mode removes all public FKs, including those owned by preserved tables.")
     else:
         lines.append("-- replica_role mode relies on session_replication_role remaining active for nested execute/transfer work.")
     lines.append("")
@@ -662,12 +713,7 @@ def gen_build_master_script_inline(
         lines.append(f"execute {templates.pg_fastload_begin.path.as_posix()}")
         lines.append("")
 
-    lines.append("-- Postgres helper: allow VARCHAR/BPCHAR -> BOOLEAN assignment (DbSchemaCLI boolean inserts)")
-    lines.append(f"execute {templates.pg_boolean_casts.path.as_posix()}")
-    lines.append("-- Fail-fast: verify varchar/bpchar -> boolean casts exist")
-    lines.append("select 't'::varchar::boolean;")
-    lines.append("select 'f'::bpchar::boolean;")
-    lines.append("")
+    _gen_emit_pg_casts(lines, cfg=cfg, templates=templates)
     if cfg.mode == cfg_GenerationMode.REFRESH:
         lines.append("-- Cleanup stale orphan child rows before entering the trigger-suppressed refresh window.")
         lines.append(f"execute {templates.pg_cleanup_orphan_children.path.as_posix()}")
@@ -769,12 +815,7 @@ def gen_build_master_script_vset(
         lines.append(f"execute {templates.pg_fastload_begin.path.as_posix()}")
         lines.append("")
 
-    lines.append("-- Postgres helper: allow VARCHAR/BPCHAR -> BOOLEAN assignment (DbSchemaCLI boolean inserts)")
-    lines.append(f"execute {templates.pg_boolean_casts.path.as_posix()}")
-    lines.append("-- Fail-fast: verify varchar/bpchar -> boolean casts exist")
-    lines.append("select 't'::varchar::boolean;")
-    lines.append("select 'f'::bpchar::boolean;")
-    lines.append("")
+    _gen_emit_pg_casts(lines, cfg=cfg, templates=templates)
     if cfg.mode == cfg_GenerationMode.REFRESH:
         lines.append("-- Cleanup stale orphan child rows before entering the trigger-suppressed refresh window.")
         lines.append(f"execute {templates.pg_cleanup_orphan_children.path.as_posix()}")
@@ -954,7 +995,15 @@ def cli_parse_args(argv: List[str] | None = None) -> argparse.Namespace:
         default=cfg_PgDisableMethod.TABLE_TRIGGERS.value,
         help="How to suppress triggers during load. "
              "table_triggers=ALTER TABLE ... DISABLE/ENABLE TRIGGER ALL (default). "
-             "replica_role=SET session_replication_role=replica|origin (requires superuser; disables triggers/FKs for session).",
+             "replica_role=SET session_replication_role=replica|origin (requires superuser; disables triggers/FKs for session). "
+             "drop_constraints=drop/re-add all public FKs via owner-invoked procedures.",
+    )
+    parser.add_argument(
+        "--pg-cast-mode",
+        choices=[m.value for m in cfg_PgCastMode],
+        default=cfg_PgCastMode.INSTALL.value,
+        help="install=recreate VARCHAR/BPCHAR -> BOOLEAN casts (default; requires superuser). "
+             "verify=only verify that bootstrap-installed casts exist.",
     )
     parser.add_argument(
         "--pg-debug-session-probes",
@@ -998,6 +1047,7 @@ def cfg_build_config(args: argparse.Namespace) -> cfg_GenerationConfig:
         raise SystemExit("--or-of-in-max-ids must be > 0")
 
     pg_disable_method = cfg_PgDisableMethod(args.pg_disable_method)
+    pg_cast_mode = cfg_PgCastMode(args.pg_cast_mode)
 
     out_master = (
         Path(args.out).expanduser().resolve()
@@ -1028,6 +1078,7 @@ def cfg_build_config(args: argparse.Namespace) -> cfg_GenerationConfig:
         include_cp=bool(args.include_cp),
         pg_fastload=bool(args.pg_fastload),
         pg_disable_method=pg_disable_method,
+        pg_cast_mode=pg_cast_mode,
         pg_debug_session_probes=bool(args.pg_debug_session_probes),
         oracle_in_strategy=oracle_in_strategy,
         or_of_in_max_ids=or_of_in_max_ids,
@@ -1063,7 +1114,10 @@ def run(cfg: cfg_GenerationConfig) -> int:
         templates.pg_cleanup_orphan_children,
         templates.disable_triggers,
         templates.enable_triggers,
+        templates.pg_fk_drop,
+        templates.pg_fk_restore,
         templates.pg_boolean_casts,
+        templates.pg_boolean_casts_verify,
         templates.pg_fastload_begin,
         templates.pg_fastload_end,
         templates.pg_purge_bcomps_excluded,
@@ -1188,6 +1242,7 @@ def run(cfg: cfg_GenerationConfig) -> int:
         print(" - address transpose CALL returns JSON metrics before the advisory lock is explicitly released.")
         print(f" - Postgres fast-load session settings: {'ENABLED' if cfg.pg_fastload else 'disabled'} (--pg-fastload)")
         print(f" - Postgres trigger suppression: {cfg.pg_disable_method.value} (--pg-disable-method)")
+        print(f" - Postgres boolean cast mode: {cfg.pg_cast_mode.value} (--pg-cast-mode)")
         print(" - subset runs acquire a session-level advisory lock on the target DB to prevent overlap.")
         print(" - Address loads use the predeclared helper table public.subset_address_stage and merge into public.address by addr_id.")
         print("   - BCOMPS purge keysets also use predeclared helper tables in the extract schema (subset_excluded_*).")
@@ -1202,10 +1257,13 @@ def run(cfg: cfg_GenerationConfig) -> int:
             if cfg.pg_disable_method == cfg_PgDisableMethod.TABLE_TRIGGERS:
                 print("   - table_triggers mode adds refresh-only trigger suppression for the preserved FK-owning tables.")
                 print("   - table_triggers changes table state globally while the refresh runs; use it against a quiesced extract DB with sufficient privileges.")
-            else:
+            elif cfg.pg_disable_method == cfg_PgDisableMethod.REPLICA_ROLE:
                 print("   - replica_role is session-local; if FK errors still occur, probe current_setting('session_replication_role') inside nested execute files.")
         if cfg.pg_disable_method == cfg_PgDisableMethod.REPLICA_ROLE:
             print("   - NOTE: replica_role requires superuser and disables triggers/FKs for the session.")
+        elif cfg.pg_disable_method == cfg_PgDisableMethod.DROP_CONSTRAINTS:
+            print("   - drop_constraints re-adds public foreign keys NOT VALID after the load.")
+            print("   - recovery after a failed run: CALL public.colin_fk_restore_all(NULL);")
         return 0
 
     # vset mode: generate only a master script (no chunk files)
@@ -1243,6 +1301,7 @@ def run(cfg: cfg_GenerationConfig) -> int:
     print(" - address transpose CALL returns JSON metrics before the advisory lock is explicitly released.")
     print(f" - Postgres fast-load session settings: {'ENABLED' if cfg.pg_fastload else 'disabled'} (--pg-fastload)")
     print(f" - Postgres trigger suppression: {cfg.pg_disable_method.value} (--pg-disable-method)")
+    print(f" - Postgres boolean cast mode: {cfg.pg_cast_mode.value} (--pg-cast-mode)")
     print(" - subset runs acquire a session-level advisory lock on the target DB to prevent overlap.")
     print(" - Address loads use the predeclared helper table public.subset_address_stage and merge into public.address by addr_id.")
     print("   - BCOMPS purge keysets also use predeclared helper tables in the extract schema (subset_excluded_*).")
@@ -1257,10 +1316,13 @@ def run(cfg: cfg_GenerationConfig) -> int:
         if cfg.pg_disable_method == cfg_PgDisableMethod.TABLE_TRIGGERS:
             print("   - table_triggers mode adds refresh-only trigger suppression for the preserved FK-owning tables.")
             print("   - table_triggers changes table state globally while the refresh runs; use it against a quiesced extract DB with sufficient privileges.")
-        else:
+        elif cfg.pg_disable_method == cfg_PgDisableMethod.REPLICA_ROLE:
             print("   - replica_role is session-local; if FK errors still occur, probe current_setting('session_replication_role') inside nested execute files.")
     if cfg.pg_disable_method == cfg_PgDisableMethod.REPLICA_ROLE:
         print("   - NOTE: replica_role requires superuser and disables triggers/FKs for the session.")
+    elif cfg.pg_disable_method == cfg_PgDisableMethod.DROP_CONSTRAINTS:
+        print("   - drop_constraints re-adds public foreign keys NOT VALID after the load.")
+        print("   - recovery after a failed run: CALL public.colin_fk_restore_all(NULL);")
     return 0
 
 

--- a/data-tool/scripts/subset/subset_pg_boolean_casts_verify.sql
+++ b/data-tool/scripts/subset/subset_pg_boolean_casts_verify.sql
@@ -1,0 +1,11 @@
+-- Verify the one-time superuser bootstrap installed the DbSchemaCLI boolean casts.
+-- Automatic explicit string I/O casts are not enough: DbSchemaCLI assignments require implicit pg_cast entries.
+select 1 / case when count(*) = 2 then 1 else 0 end as required_implicit_boolean_casts_present
+from pg_catalog.pg_cast
+where castsource in ('varchar'::regtype, 'bpchar'::regtype)
+  and casttarget = 'boolean'::regtype
+  and castcontext = 'i';
+
+-- Also verify representative values accepted by the installed conversion functions.
+select 't'::varchar::boolean;
+select 'f'::bpchar::boolean;

--- a/data-tool/scripts/subset/subset_pg_fk_drop.sql
+++ b/data-tool/scripts/subset/subset_pg_fk_drop.sql
@@ -1,0 +1,1 @@
+CALL public.colin_fk_drop_all(NULL);

--- a/data-tool/scripts/subset/subset_pg_fk_restore.sql
+++ b/data-tool/scripts/subset/subset_pg_fk_restore.sql
@@ -1,0 +1,1 @@
+CALL public.colin_fk_restore_all(NULL);

--- a/data-tool/scripts/transfer_cprd_corps.sql
+++ b/data-tool/scripts/transfer_cprd_corps.sql
@@ -19,38 +19,9 @@ values (current_timestamp);
 
 
 
--- disable triggers
-ALTER TABLE corporation DISABLE TRIGGER ALL;
-ALTER TABLE corp_name DISABLE TRIGGER ALL;
-ALTER TABLE corp_state DISABLE TRIGGER ALL;
-ALTER TABLE event DISABLE TRIGGER ALL;
-ALTER TABLE filing DISABLE TRIGGER ALL;
-ALTER TABLE filing_user DISABLE TRIGGER ALL;
-ALTER TABLE office DISABLE TRIGGER ALL;
-ALTER TABLE address DISABLE TRIGGER ALL;
-ALTER TABLE corp_comments DISABLE TRIGGER ALL;
-ALTER TABLE ledger_text DISABLE TRIGGER ALL;
-ALTER TABLE corp_party DISABLE TRIGGER ALL;
-ALTER TABLE corp_party_relationship DISABLE TRIGGER ALL;
-ALTER TABLE offices_held DISABLE TRIGGER ALL;
-ALTER TABLE completing_party DISABLE TRIGGER ALL;
-ALTER TABLE submitting_party DISABLE TRIGGER ALL;
-ALTER TABLE corp_flag DISABLE TRIGGER ALL;
-ALTER TABLE cont_out DISABLE TRIGGER ALL;
-ALTER TABLE conv_event DISABLE TRIGGER ALL;
-ALTER TABLE conv_ledger DISABLE TRIGGER ALL;
-ALTER TABLE corp_involved_amalgamating DISABLE TRIGGER ALL;
-ALTER TABLE corp_involved_cont_in DISABLE TRIGGER ALL;
-ALTER TABLE corp_restriction DISABLE TRIGGER ALL;
-ALTER TABLE correction DISABLE TRIGGER ALL;
-ALTER TABLE jurisdiction DISABLE TRIGGER ALL;
-ALTER TABLE resolution DISABLE TRIGGER ALL;
-ALTER TABLE share_series DISABLE TRIGGER ALL;
-ALTER TABLE share_struct DISABLE TRIGGER ALL;
-ALTER TABLE share_struct_cls DISABLE TRIGGER ALL;
-ALTER TABLE notification DISABLE TRIGGER ALL;
-ALTER TABLE notification_resend DISABLE TRIGGER ALL;
-ALTER TABLE party_notification DISABLE TRIGGER ALL;
+-- Drop public foreign keys so all DbSchemaCLI writer sessions can load without
+-- superuser-only constraint-trigger suppression. Definitions are captured for recovery.
+CALL public.colin_fk_drop_all(NULL);
 
 
 -- alter tables
@@ -1503,38 +1474,9 @@ alter table share_series
    alter column spec_right_ind type boolean using spec_right_ind::boolean;
 
 
--- enable triggers
-ALTER TABLE corporation ENABLE TRIGGER ALL;
-ALTER TABLE corp_name ENABLE TRIGGER ALL;
-ALTER TABLE corp_state ENABLE TRIGGER ALL;
-ALTER TABLE event ENABLE TRIGGER ALL;
-ALTER TABLE filing ENABLE TRIGGER ALL;
-ALTER TABLE filing_user ENABLE TRIGGER ALL;
-ALTER TABLE office ENABLE TRIGGER ALL;
-ALTER TABLE address ENABLE TRIGGER ALL;
-ALTER TABLE corp_comments ENABLE TRIGGER ALL;
-ALTER TABLE ledger_text ENABLE TRIGGER ALL;
-ALTER TABLE corp_party ENABLE TRIGGER ALL;
-ALTER TABLE corp_party_relationship ENABLE TRIGGER ALL;
-ALTER TABLE offices_held ENABLE TRIGGER ALL;
-ALTER TABLE completing_party ENABLE TRIGGER ALL;
-ALTER TABLE submitting_party ENABLE TRIGGER ALL;
-ALTER TABLE corp_flag ENABLE TRIGGER ALL;
-ALTER TABLE cont_out ENABLE TRIGGER ALL;
-ALTER TABLE conv_event ENABLE TRIGGER ALL;
-ALTER TABLE conv_ledger ENABLE TRIGGER ALL;
-ALTER TABLE corp_involved_amalgamating ENABLE TRIGGER ALL;
-ALTER TABLE corp_involved_cont_in ENABLE TRIGGER ALL;
-ALTER TABLE corp_restriction ENABLE TRIGGER ALL;
-ALTER TABLE correction ENABLE TRIGGER ALL;
-ALTER TABLE jurisdiction ENABLE TRIGGER ALL;
-ALTER TABLE resolution ENABLE TRIGGER ALL;
-ALTER TABLE share_series ENABLE TRIGGER ALL;
-ALTER TABLE share_struct ENABLE TRIGGER ALL;
-ALTER TABLE share_struct_cls ENABLE TRIGGER ALL;
-ALTER TABLE notification ENABLE TRIGGER ALL;
-ALTER TABLE notification_resend ENABLE TRIGGER ALL;
-ALTER TABLE party_notification ENABLE TRIGGER ALL;
+-- Restore captured foreign keys as NOT VALID: new writes are enforced without
+-- scanning or rejecting known-invalid legacy extract rows.
+CALL public.colin_fk_restore_all(NULL);
 
 -- Normalize active-corp party/office addresses while the subset-run advisory lock is held.
 -- The result-bearing CALL returns one JSON value with phase counts, their total, and elapsed seconds.


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

# Enable COLIN extract refreshes with a non-superuser PostgreSQL owner

## Summary

This PR enables the `data-tool` COLIN full-refresh and subset load/refresh workflows to run with a restricted PostgreSQL role instead of requiring the runtime connection to be a superuser.

The supported model is a single owner identity:

- a DBA creates the role/database and transfers ownership of the database and `public` schema;
- the restricted role applies the extract DDL and therefore owns the extract objects;
- the DBA installs the two database-wide boolean casts once;
- steady-state full and subset runs use the restricted owner role.

The full-refresh data mapping and boolean-to-integer-to-boolean behavior are unchanged. The main runtime change is replacing superuser-only FK trigger suppression with owner-invoked FK drop/restore procedures.

## Why

The existing refresh paths contained two PostgreSQL operations that could not be performed by a normal database/object owner:

1. `ALTER TABLE ... DISABLE/ENABLE TRIGGER ALL` includes internal FK constraint triggers and therefore requires superuser privileges.
2. Recreating casts from built-in `varchar`/`bpchar` types to `boolean` requires ownership of a source or target type, which the restricted database owner does not have.

Other operations used by these workflows—including `ALTER COLUMN TYPE`, DML, `TRUNCATE`, sequence use, materialized-view refresh, `ANALYZE`, procedures, and advisory locks—are supported by object ownership.

## Key changes

### 1. Preserve ownership with the DDL-applying role

Removed hard-coded `OWNER TO postgres` statements from:

- `data-tool/scripts/colin_corps_extract_postgres_ddl`
- `data-tool/scripts/colin_corps_extract_postgres_views_ddl`

Objects now remain owned by whichever role applies the DDL:

- local superuser installs still naturally produce `postgres`-owned objects;
- restricted installs produce objects owned by the restricted role.

The existing `ALTER SEQUENCE ... OWNED BY table.column` statements remain in place. These are sequence-to-column dependency declarations used by `pg_get_serial_sequence()` and delta ID allocation; they are distinct from `OWNER TO role` and remain valid because the applying role owns both the table and sequence.

### 2. Replace FK trigger suppression with resumable FK drop/restore

Added `data-tool/scripts/colin_fk_constraint_updates.sql`, installed by the base DDL through `\ir`.

It creates:

- `public.colin_dropped_fks`, which stores captured FK definitions;
- `public.colin_fk_drop_all(OUT dropped_count bigint)`;
- `public.colin_fk_restore_all(OUT restored_count bigint)`.

The procedures:

- operate on every FK whose referencing ordinary table is in `public`;
- run as `SECURITY INVOKER`;
- require object ownership, not superuser privileges;
- commit after each FK operation, bounding lock duration and making interrupted runs resumable;
- capture schema-qualified definitions independently of the caller's `search_path`;
- restore FKs as `NOT VALID`, avoiding a scan of existing extract data while enforcing subsequent writes.

The helper row is deleted only after an FK is restored successfully. Re-running the restore procedure resumes from the remaining rows and is a no-op after recovery completes.

### 3. Update the full refresh

`data-tool/scripts/transfer_cprd_corps.sql` now calls:

```sql
CALL public.colin_fk_drop_all(NULL);
```

before its existing boolean-to-integer conversions and transfers, and:

```sql
CALL public.colin_fk_restore_all(NULL);
```

after converting the affected columns back to boolean.

This removes the previous table-by-table `DISABLE/ENABLE TRIGGER ALL` blocks.

The following full-refresh behavior is unchanged:

- advisory locking;
- the 11 boolean columns temporarily changed to integer;
- Oracle `0/1` transfer expressions;
- conversion back to boolean;
- address transpose;
- advisory unlock.

Dropping the constraints changes table state rather than session state, so it applies to all DbSchemaCLI writer sessions.

### 4. Add restricted-runtime cast verification

The existing `subset_pg_boolean_casts.sql` remains the installer and is unchanged. It still creates the implicit:

- `varchar -> boolean` cast;
- `bpchar -> boolean` cast.

Added `data-tool/scripts/subset/subset_pg_boolean_casts_verify.sql` for restricted runs. It verifies that both required implicit casts exist in `pg_catalog.pg_cast` and tests representative `varchar`/`bpchar` conversions without performing DDL.

The generator now supports:

```text
--pg-cast-mode install
--pg-cast-mode verify
```

- `install` remains the default and preserves existing local/generated behavior;
- `verify` is used after the DBA has installed the casts once.

### 5. Add a generator FK suppression mode

The subset generator now accepts:

```text
--pg-disable-method drop_constraints
```

This mode emits the new wrapper templates:

- `subset_pg_fk_drop.sql`
- `subset_pg_fk_restore.sql`

The existing `table_triggers` and `replica_role` methods remain available. The default remains `table_triggers`, preserving existing generated output unless the restricted mode is explicitly selected.

Both inline and legacy `vset` rendering paths support the new FK and cast modes.

### 6. Propagate modes through the flow

`data-tool/flows/refresh_extract_subset_flow.py` now accepts and forwards:

- `--pg-disable-method drop_constraints`;
- `--pg-cast-mode verify`.

The public call signatures retain defaults for compatibility:

- FK suppression default: `table_triggers`;
- cast mode default: `install`.

### 7. Add DBA bootstrap and operational documentation

Added:

- `data-tool/scripts/bootstrap/colin_extract_restricted_bootstrap.sql`;
- a “Running without superuser” section in `README_COLIN_Corps_Extract.md`.

The bootstrap:

- requires a PostgreSQL superuser;
- creates or adopts the restricted login and database;
- ensures the role does not have `SUPERUSER`, `CREATEDB`, `CREATEROLE`, `REPLICATION`, or `BYPASSRLS`;
- protects against accidentally de-privileging the current DBA or another privileged role;
- transfers database and `public` schema ownership;
- deliberately does not embed a password.

## How it is used

### One-time provisioning

#### 1. Bootstrap the role and database as DBA

```bash
psql -X -v ON_ERROR_STOP=1 \
  -h <host> -p <port> \
  -U <dba> -d postgres \
  -v role=colin_extract \
  -v dbname=colin_extract \
  -f data-tool/scripts/bootstrap/colin_extract_restricted_bootstrap.sql
```

#### 2. Apply both DDL files as the restricted owner

```bash
psql -X -v ON_ERROR_STOP=1 \
  -h <host> -p <port> \
  -U colin_extract -d colin_extract \
  -f data-tool/scripts/colin_corps_extract_postgres_ddl

psql -X -v ON_ERROR_STOP=1 \
  -h <host> -p <port> \
  -U colin_extract -d colin_extract \
  -f data-tool/scripts/colin_corps_extract_postgres_views_ddl
```

#### 3. Install boolean casts once as DBA

```bash
psql -X -v ON_ERROR_STOP=1 \
  -h <host> -p <port> \
  -U <dba> -d colin_extract \
  -f data-tool/scripts/subset/subset_pg_boolean_casts.sql
```

The casts must be reinstalled whenever the database is dropped and recreated.

### Full refresh

Register the DbSchemaCLI `cprd_pg` target connection using the restricted owner and run the existing script:

```bash
dbschemacli data-tool/scripts/transfer_cprd_corps.sql
```

No cast mode is needed for full refresh because it retains the existing temporary integer-column workflow. FK drop/restore is invoked automatically.

### Subset generator

```bash
python data-tool/scripts/generate_cprd_subset_extract.py \
  --corp-file <corp-id-file> \
  --mode refresh \
  --pg-disable-method drop_constraints \
  --pg-cast-mode verify \
  --out data-tool/scripts/_generated/subset_refresh.sql
```

Run the generated master with DbSchemaCLI using a target connection registered as the same restricted owner.

### Flow entry point

```bash
python data-tool/flows/refresh_extract_subset_flow.py \
  --mode refresh \
  --pg-disable-method drop_constraints \
  --pg-cast-mode verify \
  --reset-extract-postgres
```

Important: `--reset-extract-postgres` uses `action='store_false'`. Passing it disables database reset. Restricted runs must pass it because dropping/recreating the database would remove the DBA-installed casts and require re-provisioning.

The `--run-dbschemacli` and `--refresh-views` flags have the same inverted behavior: passing them disables those actions.

### Runtime identity requirement

The following must use the same restricted owner identity or inherited owner-role membership:

- flow psql/SQLAlchemy credentials from `DATABASE_*_COLIN_MIGR`;
- DbSchemaCLI target registrations such as `cprd_pg` or `cprd_pg_subset`;
- direct psql maintenance/recovery commands.

Using different identities can cause only part of the workflow to pass owner checks.

## Failure recovery

The FK procedures must be called at top-level in autocommit mode because they commit once per constraint.

If a load fails after FK removal:

1. stop other writers;
2. reconnect as the restricted owner;
3. restore any remaining constraints:

   ```sql
   CALL public.colin_fk_restore_all(NULL);
   ```

4. confirm `public.colin_dropped_fks` is empty;
5. for an interrupted full refresh, restore any indicator columns left as integer;
6. rerun the extract.

The restore call is safe to repeat.

## Reviewer notes and intentional behavior

- The database must be quiesced while FKs are absent.
- The procedures cover all FKs on ordinary tables in `public`, not only the transfer-table list.
- User-defined triggers are not disabled by `drop_constraints` and continue to fire.
- Restored FKs are intentionally `NOT VALID`; they enforce new writes but do not scan or reject known legacy extract rows.
- Do not run blanket `VALIDATE CONSTRAINT` without understanding known legacy exceptions.
- Existing databases are not migrated merely by changing database/schema ownership. Existing objects still owned by `postgres` require a complete DBA-controlled ownership transfer or fresh provisioning.
- Do not reapply the complete base DDL over a populated database as an ownership migration.
- Restricted runs must not self-service drop/recreate the database.
- `jobs/colin-extract-refresh/**` is outside this change.

## Compatibility and performance

- Existing generator defaults remain `table_triggers` and `install`.
- Full-refresh boolean conversion behavior is unchanged.
- Restricted cast verification performs one catalog query and two scalar conversions; it does not scan business tables or recreate casts.
- FK suppression adds DDL and locking per FK but removes FK checks during transfer and restores constraints without a validation scan.
- No performance result is claimed. A controlled comparison requires the same Oracle cohort, target class, DbSchemaCLI/JDBC versions, thread count, and fast-load settings.

## Validation

Completed locally during development:

- fresh non-superuser database/schema ownership setup;
- base and views DDL application under the restricted owner;
- FK drop/restore, `NOT VALID` enforcement, idempotent restore, and partial recovery smoke checks;
- bootstrap rerun/idempotency and restricted-role attribute checks;
- restricted cast verification after DBA installation;
- generator/flow checks for flag propagation and both rendering paths.

Known validation gap:

- the generator golden-output assertion currently has whitespace/end-of-file formatting drift; cast/FK mode assertions pass;
- end-to-end Oracle→PostgreSQL DbSchemaCLI full/subset testing and performance comparison remain to be completed with external dependencies.

## Files changed

- `data-tool/flows/refresh_extract_subset_flow.py`
- `data-tool/scripts/bootstrap/colin_extract_restricted_bootstrap.sql`
- `data-tool/scripts/colin_corps_extract_postgres_ddl`
- `data-tool/scripts/colin_corps_extract_postgres_views_ddl`
- `data-tool/scripts/colin_fk_constraint_updates.sql`
- `data-tool/scripts/generate_cprd_subset_extract.py`
- `data-tool/scripts/README_COLIN_Corps_Extract.md`
- `data-tool/scripts/subset/subset_pg_boolean_casts_verify.sql`
- `data-tool/scripts/subset/subset_pg_fk_drop.sql`
- `data-tool/scripts/subset/subset_pg_fk_restore.sql`
- `data-tool/scripts/transfer_cprd_corps.sql`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
