### PR TITLE
33970 API - fix validation on initial new business

### DIFF
--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
@@ -129,7 +129,7 @@ def saving_filings(body: FilingModel,  # noqa: PLR0911, PLR0912
     business, filing = ListFilingResource.get_business_and_filing(identifier, filing_id)
 
     # basic checks
-    err_msg, err_code = ListFilingResource.put_basic_checks(identifier, filing, request, business)
+    err_msg, err_code = ListFilingResource.put_basic_checks(identifier, filing, request, business, query)
     if err_msg:
         return jsonify({"errors": [err_msg, ]}), err_code
 
@@ -533,7 +533,7 @@ class ListFilingResource:  # pylint: disable=too-many-public-methods
         return filing
 
     @staticmethod
-    def put_basic_checks(identifier, filing, client_request, business) -> tuple[dict, int]:  # noqa: PLR0911
+    def put_basic_checks(identifier, filing, client_request, business, query) -> tuple[dict, int]:  # noqa: PLR0911
         """Perform basic checks to ensure put can do something."""
         json_input = client_request.get_json(silent=True)
         if not json_input:
@@ -551,7 +551,7 @@ class ListFilingResource:  # pylint: disable=too-many-public-methods
             return ({"message": "filing/header/name is a required property"}, HTTPStatus.BAD_REQUEST)
 
         filing_business_identifier = json_input.get("filing", {}).get("business", {}).get("identifier")
-        if filing_business_identifier != identifier:
+        if not query.draft and filing_business_identifier != identifier:
             return ({"message": "filing/business/identifier does not equal the identifier in the request path."}, HTTPStatus.BAD_REQUEST)
 
         if filing_type not in [*CoreFiling.NEW_BUSINESS_FILING_TYPES, CoreFiling.FilingTypes.NOTICEOFWITHDRAWAL] \

--- a/legal-api/tests/unit/resources/v2/test_business.py
+++ b/legal-api/tests/unit/resources/v2/test_business.py
@@ -19,6 +19,7 @@ Test-Suite to ensure that the /businesses endpoint is working as expected.
 import copy
 from datetime import UTC
 from http import HTTPStatus
+from unittest.mock import patch
 
 import pytest
 
@@ -27,6 +28,7 @@ from business_common.utils.datetime import datetime
 from business_model.models import Amalgamation, Batch, Business, Filing, RegistrationBootstrap
 from legal_api.services.authz import ACCOUNT_IDENTITY, PUBLIC_USER, STAFF_ROLE, SYSTEM_ROLE
 from legal_api.services import flags
+from legal_api.services.bootstrap import RegistrationBootstrapService
 from registry_schemas.example_data import (
     AMALGAMATION_APPLICATION,
     ANNUAL_REPORT,
@@ -79,6 +81,41 @@ def test_create_bootstrap_failure_filing(client, jwt):
                      headers=create_header(jwt, [STAFF_ROLE], None))
 
     assert rv.status_code == HTTPStatus.BAD_REQUEST
+
+
+@pytest.mark.parametrize('filing_name,legal_type', [
+    ('incorporationApplication', 'CP'),
+    ('incorporationApplication', 'BC'),
+    ('registration', 'SP'),
+    ('registration', 'GP'),
+    ('amalgamationApplication', 'BC'),
+    ('continuationIn', 'C'),
+])
+def test_create_bootstrap_minimal_draft_filing_mocked_affiliation(session, client, jwt, filing_name, legal_type):
+    """Assert that a minimal filing can be used to create a draft filing."""
+    filing = {
+        'filing': {
+            'header': {
+                'name': filing_name,
+                'accountId': 28
+            },
+            filing_name: {
+                'nameRequest': {
+                    'legalType': legal_type,
+                }
+            }
+        }
+    }
+    if filing_name == 'amalgamationApplication':
+        filing['filing'][filing_name]['type'] = 'regular'
+
+    with patch.object(RegistrationBootstrapService, 'register_bootstrap', return_value=HTTPStatus.OK):
+        rv = client.post('/api/v2/businesses?draft=true', json=filing, headers=create_header(jwt, [STAFF_ROLE], None))
+
+    assert rv.status_code == HTTPStatus.CREATED
+    assert rv.json['filing']['business']['identifier']
+    assert rv.json['filing']['header']['accountId'] == 28
+    assert rv.json['filing']['header']['name'] == filing_name
 
 
 @integration_affiliation


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33970

*Description of changes:*
- only validate identifier when its not a draft (initial draft filing for bootstraps doesn't have it yet)
- added test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
