### PR TITLE
revamping striping logic

### DIFF
--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -1761,9 +1761,9 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
         return {
             "officer": {
                 "id": relationship["entity"].get("identifier"),
-                "firstName": relationship["entity"].get("givenName"),
-                "middleName": relationship["entity"].get("middleInitial"),
-                "lastName": relationship["entity"].get("familyName"),
+                "firstName": (relationship["entity"].get("givenName") or "").strip(),
+                "middleName": (relationship["entity"].get("middleInitial")or "").strip(),
+                "lastName": (relationship["entity"].get("familyName") or "").strip(),
                 "organizationName": organization_name,
                 "partyType": "organization" if organization_name else "person"
             },
@@ -1786,12 +1786,12 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
 
             rel = {
                 "entity": {
-                    "givenName": o.get("firstName"),
-                    "familyName": o.get("lastName"),
+                    "givenName": (o.get("firstName") or "").strip(),
+                    "familyName": (o.get("lastName") or "").strip(),
                     "identifier": f"{role.party.id}",
                     "businessName": o.get("organizationName"),
                     "alternateName": o.get("alternateName"),
-                    "middleInitial": o.get("middleInitial"),
+                    "middleInitial": (o.get("middleInitial") or "").strip(),
                 },
                 "mailingAddress": mailing_address,
                 "deliveryAddress": delivery_address,

--- a/legal-api/src/legal_api/resources/v2/business/colin_sync.py
+++ b/legal-api/src/legal_api/resources/v2/business/colin_sync.py
@@ -347,9 +347,9 @@ def _set_shares(primary_or_holding_business, amalgamation_filing, transaction_id
 
 def _map_entity_to_officer(entity: dict[str, str]):
     return {
-        "firstName": entity.get("givenName"),
-        "lastName": entity.get("familyName"),
-        "middleInitial": entity.get("middleInitial"),
+        "firstName": entity.get("givenName","").strip(),
+        "lastName": entity.get("familyName","").strip(),
+        "middleInitial": entity.get("middleInitial","").strip(),
         "organizationName": entity.get("businessName"),
         "id": entity.get("identifier")
     }

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -765,10 +765,9 @@ def _validate_relationship_entity_person_colin_sync(relationship: dict, legal_ty
         msg.append({"error": err_msg, "path": f"{entity_path}/givenName"})
 
     stripped_middle_initial = middle_initial.strip()
-    if middle_initial is not None and stripped_middle_initial:
-        if len(middle_initial) > custom_max_length:
-            err_msg = f"{party_roles_str} middleInitial cannot be longer than {custom_max_length} characters"
-            msg.append({"error": err_msg, "path": f"{entity_path}/middleInitial"})
+    if middle_initial is not None and stripped_middle_initial and len(middle_initial) > custom_max_length:
+        err_msg = f"{party_roles_str} middleInitial cannot be longer than {custom_max_length} characters"
+        msg.append({"error": err_msg, "path": f"{entity_path}/middleInitial"})
 
     stripped_family_name = family_name.strip()
     if (legal_type in Business.CORPS) and (not stripped_family_name):

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -760,32 +760,19 @@ def _validate_relationship_entity_person_colin_sync(relationship: dict, legal_ty
     stripped_given_name = given_name.strip()
     if (legal_type in Business.CORPS) and (not stripped_given_name):
         msg.append({"error": f"{party_roles_str} giveName is required", "path": f"{entity_path}/givenName"})
-    elif given_name != stripped_given_name:
-        msg.append({
-            "error": f"{party_roles_str} giveName cannot start or end with whitespace",
-            "path": f"{entity_path}/givenName"
-        })
     elif len(given_name) > custom_max_length:
         err_msg = f"{party_roles_str} given name cannot be longer than {custom_max_length} characters"
         msg.append({"error": err_msg, "path": f"{entity_path}/givenName"})
 
     stripped_middle_initial = middle_initial.strip()
     if middle_initial is not None and stripped_middle_initial:
-        if middle_initial != stripped_middle_initial:
-            msg.append({"error": f"{party_roles_str} middleInitial cannot start or end with whitespace",
-                        "path": f"{entity_path}/middleInitial"})
-        elif len(middle_initial) > custom_max_length:
+        if len(middle_initial) > custom_max_length:
             err_msg = f"{party_roles_str} middleInitial cannot be longer than {custom_max_length} characters"
             msg.append({"error": err_msg, "path": f"{entity_path}/middleInitial"})
 
     stripped_family_name = family_name.strip()
     if (legal_type in Business.CORPS) and (not stripped_family_name):
         msg.append({"error": f"{party_roles_str} familyName is required", "path": f"{entity_path}/familyName"})
-    elif family_name != stripped_family_name:
-        msg.append({
-            "error": f"{party_roles_str} familyName cannot start or end with whitespace",
-            "path": f"{entity_path}/familyName"
-        })
     elif len(family_name) > family_name_max_length:
         err_msg = f"{party_roles_str} family name cannot be longer than {family_name_max_length} characters"
         msg.append({"error": err_msg, "path": f"{entity_path}/familyName"})


### PR DESCRIPTION
*Issue #:* /bcgov/entity#32790 

⏺ Issue #32790 — Voluntary Dissolution: Whitespace in Party Names                                                                                                                                                                                  
                                                                                                                                                                                                                                                 
  Changes made (bcgov/lear, branch 32790_issue):                                                                                                                                                                                                   
   
  - common_validations.py — Removed 3 validation blocks that rejected givenName, middleInitial, and familyName with leading/trailing whitespace. The API now accepts these names.                                                                  
  - colin_sync.py — Added .strip() when mapping givenName, familyName, and middleInitial to COLIN so whitespace is never persisted to the parties table.                                                                                         
  - report.py — Added .strip() in both name mapping blocks (~lines 1764 and 1789) so whitespace is stripped before PDF generation.                                                                                                                 
                                                                                                                                                                                                                                                   
  Tested locally:                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                   
  - Submitted a CP voluntary dissolution filing (CP1002795) with intentional leading/trailing whitespace in all name fields ("  Jane  ", "  Doe  ", "  Completing  " etc.)                                                                         
  - Filing was accepted and saved as DRAFT (filingId: 3109606) — previously would have been rejected with validation errors
  - Filing was fetched back and confirmed saved correctly                                                                                                                                                                                          
  - COLIN sync and PDF stripping are not testable locally (require COLIN service and Minio) but code changes are in place                                                                                                                          
                                                                                                                                                                                                                                                     


