### PR TITLE
34300 - Serve uploaded documents from DRS and stamp affidavit on download

### DIFF
--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -13,6 +13,7 @@ import base64
 import copy
 import json
 import os
+import re
 from contextlib import suppress
 from http import HTTPStatus
 from pathlib import Path
@@ -76,13 +77,35 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
     def _get_static_report(self):
         document_type = ReportMeta.static_reports[self._report_key]["documentType"]
         document: Document = self._filing.documents.filter(Document.type == document_type).first()
-        from legal_api.services import MinioService
-        response = MinioService.get_file(document.file_key)
+        # DRS-backed keys are "{documentClass}-{documentServiceId}", e.g. "COOP-DS0000101951";
+        # legacy Minio keys (UUIDs) and bare DRS ids ("DS...") do not match.
+        if match := re.match(r"^([A-Z]+)-(DS\d+)$", document.file_key or ""):
+            from legal_api.services import doc_service
+            drs_response = doc_service.get_document(match.group(2), match.group(1), doc_binary=True)
+            document_data, status = drs_response.content, drs_response.status_code
+        else:
+            from legal_api.services import MinioService
+            minio_response = MinioService.get_file(document.file_key)
+            document_data, status = minio_response.data, minio_response.status
+        if self._report_key == "affidavit" and status == HTTPStatus.OK:
+            # the affidavit is an uploaded document, so the registrar's certification stamp is applied here
+            document_data = self._certify_uploaded_document(document_data)
         return current_app.response_class(
-            response=response.data,
-            status=response.status,
+            response=document_data,
+            status=status,
             mimetype="application/pdf"
         )
+
+    def _certify_uploaded_document(self, document_bytes: bytes) -> bytes:
+        """Apply the registrar's certification stamp to an uploaded document."""
+        from legal_api.services import PdfService
+        from legal_api.services.pdf_service import RegistrarStampData
+        business = self._business
+        if not business and self._filing.business_id:
+            business = Business.find_by_internal_id(self._filing.business_id)
+        identifier = business.identifier if business else self._filing.temp_reg
+        stamp_data = RegistrarStampData(self._filing.filing_date, identifier)
+        return PdfService().create_certified_copy(document_bytes, stamp_data).read()
 
     def _get_report(self, regenerate: bool = False):
         # Try to get report from DRS first: get to here if duplicate UI request before refreshing filing documents.

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -97,7 +97,11 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
         )
 
     def _certify_uploaded_document(self, document_bytes: bytes) -> bytes:
-        """Apply the registrar's certification stamp to an uploaded document."""
+        """Apply the registrar's certification stamp when the document is downloaded.
+
+        Documents are never stamped on upload; the stamp is applied to each
+        served copy and the stored original is left unchanged.
+        """
         from legal_api.services import PdfService
         from legal_api.services.pdf_service import RegistrarStampData
         business = self._business

--- a/legal-api/tests/unit/reports/test_report.py
+++ b/legal-api/tests/unit/reports/test_report.py
@@ -1209,8 +1209,8 @@ def _make_static_report_filing(identifier, document_type, file_key):
     return filing
 
 
-def _make_pdf_bytes(text):
-    """Build a minimal one-page pdf."""
+def _make_pdf_bytes(text, pages=1):
+    """Build a minimal pdf with the given number of pages."""
     import io as _io
 
     from reportlab.lib.pagesizes import letter as _letter
@@ -1218,8 +1218,9 @@ def _make_pdf_bytes(text):
 
     buffer = _io.BytesIO()
     can = _canvas.Canvas(buffer, pagesize=_letter)
-    can.drawString(100, 700, text)
-    can.showPage()
+    for page_num in range(pages):
+        can.drawString(100, 700, f'{text} page {page_num + 1}')
+        can.showPage()
     can.save()
     return buffer.getvalue()
 
@@ -1266,7 +1267,8 @@ def test_affidavit_static_report_is_certified(session, test_name, file_key):
 
     identifier = 'CP1234567'
     filing = _make_static_report_filing(identifier, 'affidavit', file_key)
-    pdf_bytes = _make_pdf_bytes('Affidavit body')
+    # two pages so the stamp can be shown to land on the first page only
+    pdf_bytes = _make_pdf_bytes('Affidavit body', pages=2)
 
     drs_response = MagicMock(content=pdf_bytes, status_code=HTTPStatus.OK)
     minio_response = MagicMock(data=pdf_bytes, status=HTTPStatus.OK)
@@ -1276,6 +1278,13 @@ def test_affidavit_static_report_is_certified(session, test_name, file_key):
 
     stamped = PdfReader(_io.BytesIO(response.get_data()))
     text = stamped.get_page(0).extract_text()
-    assert 'Affidavit body' in text
+    assert 'Affidavit body page 1' in text
+    # The stamp's text half, drawn by create_registrars_stamp.
     assert 'Filed on' in text
     assert identifier in text
+    # The "CERTIFIED COPY ... Registrar of Companies" box and the registrar's name are pixels
+    # inside the registrar_signature_and_text image, not pdf text, so they cannot be asserted
+    # via text extraction; assert the image itself instead. The source pdf has no images, so
+    # the single image on page 1 is the stamp, and none on page 2 proves first-page-only.
+    assert len(stamped.pages[0].images) == 1
+    assert len(stamped.pages[1].images) == 0

--- a/legal-api/tests/unit/reports/test_report.py
+++ b/legal-api/tests/unit/reports/test_report.py
@@ -1189,3 +1189,93 @@ def test_special_resolution_drs_report_type(session, filing_type, expected_repor
     report._document_service.get_filing_report_by_filing_id.assert_called_once_with(
         identifier, filing.id, expected_report_type)
     assert response.status_code == HTTPStatus.OK
+
+
+def _make_static_report_filing(identifier, document_type, file_key):
+    """Create a completed coop dissolution filing with an uploaded document row."""
+    from business_model.models import Document
+
+    business = factory_business(identifier=identifier, entity_type='CP')
+    filing_json = copy.deepcopy(FILING_HEADER)
+    filing_json['filing']['header']['name'] = 'dissolution'
+    filing_json['filing']['business']['identifier'] = identifier
+    filing_json['filing']['business']['legalType'] = 'CP'
+    filing_json['filing']['dissolution'] = copy.deepcopy(DISSOLUTION)
+    filing = factory_completed_filing(business, filing_json, filing_date=LegislationDatetime.now())
+
+    document = Document(type=document_type, file_key=file_key, filing_id=filing.id, business_id=business.id)
+    db.session.add(document)
+    db.session.commit()
+    return filing
+
+
+def _make_pdf_bytes(text):
+    """Build a minimal one-page pdf."""
+    import io as _io
+
+    from reportlab.lib.pagesizes import letter as _letter
+    from reportlab.pdfgen import canvas as _canvas
+
+    buffer = _io.BytesIO()
+    can = _canvas.Canvas(buffer, pagesize=_letter)
+    can.drawString(100, 700, text)
+    can.showPage()
+    can.save()
+    return buffer.getvalue()
+
+
+@pytest.mark.parametrize('test_name,file_key,expect_drs', [
+    ('drs_key', 'COOP-DS0000101951', True),
+    ('legacy_minio_key', '3c7aff7b-3351-4911-90fa-402189fdd94d.pdf', False),
+    ('legacy_bare_drs_id', 'DS0000100800', False),
+])
+def test_get_static_report_drs_dispatch(session, test_name, file_key, expect_drs):
+    """Assert static report documents are served from the DRS or Minio based on the file key shape (#34300)."""
+    from legal_api.services import MinioService, doc_service
+
+    filing = _make_static_report_filing('CP1234567', 'court_order', file_key)
+
+    report = Report(filing)
+    drs_response = MagicMock(content=b'drs-pdf', status_code=HTTPStatus.OK)
+    minio_response = MagicMock(data=b'minio-pdf', status=HTTPStatus.OK)
+    with patch.object(doc_service, 'get_document', return_value=drs_response) as mock_drs, \
+            patch.object(MinioService, 'get_file', return_value=minio_response) as mock_minio:
+        response = report.get_pdf(report_type='uploadedCourtOrder')
+
+    if expect_drs:
+        mock_drs.assert_called_once_with('DS0000101951', 'COOP', doc_binary=True)
+        mock_minio.assert_not_called()
+        assert response.data == b'drs-pdf'
+    else:
+        mock_drs.assert_not_called()
+        mock_minio.assert_called_once_with(file_key)
+        assert response.data == b'minio-pdf'
+
+
+@pytest.mark.parametrize('test_name,file_key', [
+    ('drs_backed', 'COOP-DS0000101951'),
+    ('minio_backed', '3c7aff7b-3351-4911-90fa-402189fdd94d.pdf'),
+])
+def test_affidavit_static_report_is_certified(session, test_name, file_key):
+    """Assert the uploaded coop dissolution affidavit is served with the registrar's certification stamp (#34300)."""
+    import io as _io
+
+    from pypdf import PdfReader
+
+    from legal_api.services import MinioService, doc_service
+
+    identifier = 'CP1234567'
+    filing = _make_static_report_filing(identifier, 'affidavit', file_key)
+    pdf_bytes = _make_pdf_bytes('Affidavit body')
+
+    drs_response = MagicMock(content=pdf_bytes, status_code=HTTPStatus.OK)
+    minio_response = MagicMock(data=pdf_bytes, status=HTTPStatus.OK)
+    with patch.object(doc_service, 'get_document', return_value=drs_response), \
+            patch.object(MinioService, 'get_file', return_value=minio_response):
+        response = Report(filing).get_pdf(report_type='affidavit')
+
+    stamped = PdfReader(_io.BytesIO(response.get_data()))
+    text = stamped.get_page(0).extract_text()
+    assert 'Affidavit body' in text
+    assert 'Filed on' in text
+    assert identifier in text


### PR DESCRIPTION
Issue #: bcgov/entity#34300

## Description

- `Report._get_static_report` now serves uploaded client documents from the DRS when `documents.file_key` is a DRS key (`{documentClass}-{documentServiceId}`, e.g. `COOP-DS0000101951`). Legacy Minio UUID keys and pre-existing bare `DS...` keys are unchanged and continue to be served from Minio.
- The registrar's certification stamp is applied to the coop dissolution affidavit at serve time (both DRS and Minio backed), so the emailed "Certified Affidavit.pdf" attachment and document downloads match their name. Stored originals remain unstamped, consistent with the serve-time certification of generated reports. The emailer and ledger downloads inherit this via the documents endpoint with no changes.

## Testing

- New unit tests: DRS/Minio dispatch by key shape (3 cases) and affidavit certification for both storage backends (asserts "Filed on", identifier, and original body text on page 1).
- Verified end to end locally: affidavit document row keyed to a DRS dev document, served through `GET /api/v2/businesses/{identifier}/filings/{filing_id}/documents/affidavit` — response fetched from DRS (no Minio) with the certification stamp applied.