### PR TITLE
34400 - Serve and delete uploaded documents from DRS by file key shape

### DIFF
--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_documents.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_documents.py
@@ -15,6 +15,7 @@
 
 Provides all the search and retrieval from the business entity documents.
 """
+import re
 from http import HTTPStatus
 from typing import Final
 
@@ -34,6 +35,7 @@ from legal_api.reports import get_pdf
 from legal_api.reports.document_service import DocumentService
 from legal_api.resources.v2.business.bp import bp
 from legal_api.services import MinioService, authorized
+from legal_api.services import doc_service as client_doc_service
 from legal_api.utils.auth import jwt
 from legal_api.utils.util import cors_preflight
 
@@ -120,6 +122,15 @@ def get_documents(identifier: str, # noqa: PLR0911, PLR0912
             return get_pdf(filing.storage, legal_filing_name)
         elif file_key and (document := Document.find_by_file_key(file_key)):
             if document.filing_id == filing.id:  # make sure the file belongs to this filing
+                # DRS-backed keys are "{documentClass}-{documentServiceId}", e.g. "COOP-DS0000101951";
+                # legacy Minio keys (UUIDs) do not match.
+                if match := re.match(r"^([A-Z]+)-(DS\d+)$", document.file_key):
+                    drs_response = client_doc_service.get_document(match.group(2), match.group(1), doc_binary=True)
+                    return current_app.response_class(
+                        response=drs_response.content,
+                        status=drs_response.status_code,
+                        mimetype=APP_PDF
+                    )
                 response = MinioService.get_file(document.file_key)
                 return current_app.response_class(
                     response=response.data,

--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
@@ -16,6 +16,7 @@
 Provides all the search and retrieval from the business entity datastore.
 """
 import copy
+import re
 from contextlib import suppress
 from datetime import UTC
 from datetime import datetime as _datetime
@@ -39,6 +40,7 @@ from business_common.utils.legislation_datetime import LegislationDatetime
 from business_model.models import (
     Address,
     Business,
+    Document,
     Filing,
     OfficeType,
     RegistrationBootstrap,
@@ -62,6 +64,7 @@ from legal_api.services import (
     MinioService,
     RegistrationBootstrapService,
     authorized,
+    doc_service,
     flags,
     namex,
 )
@@ -1110,8 +1113,20 @@ class ListFilingResource:  # pylint: disable=too-many-public-methods
         return is_future_effective
 
     @staticmethod
+    def delete_uploaded_file(file_key: str):
+        """Delete an uploaded file from the DRS or Minio based on the file key shape.
+
+        DRS-backed keys are "{documentClass}-{documentServiceId}", e.g. "COOP-DS0000101951";
+        legacy Minio keys (UUIDs) do not match.
+        """
+        if re.match(r"^([A-Z]+)-(DS\d+)$", file_key):
+            doc_service.delete_document(Document(file_key=file_key))
+        else:
+            MinioService.delete_file(file_key)
+
+    @staticmethod
     def delete_from_minio(filing_type: str, filing_json: dict):
-        """Delete file from minio."""
+        """Delete the filing's uploaded files from the DRS or Minio."""
         if (filing_type == Filing.FILINGS["incorporationApplication"].get("name")
                 and (cooperative := filing_json
                      .get("filing", {})
@@ -1122,21 +1137,21 @@ class ListFilingResource:  # pylint: disable=too-many-public-methods
                      .get("filing", {})
                      .get("alteration", {}))):
             if rules_file_key := cooperative.get("rulesFileKey", None):
-                MinioService.delete_file(rules_file_key)
+                ListFilingResource.delete_uploaded_file(rules_file_key)
             if memorandum_file_key := cooperative.get("memorandumFileKey", None):
-                MinioService.delete_file(memorandum_file_key)
+                ListFilingResource.delete_uploaded_file(memorandum_file_key)
         elif filing_type == Filing.FILINGS["dissolution"].get("name") \
                 and (affidavit_file_key := filing_json
                      .get("filing", {})
                      .get("dissolution", {})
                      .get("affidavitFileKey", None)):
-            MinioService.delete_file(affidavit_file_key)
+            ListFilingResource.delete_uploaded_file(affidavit_file_key)
         elif filing_type == Filing.FILINGS["courtOrder"].get("name") \
                 and (file_key := filing_json
                      .get("filing", {})
                      .get("courtOrder", {})
                      .get("fileKey", None)):
-            MinioService.delete_file(file_key)
+            ListFilingResource.delete_uploaded_file(file_key)
         elif filing_type == Filing.FILINGS["continuationIn"].get("name"):
             ListFilingResource.delete_continuation_in_files(filing_json)
 
@@ -1147,13 +1162,13 @@ class ListFilingResource:  # pylint: disable=too-many-public-methods
 
         # Delete affidavit file
         if affidavit_file_key := continuation_in.get("foreignJurisdiction", {}).get("affidavitFileKey", None):
-            MinioService.delete_file(affidavit_file_key)
+            ListFilingResource.delete_uploaded_file(affidavit_file_key)
 
         # Delete authorization file(s)
         authorization_files = continuation_in.get("authorization", {}).get("files", [])
         for file in authorization_files:
             if auth_file_key := file.get("fileKey", None):
-                MinioService.delete_file(auth_file_key)
+                ListFilingResource.delete_uploaded_file(auth_file_key)
 
     @staticmethod
     def details_for_invoice(business_identifier: str, corp_type: str):

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
@@ -2139,3 +2139,43 @@ def test_temp_document_list_for_now(app, mocker, session, client, jwt, monkeypat
 
     assert rv.status_code == expected_http_code
     assert rv_data == expected
+
+
+@pytest.mark.parametrize('test_name,file_key,expect_drs', [
+    ('drs_key', 'CORP-DS0000101951', True),
+    ('legacy_minio_key', '3c7aff7b-3351-4911-90fa-402189fdd94d.pdf', False),
+])
+def test_get_static_document_by_file_key_shape(session, client, jwt, mocker, test_name, file_key, expect_drs):
+    """Assert static documents are served from the DRS or Minio based on the file key shape."""
+    from unittest.mock import MagicMock, patch
+
+    from business_model.models import Document
+    from legal_api.resources.v2.business.business_filings import business_documents
+
+    identifier = 'CP7654321'
+    business = factory_business(identifier)
+    filing_json = copy.deepcopy(FILING_HEADER)
+    filing_json['filing']['header']['name'] = 'continuationIn'
+    filing = factory_filing(business, filing_json)
+
+    document = Document(type='authorization_file', file_key=file_key, filing_id=filing.id, business_id=business.id)
+    document.save()
+
+    mocker.patch.object(business_documents, '_is_document_available', return_value=True)
+    drs_response = MagicMock(content=b'drs-pdf', status_code=HTTPStatus.OK)
+    minio_response = MagicMock(data=b'minio-pdf', status=HTTPStatus.OK)
+
+    with patch.object(business_documents.client_doc_service, 'get_document', return_value=drs_response) as mock_drs, \
+            patch.object(business_documents.MinioService, 'get_file', return_value=minio_response) as mock_minio:
+        rv = client.get(f'/api/v2/businesses/{identifier}/filings/{filing.id}/documents/static/{file_key}',
+                        headers=create_header(jwt, [STAFF_ROLE], identifier, **{'accept': 'application/pdf'}))
+
+    assert rv.status_code == HTTPStatus.OK
+    if expect_drs:
+        mock_drs.assert_called_once_with('DS0000101951', 'CORP', doc_binary=True)
+        mock_minio.assert_not_called()
+        assert rv.data == b'drs-pdf'
+    else:
+        mock_drs.assert_not_called()
+        mock_minio.assert_called_once_with(file_key)
+        assert rv.data == b'minio-pdf'

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filings.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filings.py
@@ -2353,3 +2353,49 @@ def test_ta(session, requests_mock, client, jwt, monkeypatch, test_name, legal_t
         assert rv.status_code == HTTPStatus.FORBIDDEN
         assert rv.json[0]['message'] == 'Permission Denied - transition filing is currently not available for this user and/or account.'
     
+
+@pytest.mark.parametrize('test_name,file_key,expect_drs', [
+    ('drs_key', 'COOP-DS0000101951', True),
+    ('legacy_minio_key', '3c7aff7b-3351-4911-90fa-402189fdd94d.pdf', False),
+    ('legacy_bare_drs_id', 'DS0000100800', False),
+])
+def test_delete_uploaded_file_dispatch(session, test_name, file_key, expect_drs):
+    """Assert uploaded files are deleted from the DRS or Minio based on the file key shape."""
+    from legal_api.resources.v2.business.business_filings import business_filings
+
+    with patch.object(business_filings.doc_service, 'delete_document') as mock_drs, \
+            patch.object(MinioService, 'delete_file') as mock_minio:
+        ListFilingResource.delete_uploaded_file(file_key)
+
+    if expect_drs:
+        mock_drs.assert_called_once()
+        assert mock_drs.call_args[0][0].file_key == file_key
+        mock_minio.assert_not_called()
+    else:
+        mock_drs.assert_not_called()
+        mock_minio.assert_called_once_with(file_key)
+
+
+def test_delete_dissolution_filing_in_draft_with_drs_file(session, client, jwt):
+    """Assert that deleting a draft dissolution removes its DRS-backed affidavit from the DRS."""
+    from legal_api.resources.v2.business.business_filings import business_filings
+
+    identifier = 'CP7654321'
+    file_key = 'COOP-DS0000101951'
+    b = factory_business(identifier)
+    filing_json = copy.deepcopy(FILING_HEADER)
+    filing_json['filing']['header']['name'] = 'dissolution'
+    filing_json['filing']['business']['legalType'] = 'CP'
+    filing_json['filing']['dissolution'] = copy.deepcopy(DISSOLUTION)
+    filing_json['filing']['dissolution']['affidavitFileKey'] = file_key
+    filing = factory_filing(b, filing_json, filing_type='dissolution')
+    headers = create_header(jwt, [STAFF_ROLE], identifier)
+
+    with patch.object(business_filings.doc_service, 'delete_document') as mock_drs, \
+            patch.object(MinioService, 'delete_file') as mock_minio:
+        rv = client.delete(f'/api/v2/businesses/{identifier}/filings/{filing.id}', headers=headers)
+
+    assert rv.status_code == HTTPStatus.OK
+    mock_drs.assert_called_once()
+    assert mock_drs.call_args[0][0].file_key == file_key
+    mock_minio.assert_not_called()


### PR DESCRIPTION
Issue #: bcgov/entity#34400

The static document download route and draft filing deletion now dispatch to the DRS for DRS-backed file keys (`{documentClass}-{documentServiceId}`), with legacy Minio keys unchanged.