### PR TITLE
34389 add court order metadata

### DIFF
--- a/python/common/business-registry-model/pyproject.toml
+++ b/python/common/business-registry-model/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "business-model"
-version = "3.4.5"
+version = "3.4.6"
 description = ""
 authors = [
     {name = "thor",email = "1042854+thorwolpert@users.noreply.github.com"}

--- a/python/common/business-registry-model/src/business_model_migrations/versions/20260727_162109_d7fc1a767d69_.py
+++ b/python/common/business-registry-model/src/business_model_migrations/versions/20260727_162109_d7fc1a767d69_.py
@@ -5,9 +5,8 @@ Revises: 1cdc6fdbf4cf
 Create Date: 2026-07-27 16:21:09.583470
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'd7fc1a767d69'
@@ -56,4 +55,13 @@ def upgrade():
 
 
 def downgrade():
-    pass
+    # Remove court order data from metadata of filings
+    op.execute(
+        """
+        UPDATE filings f
+        SET meta_data = JSONB_SET(meta_data, '{courtOrder}', 'jsonb_build_object()')
+        FROM court_orders co
+        WHERE 
+            co.filing_id = f.id
+        """
+    )

--- a/python/common/business-registry-model/src/business_model_migrations/versions/20260727_162109_d7fc1a767d69_.py
+++ b/python/common/business-registry-model/src/business_model_migrations/versions/20260727_162109_d7fc1a767d69_.py
@@ -1,0 +1,59 @@
+"""Add court order metadata
+
+Revision ID: d7fc1a767d69
+Revises: 1cdc6fdbf4cf
+Create Date: 2026-07-27 16:21:09.583470
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd7fc1a767d69'
+down_revision = '1cdc6fdbf4cf'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add court order data to metadata of filings
+    op.execute(
+        """
+        UPDATE filings f
+        SET meta_data = JSONB_SET(meta_data, '{courtOrder}',
+                            jsonb_strip_nulls(jsonb_build_object(
+                                'fileNumber', co.file_number,
+                                'orderDetails', CASE WHEN co.order_details IS NOT NULL AND co.order_details <> '' THEN co.order_details ELSE NULL END,
+                                'effectOfOrder', CASE WHEN co.effect_of_order IS NOT NULL AND co.effect_of_order <> '' THEN co.effect_of_order ELSE NULL END
+                            ))
+                        )
+        FROM court_orders co
+        WHERE 
+            co.filing_id = f.id
+        """
+    )
+    # Add court order filing document to metadata
+    op.execute(
+        """
+        UPDATE filings f
+        SET meta_data = JSONB_SET(meta_data, '{courtOrder,files}',
+                            jsonb_build_array(
+                                jsonb_build_object(
+                                    'fileName', concat('Court Order ', co.file_number, '.pdf'),
+                                    'fileKey', d.file_key
+                                )
+                            )
+                        )
+        FROM court_orders co
+            JOIN documents d ON co.filing_id = d.filing_id
+        WHERE 
+            co.filing_id = f.id AND 
+            f.filing_type = 'courtOrder' AND 
+            d.type = 'court_order'
+        """
+    )
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
*Issue #:* /bcgov/entity#34389

*Description of changes:*
  - Adding court order details into metadata to make sure the corrected data is not showing in the ledger (we could use court_order version table for this instead but data migration might not be able to populate this in the tombstone pipeline)
  - Adding court order files into metadata for the same reason + we need to support multiple court order documents in court order filing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
