### PR TITLE
34424 - Single certified copy stamp for coop dissolution affidavit

### DIFF
--- a/legal-api/src/legal_api/reports/document_service.py
+++ b/legal-api/src/legal_api/reports/document_service.py
@@ -34,19 +34,23 @@ DRS_REPORT_PARAMS: str = "?reportType={report_type}&drsId={drs_id}"
 DRS_DOCUMENT_PARAMS: str = "?documentClass={document_class}&drsId={drs_id}"
 # Used for audit trail and db queries.
 BUSINESS_API_ACCOUNT_ID: str = "business-api"
+# Each output key may map to more than one DRS documentClass-documentType combination.
 FILING_DOCUMENTS = {
-    "certifiedRules": {
+    "certifiedRules": [{
         "documentType": "COOP_RULES",
         "documentClass": "COOP"
-    },
-    "certifiedMemorandum": {
+    }],
+    "certifiedMemorandum": [{
         "documentType": "COOP_MEMORANDUM",
         "documentClass": "COOP"
-    },
-    "affidavit": {
-        "documentType": "CORP_AFFIDAVIT",  # "COSD",
+    }],
+    "affidavit": [{
+        "documentType": "COSD",
+        "documentClass": "COOP"
+    }, {
+        "documentType": "CORP_AFFIDAVIT",
         "documentClass": "CORP"
-    }
+    }]
 }
 STATIC_DOCUMENTS = {
     "Unlimited Liability Corporation Information": {
@@ -520,10 +524,10 @@ class DocumentService:
                         ):
                         static_doc["url"] = static_doc["url"] + query_params
                         break
-            elif (
-                FILING_DOCUMENTS.get(key) and
-                doc.get("documentClass") == FILING_DOCUMENTS[key].get("documentClass") and
-                doc.get("documentType") == FILING_DOCUMENTS[key].get("documentType")
+            elif any(
+                doc.get("documentClass") == combo.get("documentClass") and
+                doc.get("documentType") == combo.get("documentType")
+                for combo in FILING_DOCUMENTS.get(key, [])
             ):
                 doc_list[key] = doc_list[key] + query_params
                 break

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -80,6 +80,8 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
         # DRS-backed keys are "{documentClass}-{documentServiceId}", e.g. "COOP-DS0000101951";
         # legacy Minio keys (UUIDs) and bare DRS ids ("DS...") do not match.
         if match := re.match(r"^([A-Z]+)-(DS\d+)$", document.file_key or ""):
+            # the DRS applies the certified copy stamp itself for configured combinations
+            # (e.g. COOP-COSD), so DRS-served documents must not be stamped again here
             from legal_api.services import doc_service
             drs_response = doc_service.get_document(match.group(2), match.group(1), doc_binary=True)
             document_data, status = drs_response.content, drs_response.status_code
@@ -87,9 +89,9 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
             from legal_api.services import MinioService
             minio_response = MinioService.get_file(document.file_key)
             document_data, status = minio_response.data, minio_response.status
-        if self._report_key == "affidavit" and status == HTTPStatus.OK:
-            # the affidavit is an uploaded document, so the registrar's certification stamp is applied here
-            document_data = self._certify_uploaded_document(document_data)
+            if self._report_key == "affidavit" and status == HTTPStatus.OK:
+                # legacy storage never stamps, so the registrar's certification stamp is applied here
+                document_data = self._certify_uploaded_document(document_data)
         return current_app.response_class(
             response=document_data,
             status=status,

--- a/legal-api/tests/unit/reports/test_document_service.py
+++ b/legal-api/tests/unit/reports/test_document_service.py
@@ -197,6 +197,31 @@ DRS_STATIC1 = [
     "url": ""
   }
 ]
+DOCS_STATIC3 = {
+  "documents": {
+    "affidavit": "https://test.com/CP1044808/filings/233801/documents/affidavit",
+    "certificateOfDissolution": "https://test.com/CP1044808/filings/233801/documents/certificateOfDissolution",
+    "legalFilings": [
+      {"dissolution": "https://test.com/CP1044808/filings/233801/documents/dissolution"}
+    ],
+    "receipt": "https://test.com/CP1044808/filings/233801/documents/receipt"
+  }
+}
+DRS_STATIC3 = [
+  {
+    "consumerDocumentId": "0100000527",
+    "dateCreated": "2026-06-29T19:19:32+00:00",
+    "datePublished": "2026-06-29T00:00:00+00:00",
+    "documentClass": "COOP",
+    "documentType": "COSD",
+    "documentTypeDescription": "Statement of Dissolution",
+    "entityIdentifier": "CP1044808",
+    "eventIdentifier": 233801,
+    "identifier": "DS0000101951",
+    "name": "",
+    "url": ""
+  }
+]
 DRS_STATIC2 = [
   {
     "consumerDocumentId": "0100000193",
@@ -233,6 +258,7 @@ TEST_FILING_UPDATE_DATA = [
     ("Colin docs", DOCS_COLIN, DRS_COLIN, "reportType=RECEIPT&drsId=DSR0000100896", "reportType=FILING&drsId=DSR0000100897", "reportType=NOA&drsId=DSR0000100898", "reportType=CERT&drsId=DSR0000100899", None),
     ("Static 1", DOCS_STATIC1, DRS_STATIC1, None, None, None, None, "documentClass=COOP&drsId=DS0000101630"),
     ("Static 2", DOCS_STATIC2, DRS_STATIC2, None, None, None, None, "documentClass=CORP&drsId=DS0000100741"),
+    ("Static 3", DOCS_STATIC3, DRS_STATIC3, None, None, None, None, "documentClass=COOP&drsId=DS0000101951"),
 ]
 # testdata pattern is ({description}, {doc_data}, {drs_data}, {receipt}, {filing}, {noa}, {cert}, {static}, {meta}, {filing_id})
 TEST_BUSINESS_UPDATE_DATA = [
@@ -241,6 +267,7 @@ TEST_BUSINESS_UPDATE_DATA = [
     ("Colin docs", DOCS_COLIN, DRS_COLIN, "reportType=RECEIPT&drsId=DSR0000100896", "reportType=FILING&drsId=DSR0000100897", "reportType=NOA&drsId=DSR0000100898", "reportType=CERT&drsId=DSR0000100899", None,  META_COLIN, 0),
     ("Static 1", DOCS_STATIC1, DRS_STATIC1, None, None, None, None, "documentClass=COOP&drsId=DS0000101630", META_MODERN, 233791),
     ("Static 2", DOCS_STATIC2, DRS_STATIC2, None, None, None, None, "documentClass=CORP&drsId=DS0000100741", META_MODERN, 155753),
+    ("Static 3", DOCS_STATIC3, DRS_STATIC3, None, None, None, None, "documentClass=COOP&drsId=DS0000101951", META_MODERN, 233801),
 ]
 # testdata pattern is ({has_data}, {report_key}, {report_type})
 TEST_REPORT_META_DATA = [

--- a/legal-api/tests/unit/reports/test_report.py
+++ b/legal-api/tests/unit/reports/test_report.py
@@ -1253,12 +1253,14 @@ def test_get_static_report_drs_dispatch(session, test_name, file_key, expect_drs
         assert response.data == b'minio-pdf'
 
 
-@pytest.mark.parametrize('test_name,file_key', [
-    ('drs_backed', 'COOP-DS0000101951'),
-    ('minio_backed', '3c7aff7b-3351-4911-90fa-402189fdd94d.pdf'),
+@pytest.mark.parametrize('test_name,file_key,expect_stamp', [
+    # the DRS applies its own certified copy stamp for configured combinations (e.g. COOP-COSD),
+    # so the api must serve DRS bytes unmodified to avoid double stamping (#34424)
+    ('drs_backed', 'COOP-DS0000101951', False),
+    ('minio_backed', '3c7aff7b-3351-4911-90fa-402189fdd94d.pdf', True),
 ])
-def test_affidavit_static_report_is_certified(session, test_name, file_key):
-    """Assert the uploaded coop dissolution affidavit is served with the registrar's certification stamp (#34300)."""
+def test_affidavit_static_report_certification(session, test_name, file_key, expect_stamp):
+    """Assert the registrar's certification stamp is applied only to legacy storage-backed affidavits."""
     import io as _io
 
     from pypdf import PdfReader
@@ -1276,6 +1278,10 @@ def test_affidavit_static_report_is_certified(session, test_name, file_key):
             patch.object(MinioService, 'get_file', return_value=minio_response):
         response = Report(filing).get_pdf(report_type='affidavit')
 
+    if not expect_stamp:
+        # DRS-served bytes pass through untouched (the DRS stamp, when configured, is already in them)
+        assert response.get_data() == pdf_bytes
+        return
     stamped = PdfReader(_io.BytesIO(response.get_data()))
     text = stamped.get_page(0).extract_text()
     assert 'Affidavit body page 1' in text


### PR DESCRIPTION
Issue #: bcgov/entity#34424

## Description

- The DRS applies its own certified copy stamp at serve time for configured class-type combinations (COOP-COOP_RULES, COOP-COOP_MEMORANDUM, COOP-COSD, all environments), so the api-side registrar stamp added in #4627 produced a double stamp on DRS-backed affidavits. 
- `FILING_DOCUMENTS` entries in `document_service.py` now hold a list of DRS documentClass-documentType combinations, and the coop dissolution affidavit (COOP-COSD) mapping is added alongside the existing CORP-CORP_AFFIDAVIT one. `_update_static_document` matches any combination, so the ledger affidavit url is decorated with the DRS download parameters and downloads route through the DRS (single stamp) path.

## Testing

- Affidavit serve test now parametrized on stamp expectation: DRS-backed asserts byte-for-byte passthrough (no second stamp); legacy-backed keeps the full stamp assertions (text and first-page-only image).
- New "Static 3" case in the filing and ledger document list tests asserts a COOP-COSD DRS record decorates the affidavit url with `documentClass=COOP&drsId=...`.
- Full `tests/unit/reports` suite: 306 passed. Lint clean.