### PR TITLE
33654 - account linking key forwarding for auth and pay

### DIFF
--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_documents.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_documents.py
@@ -36,6 +36,7 @@ from legal_api.reports.document_service import DocumentService
 from legal_api.resources.v2.business.bp import bp
 from legal_api.services import MinioService, authorized
 from legal_api.services import doc_service as client_doc_service
+from legal_api.services.request_context import add_account_linking_key_header
 from legal_api.utils.auth import jwt
 from legal_api.utils.util import cors_preflight
 
@@ -232,6 +233,7 @@ def _get_receipt(business: Business, filing: Filing, token):
         effective_date = LegislationDatetime.format_as_report_string(filing.storage.effective_date)
 
     headers = {"Authorization": "Bearer " + token}
+    add_account_linking_key_header(headers)
 
     corp_name = _get_corp_name(business, filing.storage)
 

--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
@@ -72,6 +72,7 @@ from legal_api.services.authz import is_allowed
 from legal_api.services.event_publisher import publish_to_queue
 from legal_api.services.filings import validate
 from legal_api.services.permissions import PermissionService
+from legal_api.services.request_context import add_account_linking_key_header
 from legal_api.services.utils import get_str
 from legal_api.utils.auth import jwt
 
@@ -271,6 +272,7 @@ def patch_filings(identifier, filing_id=None):
         payment_svc_url = "{}/{}".format(current_app.config.get("PAYMENT_SVC_URL"), filing.payment_token)
         token = jwt.get_token_auth_header()
         headers = {"Authorization": "Bearer " + token}
+        add_account_linking_key_header(headers)
         rv = requests.delete(url=payment_svc_url, headers=headers, timeout=20.0)
         if rv.status_code in (HTTPStatus.OK, HTTPStatus.ACCEPTED):
             filing.reset_filing_to_draft()
@@ -387,6 +389,7 @@ class ListFilingResource:  # pylint: disable=too-many-public-methods
                 "Authorization": f"Bearer {jwt.get_token_auth_header()}",
                 "Content-Type": "application/json"
             }
+            add_account_linking_key_header(headers)
             payment_svc_url = current_app.config.get("PAYMENT_SVC_URL")
 
             if payment_token := filing_dict.get("filing", {}).get("header", {}).get("paymentToken"):
@@ -1057,6 +1060,7 @@ class ListFilingResource:  # pylint: disable=too-many-public-methods
             token = user_jwt.get_token_auth_header()
             headers = {"Authorization": "Bearer " + token,
                        "Content-Type": "application/json"}
+            add_account_linking_key_header(headers)
             current_app.logger.debug(f"Pay api call - url: {payment_svc_url}, payload: {payload}")
             rv = requests.post(url=payment_svc_url,
                                json=payload,

--- a/legal-api/src/legal_api/resources/v2/business/business_tasks.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_tasks.py
@@ -28,6 +28,7 @@ from requests import exceptions
 from business_common.utils.legislation_datetime import LegislationDatetime
 from business_model.models import Business, Filing
 from legal_api.services import check_warnings, namex
+from legal_api.services.request_context import add_account_linking_key_header
 from legal_api.services.warnings.business.business_checks import BusinessWarningCodes, WarningType
 from legal_api.utils.auth import jwt
 
@@ -130,6 +131,7 @@ def construct_task_list(business: Business):  # noqa: PLR0915
                     "Authorization": f"Bearer {jwt.get_token_auth_header()}",
                     "Content-Type": "application/json"
                 }
+                add_account_linking_key_header(headers)
                 pay_response = requests.get(
                     url=f'{current_app.config.get("PAYMENT_SVC_URL")}/{filing.payment_token}',
                     headers=headers

--- a/legal-api/src/legal_api/services/authz.py
+++ b/legal-api/src/legal_api/services/authz.py
@@ -33,7 +33,7 @@ from legal_api.services.digital_credentials_auth import (
     are_digital_credentials_allowed,
     get_digital_credentials_preconditions,
 )
-from legal_api.services.request_context import get_request_context
+from legal_api.services.request_context import add_account_linking_key_header, get_request_context
 from legal_api.services.warnings.business.business_checks import WarningType
 
 SYSTEM_ROLE = "system"
@@ -86,6 +86,7 @@ def _call_auth_api(path: str, token: str) -> Response:
     auth_url += path
 
     headers = {"Authorization": "Bearer " + token}
+    add_account_linking_key_header(headers)
     try:
         http = Session()
         retries = Retry(total=5,

--- a/legal-api/src/legal_api/services/request_context.py
+++ b/legal-api/src/legal_api/services/request_context.py
@@ -33,7 +33,12 @@ def build_from_flask() -> RequestContext:
 
     # Account header (configurable)
     account_id = request.headers.get("Account-Id", None)
-    account_linking_key = request.headers.get("Account-Linking-Key", None)
+
+    # Avoid .get() here for backwards compatibility on existing test mocks that doesn't pass the default argument 
+    # through and raises KeyError instead of returning the default.
+    account_linking_key = None
+    if "Account-Linking-Key" in request.headers:
+        account_linking_key = request.headers["Account-Linking-Key"]
 
     # Token info and user
     token_info = getattr(g, "jwt_oidc_token_info", None)
@@ -59,5 +64,8 @@ def get_request_context() -> RequestContext:
 
 def add_account_linking_key_header(headers: dict) -> None:
     """Forward the incoming Account-Linking-Key header to an outgoing auth-api/pay-api call, if present."""
-    if account_linking_key := get_request_context().account_linking_key:
-        headers["Account-Linking-Key"] = account_linking_key
+    if not has_request_context():
+        return
+
+    if "Account-Linking-Key" in request.headers:
+        headers["Account-Linking-Key"] = request.headers["Account-Linking-Key"]

--- a/legal-api/src/legal_api/services/request_context.py
+++ b/legal-api/src/legal_api/services/request_context.py
@@ -34,11 +34,7 @@ def build_from_flask() -> RequestContext:
     # Account header (configurable)
     account_id = request.headers.get("Account-Id", None)
 
-    # Avoid .get() here for backwards compatibility on existing test mocks that doesn't pass the default argument 
-    # through and raises KeyError instead of returning the default.
-    account_linking_key = None
-    if "Account-Linking-Key" in request.headers:
-        account_linking_key = request.headers["Account-Linking-Key"]
+    account_linking_key = request.headers.get("Account-Linking-Key", None)
 
     # Token info and user
     token_info = getattr(g, "jwt_oidc_token_info", None)

--- a/legal-api/src/legal_api/services/request_context.py
+++ b/legal-api/src/legal_api/services/request_context.py
@@ -63,5 +63,5 @@ def add_account_linking_key_header(headers: dict) -> None:
     if not has_request_context():
         return
 
-    if "Account-Linking-Key" in request.headers:
-        headers["Account-Linking-Key"] = request.headers["Account-Linking-Key"]
+    if account_linking_key := request.headers.get("Account-Linking-Key"):
+        headers["Account-Linking-Key"] = account_linking_key

--- a/legal-api/src/legal_api/services/request_context.py
+++ b/legal-api/src/legal_api/services/request_context.py
@@ -23,6 +23,7 @@ from business_model.models import User
 class RequestContext:
     account_id: str | None = None
     user: User | None = None
+    account_linking_key: str | None = None
 
 
 def build_from_flask() -> RequestContext:
@@ -32,6 +33,7 @@ def build_from_flask() -> RequestContext:
 
     # Account header (configurable)
     account_id = request.headers.get("Account-Id", None)
+    account_linking_key = request.headers.get("Account-Linking-Key", None)
 
     # Token info and user
     token_info = getattr(g, "jwt_oidc_token_info", None)
@@ -40,6 +42,7 @@ def build_from_flask() -> RequestContext:
     return RequestContext(
         account_id=account_id,
         user=user,
+        account_linking_key=account_linking_key,
     )
 
 
@@ -52,3 +55,9 @@ def get_request_context() -> RequestContext:
         rc = build_from_flask()
         g.request_context = rc
     return rc
+
+
+def add_account_linking_key_header(headers: dict) -> None:
+    """Forward the incoming Account-Linking-Key header to an outgoing auth-api/pay-api call, if present."""
+    if account_linking_key := get_request_context().account_linking_key:
+        headers["Account-Linking-Key"] = account_linking_key

--- a/legal-api/tests/unit/core/test_filing_ledger.py
+++ b/legal-api/tests/unit/core/test_filing_ledger.py
@@ -75,8 +75,8 @@ def test_simple_ledger_search(app, session, client, jwt, monkeypatch, mock_drs_s
     token = helper_create_jwt(jwt, roles=[STAFF_ROLE], username='testuser')
     headers = {'Authorization': 'Bearer ' + token, 'Account-Id': 1}
 
-    def mock_auth(one, two):
-        return headers.get(one, two)
+    def mock_auth(key, default=None):
+        return headers.get(key, default)
 
    # test
     with app.test_request_context():

--- a/legal-api/tests/unit/core/test_filing_ledger.py
+++ b/legal-api/tests/unit/core/test_filing_ledger.py
@@ -75,8 +75,8 @@ def test_simple_ledger_search(app, session, client, jwt, monkeypatch, mock_drs_s
     token = helper_create_jwt(jwt, roles=[STAFF_ROLE], username='testuser')
     headers = {'Authorization': 'Bearer ' + token, 'Account-Id': 1}
 
-    def mock_auth(one, two):  # pylint: disable=unused-argument; mocks of library methods
-        return headers[one]
+    def mock_auth(one, two):
+        return headers.get(one, two)
 
    # test
     with app.test_request_context():

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
@@ -2036,6 +2036,42 @@ def test_get_receipt_request_mock(session, client, jwt, requests_mock):
     assert requests_mock.called_once
 
 
+def test_get_receipt_forwards_account_linking_key(session, client, jwt, requests_mock):
+    """Assert that the receipt call forwards the Account-Linking-Key header when present on the request."""
+    identifier = 'CP7654321'
+    business = factory_business(identifier)
+    filing_name = 'incorporationApplication'
+    payment_id = '12345'
+
+    filing_json = copy.deepcopy(FILING_HEADER)
+    filing_json['filing']['header']['name'] = filing_name
+    filing_json['filing'][filing_name] = INCORPORATION
+    filing_json['filing'].pop('business')
+
+    filing_date = datetime.now(UTC)
+    filing = factory_filing(business, filing_json, filing_date=filing_date)
+    filing.skip_status_listener = True
+    filing._status = 'PAID'
+    filing._payment_token = payment_id
+    filing._payment_completion_date = filing_date
+    filing.save()
+
+    pay_mock = requests_mock.post(f"{current_app.config.get('PAYMENT_SVC_URL')}/{payment_id}/receipts",
+                                  json={'foo': 'bar'},
+                                  status_code=HTTPStatus.CREATED)
+
+    rv = client.get(f'/api/v2/businesses/{identifier}/filings/{filing.id}/documents/receipt',
+                    headers=create_header(jwt,
+                                          [STAFF_ROLE],
+                                          identifier,
+                                          **{'accept': 'application/pdf',
+                                             'Account-Linking-Key': 'test-linking-key'})
+                    )
+
+    assert rv.status_code == HTTPStatus.CREATED
+    assert pay_mock.last_request.headers.get('Account-Linking-Key') == 'test-linking-key'
+
+
 def test_get_receipt_no_receipt_ca(session, client, jwt, requests_mock):
     """Assert that a receipt is generated."""
     from legal_api.resources.v2.business.business_filings.business_documents import _get_receipt

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
@@ -71,6 +71,11 @@ DELAY_DISSOLUTION = {
 }
 
 
+def mock_auth(headers: dict):
+    """Return a stub for flask.request.headers.get."""
+    return lambda key, default=None: headers.get(key, default)
+
+
 def basic_test_helper():
     identifier = 'CP7654321'
     business = factory_business(identifier)
@@ -1637,12 +1642,9 @@ def test_document_list_for_various_filing_states(app, session, mocker, client, j
 
     account_id: str = '1'
     headers=create_header(jwt, [STAFF_ROLE], identifier, account_id=account_id)
-    def mock_auth(one, two):
-        return headers.get(one, two)
-
     # test
     with app.test_request_context():
-        monkeypatch.setattr('flask.request.headers.get', mock_auth)
+        monkeypatch.setattr('flask.request.headers.get', mock_auth(headers))
         account_products_mock = []
         with requests_mock.Mocker() as m:
             mock_url = f"{app.config['AUTH_SVC_URL']}/orgs/{account_id}/products?include_hidden=true"
@@ -1765,11 +1767,8 @@ def test_continuation_out_uploaded_documents(app, session, client, jwt, monkeypa
     account_id = '1'
     headers = create_header(jwt, [STAFF_ROLE], identifier, account_id=account_id)
 
-    def mock_auth(one, two):
-        return headers.get(one, two)
-
     with app.test_request_context():
-        monkeypatch.setattr('flask.request.headers.get', mock_auth)
+        monkeypatch.setattr('flask.request.headers.get', mock_auth(headers))
         with requests_mock.Mocker() as m:
             mock_url = f"{app.config['AUTH_SVC_URL']}/orgs/{account_id}/products?include_hidden=true"
             m.get(mock_url, json=[], status_code=HTTPStatus.OK)
@@ -1834,11 +1833,8 @@ def test_continuation_out_uploaded_documents_returned_for_non_staff(non_staff_ro
     account_id = '1'
     headers = create_header(jwt, [non_staff_role], identifier, account_id=account_id)
 
-    def mock_auth(one, two):
-        return headers.get(one, two)
-
     with app.test_request_context():
-        monkeypatch.setattr('flask.request.headers.get', mock_auth)
+        monkeypatch.setattr('flask.request.headers.get', mock_auth(headers))
         with requests_mock.Mocker() as m:
             m.get(f"{app.config.get('AUTH_SVC_URL')}/entities/{identifier}/authorizations",
                   json={'roles': ['view']}, status_code=HTTPStatus.OK)
@@ -1947,12 +1943,9 @@ def test_temp_document_list_for_various_filing_states(app, mocker, session, clie
     filing.save()
     account_id: str = '1'
     headers=create_header(jwt, [STAFF_ROLE], temp_identifier, account_id=account_id)
-    def mock_auth(one, two):
-        return headers.get(one, two)
-
     # test
     with app.test_request_context():
-        monkeypatch.setattr('flask.request.headers.get', mock_auth)
+        monkeypatch.setattr('flask.request.headers.get', mock_auth(headers))
         account_products_mock = []
         with requests_mock.Mocker() as m:
             mock_url = f"{app.config['AUTH_SVC_URL']}/orgs/{account_id}/products?include_hidden=true"
@@ -2132,12 +2125,9 @@ def test_temp_document_list_for_now(app, mocker, session, client, jwt, monkeypat
     filing.save()
     account_id: str = '1'
     headers=create_header(jwt, [STAFF_ROLE], temp_identifier, account_id=account_id)
-    def mock_auth(one, two):
-        return headers.get(one, two)
-
     # test
     with app.test_request_context():
-        monkeypatch.setattr('flask.request.headers.get', mock_auth)
+        monkeypatch.setattr('flask.request.headers.get', mock_auth(headers))
         account_products_mock = []
         with requests_mock.Mocker() as m:
             mock_url = f"{app.config['AUTH_SVC_URL']}/orgs/{account_id}/products?include_hidden=true"

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
@@ -1637,8 +1637,8 @@ def test_document_list_for_various_filing_states(app, session, mocker, client, j
 
     account_id: str = '1'
     headers=create_header(jwt, [STAFF_ROLE], identifier, account_id=account_id)
-    def mock_auth(one, two):  # pylint: disable=unused-argument; mocks of library methods
-        return headers[one]
+    def mock_auth(one, two):
+        return headers.get(one, two)
 
     # test
     with app.test_request_context():
@@ -1765,8 +1765,8 @@ def test_continuation_out_uploaded_documents(app, session, client, jwt, monkeypa
     account_id = '1'
     headers = create_header(jwt, [STAFF_ROLE], identifier, account_id=account_id)
 
-    def mock_auth(one, two):  # pylint: disable=unused-argument; mocks of library methods
-        return headers[one]
+    def mock_auth(one, two):
+        return headers.get(one, two)
 
     with app.test_request_context():
         monkeypatch.setattr('flask.request.headers.get', mock_auth)
@@ -1834,8 +1834,8 @@ def test_continuation_out_uploaded_documents_returned_for_non_staff(non_staff_ro
     account_id = '1'
     headers = create_header(jwt, [non_staff_role], identifier, account_id=account_id)
 
-    def mock_auth(one, two):  # pylint: disable=unused-argument; mocks of library methods
-        return headers[one]
+    def mock_auth(one, two):
+        return headers.get(one, two)
 
     with app.test_request_context():
         monkeypatch.setattr('flask.request.headers.get', mock_auth)
@@ -1947,8 +1947,8 @@ def test_temp_document_list_for_various_filing_states(app, mocker, session, clie
     filing.save()
     account_id: str = '1'
     headers=create_header(jwt, [STAFF_ROLE], temp_identifier, account_id=account_id)
-    def mock_auth(one, two):  # pylint: disable=unused-argument; mocks of library methods
-        return headers[one]
+    def mock_auth(one, two):
+        return headers.get(one, two)
 
     # test
     with app.test_request_context():
@@ -2132,8 +2132,8 @@ def test_temp_document_list_for_now(app, mocker, session, client, jwt, monkeypat
     filing.save()
     account_id: str = '1'
     headers=create_header(jwt, [STAFF_ROLE], temp_identifier, account_id=account_id)
-    def mock_auth(one, two):  # pylint: disable=unused-argument; mocks of library methods
-        return headers[one]
+    def mock_auth(one, two):
+        return headers.get(one, two)
 
     # test
     with app.test_request_context():

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filings.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filings.py
@@ -27,7 +27,7 @@ from unittest.mock import patch
 import datedelta
 import pytest
 from dateutil.parser import parse
-from flask import current_app
+from flask import current_app, g
 from minio.error import S3Error
 from reportlab.lib.pagesizes import letter
 
@@ -1807,6 +1807,35 @@ def test_coa(session, requests_mock, client, jwt, test_name, legal_type, identif
         assert future_effective_date == valid_date
     else:
         assert 'futureEffectiveDate' not in rv.json['filing']['header']
+
+
+def test_create_invoice_forwards_account_linking_key(session, requests_mock, client, jwt):
+    """Assert that create_invoice forwards the Account-Linking-Key header when present on the request."""
+    identifier = 'CP1234567'
+    coa = copy.deepcopy(FILING_HEADER)
+    coa['filing']['header']['name'] = 'changeOfAddress'
+    coa['filing']['changeOfAddress'] = CHANGE_OF_ADDRESS
+    coa['filing']['changeOfAddress']['offices']['registeredOffice']['deliveryAddress']['addressCountry'] = 'CA'
+    coa['filing']['changeOfAddress']['offices']['registeredOffice']['mailingAddress']['addressCountry'] = 'CA'
+    coa['filing']['business']['identifier'] = identifier
+
+    b = factory_business(identifier, (datetime.now(UTC) - datedelta.YEAR), None, Business.LegalTypes.COOP.value)
+    factory_business_mailing_address(b)
+
+    pay_mock = requests_mock.post(current_app.config.get('PAYMENT_SVC_URL'),
+                                  json={'id': 21322,
+                                        'statusCode': 'COMPLETED',
+                                        'isPaymentActionRequired': False},
+                                  status_code=HTTPStatus.CREATED)
+    g.pop('request_context', None)  # clear request context so it isn't cached before request
+    rv = client.post(f'/api/v2/businesses/{identifier}/filings',
+                     json=coa,
+                     headers=create_header(jwt, [STAFF_ROLE], identifier,
+                                           **{'Account-Linking-Key': 'test-linking-key'})
+                     )
+
+    assert rv.status_code == HTTPStatus.CREATED
+    assert pay_mock.last_request.headers.get('Account-Linking-Key') == 'test-linking-key'
 
 
 def test_rules_memorandum_in_sr(session, mocker, requests_mock, client, jwt, ):

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filings.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filings.py
@@ -27,7 +27,7 @@ from unittest.mock import patch
 import datedelta
 import pytest
 from dateutil.parser import parse
-from flask import current_app, g
+from flask import current_app
 from minio.error import S3Error
 from reportlab.lib.pagesizes import letter
 
@@ -1827,7 +1827,6 @@ def test_create_invoice_forwards_account_linking_key(session, requests_mock, cli
                                         'statusCode': 'COMPLETED',
                                         'isPaymentActionRequired': False},
                                   status_code=HTTPStatus.CREATED)
-    g.pop('request_context', None)  # clear request context so it isn't cached before request
     rv = client.post(f'/api/v2/businesses/{identifier}/filings',
                      json=coa,
                      headers=create_header(jwt, [STAFF_ROLE], identifier,

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filings_ledger.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filings_ledger.py
@@ -60,8 +60,8 @@ def test_get_all_business_filings_only_one_in_ledger(app, session, client, jwt, 
 
     print('test_get_all_business_filings - filing:', filings)
     headers=create_header(jwt, [STAFF_ROLE], identifier)
-    def mock_auth(one, two):  # pylint: disable=unused-argument; mocks of library methods
-        return headers[one]
+    def mock_auth(one, two):
+        return headers.get(one, two)
 
     # test
     with app.test_request_context():
@@ -90,8 +90,8 @@ def test_get_all_business_filings_multi_in_ledger(app, session, client, jwt, mon
             datetime.date(add_years(datetime(2001, 8, 5, 7, 7, 58, 272362), i)).isoformat()
         factory_filing(b, ar)
     headers=create_header(jwt, [STAFF_ROLE], identifier)
-    def mock_auth(one, two):  # pylint: disable=unused-argument; mocks of library methods
-        return headers[one]
+    def mock_auth(one, two):
+        return headers.get(one, two)
 
     # test
     with app.test_request_context():
@@ -111,8 +111,8 @@ def test_ledger_search(app, session, client, jwt, monkeypatch, mock_drs_service,
     business = factory_business(identifier=identifier, founding_date=founding_date, last_ar_date=None, entity_type=Business.LegalTypes.BCOMP.value)
     num_of_files = load_ledger(business, founding_date)
     headers=create_header(jwt, [UserRoles.system], identifier)
-    def mock_auth(one, two):  # pylint: disable=unused-argument; mocks of library methods
-        return headers[one]
+    def mock_auth(one, two):
+        return headers.get(one, two)
 
     # test
     with app.test_request_context():
@@ -177,8 +177,8 @@ def test_ledger_comment_count(app, session, client, jwt, monkeypatch, mock_drs_s
         filing_storage.comments.append(comment)
     filing_storage.save()
     headers=create_header(jwt, [UserRoles.system], identifier)
-    def mock_auth(one, two):  # pylint: disable=unused-argument; mocks of library methods
-        return headers[one]
+    def mock_auth(one, two):
+        return headers.get(one, two)
 
     # test
     with app.test_request_context():
@@ -222,8 +222,8 @@ def test_get_all_business_filings_permitted_statuses(app, session, client, jwt, 
     filing_storage.skip_status_listener = True
     filing_storage.save()
     headers=create_header(jwt, [UserRoles.system], identifier)
-    def mock_auth(one, two):  # pylint: disable=unused-argument; mocks of library methods
-        return headers[one]
+    def mock_auth(one, two):
+        return headers.get(one, two)
 
     # test
     with app.test_request_context():
@@ -279,8 +279,8 @@ def test_ledger_court_order(app, session, client, jwt, test_name, file_number, o
     filing.save()
 
     headers=create_header(jwt, [UserRoles.system], identifier)
-    def mock_auth(one, two):  # pylint: disable=unused-argument; mocks of library methods
-        return headers[one]
+    def mock_auth(one, two):
+        return headers.get(one, two)
 
     # test
     with app.test_request_context():
@@ -314,8 +314,8 @@ def test_ledger_display_name_annual_report(app, session, client, jwt, monkeypatc
     filing_storage._meta_data = meta_data
     filing_storage.save()
     headers=create_header(jwt, [UserRoles.system], identifier)
-    def mock_auth(one, two):  # pylint: disable=unused-argument; mocks of library methods
-        return headers[one]
+    def mock_auth(one, two):
+        return headers.get(one, two)
 
     # test
     with app.test_request_context():
@@ -340,8 +340,8 @@ def test_ledger_display_unknown_name(app, session, client, jwt, monkeypatch, moc
     filing_storage._meta_data = meta_data
     filing_storage.save()
     headers=create_header(jwt, [UserRoles.system], identifier)
-    def mock_auth(one, two):  # pylint: disable=unused-argument; mocks of library methods
-        return headers[one]
+    def mock_auth(one, two):
+        return headers.get(one, two)
 
     # test
     with app.test_request_context():
@@ -371,8 +371,8 @@ def test_ledger_display_alteration_report(app, session, client, jwt, monkeypatch
     filing_storage._meta_data = meta_data
     filing_storage.save()
     headers=create_header(jwt, [UserRoles.system], identifier)
-    def mock_auth(one, two):  # pylint: disable=unused-argument; mocks of library methods
-        return headers[one]
+    def mock_auth(one, two):
+        return headers.get(one, two)
 
     # test
     with app.test_request_context():
@@ -415,8 +415,8 @@ def test_ledger_display_restoration(app, session, client, jwt, restoration_type,
 
     factory_completed_filing(business, filing, filing_date=filing_date)
     headers=create_header(jwt, [UserRoles.system], identifier)
-    def mock_auth(one, two):  # pylint: disable=unused-argument; mocks of library methods
-        return headers[one]
+    def mock_auth(one, two):
+        return headers.get(one, two)
 
     # test
     with app.test_request_context():
@@ -468,8 +468,8 @@ def test_ledger_display_incorporation(app, session, client, jwt, test_name, enti
                }
     f._meta_data = {**{'applicationDate': today}, **ia_meta}
     headers=create_header(jwt, [UserRoles.system], identifier)
-    def mock_auth(one, two):  # pylint: disable=unused-argument; mocks of library methods
-        return headers[one]
+    def mock_auth(one, two):
+        return headers.get(one, two)
 
     # test
     with app.test_request_context():
@@ -491,8 +491,8 @@ def test_ledger_display_corrected_incorporation(app, session, client, jwt, monke
     original.parent_filing_id = correction.id
     original.save()
     headers=create_header(jwt, [UserRoles.system], identifier)
-    def mock_auth(one, two):  # pylint: disable=unused-argument; mocks of library methods
-        return headers[one]
+    def mock_auth(one, two):
+        return headers.get(one, two)
 
     # test
     with app.test_request_context():
@@ -531,8 +531,8 @@ def test_ledger_display_corrected_annual_report(app, session, client, jwt, monke
     correction._meta_data = {**{'applicationDate': today}, **correction_meta}
     correction.save()
     headers=create_header(jwt, [UserRoles.system], identifier)
-    def mock_auth(one, two):  # pylint: disable=unused-argument; mocks of library methods
-        return headers[one]
+    def mock_auth(one, two):
+        return headers.get(one, two)
 
     # test
     with app.test_request_context():
@@ -597,8 +597,8 @@ def test_ledger_redaction(app, session, client, jwt, test_name, submitter_role, 
         setattr(new_filing, 'skip_status_listener', True)  # skip status listener
         new_filing.save()
         headers=create_header(jwt, [jwt_role], identifier)
-        def mock_auth(one, two):  # pylint: disable=unused-argument; mocks of library methods
-            return headers[one]
+        def mock_auth(one, two):
+            return headers.get(one, two)
 
         # test
         with app.test_request_context():
@@ -650,8 +650,8 @@ def test_ledger_display_special_resolution_correction(app, session, client, jwt,
     correction_2._meta_data = {**{'applicationDate': today}, **correction_2_meta}
     correction_2.save()
     headers=create_header(jwt, [UserRoles.system], identifier)
-    def mock_auth(one, two):  # pylint: disable=unused-argument; mocks of library methods
-        return headers[one]
+    def mock_auth(one, two):
+        return headers.get(one, two)
 
     # test
     with app.test_request_context():
@@ -692,8 +692,8 @@ def test_ledger_display_non_special_resolution_correction_name(app, session, cli
     correction._meta_data = {**{'applicationDate': today}, **correction_meta}
     correction.save()
     headers=create_header(jwt, [UserRoles.system], identifier)
-    def mock_auth(one, two):  # pylint: disable=unused-argument; mocks of library methods
-        return headers[one]
+    def mock_auth(one, two):
+        return headers.get(one, two)
 
     # test
     with app.test_request_context():

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filings_ledger.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filings_ledger.py
@@ -47,6 +47,13 @@ from tests.unit.models import (
 from tests.unit.services.utils import create_header
 
 REGISTER_CORRECTION_APPLICATION = 'Register Correction Application'
+
+
+def mock_auth(headers: dict):
+    """Return a stub for flask.request.headers.get."""
+    return lambda key, default=None: headers.get(key, default)
+
+
 def test_get_all_business_filings_only_one_in_ledger(app, session, client, jwt, monkeypatch, mock_drs_service, mocker):
     """Assert that the business info can be received in a valid JSONSchema format."""
     import copy
@@ -60,12 +67,9 @@ def test_get_all_business_filings_only_one_in_ledger(app, session, client, jwt, 
 
     print('test_get_all_business_filings - filing:', filings)
     headers=create_header(jwt, [STAFF_ROLE], identifier)
-    def mock_auth(one, two):
-        return headers.get(one, two)
-
     # test
     with app.test_request_context():
-        monkeypatch.setattr('flask.request.headers.get', mock_auth)
+        monkeypatch.setattr('flask.request.headers.get', mock_auth(headers))
         rv = client.get(f'/api/v2/businesses/{identifier}/filings',
                         headers=headers)
 
@@ -90,12 +94,9 @@ def test_get_all_business_filings_multi_in_ledger(app, session, client, jwt, mon
             datetime.date(add_years(datetime(2001, 8, 5, 7, 7, 58, 272362), i)).isoformat()
         factory_filing(b, ar)
     headers=create_header(jwt, [STAFF_ROLE], identifier)
-    def mock_auth(one, two):
-        return headers.get(one, two)
-
     # test
     with app.test_request_context():
-        monkeypatch.setattr('flask.request.headers.get', mock_auth)
+        monkeypatch.setattr('flask.request.headers.get', mock_auth(headers))
         rv = client.get(f'/api/v2/businesses/{identifier}/filings',
                         headers=headers)
 
@@ -111,12 +112,9 @@ def test_ledger_search(app, session, client, jwt, monkeypatch, mock_drs_service,
     business = factory_business(identifier=identifier, founding_date=founding_date, last_ar_date=None, entity_type=Business.LegalTypes.BCOMP.value)
     num_of_files = load_ledger(business, founding_date)
     headers=create_header(jwt, [UserRoles.system], identifier)
-    def mock_auth(one, two):
-        return headers.get(one, two)
-
     # test
     with app.test_request_context():
-        monkeypatch.setattr('flask.request.headers.get', mock_auth)
+        monkeypatch.setattr('flask.request.headers.get', mock_auth(headers))
         rv = client.get(f'/api/v2/businesses/{identifier}/filings',
                         headers=headers)
 
@@ -177,12 +175,9 @@ def test_ledger_comment_count(app, session, client, jwt, monkeypatch, mock_drs_s
         filing_storage.comments.append(comment)
     filing_storage.save()
     headers=create_header(jwt, [UserRoles.system], identifier)
-    def mock_auth(one, two):
-        return headers.get(one, two)
-
     # test
     with app.test_request_context():
-        monkeypatch.setattr('flask.request.headers.get', mock_auth)
+        monkeypatch.setattr('flask.request.headers.get', mock_auth(headers))
         rv = client.get(f'/api/v2/businesses/{identifier}/filings',
                         headers=headers)
 
@@ -222,12 +217,9 @@ def test_get_all_business_filings_permitted_statuses(app, session, client, jwt, 
     filing_storage.skip_status_listener = True
     filing_storage.save()
     headers=create_header(jwt, [UserRoles.system], identifier)
-    def mock_auth(one, two):
-        return headers.get(one, two)
-
     # test
     with app.test_request_context():
-        monkeypatch.setattr('flask.request.headers.get', mock_auth)
+        monkeypatch.setattr('flask.request.headers.get', mock_auth(headers))
         rv = client.get(f'/api/v2/businesses/{identifier}/filings',
                         headers=headers)
 
@@ -279,12 +271,9 @@ def test_ledger_court_order(app, session, client, jwt, test_name, file_number, o
     filing.save()
 
     headers=create_header(jwt, [UserRoles.system], identifier)
-    def mock_auth(one, two):
-        return headers.get(one, two)
-
     # test
     with app.test_request_context():
-        monkeypatch.setattr('flask.request.headers.get', mock_auth)
+        monkeypatch.setattr('flask.request.headers.get', mock_auth(headers))
         rv = client.get(f'/api/v2/businesses/{identifier}/filings',
                         headers=headers)
 
@@ -314,12 +303,9 @@ def test_ledger_display_name_annual_report(app, session, client, jwt, monkeypatc
     filing_storage._meta_data = meta_data
     filing_storage.save()
     headers=create_header(jwt, [UserRoles.system], identifier)
-    def mock_auth(one, two):
-        return headers.get(one, two)
-
     # test
     with app.test_request_context():
-        monkeypatch.setattr('flask.request.headers.get', mock_auth)
+        monkeypatch.setattr('flask.request.headers.get', mock_auth(headers))
         rv = client.get(f'/api/v2/businesses/{identifier}/filings',
                         headers=headers)
 
@@ -340,12 +326,9 @@ def test_ledger_display_unknown_name(app, session, client, jwt, monkeypatch, moc
     filing_storage._meta_data = meta_data
     filing_storage.save()
     headers=create_header(jwt, [UserRoles.system], identifier)
-    def mock_auth(one, two):
-        return headers.get(one, two)
-
     # test
     with app.test_request_context():
-        monkeypatch.setattr('flask.request.headers.get', mock_auth)
+        monkeypatch.setattr('flask.request.headers.get', mock_auth(headers))
         rv = client.get(f'/api/v2/businesses/{identifier}/filings',
                         headers=headers)
 
@@ -371,12 +354,9 @@ def test_ledger_display_alteration_report(app, session, client, jwt, monkeypatch
     filing_storage._meta_data = meta_data
     filing_storage.save()
     headers=create_header(jwt, [UserRoles.system], identifier)
-    def mock_auth(one, two):
-        return headers.get(one, two)
-
     # test
     with app.test_request_context():
-        monkeypatch.setattr('flask.request.headers.get', mock_auth)
+        monkeypatch.setattr('flask.request.headers.get', mock_auth(headers))
         rv = client.get(f'/api/v2/businesses/{identifier}/filings',
                         headers=headers)
 
@@ -415,12 +395,9 @@ def test_ledger_display_restoration(app, session, client, jwt, restoration_type,
 
     factory_completed_filing(business, filing, filing_date=filing_date)
     headers=create_header(jwt, [UserRoles.system], identifier)
-    def mock_auth(one, two):
-        return headers.get(one, two)
-
     # test
     with app.test_request_context():
-        monkeypatch.setattr('flask.request.headers.get', mock_auth)
+        monkeypatch.setattr('flask.request.headers.get', mock_auth(headers))
         rv = client.get(f'/api/v2/businesses/{identifier}/filings',
                         headers=headers)
 
@@ -468,12 +445,9 @@ def test_ledger_display_incorporation(app, session, client, jwt, test_name, enti
                }
     f._meta_data = {**{'applicationDate': today}, **ia_meta}
     headers=create_header(jwt, [UserRoles.system], identifier)
-    def mock_auth(one, two):
-        return headers.get(one, two)
-
     # test
     with app.test_request_context():
-        monkeypatch.setattr('flask.request.headers.get', mock_auth)
+        monkeypatch.setattr('flask.request.headers.get', mock_auth(headers))
         rv = client.get(f'/api/v2/businesses/{identifier}/filings',
                         headers=headers)
 
@@ -491,12 +465,9 @@ def test_ledger_display_corrected_incorporation(app, session, client, jwt, monke
     original.parent_filing_id = correction.id
     original.save()
     headers=create_header(jwt, [UserRoles.system], identifier)
-    def mock_auth(one, two):
-        return headers.get(one, two)
-
     # test
     with app.test_request_context():
-        monkeypatch.setattr('flask.request.headers.get', mock_auth)
+        monkeypatch.setattr('flask.request.headers.get', mock_auth(headers))
         rv = client.get(f'/api/v2/businesses/{identifier}/filings',
                         headers=headers)
 
@@ -531,12 +502,9 @@ def test_ledger_display_corrected_annual_report(app, session, client, jwt, monke
     correction._meta_data = {**{'applicationDate': today}, **correction_meta}
     correction.save()
     headers=create_header(jwt, [UserRoles.system], identifier)
-    def mock_auth(one, two):
-        return headers.get(one, two)
-
     # test
     with app.test_request_context():
-        monkeypatch.setattr('flask.request.headers.get', mock_auth)
+        monkeypatch.setattr('flask.request.headers.get', mock_auth(headers))
         rv = client.get(f'/api/v2/businesses/{identifier}/filings',
                         headers=headers)
 
@@ -597,12 +565,9 @@ def test_ledger_redaction(app, session, client, jwt, test_name, submitter_role, 
         setattr(new_filing, 'skip_status_listener', True)  # skip status listener
         new_filing.save()
         headers=create_header(jwt, [jwt_role], identifier)
-        def mock_auth(one, two):
-            return headers.get(one, two)
-
         # test
         with app.test_request_context():
-            monkeypatch.setattr('flask.request.headers.get', mock_auth)
+            monkeypatch.setattr('flask.request.headers.get', mock_auth(headers))
             rv = client.get(f'/api/v2/businesses/{identifier}/filings',
                             headers=headers)
     except Exception as err:
@@ -650,12 +615,9 @@ def test_ledger_display_special_resolution_correction(app, session, client, jwt,
     correction_2._meta_data = {**{'applicationDate': today}, **correction_2_meta}
     correction_2.save()
     headers=create_header(jwt, [UserRoles.system], identifier)
-    def mock_auth(one, two):
-        return headers.get(one, two)
-
     # test
     with app.test_request_context():
-        monkeypatch.setattr('flask.request.headers.get', mock_auth)
+        monkeypatch.setattr('flask.request.headers.get', mock_auth(headers))
         rv = client.get(f'/api/v2/businesses/{identifier}/filings',
                         headers=headers)
 
@@ -692,12 +654,9 @@ def test_ledger_display_non_special_resolution_correction_name(app, session, cli
     correction._meta_data = {**{'applicationDate': today}, **correction_meta}
     correction.save()
     headers=create_header(jwt, [UserRoles.system], identifier)
-    def mock_auth(one, two):
-        return headers.get(one, two)
-
     # test
     with app.test_request_context():
-        monkeypatch.setattr('flask.request.headers.get', mock_auth)
+        monkeypatch.setattr('flask.request.headers.get', mock_auth(headers))
         rv = client.get(f'/api/v2/businesses/{identifier}/filings',
                         headers=headers)
 

--- a/legal-api/tests/unit/resources/v2/test_business_tasks.py
+++ b/legal-api/tests/unit/resources/v2/test_business_tasks.py
@@ -230,6 +230,35 @@ def test_get_tasks_error_filings(session, client, jwt):
     assert rv.json['tasks'][0]['task']['filing']['header']['filingId'] == filing.id
 
 
+def test_get_tasks_forwards_account_linking_key(app, session, client, jwt, requests_mock):
+    """Assert that the pay-api call forwards the Account-Linking-Key header when present on the request."""
+    from business_model.models import Filing
+    from tests.unit.models import AR_FILING
+
+    identifier = 'CP7654321'
+    b = factory_business(identifier, last_ar_date=datetime(2019, 8, 13))
+    factory_business_mailing_address(b)
+
+    filing = Filing()
+    filing.business_id = b.id
+    filing.filing_date = datetime(2019, 8, 5, 7, 7, 58, 272362)
+    filing.filing_json = AR_FILING
+    filing.payment_token = 2
+    filing.payment_status_code = 'CREATED'
+    filing.save()
+
+    pay_mock = requests_mock.get(f"{app.config.get('PAYMENT_SVC_URL')}/{filing.payment_token}",
+                                 json={'isPaymentActionRequired': False, 'paymentMethod': 'DIRECT_PAY'},
+                                 status_code=HTTPStatus.OK)
+
+    rv = client.get(f'/api/v2/businesses/{identifier}/tasks',
+                    headers=create_header(jwt, [STAFF_ROLE], identifier,
+                                          **{'Account-Linking-Key': 'test-linking-key'}))
+
+    assert rv.status_code == HTTPStatus.OK
+    assert pay_mock.last_request.headers.get('Account-Linking-Key') == 'test-linking-key'
+
+
 def test_get_tasks_pending_correction_filings(session, client, jwt):
     """Assert that to-do list returns the error filings."""
     from freezegun import freeze_time

--- a/legal-api/tests/unit/services/test_authorization.py
+++ b/legal-api/tests/unit/services/test_authorization.py
@@ -548,7 +548,6 @@ def test_authorized_missing_args():
 def test_call_auth_api_forwards_account_linking_key(app, jwt, requests_mock):
     """Assert that _call_auth_api forwards the Account-Linking-Key header when present on the request."""
     identifier = 'CP1234567'
-    g.pop('request_context', None)
     with jwt_request_context(app, jwt, roles=[BASIC_USER], username='test-user',
                              **{'Account-Linking-Key': 'test-linking-key'}):
         auth_mock = requests_mock.get(

--- a/legal-api/tests/unit/services/test_authorization.py
+++ b/legal-api/tests/unit/services/test_authorization.py
@@ -545,6 +545,22 @@ def test_authorized_missing_args():
     assert not rv
 
 
+def test_call_auth_api_forwards_account_linking_key(app, jwt, requests_mock):
+    """Assert that _call_auth_api forwards the Account-Linking-Key header when present on the request."""
+    identifier = 'CP1234567'
+    g.pop('request_context', None)
+    with jwt_request_context(app, jwt, roles=[BASIC_USER], username='test-user',
+                             **{'Account-Linking-Key': 'test-linking-key'}):
+        auth_mock = requests_mock.get(
+            f"{app.config['AUTH_SVC_URL']}/entities/{identifier}/authorizations",
+            json={'roles': ['view']},
+            status_code=HTTPStatus.OK
+        )
+        authorized(identifier, jwt, ['view'])
+
+    assert auth_mock.last_request.headers.get('Account-Linking-Key') == 'test-linking-key'
+
+
 def test_authorized_bad_url(monkeypatch, app, jwt):
     """Assert that an invalid auth service URL returns False."""
     identifier = 'CP1234567'

--- a/legal-api/tests/unit/services/test_request_context.py
+++ b/legal-api/tests/unit/services/test_request_context.py
@@ -24,13 +24,16 @@ from tests.unit.services.utils import helper_create_jwt_json_token_claims
 
 
 @pytest.fixture(autouse=True)
-def clear_request_context_cache():
-    """Clear flask.g state that would otherwise leak between tests sharing an app context."""
+def isolate_request_context(monkeypatch):
+    """Isolate flask.g for each test in this module.
+
+    The `app` fixture is session scoped and keeps a single app context open for the whole run,
+    Use monkeypatch so g is restored to its initial state after each test.
+    """
+    monkeypatch.setattr(g, 'jwt_oidc_token_info', None, raising=False)
     g.pop('request_context', None)
-    g.pop('jwt_oidc_token_info', None)
     yield
     g.pop('request_context', None)
-    g.pop('jwt_oidc_token_info', None)
 
 
 @pytest.mark.parametrize('headers,expected', [

--- a/legal-api/tests/unit/services/test_request_context.py
+++ b/legal-api/tests/unit/services/test_request_context.py
@@ -1,0 +1,73 @@
+# Copyright © 2026 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to assure the RequestContext service.
+
+Test-Suite to ensure that RequestContext and its helpers work as expected.
+"""
+import pytest
+from flask import g
+
+from legal_api.services.request_context import add_account_linking_key_header, build_from_flask, get_request_context
+from tests.unit.services.utils import helper_create_jwt_json_token_claims
+
+
+@pytest.fixture(autouse=True)
+def clear_request_context_cache():
+    """Clear flask.g state that would otherwise leak between tests sharing an app context."""
+    g.pop('request_context', None)
+    g.pop('jwt_oidc_token_info', None)
+    yield
+    g.pop('request_context', None)
+    g.pop('jwt_oidc_token_info', None)
+
+
+@pytest.mark.parametrize('headers,expected', [
+    ({'Account-Linking-Key': 'test-linking-key'}, 'test-linking-key'),
+    ({}, None),
+])
+def test_build_from_flask_account_linking_key(app, headers, expected):
+    """Assert that build_from_flask reads the Account-Linking-Key header when present."""
+    with app.test_request_context(headers=headers):
+        rc = build_from_flask()
+        assert rc.account_linking_key == expected
+
+
+def test_get_request_context_backwards_compatible(app, session):
+    """Assert get_request_context() behaves as before when no Account-Linking-Key header is present."""
+    token_info = helper_create_jwt_json_token_claims(username='test-user')
+    with app.test_request_context(headers={'Account-Id': '1234'}):
+        g.jwt_oidc_token_info = token_info
+        rc = get_request_context()
+        assert rc.account_id == '1234'
+        assert rc.user is not None
+        assert rc.user.username == 'test-user'
+        assert rc.account_linking_key is None
+
+
+def test_add_account_linking_key_header_present(app):
+    """Assert that the header is forwarded onto a headers dict when present on the request."""
+    with app.test_request_context(headers={'Account-Linking-Key': 'test-linking-key'}):
+        headers = {'Authorization': 'Bearer token'}
+        add_account_linking_key_header(headers)
+        assert headers == {'Authorization': 'Bearer token', 'Account-Linking-Key': 'test-linking-key'}
+
+
+def test_add_account_linking_key_header_absent(app):
+    """Assert that no header is added onto a headers dict when absent on the request."""
+    with app.test_request_context():
+        headers = {'Authorization': 'Bearer token'}
+        add_account_linking_key_header(headers)
+        assert headers == {'Authorization': 'Bearer token'}
+

--- a/legal-api/tests/unit/services/test_request_context.py
+++ b/legal-api/tests/unit/services/test_request_context.py
@@ -44,11 +44,11 @@ def test_build_from_flask_account_linking_key(app, headers, expected):
         assert rc.account_linking_key == expected
 
 
-def test_get_request_context_backwards_compatible(app, session):
+def test_get_request_context_backwards_compatible(app, session, monkeypatch):
     """Assert get_request_context() behaves as before when no Account-Linking-Key header is present."""
     token_info = helper_create_jwt_json_token_claims(username='test-user')
     with app.test_request_context(headers={'Account-Id': '1234'}):
-        g.jwt_oidc_token_info = token_info
+        monkeypatch.setattr(g, 'jwt_oidc_token_info', token_info, raising=False)
         rc = get_request_context()
         assert rc.account_id == '1234'
         assert rc.user is not None

--- a/legal-api/tests/unit/services/utils.py
+++ b/legal-api/tests/unit/services/utils.py
@@ -73,14 +73,15 @@ def jwt_request_context(app,
                         jwt_manager: JwtManager,
                         roles: List[str] = [],
                         username: str = 'test-user',
-                        account_id: str = '1'):
+                        account_id: str = '1',
+                        **kwargs):
     """Push a Flask request context with a valid JWT and populate
     request_ctx.current_user the way the @jwt.has_one_of_roles decorator
     would in production. Used by tests that call authz functions directly
     instead of routing through a JWT-decorated view.
     """
     token = helper_create_jwt(jwt_manager, roles=roles, username=username)
-    headers = {'Authorization': f'Bearer {token}', 'Account-Id': account_id}
+    headers = {'Authorization': f'Bearer {token}', 'Account-Id': account_id, **kwargs}
     with app.test_request_context(headers=headers):
         jwt_manager._require_auth_validation()
         yield


### PR DESCRIPTION
*Issue #:* /bcgov/entity/33654

*Description of changes:*
- Update auth and pay api calls to forward along Account-Linking-Key is present
- This is intended to be backwards compatible, processing is done on auth and pay side when the linking key is provided.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
