### PR TITLE
34457 - Distinct DRS report types for coop annual report bundled outputs

### DIFF
--- a/legal-api/src/legal_api/reports/document_service.py
+++ b/legal-api/src/legal_api/reports/document_service.py
@@ -354,7 +354,8 @@ class DocumentService:
         headers = self._get_request_headers(BUSINESS_API_ACCOUNT_ID, APP_PDF)
         url: str = self.url.replace(DOC_PATH, "")
         get_url = GET_REPORT_PATH
-        if report_type in [ReportTypes.FILING.value, ReportTypes.FILING_2.value, ReportTypes.NOA.value]:
+        if report_type in [ReportTypes.FILING.value, ReportTypes.FILING_2.value, ReportTypes.FILING_4.value,
+                           ReportTypes.NOA.value]:
             get_url = GET_REPORT_CERTIFIED_PATH
         get_url = get_url.format(url=url, product=self.product_code, drsId=drs_id)
         response = requests.get(url=get_url, headers=headers)

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -127,6 +127,13 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
             # the FILING report type with that filing's own report, or the DRS lookup below serves
             # whichever of the two documents was stored first (#34299).
             report_meta = {**report_meta, "reportType": ReportTypes.FILING_2.value}
+        if self._filing.filing_type == "annualReport" and \
+                (accompanying_type := {"changeOfDirectors": ReportTypes.FILING_2.value,
+                                       "changeOfAddress": ReportTypes.FILING_4.value}.get(self._report_key)):
+            # A coop annual report can bundle director and address changes as additional legal filings;
+            # each output must have its own report type or the DRS lookup below serves whichever of the
+            # documents was stored first (#34457).
+            report_meta = {**report_meta, "reportType": accompanying_type}
         report_type = report_meta.get("reportType")
         if business_identifier and not regenerate:  # Skip if regenerating and replacing DRS doc.
             document, status = self._document_service.get_filing_report_by_filing_id(

--- a/legal-api/tests/unit/reports/test_report.py
+++ b/legal-api/tests/unit/reports/test_report.py
@@ -1191,6 +1191,46 @@ def test_special_resolution_drs_report_type(session, filing_type, expected_repor
     assert response.status_code == HTTPStatus.OK
 
 
+@pytest.mark.parametrize('filing_type,report_key,expected_report_type', [
+    ('annualReport', 'annualReport', 'FILING'),
+    ('annualReport', 'changeOfDirectors', 'FILING-2'),
+    ('annualReport', 'changeOfAddress', 'FILING-4'),
+    ('changeOfDirectors', 'changeOfDirectors', 'FILING'),
+    ('changeOfAddress', 'changeOfAddress', 'FILING'),
+])
+def test_coop_annual_report_drs_report_types(session, filing_type, report_key, expected_report_type):
+    """Assert each legal filing bundled in a coop annual report uses a distinct DRS report type (#34457).
+
+    When stored with the same FILING report type as the annual report's own output, the DRS-first
+    lookup serves whichever of the documents was stored first, so every output shows the same content.
+    """
+    identifier = 'CP1234567'
+    business = factory_business(identifier=identifier, entity_type='CP')
+
+    filing_json = copy.deepcopy(FILING_HEADER)
+    filing_json['filing']['header']['name'] = filing_type
+    filing_json['filing']['business']['identifier'] = identifier
+    filing_json['filing']['business']['legalType'] = 'CP'
+    if filing_type == 'annualReport':
+        filing_json['filing']['annualReport'] = copy.deepcopy(ANNUAL_REPORT['filing']['annualReport'])
+    if report_key == 'changeOfDirectors':
+        filing_json['filing']['changeOfDirectors'] = copy.deepcopy(CHANGE_OF_DIRECTORS)
+    if report_key == 'changeOfAddress':
+        filing_json['filing']['changeOfAddress'] = copy.deepcopy(CHANGE_OF_ADDRESS)
+    filing = factory_completed_filing(business, filing_json)
+
+    report = Report(filing)
+    report._report_key = report_key
+    report._document_service = MagicMock()
+    report._document_service.get_filing_report_by_filing_id.return_value = (b'pdf', HTTPStatus.OK)
+
+    response = report._get_report()
+
+    report._document_service.get_filing_report_by_filing_id.assert_called_once_with(
+        identifier, filing.id, expected_report_type)
+    assert response.status_code == HTTPStatus.OK
+
+
 def _make_static_report_filing(identifier, document_type, file_key):
     """Create a completed coop dissolution filing with an uploaded document row."""
     from business_model.models import Document


### PR DESCRIPTION
Issue #bcgov/entity#34457 

Description:
a coop AR's bundled changeOfDirectors/changeOfAddress outputs shared the FILING DRS report type with the AR's own report, so every output served whichever document was stored first; they now use FILING-2/FILING-4 (same pattern as https://github.com/bcgov/lear/pull/4592).