### PR TITLE
34465 Colin API - auth info status tweak

### DIFF
--- a/colin-api/src/colin_api/models/business.py
+++ b/colin-api/src/colin_api/models/business.py
@@ -123,6 +123,16 @@ class Business:  # pylint: disable=too-many-instance-attributes, too-many-public
     def __init__(self):
         """Initialize with all values None."""
 
+    @property
+    def lear_state(self) -> str:
+        """Return the LEAR-style business state: only op-state ACT is active, everything else is historical.
+
+        Same rule as the tombstone migration (data-tool tombstone_utils) and the search
+        importers - keyed off CORP_OP_STATE.OP_STATE_TYP_CD (ACT/HIS), not the
+        fine-grained corp state code.
+        """
+        return 'ACTIVE' if self.corp_state_class == 'ACT' else 'HISTORICAL'
+
     def as_dict(self) -> Dict:
         """Return dict version of self."""
         return {
@@ -414,7 +424,9 @@ class Business:  # pylint: disable=too-many-instance-attributes, too-many-public
             'identifier': business.corp_num,
             'legalName': business.corp_name,
             'legalType': business.corp_type,
-            'status': business.status,
+            # LEAR-style state, not COLIN's free-text status description - auth stores it
+            # verbatim and the dashboard filters on ACTIVE/HISTORICAL
+            'status': business.lear_state,
             'goodStanding': business.good_standing,
             'businessNumber': business.business_number,
             # find_by_identifier returns the COLIN 'True'/'False' string; normalize for callers

--- a/colin-api/src/colin_api/version.py
+++ b/colin-api/src/colin_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.171.8'  # pylint: disable=invalid-name
+__version__ = '2.171.9'  # pylint: disable=invalid-name

--- a/colin-api/tests/unit/api/test_business_auth_info.py
+++ b/colin-api/tests/unit/api/test_business_auth_info.py
@@ -42,7 +42,8 @@ def _business(**overrides):
     business.corp_num = '0870226'
     business.corp_name = 'COLIN TEST COMPANY LTD.'
     business.corp_type = 'BC'
-    business.status = 'Active'
+    # CORP_OP_STATE.OP_STATE_TYP_CD - only ever ACT/HIS; drives the response's LEAR-style status
+    business.corp_state_class = 'ACT'
     business.good_standing = True
     business.business_number = '791861078BC0001'
     # COLIN returns admin_freeze as a 'True'/'False' string
@@ -96,13 +97,23 @@ def test_get_auth_info(client, mocker, authorized, mock_db):  # pylint: disable=
         'identifier': '0870226',
         'legalName': 'COLIN TEST COMPANY LTD.',
         'legalType': 'BC',
-        'status': 'Active',
+        'status': 'ACTIVE',
         'goodStanding': True,
         'businessNumber': '791861078BC0001',
         'adminFreeze': False,
         'email': 'registered.office@test.com',
         'passCode': PASS_CODE
     }
+
+
+def test_get_auth_info_maps_historical_state(client, mocker, authorized, mock_db):  # pylint: disable=unused-argument
+    """Assert a non-active corp (eg. amalgamated or dissolved) reports the LEAR-style HISTORICAL."""
+    mocker.patch.object(Business, 'find_by_identifier', return_value=_business(corp_state_class='HIS'))
+
+    rv = client.get(AUTH_INFO_URL)
+
+    assert rv.status_code == 200
+    assert rv.json['status'] == 'HISTORICAL'
 
 
 def test_get_auth_info_strips_bc_prefix(client, mocker, authorized, mock_db):  # pylint: disable=unused-argument


### PR DESCRIPTION
*Issue #:* /bcgov/entity#34465

*Description of changes:*
- update to return simplified status in auth-info call 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
