### PR TITLE
34514 - return entities with 0001 founding date

### DIFF
--- a/python/common/business-registry-model/src/business_model/models/business.py
+++ b/python/common/business-registry-model/src/business_model/models/business.py
@@ -367,6 +367,8 @@ class Business(db.Model, Versioned):  # pylint: disable=too-many-instance-attrib
     @property
     def next_anniversary(self):
         """Retrieve the next anniversary date for which an AR filing is due."""
+        if not self.founding_date or self.founding_date.year <= 1:
+            return None
         _founding_date = LegislationDatetime.as_legislation_timezone(self.founding_date)
         next_ar_year = (self.last_ar_year if self.last_ar_year else _founding_date.year) + 1
         no_of_years_to_add = next_ar_year - _founding_date.year
@@ -671,6 +673,7 @@ class Business(db.Model, Versioned):  # pylint: disable=too-many-instance-attrib
                 (self.last_ar_year if self.last_ar_year else self.founding_date.year) + 1
             )
 
+        next_anniversary = self.next_anniversary
         d = {
             **slim_json,
             'arMinDate': ar_min_date.isoformat() if ar_min_date else '',
@@ -686,7 +689,7 @@ class Business(db.Model, Versioned):  # pylint: disable=too-many-instance-attrib
             'naicsKey': self.naics_key,
             'naicsCode': self.naics_code,
             'naicsDescription': self.naics_description,
-            'nextAnnualReport': self.next_anniversary.isoformat(),
+            'nextAnnualReport': next_anniversary.isoformat() if next_anniversary else '',
             'noDissolution': self.no_dissolution,
             'associationType': self.association_type,
             'allowedActions': self.allowable_actions,
@@ -725,9 +728,9 @@ class Business(db.Model, Versioned):  # pylint: disable=too-many-instance-attrib
 
     def _extend_json(self, d):
         """Include conditional fields to json."""
-        if self.last_coa_date:
+        if self.last_coa_date and self.last_coa_date.year > 1:
             d['lastAddressChangeDate'] = LegislationDatetime.format_as_legislation_date(self.last_coa_date)
-        if self.last_cod_date:
+        if self.last_cod_date and self.last_cod_date.year > 1:
             d['lastDirectorChangeDate'] = LegislationDatetime.format_as_legislation_date(self.last_cod_date)
 
         if self.dissolution_date:

--- a/python/common/business-registry-model/tests/models/test_business.py
+++ b/python/common/business-registry-model/tests/models/test_business.py
@@ -423,10 +423,10 @@ def test_business_json(app, session):
 def test_business_json_sentinel_founding_date(app, session):
     """Assert json() succeeds when founding_date is a year-1 COLIN sentinel."""
     business = Business(
-        legal_name='VICTORIA HARBOUR RAILWAY COMPANY',
-        legal_type=Business.LegalTypes.RAILWAYS.value,
+        legal_name='legal_name',
+        legal_type=Business.LegalTypes.COMP.value,
         founding_date=datetime(1, 1, 1, 8, 0, 0, tzinfo=UTC),
-        identifier='RLY0000001',
+        identifier='BC1234567',
         state=Business.State.ACTIVE,
     )
 

--- a/python/common/business-registry-model/tests/models/test_business.py
+++ b/python/common/business-registry-model/tests/models/test_business.py
@@ -420,6 +420,22 @@ def test_business_json(app, session):
     assert business.json() == d
 
 
+def test_business_json_sentinel_founding_date(app, session):
+    """Assert json() succeeds when founding_date is a year-1 COLIN sentinel."""
+    business = Business(
+        legal_name='VICTORIA HARBOUR RAILWAY COMPANY',
+        legal_type=Business.LegalTypes.RAILWAYS.value,
+        founding_date=datetime(1, 1, 1, 8, 0, 0, tzinfo=UTC),
+        identifier='RLY0000001',
+        state=Business.State.ACTIVE,
+    )
+
+    assert business.next_anniversary is None
+    business_json = business.json()
+    assert business_json['nextAnnualReport'] == ''
+    assert business_json['foundingDate'] == '0001-01-01T08:00:00+00:00'
+
+
 ALTERNATE_NAME_1 = "operating name 1"
 ALTERNATE_NAME_1_IDENTIFIER = "FM1111111"
 ALTERNATE_NAME_1_START_DATE = "2023-09-02"

--- a/python/common/business-registry-model/tests/models/test_business.py
+++ b/python/common/business-registry-model/tests/models/test_business.py
@@ -424,9 +424,13 @@ def test_business_json_sentinel_founding_date(app, session):
     """Assert json() succeeds when founding_date is a year-1 COLIN sentinel."""
     business = Business(
         legal_name='legal_name',
-        legal_type=Business.LegalTypes.COMP.value,
+        legal_type=Business.LegalTypes.COOP.value,
         founding_date=datetime(1, 1, 1, 8, 0, 0, tzinfo=UTC),
-        identifier='BC1234567',
+        last_coa_date=datetime(1, 1, 1, 8, 0, 0, tzinfo=UTC),
+        last_cod_date=datetime(1, 1, 1, 8, 0, 0, tzinfo=UTC),
+        last_ledger_timestamp=EPOCH_DATETIME,
+        identifier='CP1234567',
+        last_modified=EPOCH_DATETIME,
         state=Business.State.ACTIVE,
     )
 
@@ -434,6 +438,8 @@ def test_business_json_sentinel_founding_date(app, session):
     business_json = business.json()
     assert business_json['nextAnnualReport'] == ''
     assert business_json['foundingDate'] == '0001-01-01T08:00:00+00:00'
+    assert business_json['lastAddressChangeDate'] == ''
+    assert business_json['lastDirectorChangeDate'] == ''
 
 
 ALTERNATE_NAME_1 = "operating name 1"


### PR DESCRIPTION
*Issue #:* /bcgov/entity#34514

*Description of changes:*
We're migrating low-volume entities from legacy DB and mainframe to modernized. Railways with a founding date of:
"foundingDate": "0001-01-01T08:00:00+00:00"
were failing to return:
<img width="706" height="470" alt="image" src="https://github.com/user-attachments/assets/28efcce3-3bc0-4a81-aaff-490da94e7d2c" />

This fixes that

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
