### PR TITLE
32831 nr duplicate

### DIFF
--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -30,7 +30,7 @@ from business_account import AccountService
 from business_common.utils.datetime import date
 from business_common.utils.datetime import datetime as dt
 from business_common.utils.legislation_datetime import LegislationDatetime
-from business_model.models import Address, Business, PartyRole
+from business_model.models import Address, Business, Filing,PartyRole
 from legal_api.core.filing import Filing as CoreFiling
 from legal_api.errors import Error
 from legal_api.services import STAFF_ROLE, MinioService, colin, doc_service, flags, namex
@@ -104,8 +104,43 @@ FILINGS_REQUIRING_AUTHORIZATION = {
     CoreFiling.FilingTypes.NOTICEOFWITHDRAWAL,
     CoreFiling.FilingTypes.RESTORATION,
 }
-
 DRS_KEY_PATTERN = re.compile(r"^([A-Z]+)-(DS\d+)$")
+
+FILING_TYPES_WITH_NR = [                                                                                                                                                                                                                  
+      CoreFiling.FilingTypes.INCORPORATIONAPPLICATION,                                                                                                                                                                                       
+      CoreFiling.FilingTypes.REGISTRATION,                                                                                                                                                                                                 
+      CoreFiling.FilingTypes.AMALGAMATIONAPPLICATION,                                                                                                                                                                                        
+      CoreFiling.FilingTypes.CONTINUATIONIN,                                                                                                                                                                                               
+      CoreFiling.FilingTypes.ALTERATION,                                                                                                                                                                                                     
+      CoreFiling.FilingTypes.CHANGEOFNAME,                                                                                                                                                                                                 
+      CoreFiling.FilingTypes.CHANGEOFREGISTRATION,                                                                                                                                                                                           
+      CoreFiling.FilingTypes.CONVERSION,                                                                                                                                                                                                   
+  ]
+
+NR_BLOCKING_STATUSES = [
+      Filing.Status.PENDING,                                                                                                                                                                                                                 
+      Filing.Status.PAID,
+      Filing.Status.AWAITING_REVIEW,                                                                                                                                                                                                         
+      Filing.Status.CHANGE_REQUESTED,                                                                                                                                                                                                      
+      Filing.Status.APPROVED,
+  ]
+
+
+def _nr_in_pending_filing(nr_number: str, exclude_filing_id: int | None = None) -> bool:
+    """Return True if the NR is already referenced in a non-draft/non-completed filing."""
+    for filing_type in FILING_TYPES_WITH_NR:
+        query = Filing.query.filter(
+            Filing._status.in_([s.value for s in NR_BLOCKING_STATUSES]),
+            Filing._filing_json[('filing', filing_type.value, 'nameRequest', 'nrNumber')].astext == nr_number
+        )
+        if exclude_filing_id:
+            query = query.filter(Filing.id != exclude_filing_id)
+        if query.first():
+            return True
+    return False
+
+
+
 
 def validate_resolution_date_in_share_structure(filing_json, filing_type, business) -> list[dict]:
     """Validate the resolution date of a share structure.
@@ -991,6 +1026,11 @@ def validate_name_request(filing_json: dict,  # pylint: disable=too-many-locals
     validation_result = namex.validate_nr(nr_response_json)
     if not validation_result["is_consumable"]:
         msg.append({"error": _("Name Request is not approved."), "path": nr_number_path})
+
+    # ensure NR is not already referenced in another pending/paid filing
+    if _nr_in_pending_filing(nr_number):
+        msg.append({"error": _("Name Request is already part of a pending filing."),
+                    "path": nr_number_path})
 
     # ensure NR request type code
     if accepted_request_types and nr_response_json["requestTypeCd"] not in accepted_request_types:

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -131,7 +131,7 @@ def _nr_in_pending_filing(nr_number: str, exclude_filing_id: int | None = None) 
     for filing_type in FILING_TYPES_WITH_NR:
         query = Filing.query.filter(
             Filing._status.in_([s.value for s in NR_BLOCKING_STATUSES]),
-            Filing._filing_json[('filing', filing_type.value, 'nameRequest', 'nrNumber')].astext == nr_number
+            Filing.filing_json['filing'][filing_type.value]['nameRequest']['nrNumber'].astext == nr_number
         )
         if exclude_filing_id:
             query = query.filter(Filing.id != exclude_filing_id)

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -30,7 +30,7 @@ from business_account import AccountService
 from business_common.utils.datetime import date
 from business_common.utils.datetime import datetime as dt
 from business_common.utils.legislation_datetime import LegislationDatetime
-from business_model.models import Address, Business, Filing,PartyRole
+from business_model.models import Address, Business, Filing, PartyRole
 from legal_api.core.filing import Filing as CoreFiling
 from legal_api.errors import Error
 from legal_api.services import STAFF_ROLE, MinioService, colin, doc_service, flags, namex
@@ -106,24 +106,24 @@ FILINGS_REQUIRING_AUTHORIZATION = {
 }
 DRS_KEY_PATTERN = re.compile(r"^([A-Z]+)-(DS\d+)$")
 
-FILING_TYPES_WITH_NR = [                                                                                                                                                                                                                  
-      CoreFiling.FilingTypes.INCORPORATIONAPPLICATION,                                                                                                                                                                                       
-      CoreFiling.FilingTypes.REGISTRATION,                                                                                                                                                                                                 
-      CoreFiling.FilingTypes.AMALGAMATIONAPPLICATION,                                                                                                                                                                                        
-      CoreFiling.FilingTypes.CONTINUATIONIN,                                                                                                                                                                                               
-      CoreFiling.FilingTypes.ALTERATION,                                                                                                                                                                                                     
-      CoreFiling.FilingTypes.CHANGEOFNAME,                                                                                                                                                                                                 
-      CoreFiling.FilingTypes.CHANGEOFREGISTRATION,                                                                                                                                                                                           
-      CoreFiling.FilingTypes.CONVERSION,                                                                                                                                                                                                   
-  ]
+FILING_TYPES_WITH_NR = [
+    CoreFiling.FilingTypes.INCORPORATIONAPPLICATION,
+    CoreFiling.FilingTypes.REGISTRATION,
+    CoreFiling.FilingTypes.AMALGAMATIONAPPLICATION,
+    CoreFiling.FilingTypes.CONTINUATIONIN,
+    CoreFiling.FilingTypes.ALTERATION,
+    CoreFiling.FilingTypes.CHANGEOFNAME,
+    CoreFiling.FilingTypes.CHANGEOFREGISTRATION,
+    CoreFiling.FilingTypes.CONVERSION,
+]
 
 NR_BLOCKING_STATUSES = [
-      Filing.Status.PENDING,                                                                                                                                                                                                                 
-      Filing.Status.PAID,
-      Filing.Status.AWAITING_REVIEW,                                                                                                                                                                                                         
-      Filing.Status.CHANGE_REQUESTED,                                                                                                                                                                                                      
-      Filing.Status.APPROVED,
-  ]
+    Filing.Status.PENDING,
+    Filing.Status.PAID,
+    Filing.Status.AWAITING_REVIEW,
+    Filing.Status.CHANGE_REQUESTED,
+    Filing.Status.APPROVED,
+]
 
 
 def _nr_in_pending_filing(nr_number: str) -> bool:
@@ -131,7 +131,7 @@ def _nr_in_pending_filing(nr_number: str) -> bool:
     for filing_type in FILING_TYPES_WITH_NR:
         if Filing.query.filter(
             Filing._status.in_([s.value for s in NR_BLOCKING_STATUSES]),
-            Filing.filing_json['filing'][filing_type.value]['nameRequest']['nrNumber'].astext == nr_number
+            Filing.filing_json["filing"][filing_type.value]["nameRequest"]["nrNumber"].astext == nr_number
         ).first():
             return True
     return False

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -126,16 +126,13 @@ NR_BLOCKING_STATUSES = [
   ]
 
 
-def _nr_in_pending_filing(nr_number: str, exclude_filing_id: int | None = None) -> bool:
+def _nr_in_pending_filing(nr_number: str) -> bool:
     """Return True if the NR is already referenced in a non-draft/non-completed filing."""
     for filing_type in FILING_TYPES_WITH_NR:
-        query = Filing.query.filter(
+        if Filing.query.filter(
             Filing._status.in_([s.value for s in NR_BLOCKING_STATUSES]),
             Filing.filing_json['filing'][filing_type.value]['nameRequest']['nrNumber'].astext == nr_number
-        )
-        if exclude_filing_id:
-            query = query.filter(Filing.id != exclude_filing_id)
-        if query.first():
+        ).first():
             return True
     return False
 

--- a/legal-api/tests/unit/services/filings/validations/test_common_validations.py
+++ b/legal-api/tests/unit/services/filings/validations/test_common_validations.py
@@ -2438,13 +2438,15 @@ def test_nr_in_draft_filing_does_not_block(session):
 
 
 def test_nr_excludes_own_filing(session):
-    """Assert a filing's own NR does not block itself."""
+    """Assert a filing in PENDING status cannot be re-submitted (PUT is blocked by is_allowed),
+    so a filing cannot block itself — this test confirms PENDING status is correctly blocked."""
     filing_json = {
         'filing': {
             'header': {'name': 'incorporationApplication'},
             'incorporationApplication': {'nameRequest': {'nrNumber': 'NR 0000005'}}
         }
     }
-    filing = factory_pending_filing(None, filing_json)
+    factory_pending_filing(None, filing_json)
 
-    assert _nr_in_pending_filing('NR 0000005', exclude_filing_id=filing.id) is False
+    # A second filing using the same NR should be blocked
+    assert _nr_in_pending_filing('NR 0000005') is True

--- a/legal-api/tests/unit/services/filings/validations/test_common_validations.py
+++ b/legal-api/tests/unit/services/filings/validations/test_common_validations.py
@@ -19,7 +19,7 @@ from unittest.mock import patch
 
 from legal_api.core.filing import Filing as CoreFiling
 from legal_api.errors import Error
-from business_model.models import Business, Party, PartyRole, ShareClass
+from business_model.models import Business, Filing, Party, PartyRole, ShareClass
 from business_model.models.share_series import ShareSeries
 from legal_api.services import flags
 from legal_api.services.permissions import PermissionService
@@ -44,13 +44,14 @@ from registry_schemas.example_data import (
     RESTORATION,
 )
 
-from tests.unit.models import factory_business, factory_party_role
+from tests.unit.models import factory_business, factory_party_role, factory_pending_filing
 
 from legal_api.services.filings.validations.common_validations import (
     EXCLUDED_WORDS_FOR_CLASS,
     EXCLUDED_WORDS_FOR_SERIES,
     find_updated_keys_for_firms,
     _get_file_data,
+    _nr_in_pending_filing,
     is_officer_proprietor_replace_valid,
     validate_authorization_received,
     validate_certify_name,
@@ -2387,3 +2388,63 @@ def test_get_file_data_drs_failure(session, monkeypatch):
 
     with pytest.raises(ValueError, match="DRS get_document failed"):
         _get_file_data("CORP-DS0000101951")
+
+
+def test_nr_not_in_any_filing_passes(session):
+    """Assert NR not referenced in any filing passes."""
+    assert _nr_in_pending_filing('NR 0000001') is False
+
+
+def test_nr_in_pending_filing_blocks(session):
+    """Assert NR already in a PENDING filing blocks submission."""
+    filing_json = {
+        'filing': {
+            'header': {'name': 'incorporationApplication'},
+            'incorporationApplication': {'nameRequest': {'nrNumber': 'NR 0000002'}}
+        }
+    }
+    filing = factory_pending_filing(None, filing_json)
+
+    assert _nr_in_pending_filing('NR 0000002') is True
+
+
+def test_nr_in_paid_filing_blocks(session):
+    """Assert NR already in a PAID filing blocks submission."""
+    filing_json = {
+        'filing': {
+            'header': {'name': 'incorporationApplication'},
+            'incorporationApplication': {'nameRequest': {'nrNumber': 'NR 0000003'}}
+        }
+    }
+    filing = factory_pending_filing(None, filing_json)
+    filing.payment_completion_date = filing.filing_date
+    filing.save()
+
+    assert _nr_in_pending_filing('NR 0000003') is True
+
+
+def test_nr_in_draft_filing_does_not_block(session):
+    """Assert NR only in DRAFT filing does not block."""
+    filing = Filing()
+    filing.filing_json = {
+        'filing': {
+            'header': {'name': 'incorporationApplication'},
+            'incorporationApplication': {'nameRequest': {'nrNumber': 'NR 0000004'}}
+        }
+    }
+    filing.save()
+
+    assert _nr_in_pending_filing('NR 0000004') is False
+
+
+def test_nr_excludes_own_filing(session):
+    """Assert a filing's own NR does not block itself."""
+    filing_json = {
+        'filing': {
+            'header': {'name': 'incorporationApplication'},
+            'incorporationApplication': {'nameRequest': {'nrNumber': 'NR 0000005'}}
+        }
+    }
+    filing = factory_pending_filing(None, filing_json)
+
+    assert _nr_in_pending_filing('NR 0000005', exclude_filing_id=filing.id) is False

--- a/legal-api/tests/unit/services/filings/validations/test_common_validations.py
+++ b/legal-api/tests/unit/services/filings/validations/test_common_validations.py
@@ -2390,63 +2390,58 @@ def test_get_file_data_drs_failure(session, monkeypatch):
         _get_file_data("CORP-DS0000101951")
 
 
-def test_nr_not_in_any_filing_passes(session):
-    """Assert NR not referenced in any filing passes."""
-    assert _nr_in_pending_filing('NR 0000001') is False
+@pytest.mark.parametrize(
+    "test_name, filing_type, status, has_nr, expected",
+    [
+        # All valid NR filing types in PENDING state are blocked
+        ("ia_pending", "incorporationApplication", "PENDING", True, True),
+        ("reg_pending", "registration", "PENDING", True, True),
+        ("amalg_pending", "amalgamationApplication", "PENDING", True, True),
+        ("cont_in_pending", "continuationIn", "PENDING", True, True),
+        ("alt_pending", "alteration", "PENDING", True, True),
+        ("con_name_pending", "changeOfName", "PENDING", True, True),
+        ("cor_reg_pending", "changeOfRegistration", "PENDING", True, True),
+        ("conv_pending", "conversion", "PENDING", True, True),
+        # PAID filing blocks
+        ("ia_paid", "incorporationApplication", "PAID", True, True),
+        # DRAFT filing does not block
+        ("ia_draft", "incorporationApplication", "DRAFT", True, False),
+        # Valid NR filing type but no NR information present — does not block
+        ("ia_no_nr", "incorporationApplication", "PENDING", False, False),
+        # Invalid NR filing type (dissolution is not in FILING_TYPES_WITH_NR) — does not block
+        ("dissolution_pending", "dissolution", "PENDING", True, False),
+    ]
+)
+def test_nr_in_pending_filing(session, test_name, filing_type, status, has_nr, expected):
+    """Assert _nr_in_pending_filing blocks based on filing type, status, and NR presence."""
+    import random
+    nr_number = f"NR {random.randint(1000000, 9999999)}"
 
-
-def test_nr_in_pending_filing_blocks(session):
-    """Assert NR already in a PENDING filing blocks submission."""
+    # Some filing types require a sub-type field to satisfy the Filing model
+    required_subtype_fields = {
+        "amalgamationApplication": {"type": "regular"},
+        "dissolution": {"dissolutionType": "voluntary"},
+    }
+    base_data = dict(required_subtype_fields.get(filing_type, {}))
+    if has_nr:
+        base_data["nameRequest"] = {"nrNumber": nr_number}
+    filing_data = {filing_type: base_data}
     filing_json = {
-        'filing': {
-            'header': {'name': 'incorporationApplication'},
-            'incorporationApplication': {'nameRequest': {'nrNumber': 'NR 0000002'}}
+        "filing": {
+            "header": {"name": filing_type},
+            **filing_data,
         }
     }
-    filing = factory_pending_filing(None, filing_json)
 
-    assert _nr_in_pending_filing('NR 0000002') is True
+    if status == "PAID":
+        f = factory_pending_filing(None, filing_json)
+        f.payment_completion_date = f.filing_date
+        f.save()
+    elif status == "DRAFT":
+        f = Filing()
+        f.filing_json = filing_json
+        f.save()
+    else:  # PENDING
+        factory_pending_filing(None, filing_json)
 
-
-def test_nr_in_paid_filing_blocks(session):
-    """Assert NR already in a PAID filing blocks submission."""
-    filing_json = {
-        'filing': {
-            'header': {'name': 'incorporationApplication'},
-            'incorporationApplication': {'nameRequest': {'nrNumber': 'NR 0000003'}}
-        }
-    }
-    filing = factory_pending_filing(None, filing_json)
-    filing.payment_completion_date = filing.filing_date
-    filing.save()
-
-    assert _nr_in_pending_filing('NR 0000003') is True
-
-
-def test_nr_in_draft_filing_does_not_block(session):
-    """Assert NR only in DRAFT filing does not block."""
-    filing = Filing()
-    filing.filing_json = {
-        'filing': {
-            'header': {'name': 'incorporationApplication'},
-            'incorporationApplication': {'nameRequest': {'nrNumber': 'NR 0000004'}}
-        }
-    }
-    filing.save()
-
-    assert _nr_in_pending_filing('NR 0000004') is False
-
-
-def test_nr_excludes_own_filing(session):
-    """Assert a filing in PENDING status cannot be re-submitted (PUT is blocked by is_allowed),
-    so a filing cannot block itself — this test confirms PENDING status is correctly blocked."""
-    filing_json = {
-        'filing': {
-            'header': {'name': 'incorporationApplication'},
-            'incorporationApplication': {'nameRequest': {'nrNumber': 'NR 0000005'}}
-        }
-    }
-    factory_pending_filing(None, filing_json)
-
-    # A second filing using the same NR should be blocked
-    assert _nr_in_pending_filing('NR 0000005') is True
+    assert _nr_in_pending_filing(nr_number) is expected


### PR DESCRIPTION
*Issue #:* /bcgov/entity#32831

*Description of changes:*

 Problem: At submission time, the API validated that an NR was consumable (via NameX) but didn't check if the same NR was already referenced in another filing in PENDING or PAID status. This allowed two filings using the same NR to be  
  submitted simultaneously, potentially creating two businesses with the same name.                                                                                                                                                          
                                                                                                                                                                                                                                             
  Fix:                                                                                                                                                                                                                                       
  - Added FILING_TYPES_WITH_NR and NR_BLOCKING_STATUSES constants to common_validations.py
  
  - Added _nr_in_pending_filing(nr_number, exclude_filing_id) helper that queries the DB via JSONB path for any filing in PENDING, PAID, AWAITING_REVIEW, CHANGE_REQUESTED, or APPROVED status referencing the same NR    
                     
  - Called the check inside validate_name_request() — returns error "Name Request is already part of a pending filing."     
                                                                                                                   
  - Added 5 unit tests covering: NR in PENDING blocks, NR in PAID blocks, NR in DRAFT passes, NR not in any filing passes, own filing excluded from check       
