### PR TITLE
Stop firm admin dissolution 400'ing the ledger

### DIFF
--- a/legal-api/src/legal_api/core/meta/filing.py
+++ b/legal-api/src/legal_api/core/meta/filing.py
@@ -1051,22 +1051,22 @@ class FilingMeta:  # pylint: disable=too-few-public-methods
         if filing.filing_type == "dissolution":
             # Suppress Certificate of Dissolution for Admin Dissolution
             if filing.filing_sub_type == "administrative":
-                outputs.remove("certificateOfDissolution")
+                outputs.discard("certificateOfDissolution")
             # Suppress Certified Memorandum and Certified Rules for Coop Voluntary Dissolution
             if filing.filing_sub_type == "voluntary" and filing.json_legal_type == Business.LegalTypes.COOP:
-                outputs.remove("certifiedRules")
-                outputs.remove("certifiedMemorandum")
+                outputs.discard("certifiedRules")
+                outputs.discard("certifiedMemorandum")
         return outputs
 
     @staticmethod
     def alter_outputs_special_resolution(filing, outputs):
         """Handle output file list modification for special resolution."""
         if filing.filing_type == "specialResolution":
-            outputs.remove("certifiedMemorandum")
+            outputs.discard("certifiedMemorandum")
             if "changeOfName" in filing.meta_data.get("legalFilings", []):
                 outputs.add("certificateOfNameChange")
             if not filing.meta_data.get("alteration", {}).get("uploadNewRules"):
-                outputs.remove("certifiedRules")
+                outputs.discard("certifiedRules")
         return outputs
 
     @staticmethod

--- a/legal-api/tests/unit/core/test_filing_meta_outputs.py
+++ b/legal-api/tests/unit/core/test_filing_meta_outputs.py
@@ -1,0 +1,80 @@
+# Copyright © 2026 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Pure unit tests for FilingMeta output-list alterations.
+
+alter_outputs_dissolution operates only on the filing stand-in and the outputs
+set, so it is exercised with SimpleNamespace stubs (no DB / app context).
+"""
+from types import SimpleNamespace
+
+from business_model.models import Business
+
+from legal_api.core import FilingMeta
+
+
+def _filing(**kw):
+    defaults = {"filing_type": None, "filing_sub_type": None, "json_legal_type": None, "meta_data": None}
+    defaults.update(kw)
+    return SimpleNamespace(**defaults)
+
+
+def test_alter_outputs_dissolution_firm_administrative_no_cert_no_raise():
+    """Firms (SP/GP) carry no certificateOfDissolution output.
+
+    Admin-dissolution suppression must be a no-op rather than a KeyError.
+    Regression for bcgov/entity#33806 (admin dissolution 400'd the firm ledger).
+    """
+    filing = _filing(filing_type="dissolution", filing_sub_type="administrative",
+                     json_legal_type=Business.LegalTypes.SOLE_PROP)
+    outputs = set()
+    result = FilingMeta.alter_outputs_dissolution(filing, outputs)
+    assert result == set()
+
+
+def test_alter_outputs_dissolution_benefit_administrative_removes_cert():
+    """BC-family admin dissolution still suppresses the certificate."""
+    filing = _filing(filing_type="dissolution", filing_sub_type="administrative",
+                     json_legal_type=Business.LegalTypes.BCOMP)
+    outputs = {"certificateOfDissolution"}
+    result = FilingMeta.alter_outputs_dissolution(filing, outputs)
+    assert "certificateOfDissolution" not in result
+
+
+def test_alter_outputs_dissolution_coop_voluntary_missing_docs_no_raise():
+    """certifiedRules/certifiedMemorandum may be absent; discard must not raise."""
+    filing = _filing(filing_type="dissolution", filing_sub_type="voluntary",
+                     json_legal_type=Business.LegalTypes.COOP)
+    outputs = {"certificateOfDissolution"}
+    result = FilingMeta.alter_outputs_dissolution(filing, outputs)
+    assert result == {"certificateOfDissolution"}
+
+
+def test_alter_outputs_special_resolution_missing_docs_no_raise():
+    """certifiedMemorandum/certifiedRules may be absent; discard must not raise."""
+    filing = _filing(filing_type="specialResolution",
+                     meta_data={"legalFilings": [], "alteration": {}})
+    outputs = set()
+    result = FilingMeta.alter_outputs_special_resolution(filing, outputs)
+    assert result == set()
+
+
+def test_alter_outputs_special_resolution_removes_memorandum_keeps_new_rules():
+    """Memorandum always suppressed; rules kept when uploadNewRules is set."""
+    filing = _filing(filing_type="specialResolution",
+                     meta_data={"legalFilings": ["changeOfName"], "alteration": {"uploadNewRules": True}})
+    outputs = {"certifiedMemorandum", "certifiedRules"}
+    result = FilingMeta.alter_outputs_special_resolution(filing, outputs)
+    assert "certifiedMemorandum" not in result
+    assert "certifiedRules" in result
+    assert "certificateOfNameChange" in result

--- a/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
+++ b/legal-api/tests/unit/resources/v2/test_business_filings/test_filing_documents.py
@@ -2220,3 +2220,45 @@ def test_get_static_document_by_file_key_shape(session, client, jwt, mocker):
     assert rv.status_code == HTTPStatus.OK
     mock_drs.assert_called_once_with('DS0000101951', 'CORP', doc_binary=True)
     assert rv.data == b'drs-pdf'
+
+
+def test_admin_dissolution_firm_documents_no_certificate(app, session, client, jwt, monkeypatch, mock_drs_service):
+    """Firm (SP/GP) administrative dissolution must build its document list without error.
+
+    Regression for bcgov/entity#33806: alter_outputs_dissolution did
+    outputs.remove('certificateOfDissolution') for administrative dissolutions, but
+    firms carry no certificate output, so the set.remove raised KeyError and the
+    documents/ledger endpoint returned HTTP 400 (surfacing as "deleted" ledger history).
+    """
+    identifier = 'FM7654321'
+    business = factory_business(identifier, entity_type='SP')
+
+    filing_json = copy.deepcopy(FILING_HEADER)
+    filing_json['filing']['header']['name'] = 'dissolution'
+    filing_json['filing']['business']['legalType'] = 'SP'
+    filing_json['filing']['dissolution'] = ADMIN_DISSOLUTION
+
+    filing = factory_filing(business, filing_json, filing_date=datetime.now(UTC))
+    filing.skip_status_listener = True
+    filing._status = Filing.Status.COMPLETED
+    filing._payment_completion_date = '2017-10-01'
+    lf = [list(x.keys()) for x in filing.legal_filings()]
+    legal_filings = [item for sublist in lf for item in sublist]
+    filing._meta_data = {'legalFilings': legal_filings}
+    filing.save()
+
+    account_id = '1'
+    headers = create_header(jwt, [STAFF_ROLE], identifier, account_id=account_id)
+    with app.test_request_context():
+        monkeypatch.setattr('flask.request.headers.get', mock_auth(headers))
+        with requests_mock.Mocker() as m:
+            m.get(f"{app.config['AUTH_SVC_URL']}/orgs/{account_id}/products?include_hidden=true",
+                  json=[], status_code=HTTPStatus.OK)
+            rv = client.get(f'/api/v2/businesses/{identifier}/filings/{filing.id}/documents',
+                            headers=headers)
+
+    assert rv.status_code == HTTPStatus.OK
+    documents = rv.json['documents']
+    assert 'certificateOfDissolution' not in documents
+    assert {'dissolution': f'{base_url}/api/v2/businesses/{identifier}/filings/{filing.id}/documents/dissolution'} \
+        in documents['legalFilings']

--- a/queue_services/business-emailer/src/business_emailer/meta/filing.py
+++ b/queue_services/business-emailer/src/business_emailer/meta/filing.py
@@ -877,22 +877,22 @@ class FilingMeta:  # pylint: disable=too-few-public-methods
         if filing.filing_type == "dissolution":
             # Suppress Certificate of Dissolution for Admin Dissolution
             if filing.filing_sub_type == "administrative":
-                outputs.remove("certificateOfDissolution")
+                outputs.discard("certificateOfDissolution")
             # Suppress Certified Memorandum and Certified Rules for Coop Voluntary Dissolution
             if filing.filing_sub_type == "voluntary" and filing.json_legal_type == Business.LegalTypes.COOP:
-                outputs.remove("certifiedRules")
-                outputs.remove("certifiedMemorandum")
+                outputs.discard("certifiedRules")
+                outputs.discard("certifiedMemorandum")
         return outputs
 
     @staticmethod
     def alter_outputs_special_resolution(filing, outputs):
         """Handle output file list modification for special resolution."""
         if filing.filing_type == "specialResolution":
-            outputs.remove("certifiedMemorandum")
+            outputs.discard("certifiedMemorandum")
             if "changeOfName" in filing.meta_data.get("legalFilings", []):
                 outputs.add("certificateOfNameChange")
             if not filing.meta_data.get("alteration", {}).get("uploadNewRules"):
-                outputs.remove("certifiedRules")
+                outputs.discard("certifiedRules")
         return outputs
 
     @staticmethod

--- a/queue_services/business-emailer/tests/unit/meta/test_filing.py
+++ b/queue_services/business-emailer/tests/unit/meta/test_filing.py
@@ -137,6 +137,27 @@ def test_alter_outputs_dissolution_noop_for_non_dissolution():
     assert 'certificateOfDissolution' in result
 
 
+def test_alter_outputs_dissolution_firm_administrative_no_cert_no_raise():
+    # Firms (SP/GP) have no certificateOfDissolution in their outputs, so admin
+    # dissolution suppression must be a no-op, not a KeyError. Regression for
+    # bcgov/entity#33806 (admin dissolution 400'd the ledger for firms).
+    filing = _filing(filing_type='dissolution', filing_sub_type='administrative',
+                     json_legal_type=Business.LegalTypes.SOLE_PROP)
+    outputs = set()
+    result = FilingMeta.alter_outputs_dissolution(filing, outputs)
+    assert result == set()
+
+
+def test_alter_outputs_dissolution_coop_voluntary_missing_docs_no_raise():
+    # certifiedRules/certifiedMemorandum may be absent from outputs; suppression
+    # must discard silently rather than raising KeyError.
+    filing = _filing(filing_type='dissolution', filing_sub_type='voluntary',
+                     json_legal_type=Business.LegalTypes.COOP)
+    outputs = {'certificateOfDissolution'}
+    result = FilingMeta.alter_outputs_dissolution(filing, outputs)
+    assert result == {'certificateOfDissolution'}
+
+
 # --------------------------------------------------------------------------- #
 # alter_outputs_special_resolution                                            #
 # --------------------------------------------------------------------------- #
@@ -168,6 +189,17 @@ def test_alter_outputs_special_resolution_noop_for_other_types():
     outputs = {'certifiedMemorandum'}
     result = FilingMeta.alter_outputs_special_resolution(filing, outputs)
     assert 'certifiedMemorandum' in result
+
+
+def test_alter_outputs_special_resolution_missing_docs_no_raise():
+    # certifiedMemorandum/certifiedRules may be absent from outputs; suppression
+    # must discard silently rather than raising KeyError (same class of bug as
+    # bcgov/entity#33806).
+    filing = _filing(filing_type='specialResolution',
+                     meta_data={'legalFilings': [], 'alteration': {}})
+    outputs = set()
+    result = FilingMeta.alter_outputs_special_resolution(filing, outputs)
+    assert result == set()
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
*Issue:* bcgov/entity#33806

Description of changes: use `set.discard()` instead of `set.remove()` when suppressing dissolution / special-resolution document outputs, so admin-dissolved firms (SP/GP), which have no certificate, no longer raise KeyError and 400 the filings/documents ledger endpoint.