### PR TITLE
34553-firms-completing-party-client-skip

### DIFF
--- a/legal-api/pyproject.toml
+++ b/legal-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "legal-api"
-version = "3.1.15"
+version = "3.1.16"
 description = ""
 authors = [
     {name = "thor",email = "1042854+thorwolpert@users.noreply.github.com"}

--- a/legal-api/src/legal_api/services/filings/validations/registration.py
+++ b/legal-api/src/legal_api/services/filings/validations/registration.py
@@ -18,15 +18,17 @@ from typing import Final
 
 import pycountry
 from dateutil.relativedelta import relativedelta
+from flask import g, has_request_context
 from flask.globals import request_ctx
 from flask_babel import _ as babel
 
 from business_common.utils.legislation_datetime import LegislationDatetime
-from business_model.models import Business, PartyRole
+from business_model.models import Business, PartyRole, User
 from legal_api.core.filing import Filing
 from legal_api.errors import Error
 from legal_api.services import STAFF_ROLE, NaicsService, flags
 from legal_api.services.filings.validations.common_validations import (
+    is_same_str,
     validate_court_order,
     validate_name_request,
     validate_offices_addresses,
@@ -73,6 +75,7 @@ def validate(registration_json: dict) -> Error | None:
     msg.extend(validate_naics(registration_json))
     msg.extend(validate_business_type(registration_json, legal_type))
     msg.extend(validate_party(registration_json, legal_type))
+    msg.extend(validate_completing_party_name(registration_json))
     msg.extend(validate_parties_addresses(registration_json, filing_type))
     msg.extend(validate_start_date(registration_json))
     msg.extend(validate_offices(registration_json))
@@ -159,6 +162,52 @@ def validate_party(filing: dict, legal_type: str, filing_type="registration") ->
             msg.append({"error": "Proprietor is not valid for a General Partnership.", "path": party_path})
         if completing_parties < 1 or partner_parties < min_partners:
             msg.append({"error": "2 Partners and a Completing Party are required.", "path": party_path})
+
+    return msg
+
+
+def validate_completing_party_name(filing: dict, filing_type="registration") -> list:
+    """Validate the completing party name matches the submitting user's name.
+
+    Clients cannot edit the completing party (it is pre-populated from their login),
+    so the submitted name must match their user record; staff enter it manually from
+    a paper form and API gateway users have their own workflow, so both are skipped.
+    """
+    api_login_source = "API_GW"  # jwt loginSource of an API gateway user
+    msg = []
+    current_user = getattr(request_ctx, "current_user", None) if has_request_context() else None
+    if (not current_user
+            or jwt.validate_roles(current_user, [STAFF_ROLE])
+            or current_user.get("loginSource") == api_login_source):
+        return msg
+
+    officer = None
+    for party in filing["filing"][filing_type].get("parties", []):
+        roles = party.get("roles", [])
+        if any(role.get("roleType", "").lower().replace(" ", "_") == PartyRole.RoleTypes.COMPLETING_PARTY.value
+               for role in roles):
+            officer = party.get("officer", {})
+            break
+    if not officer or officer.get("partyType") != "person":
+        return msg
+
+    if not (user := User.find_by_jwt_token(g.jwt_oidc_token_info)):
+        return msg
+
+    user_name = " ".join(" ".join(
+        filter(None, [user.firstname, user.middlename, user.lastname])
+    ).split())
+    if not user_name:
+        return msg  # user record has no name to verify against
+
+    filing_name = " ".join(" ".join(
+        filter(None, [officer.get("firstName"), officer.get("middleName"), officer.get("lastName")])
+    ).split())
+    if not is_same_str(filing_name, user_name):
+        msg.append({
+            "error": "Completing party name must match the name of the logged in user.",
+            "path": f"/filing/{filing_type}/parties"
+        })
 
     return msg
 

--- a/legal-api/src/legal_api/services/filings/validations/registration.py
+++ b/legal-api/src/legal_api/services/filings/validations/registration.py
@@ -75,7 +75,6 @@ def validate(registration_json: dict) -> Error | None:
     msg.extend(validate_naics(registration_json))
     msg.extend(validate_business_type(registration_json, legal_type))
     msg.extend(validate_party(registration_json, legal_type))
-    msg.extend(validate_completing_party_name(registration_json))
     msg.extend(validate_parties_addresses(registration_json, filing_type))
     msg.extend(validate_start_date(registration_json))
     msg.extend(validate_offices(registration_json))
@@ -163,6 +162,8 @@ def validate_party(filing: dict, legal_type: str, filing_type="registration") ->
         if completing_parties < 1 or partner_parties < min_partners:
             msg.append({"error": "2 Partners and a Completing Party are required.", "path": party_path})
 
+    msg.extend(validate_completing_party_name(filing, filing_type))
+
     return msg
 
 
@@ -191,15 +192,12 @@ def validate_completing_party_name(filing: dict, filing_type="registration") -> 
     if not officer or officer.get("partyType") != "person":
         return msg
 
-    if not (user := User.find_by_jwt_token(g.jwt_oidc_token_info)):
+    if not (user := User.get_or_create_user_by_jwt(g.jwt_oidc_token_info)):
         return msg
 
     user_name = " ".join(" ".join(
         filter(None, [user.firstname, user.middlename, user.lastname])
     ).split())
-    if not user_name:
-        return msg  # user record has no name to verify against
-
     filing_name = " ".join(" ".join(
         filter(None, [officer.get("firstName"), officer.get("middleName"), officer.get("lastName")])
     ).split())

--- a/legal-api/tests/unit/services/filings/validations/test_change_of_registration.py
+++ b/legal-api/tests/unit/services/filings/validations/test_change_of_registration.py
@@ -22,11 +22,13 @@ from legal_api.services.permissions import PermissionService
 import pytest
 from registry_schemas.example_data import CHANGE_OF_REGISTRATION_TEMPLATE, REGISTRATION
 
-from business_model.models import Business
+from business_model.models import Business, User
 from legal_api.services import NaicsService, NameXService, flags
+from legal_api.services.authz import BASIC_USER, STAFF_ROLE
 from legal_api.services.filings.validations.change_of_registration import validate
 
 from tests.unit.services.filings.validations import create_party, create_party_address
+from tests.unit.services.utils import jwt_request_context
 
 
 now = datetime.now().strftime('%Y-%m-%d')
@@ -325,4 +327,38 @@ def test_change_of_registration_permission_checks(mock_is_officer_replace, mock_
     assert err
     assert err.code == HTTPStatus.FORBIDDEN
     assert 'DBA' in err.msg[0]['message']
-   
+
+
+@pytest.mark.parametrize(
+    'test_name, roles, user_name, expected_error', [
+        ('client_name_matches', [BASIC_USER], ('Joe', 'P', 'Swanson'), None),
+        ('client_name_mismatch', [BASIC_USER], ('Different', None, 'Person'),
+         'Completing party name must match the name of the logged in user.'),
+        ('staff_skipped', [STAFF_ROLE], ('Different', None, 'Person'), None),
+    ]
+)
+def test_change_of_registration_completing_party_name(app, session, jwt, test_name, roles, user_name, expected_error):
+    """Assert the completing party name is validated against the user record for client filings."""
+    filing = copy.deepcopy(GP_CHANGE_OF_REGISTRATION)
+    business = Business(identifier=filing['filing']['business']['identifier'],
+                        legal_type=filing['filing']['business']['legalType'])
+
+    firstname, middlename, lastname = user_name
+    login_source = 'IDIR' if STAFF_ROLE in roles else 'BCSC'
+    user = User(username='cp-test-user', firstname=firstname, middlename=middlename, lastname=lastname,
+                sub='sub', iss='iss', idp_userid='123', login_source=login_source)
+    user.save()
+
+    with patch.object(NameXService, 'query_nr_number', return_value=MockResponse(nr_response)):
+        with patch.object(NaicsService, 'find_by_code', return_value=naics_response):
+            with jwt_request_context(app, jwt, roles, login_source=login_source):
+                err = validate(business, filing)
+
+    if expected_error:
+        assert err is not None
+        assert any(msg['error'] == expected_error for msg in err.msg)
+    else:
+        assert err is None or all(
+            msg['error'] != 'Completing party name must match the name of the logged in user.'
+            for msg in err.msg
+        )

--- a/legal-api/tests/unit/services/filings/validations/test_registration.py
+++ b/legal-api/tests/unit/services/filings/validations/test_registration.py
@@ -445,19 +445,25 @@ def test_registration_completing_party_validation(app, session, jwt):
     assert permission_error is not None, "Permission error not found in validation messages."
                 
 
+MISMATCH_ERROR = 'Completing party name must match the name of the logged in user.'
+
+
 @pytest.mark.parametrize(
-    'test_name, roles, login_source, user_name, expected_error', [
-        ('client_name_matches', [BASIC_USER], 'BCSC', ('Joe', 'P', 'Swanson'), None),
+    'test_name, roles, login_source, user_name, token_name, expected_error', [
+        ('client_name_matches', [BASIC_USER], 'BCSC', ('Joe', 'P', 'Swanson'), None, None),
         ('client_long_name_matches', [BASIC_USER], 'BCSC',
-         ('Josephakis Vasilliadopolous Constantinople', None, 'Swanson'), None),
-        ('client_name_mismatch', [BASIC_USER], 'BCSC', ('Different', None, 'Person'),
-         'Completing party name must match the name of the logged in user.'),
-        ('client_no_user_record', [BASIC_USER], 'BCSC', None, None),
-        ('staff_skipped', [STAFF_ROLE], 'IDIR', ('Different', None, 'Person'), None),
-        ('api_gw_skipped', [BASIC_USER], 'API_GW', ('Different', None, 'Person'), None),
+         ('Josephakis Vasilliadopolous Constantinople', None, 'Swanson'), None, None),
+        ('client_name_mismatch', [BASIC_USER], 'BCSC', ('Different', None, 'Person'), None, MISMATCH_ERROR),
+        ('client_first_filing_user_created_from_token', [BASIC_USER], 'BCSC', None, ('Joe P', 'Swanson'), None),
+        ('client_first_filing_token_name_mismatch', [BASIC_USER], 'BCSC', None, ('Different', 'Person'),
+         MISMATCH_ERROR),
+        ('client_user_record_no_name', [BASIC_USER], 'BCSC', (None, None, None), None, MISMATCH_ERROR),
+        ('staff_skipped', [STAFF_ROLE], 'IDIR', ('Different', None, 'Person'), None, None),
+        ('api_gw_skipped', [BASIC_USER], 'API_GW', ('Different', None, 'Person'), None, None),
     ]
 )
-def test_validate_completing_party_name(app, session, jwt, test_name, roles, login_source, user_name, expected_error):
+def test_validate_completing_party_name(app, session, jwt, test_name, roles, login_source, user_name, token_name,
+                                        expected_error):
     """Assert the completing party name is validated against the user record for client filings."""
     filing = copy.deepcopy(GP_REGISTRATION)
     if test_name == 'client_long_name_matches':
@@ -471,20 +477,23 @@ def test_validate_completing_party_name(app, session, jwt, test_name, roles, log
                     sub='sub', iss='iss', idp_userid='123', login_source=login_source)
         user.save()
 
+    extra_claims = {'firstname': token_name[0], 'lastname': token_name[1]} if token_name else None
+
     naics_response = {
         'code': REGISTRATION['business']['naics']['naicsCode'],
         'classTitle': REGISTRATION['business']['naics']['naicsDescription']
     }
     with patch.object(NameXService, 'query_nr_number', return_value=_mock_nr_response('GP')):
         with patch.object(NaicsService, 'find_by_code', return_value=naics_response):
-            with jwt_request_context(app, jwt, roles, login_source=login_source):
+            with jwt_request_context(app, jwt, roles, login_source=login_source, extra_claims=extra_claims):
                 err = validate(None, filing)
+
+    if token_name:
+        # a first time filer has no user record yet; one is created from the JWT during validation
+        assert User.query.filter_by(idp_userid='123').one_or_none() is not None
 
     if expected_error:
         assert err is not None
         assert any(msg['error'] == expected_error for msg in err.msg)
     else:
-        assert err is None or all(
-            msg['error'] != 'Completing party name must match the name of the logged in user.'
-            for msg in err.msg
-        )
+        assert err is None or all(msg['error'] != MISMATCH_ERROR for msg in err.msg)

--- a/legal-api/tests/unit/services/filings/validations/test_registration.py
+++ b/legal-api/tests/unit/services/filings/validations/test_registration.py
@@ -21,7 +21,7 @@ import pytest
 from dateutil.relativedelta import relativedelta
 
 from business_common.utils.legislation_datetime import LegislationDatetime
-from business_model.models import Business
+from business_model.models import Business, User
 from legal_api.services import NaicsService, NameXService, flags 
 from legal_api.services.filings.validations.validation import validate
 from legal_api.services.authz import BASIC_USER, STAFF_ROLE
@@ -444,3 +444,47 @@ def test_registration_completing_party_validation(app, session, jwt):
             break
     assert permission_error is not None, "Permission error not found in validation messages."
                 
+
+@pytest.mark.parametrize(
+    'test_name, roles, login_source, user_name, expected_error', [
+        ('client_name_matches', [BASIC_USER], 'BCSC', ('Joe', 'P', 'Swanson'), None),
+        ('client_long_name_matches', [BASIC_USER], 'BCSC',
+         ('Josephakis Vasilliadopolous Constantinople', None, 'Swanson'), None),
+        ('client_name_mismatch', [BASIC_USER], 'BCSC', ('Different', None, 'Person'),
+         'Completing party name must match the name of the logged in user.'),
+        ('client_no_user_record', [BASIC_USER], 'BCSC', None, None),
+        ('staff_skipped', [STAFF_ROLE], 'IDIR', ('Different', None, 'Person'), None),
+        ('api_gw_skipped', [BASIC_USER], 'API_GW', ('Different', None, 'Person'), None),
+    ]
+)
+def test_validate_completing_party_name(app, session, jwt, test_name, roles, login_source, user_name, expected_error):
+    """Assert the completing party name is validated against the user record for client filings."""
+    filing = copy.deepcopy(GP_REGISTRATION)
+    if test_name == 'client_long_name_matches':
+        filing['filing']['registration']['parties'][0]['officer']['firstName'] = \
+            'Josephakis Vasilliadopolous Constantinople'
+        filing['filing']['registration']['parties'][0]['officer']['middleName'] = ''
+
+    if user_name:
+        firstname, middlename, lastname = user_name
+        user = User(username='cp-test-user', firstname=firstname, middlename=middlename, lastname=lastname,
+                    sub='sub', iss='iss', idp_userid='123', login_source=login_source)
+        user.save()
+
+    naics_response = {
+        'code': REGISTRATION['business']['naics']['naicsCode'],
+        'classTitle': REGISTRATION['business']['naics']['naicsDescription']
+    }
+    with patch.object(NameXService, 'query_nr_number', return_value=_mock_nr_response('GP')):
+        with patch.object(NaicsService, 'find_by_code', return_value=naics_response):
+            with jwt_request_context(app, jwt, roles, login_source=login_source):
+                err = validate(None, filing)
+
+    if expected_error:
+        assert err is not None
+        assert any(msg['error'] == expected_error for msg in err.msg)
+    else:
+        assert err is None or all(
+            msg['error'] != 'Completing party name must match the name of the logged in user.'
+            for msg in err.msg
+        )

--- a/legal-api/tests/unit/services/utils.py
+++ b/legal-api/tests/unit/services/utils.py
@@ -31,7 +31,8 @@ jwt_json_token_header = {
 }
 
 
-def helper_create_jwt_json_token_claims(roles: List[str] = [], username: str = 'test-user'):
+def helper_create_jwt_json_token_claims(roles: List[str] = [], username: str = 'test-user',
+                                        login_source: str = 'IDIR'):
     """Create a jwt token claims"""
     return {
         'iss': 'https://example.localdomain/auth/realms/example',
@@ -43,17 +44,18 @@ def helper_create_jwt_json_token_claims(roles: List[str] = [], username: str = '
         'typ': 'Bearer',
         'username': f'{username}',
         'idp_userid': '123',
-        'loginSource': 'IDIR',
+        'loginSource': login_source,
         'realm_access': {
             'roles': [] + roles
         }
     }
 
 
-def helper_create_jwt(jwt_manager: JwtManager, roles: List[str] = [], username: str = 'test-user'):
+def helper_create_jwt(jwt_manager: JwtManager, roles: List[str] = [], username: str = 'test-user',
+                      login_source: str = 'IDIR'):
     """Create a jwt bearer token with the correct keys, roles and username."""
     token_header = jwt_json_token_header
-    token_claims = helper_create_jwt_json_token_claims(roles=roles, username=username)
+    token_claims = helper_create_jwt_json_token_claims(roles=roles, username=username, login_source=login_source)
     return jwt_manager.create_jwt(token_claims, token_header)
 
 
@@ -74,13 +76,14 @@ def jwt_request_context(app,
                         roles: List[str] = [],
                         username: str = 'test-user',
                         account_id: str = '1',
+                        login_source: str = 'IDIR',
                         **kwargs):
     """Push a Flask request context with a valid JWT and populate
     request_ctx.current_user the way the @jwt.has_one_of_roles decorator
     would in production. Used by tests that call authz functions directly
     instead of routing through a JWT-decorated view.
     """
-    token = helper_create_jwt(jwt_manager, roles=roles, username=username)
+    token = helper_create_jwt(jwt_manager, roles=roles, username=username, login_source=login_source)
     headers = {'Authorization': f'Bearer {token}', 'Account-Id': account_id, **kwargs}
     with app.test_request_context(headers=headers):
         jwt_manager._require_auth_validation()

--- a/legal-api/tests/unit/services/utils.py
+++ b/legal-api/tests/unit/services/utils.py
@@ -32,7 +32,7 @@ jwt_json_token_header = {
 
 
 def helper_create_jwt_json_token_claims(roles: List[str] = [], username: str = 'test-user',
-                                        login_source: str = 'IDIR'):
+                                        login_source: str = 'IDIR', extra_claims: dict = None):
     """Create a jwt token claims"""
     return {
         'iss': 'https://example.localdomain/auth/realms/example',
@@ -43,19 +43,24 @@ def helper_create_jwt_json_token_claims(roles: List[str] = [], username: str = '
         'jti': 'flask-jwt-oidc-test-support',
         'typ': 'Bearer',
         'username': f'{username}',
+        # name matches the completing party officer in the registry_schemas example filings
+        'firstname': 'Joe P',
+        'lastname': 'Swanson',
         'idp_userid': '123',
         'loginSource': login_source,
         'realm_access': {
             'roles': [] + roles
-        }
+        },
+        **(extra_claims or {}),
     }
 
 
 def helper_create_jwt(jwt_manager: JwtManager, roles: List[str] = [], username: str = 'test-user',
-                      login_source: str = 'IDIR'):
+                      login_source: str = 'IDIR', extra_claims: dict = None):
     """Create a jwt bearer token with the correct keys, roles and username."""
     token_header = jwt_json_token_header
-    token_claims = helper_create_jwt_json_token_claims(roles=roles, username=username, login_source=login_source)
+    token_claims = helper_create_jwt_json_token_claims(roles=roles, username=username, login_source=login_source,
+                                                       extra_claims=extra_claims)
     return jwt_manager.create_jwt(token_claims, token_header)
 
 
@@ -77,13 +82,15 @@ def jwt_request_context(app,
                         username: str = 'test-user',
                         account_id: str = '1',
                         login_source: str = 'IDIR',
+                        extra_claims: dict = None,
                         **kwargs):
     """Push a Flask request context with a valid JWT and populate
     request_ctx.current_user the way the @jwt.has_one_of_roles decorator
     would in production. Used by tests that call authz functions directly
     instead of routing through a JWT-decorated view.
     """
-    token = helper_create_jwt(jwt_manager, roles=roles, username=username, login_source=login_source)
+    token = helper_create_jwt(jwt_manager, roles=roles, username=username, login_source=login_source,
+                              extra_claims=extra_claims)
     headers = {'Authorization': f'Bearer {token}', 'Account-Id': account_id, **kwargs}
     with app.test_request_context(headers=headers):
         jwt_manager._require_auth_validation()


### PR DESCRIPTION
*Issue #:* /bcgov/entity34553

*Description of changes:*
Adds validation on firm registrations filed by clients that the completing party name matches the submitting user's name from their login (Keycloak).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
