### PR TITLE
34236 Emailer - involuntary dissolution ux

### DIFF
--- a/queue_services/business-emailer/src/business_emailer/email_processors/__init__.py
+++ b/queue_services/business-emailer/src/business_emailer/email_processors/__init__.py
@@ -321,7 +321,12 @@ def get_pdfs(  # noqa: PLR0913
     pdfs = []
     attach_order = 1
     filings_with_unimplemented_outputs = ["amalgamationOut", "consentAmalgamationOut", "continuationOut"]
-    receipt_only_sub_filings = [("changeOfLiquidators", "liquidationReport")]
+    receipt_only_sub_filings = [
+        ("changeOfLiquidators", "liquidationReport"),
+        ("changeOfReceivers", "appointReceiver"),
+        ("changeOfReceivers", "ceaseReceiver"),
+        ("changeOfReceivers", "changeAddressReceiver"),
+    ]
 
     filing_key = (filing.filing_type, filing.filing_sub_type)
     if filing.filing_type not in filings_with_unimplemented_outputs and filing_key not in receipt_only_sub_filings:

--- a/queue_services/business-emailer/src/business_emailer/email_processors/involuntary_dissolution_stage_1_notification.py
+++ b/queue_services/business-emailer/src/business_emailer/email_processors/involuntary_dissolution_stage_1_notification.py
@@ -106,12 +106,17 @@ def process(email_info: dict, token: str) -> dict:
     number_description = "Registration" \
         if business.legal_type == Business.LegalTypes.EXTRA_PRO_A.value else "Incorporation"
 
+    business_number = None
+    if len(business.tax_id or "") > 9:  # noqa: PLR2004
+        # Only show if bn15 is saved, format for ux
+        business_number = business.tax_id.replace("BC", " BC")
+
     body = jnja_template.render(
         action=content["action"],
         attachment_name=content["attachment_name"],
         business_identifier=business_identifier,
         business_name=business_name,
-        business_number=business.tax_id,
+        business_number=business_number,
         delay_type=content["delay_type"],
         entity_dashboard_url=entity_dashboard_url,
         extra_provincials_display=format_extra_provincials(extra_provincials),

--- a/queue_services/business-emailer/src/business_emailer/email_processors/util.py
+++ b/queue_services/business-emailer/src/business_emailer/email_processors/util.py
@@ -165,15 +165,15 @@ FILING_ATTACHMENTS = {
             "extraPdfTypes": [],
         },
         "changeOfReceivers-appointReceiver": {
-            "attachments": ["Appoint Receiver/Receiver Manager", "Receipt"],
+            "attachments": ["Receipt"],
             "extraPdfTypes": [],
         },
         "changeOfReceivers-ceaseReceiver": {
-            "attachments": ["Cease Receiver or Receiver Manager", "Receipt"],
+            "attachments": ["Receipt"],
             "extraPdfTypes": [],
         },
         "changeOfReceivers-changeAddressReceiver": {
-            "attachments": ["Change of Address of Receiver/Receiver Manager", "Receipt"],
+            "attachments": ["Receipt"],
             "extraPdfTypes": [],
         },
         "consentContinuationOut": {

--- a/queue_services/business-emailer/src/business_emailer/email_templates/dissolution-involuntary-stage-1.md
+++ b/queue_services/business-emailer/src/business_emailer/email_templates/dissolution-involuntary-stage-1.md
@@ -32,8 +32,6 @@ The following document is attached to this email:
 
 - {{ attachment_name }}
 
-This document is also available through your [BC Business Registry account]({{ entity_dashboard_url }}).
-
 ---
 
 [[business-registry-footer.md]]

--- a/queue_services/business-emailer/tests/unit/email_processors/test_filing_notification.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_filing_notification.py
@@ -550,16 +550,13 @@ def test_maintenance_notification(app, session, mock_pdfs, mock_recipients, mock
         {'fileName': 'Receipt.pdf', 'content': 'pdf_content_receipt', 'order': '1'},
     ]),
     ('changeOfReceivers', 'appointReceiver', None, 'COMPLETED', False, False, [
-        {'fileName': 'Appoint Receiver/Receiver Manager.pdf', 'content': 'pdf_content_filing', 'order': '1'},
-        {'fileName': 'Receipt.pdf', 'content': 'pdf_content_receipt', 'order': '2'},
+        {'fileName': 'Receipt.pdf', 'content': 'pdf_content_receipt', 'order': '1'},
     ]),
     ('changeOfReceivers', 'ceaseReceiver', None, 'COMPLETED', False, False, [
-        {'fileName': 'Cease Receiver or Receiver Manager.pdf', 'content': 'pdf_content_filing', 'order': '1'},
-        {'fileName': 'Receipt.pdf', 'content': 'pdf_content_receipt', 'order': '2'},
+        {'fileName': 'Receipt.pdf', 'content': 'pdf_content_receipt', 'order': '1'},
     ]),
     ('changeOfReceivers', 'changeAddressReceiver', None, 'COMPLETED', False, False, [
-        {'fileName': 'Change of Address of Receiver/Receiver Manager.pdf', 'content': 'pdf_content_filing', 'order': '1'},
-        {'fileName': 'Receipt.pdf', 'content': 'pdf_content_receipt', 'order': '2'},
+        {'fileName': 'Receipt.pdf', 'content': 'pdf_content_receipt', 'order': '1'},
     ]),
 ], ids=[
     'alteration - PAID no name change',
@@ -589,9 +586,9 @@ def test_maintenance_notification(app, session, mock_pdfs, mock_recipients, mock
     'changeOfLiquidators - ceaseLiquidator',
     'changeOfLiquidators - changeAddressLiquidator',
     'changeOfLiquidators - liquidationReport (receipt only)',
-    'changeOfReceivers - appointReceiver',
-    'changeOfReceivers - ceaseReceiver',
-    'changeOfReceivers - changeAddressReceiver'
+    'changeOfReceivers - appointReceiver (receipt only)',
+    'changeOfReceivers - ceaseReceiver (receipt only)',
+    'changeOfReceivers - changeAddressReceiver (receipt only)'
 ])
 def test_maintenance_filing_attachments(session, config, mock_recipients, mock_user_email, mock_auth_recipient,
                                         filing_type, filing_sub_type, legal_type, status, has_name_change, has_rule_change, expected_attachments):

--- a/queue_services/business-emailer/tests/unit/email_processors/test_involuntary_dissolution_stage_1_notification.py
+++ b/queue_services/business-emailer/tests/unit/email_processors/test_involuntary_dissolution_stage_1_notification.py
@@ -142,6 +142,41 @@ def test_involuntary_dissolution_stage_1_notification_extra_provincials(app, ses
             assert 'British Columbia' not in body
 
 
+@pytest.mark.parametrize(
+        'test_name, tax_id, expected_display', [
+            ('BN15', '123456789BC0001', '123456789 BC0001'),
+            ('BN9_OMITTED', '123456789', None),
+            ('NO_BN_OMITTED', None, None),
+        ]
+)
+def test_involuntary_dissolution_stage_1_notification_business_number(app, session, test_name,
+                                                                      tax_id, expected_display):
+    """Assert that the business number is only displayed when a bn15 is saved, formatted for ux."""
+    token = 'token'
+    business = create_business('BC1234567', 'BC', 'Test Business')
+    business.tax_id = tax_id
+    business.save()
+    furnishing = create_furnishing(session, business=business,
+                                   furnishing_name=Furnishing.FurnishingName.DISSOLUTION_COMMENCEMENT_NO_AR)
+    message_payload = {
+        'furnishing': {
+            'type': 'INVOLUNTARY_DISSOLUTION',
+            'furnishingId': furnishing.id,
+            'furnishingName': furnishing.furnishing_name
+        }
+    }
+
+    with patch.object(involuntary_dissolution_stage_1_notification, '_get_pdfs', return_value=[]):
+        with patch.object(involuntary_dissolution_stage_1_notification, 'get_jurisdictions', return_value=None):
+            email = involuntary_dissolution_stage_1_notification.process(message_payload, token)
+
+            body = email['content']['body']
+            if expected_display:
+                assert f'**Business Number:** {expected_display}' in body
+            else:
+                assert '**Business Number:**' not in body
+
+
 def test_involuntary_dissolution_stage_1_notification_xpro_skips_mras(app, session):
     """Assert that XPRO furnishings do not look up MRAS jurisdictions."""
     token = 'token'


### PR DESCRIPTION
*Issue #:* /bcgov/entity#34236

*Description of changes:*
- BN number formatting same as filing processor
- remove some text in the template (filing doesn't exist so output won't be there)
- Updated changeOfReceivers sub filings as receipt only as output is not going to be built (no change visible to user, but there won't be any error log)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
