### PR TITLE
34541 - Italicize Business Corporations Act in Notice of Articles CCC statement

### DIFF
--- a/legal-api/pyproject.toml
+++ b/legal-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "legal-api"
-version = "3.1.18"
+version = "3.1.19"
 description = ""
 authors = [
     {name = "thor",email = "1042854+thorwolpert@users.noreply.github.com"}

--- a/legal-api/report-templates/template-parts/common/statement.html
+++ b/legal-api/report-templates/template-parts/common/statement.html
@@ -16,7 +16,7 @@
     <div class="section-title mt-4">BC Community Contribution Company Statement</div>
     <div class="section-data mt-4">
       This company is a community contribution company and, as such, has purposes beneficial to society.
-      This company is restricted, in accordance with Part 2.2 of the Business Corporations Act, in its ability to pay dividends and to
+      This company is restricted, in accordance with Part 2.2 of the <span class="italic">Business Corporations Act</span>, in its ability to pay dividends and to
       distribute its assets on dissolution or otherwise.
     </div>
   </div>


### PR DESCRIPTION
*Issue:*bcgov/entity#34541

Description of changes:
Apply the same italics fix from #4695 to the Notice of Articles CCC statement (common/statement.html), which renders the same text but was missed.