### PR TITLE
34085 34087 Legal API - Amalg colin business output and colin sync flow

### DIFF
--- a/colin-api/src/colin_api/models/business_snapshot.py
+++ b/colin-api/src/colin_api/models/business_snapshot.py
@@ -86,6 +86,10 @@ class BusinessSnapshot:  # pylint: disable=too-few-public-methods
             'foundingDate': cls._to_iso_datetime(business.founding_date),
             'taxId': business.business_number,
             'hasFutureEffectiveFiling': cls._has_future_effective_filing(cursor, business.corp_num),
+            'jurisdiction': business.jurisdiction,
+            'homeJurisdictionNumber': business.home_juris_num,
+            'homeCompanyName': business.home_company_nme,
+            'homeRecognitionDate': cls._to_iso_datetime(business.home_recogn_dt),
         }
 
     @staticmethod

--- a/colin-api/src/colin_api/models/filing.py
+++ b/colin-api/src/colin_api/models/filing.py
@@ -1805,10 +1805,7 @@ class Filing:  # pylint: disable=too-many-instance-attributes;
 
             identifier = amalgamating_business.get('identifier')
 
-            if ((foreign_jurisdiction := amalgamating_business.get('foreignJurisdiction', {})) and
-                not (identifier.startswith('A') and  # is expro
-                     foreign_jurisdiction.get('country') == 'CA' and
-                     foreign_jurisdiction.get('region') == 'BC')):
+            if foreign_jurisdiction := amalgamating_business.get('foreignJurisdiction'):
                 corp_involved.home_juri_num = identifier
                 corp_involved.foreign_nme = amalgamating_business.get('legalName')
 

--- a/colin-api/src/colin_api/version.py
+++ b/colin-api/src/colin_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.172.0'  # pylint: disable=invalid-name
+__version__ = '2.172.1'  # pylint: disable=invalid-name

--- a/colin-api/tests/unit/__init__.py
+++ b/colin-api/tests/unit/__init__.py
@@ -78,6 +78,8 @@ def build_business(**overrides):
     # convert_to_json_datetime emits a '-00:00' suffix
     business.founding_date = '2000-01-01T08:00:00-00:00'
     business.email = 'registered.office@test.com'
+    # find_by_identifier resolves 'BC' for non-XPRO corps; home_* stay None
+    business.jurisdiction = 'BC'
     for key, value in overrides.items():
         setattr(business, key, value)
     return business

--- a/colin-api/tests/unit/api/test_business_snapshot.py
+++ b/colin-api/tests/unit/api/test_business_snapshot.py
@@ -142,7 +142,8 @@ def test_get_snapshot_null_good_standing(client, mocker, authorized, mock_db,
     assert rv.json['business']['goodStanding'] is None
 
 
-def test_get_snapshot_extraprovincial(client, mocker, authorized, mock_db, mock_lookups):  # pylint: disable=unused-argument
+def test_get_snapshot_extraprovincial(client, mocker, authorized, mock_db,
+                                      mock_lookups):  # pylint: disable=unused-argument
     """Assert an extraprovincial (A) corp snapshots with its home jurisdiction data."""
     find = mocker.patch.object(Business, 'find_by_identifier', return_value=build_business(
         corp_num='A0077777',

--- a/colin-api/tests/unit/api/test_business_snapshot.py
+++ b/colin-api/tests/unit/api/test_business_snapshot.py
@@ -36,7 +36,11 @@ def test_get_snapshot(client, mocker, authorized, mock_db, mock_lookups):  # pyl
             'adminFreeze': False,
             'foundingDate': '2000-01-01T08:00:00+00:00',
             'taxId': '791861078BC0001',
-            'hasFutureEffectiveFiling': False
+            'hasFutureEffectiveFiling': False,
+            'jurisdiction': 'BC',
+            'homeJurisdictionNumber': None,
+            'homeCompanyName': None,
+            'homeRecognitionDate': None
         },
         'parties': [{
             'officer': {
@@ -136,6 +140,30 @@ def test_get_snapshot_null_good_standing(client, mocker, authorized, mock_db,
 
     assert rv.status_code == 200
     assert rv.json['business']['goodStanding'] is None
+
+
+def test_get_snapshot_extraprovincial(client, mocker, authorized, mock_db, mock_lookups):  # pylint: disable=unused-argument
+    """Assert an extraprovincial (A) corp snapshots with its home jurisdiction data."""
+    find = mocker.patch.object(Business, 'find_by_identifier', return_value=build_business(
+        corp_num='A0077777',
+        corp_type='A',
+        jurisdiction='ON',
+        home_juris_num='1234567',
+        home_company_nme='HOME COMPANY INC.',
+        home_recogn_dt='1999-01-01T08:00:00-00:00'
+    ))
+
+    rv = client.get('/api/v1/businesses/A0077777/snapshot')
+
+    assert rv.status_code == 200
+    # no BC-strip on an A identifier
+    assert find.call_args.args[0] == 'A0077777'
+    assert rv.json['business']['identifier'] == 'A0077777'
+    assert rv.json['business']['legalType'] == 'A'
+    assert rv.json['business']['jurisdiction'] == 'ON'
+    assert rv.json['business']['homeJurisdictionNumber'] == '1234567'
+    assert rv.json['business']['homeCompanyName'] == 'HOME COMPANY INC.'
+    assert rv.json['business']['homeRecognitionDate'] == '1999-01-01T08:00:00+00:00'
 
 
 def test_get_snapshot_single_connection_and_scope(client, mocker, authorized, mock_db,

--- a/colin-api/tests/unit/models/__init__.py
+++ b/colin-api/tests/unit/models/__init__.py
@@ -1,1 +1,14 @@
-"""Unit tests for colin-api models."""
+# Copyright © 2026 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for colin-api model logic that runs against a mocked cursor."""

--- a/colin-api/tests/unit/models/test_filing_amalgamating_businesses.py
+++ b/colin-api/tests/unit/models/test_filing_amalgamating_businesses.py
@@ -1,0 +1,113 @@
+# Copyright © 2026 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for Filing._process_amalgamating_businesses entry classification."""
+from unittest.mock import MagicMock
+
+from colin_api.models import Business
+from colin_api.models.corp_involved import CorpInvolved
+from colin_api.models.filing import Filing
+
+
+def _process(mocker, amalgamating_businesses):
+    """Run _process_amalgamating_businesses over the entries; return (corp_involved rows, state updates)."""
+    created = []
+    mocker.patch.object(CorpInvolved, 'create_corp_involved', side_effect=lambda _cursor, obj: created.append(obj))
+    update_corp_state = mocker.patch.object(Business, 'update_corp_state')
+
+    filing = Filing()
+    filing.event_id = 1234567
+    filing.body = {'amalgamatingBusinesses': amalgamating_businesses}
+    Filing._process_amalgamating_businesses(MagicMock(), filing)  # pylint: disable=protected-access
+
+    return created, update_corp_state
+
+
+def test_identifier_entry_bc_corp(mocker):
+    """Assert a BC identifier entry is HAM'd under its bare corp num."""
+    created, update_corp_state = _process(mocker, [
+        {'role': 'amalgamating', 'identifier': 'BC0870226'}
+    ])
+
+    assert len(created) == 1
+    assert created[0].corp_num == '0870226'
+    assert created[0].home_juri_num is None
+    assert created[0].adopted_corp_ind is None
+    update_corp_state.assert_called_once()
+    assert update_corp_state.call_args.args[2] == '0870226'
+    assert update_corp_state.call_args.args[3] == Business.CorpStateTypes.AMALGAMATED.value
+
+
+def test_identifier_entry_expro(mocker):
+    """Assert an identifier-only extraprovincial (A) entry is HAM'd under its full identifier."""
+    created, update_corp_state = _process(mocker, [
+        {'role': 'amalgamating', 'identifier': 'A0077777'}
+    ])
+
+    assert len(created) == 1
+    assert created[0].corp_num == 'A0077777'
+    assert created[0].home_juri_num is None
+    assert created[0].foreign_nme is None
+    update_corp_state.assert_called_once()
+    assert update_corp_state.call_args.args[2] == 'A0077777'
+    assert update_corp_state.call_args.args[3] == Business.CorpStateTypes.AMALGAMATED.value
+
+
+def test_holding_entry_marks_adopted(mocker):
+    """Assert a holding/primary identifier entry sets the adopted corp indicator."""
+    created, _ = _process(mocker, [
+        {'role': 'holding', 'identifier': 'BC0870226'}
+    ])
+
+    assert created[0].adopted_corp_ind == 'Y'
+
+
+def test_foreign_entry(mocker):
+    """Assert a true foreign entry records home jurisdiction data and no corp state change."""
+    created, update_corp_state = _process(mocker, [
+        {
+            'role': 'amalgamating',
+            'identifier': 'AB-1234567',
+            'legalName': 'FOREIGN CO.',
+            'foreignJurisdiction': {'country': 'CA', 'region': 'AB'}
+        }
+    ])
+
+    assert len(created) == 1
+    assert created[0].corp_num is None
+    assert created[0].home_juri_num == 'AB-1234567'
+    assert created[0].foreign_nme == 'FOREIGN CO.'
+    assert created[0].can_jur_typ_cd == 'AB'
+    update_corp_state.assert_not_called()
+
+
+def test_foreign_federal_and_international_entries(mocker):
+    """Assert federal and non-Canadian foreign entries map their jurisdiction codes."""
+    created, _ = _process(mocker, [
+        {
+            'role': 'amalgamating',
+            'identifier': '7654321',
+            'legalName': 'FEDERAL CO.',
+            'foreignJurisdiction': {'country': 'CA', 'region': 'FEDERAL'}
+        },
+        {
+            'role': 'amalgamating',
+            'identifier': 'US-1',
+            'legalName': 'US CO.',
+            'foreignJurisdiction': {'country': 'US', 'region': 'DE'}
+        }
+    ])
+
+    assert created[0].can_jur_typ_cd == 'FD'
+    assert created[1].can_jur_typ_cd == 'OT'
+    assert created[1].othr_juri_desc == 'US, DE'

--- a/legal-api/poetry.lock
+++ b/legal-api/poetry.lock
@@ -316,7 +316,7 @@ files = [
 
 [[package]]
 name = "business-model"
-version = "3.4.11"
+version = "3.4.12"
 description = ""
 optional = false
 python-versions = ">=3.13,<3.14"
@@ -343,7 +343,7 @@ sql-versioning = {git = "https://github.com/bcgov/lear.git", rev = "main", subdi
 type = "git"
 url = "https://github.com/bcgov/lear.git"
 reference = "main"
-resolved_reference = "71fbd531a0a89db74d9182922eed949bb8104b0b"
+resolved_reference = "04bdcdb5a104437c590c45ee2aba453b8a901bd5"
 subdirectory = "python/common/business-registry-model"
 
 [[package]]

--- a/legal-api/src/legal_api/reports/business_document.py
+++ b/legal-api/src/legal_api/reports/business_document.py
@@ -593,10 +593,15 @@ class BusinessDocument:
                                                                             amalgamation.id)
                 for amalgamating_business in amalgamating_businesses:
                     ting_business = None
+                    identifier = amalgamating_business.foreign_identifier
                     if not (foreign_name := amalgamating_business.foreign_name):
-                        ting_business = VersionedBusinessDetailsService.get_business_revision_obj(amalgamation_application,
-                                                                                                  amalgamating_business.business_id)
-                    amalgamated_businesses_info = get_formatted_amalg_business_data(amalgamating_business.foreign_identifier,
+                        if amalgamating_business.colin_identifier:
+                            # a COLIN business not loaded in LEAR - name is resolved from COLIN
+                            identifier = amalgamating_business.colin_identifier
+                        else:
+                            ting_business = VersionedBusinessDetailsService.get_business_revision_obj(amalgamation_application,
+                                                                                                      amalgamating_business.business_id)
+                    amalgamated_businesses_info = get_formatted_amalg_business_data(identifier,
                                                                                     foreign_name,
                                                                                     amalgamating_business.foreign_jurisdiction,
                                                                                     amalgamating_business.foreign_jurisdiction_region,

--- a/legal-api/src/legal_api/reports/business_document.py
+++ b/legal-api/src/legal_api/reports/business_document.py
@@ -576,39 +576,51 @@ class BusinessDocument:
         if filings:
             amalgamation_application = filings[0]
             business["business"]["amalgamatedEntity"] = True
-            if (self._epoch_filing_date and amalgamation_application.effective_date < self._epoch_filing_date) or\
-                    (self._tombstone_filing_date and
-                     amalgamation_application.effective_date < self._tombstone_filing_date):
+            if self._is_imported_amalgamation(amalgamation_application):
                 # imported from COLIN
-                amalgamated_businesses_info = {
+                amalgamated_businesses.append({
                     "legalName": "N/A",
                     "identifier": "N/A",
                     "jurisdiction": "N/A"
-                }
-                amalgamated_businesses.append(amalgamated_businesses_info)
+                })
             else:
                 amalgamation = Amalgamation.get_revision(amalgamation_application.transaction_id,
                                                          amalgamation_application.business_id)
                 amalgamating_businesses = AmalgamatingBusiness.get_revision(amalgamation_application.transaction_id,
                                                                             amalgamation.id)
-                for amalgamating_business in amalgamating_businesses:
-                    ting_business = None
-                    identifier = amalgamating_business.foreign_identifier
-                    if not (foreign_name := amalgamating_business.foreign_name):
-                        if amalgamating_business.colin_identifier:
-                            # a COLIN business not loaded in LEAR - name is resolved from COLIN
-                            identifier = amalgamating_business.colin_identifier
-                        else:
-                            ting_business = VersionedBusinessDetailsService.get_business_revision_obj(amalgamation_application,
-                                                                                                      amalgamating_business.business_id)
-                    amalgamated_businesses_info = get_formatted_amalg_business_data(identifier,
-                                                                                    foreign_name,
-                                                                                    amalgamating_business.foreign_jurisdiction,
-                                                                                    amalgamating_business.foreign_jurisdiction_region,
-                                                                                    ting_business)
-                    amalgamated_businesses.append(amalgamated_businesses_info)
+                amalgamated_businesses = [
+                    self._amalgamating_business_data(amalgamation_application, amalgamating_business)
+                    for amalgamating_business in amalgamating_businesses
+                ]
 
         business["amalgamatedEntities"] = amalgamated_businesses
+
+    def _is_imported_amalgamation(self, amalgamation_application: Filing) -> bool:
+        """Return whether the amalgamation predates this business's COLIN import/tombstone migration."""
+        effective_date = amalgamation_application.effective_date
+        return bool(
+            (self._epoch_filing_date and effective_date < self._epoch_filing_date) or
+            (self._tombstone_filing_date and effective_date < self._tombstone_filing_date)
+        )
+
+    @staticmethod
+    def _amalgamating_business_data(amalgamation_application: Filing,
+                                    amalgamating_business: AmalgamatingBusiness) -> dict:
+        """Return one amalgamating business's formatted report data."""
+        ting_business = None
+        identifier = amalgamating_business.foreign_identifier
+        if not (foreign_name := amalgamating_business.foreign_name):
+            if amalgamating_business.colin_identifier:
+                # a COLIN business not loaded in LEAR - name is resolved from COLIN
+                identifier = amalgamating_business.colin_identifier
+            else:
+                ting_business = VersionedBusinessDetailsService.get_business_revision_obj(
+                    amalgamation_application, amalgamating_business.business_id)
+        return get_formatted_amalg_business_data(identifier,
+                                                 foreign_name,
+                                                 amalgamating_business.foreign_jurisdiction,
+                                                 amalgamating_business.foreign_jurisdiction_region,
+                                                 ting_business)
 
     def _set_amalgamating_details(self, business: dict):
         if ("amalgamatedInto" in business["business"]) and business.get("amalgamatedEntities"):

--- a/legal-api/src/legal_api/reports/report.py
+++ b/legal-api/src/legal_api/reports/report.py
@@ -27,8 +27,6 @@ from flask import current_app, jsonify
 from business_common.utils.datetime import datetime
 from business_common.utils.legislation_datetime import LegislationDatetime
 from business_model.models import (
-    AmalgamatingBusiness,
-    Amalgamation,
     Business,
     ConsentContinuationOut,
     CorpType,
@@ -955,13 +953,13 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
         filing["incorporationAgreement"] = amalgamation.get("incorporationAgreement", {})
 
         self._set_amalgamating_businesses(filing)
-        if amalgamation["type"] in [Amalgamation.AmalgamationTypes.horizontal.name,
-                                    Amalgamation.AmalgamationTypes.vertical.name]:
-            self._set_from_primary_or_holding_business_data(filing)
-        else:
-            filing["offices"] = amalgamation.get("offices", {})
-            filing["parties"] = amalgamation["parties"]
-            filing["shareClasses"] = amalgamation.get("shareStructure", {}).get("shareClasses", [])
+        filing["offices"] = amalgamation.get("offices", {})
+        filing["parties"] = amalgamation["parties"]
+        filing["shareClasses"] = amalgamation.get("shareStructure", {}).get("shareClasses", [])
+        filing["resolutions"] = [
+            {"date": datetime.fromisoformat(date).strftime(OUTPUT_DATE_FORMAT)}
+            for date in amalgamation.get("shareStructure", {}).get("resolutionDates", [])
+        ]
 
         # Formatting addresses for registered and records office
         self._format_address(filing["offices"]["registeredOffice"]["deliveryAddress"])
@@ -1005,12 +1003,16 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
         for amalgamating_business in amalgamating_businesses:
             identifier = amalgamating_business.get("identifier")
             ting_business = None
-            if not (foreign_name := amalgamating_business.get("legalName")):
+            foreign_name = None
+            if foreign_jurisdiction := amalgamating_business.get("foreignJurisdiction"):
+                foreign_name = amalgamating_business.get("legalName")
+            else:
+                # a LEAR business, or a COLIN business not loaded in LEAR (no LEAR row)
                 ting_business = self._get_versioned_amalgamating_business(identifier)
             amalgamated_businesses_info = get_formatted_amalg_business_data(identifier,
                                                                             foreign_name,
-                                                                            amalgamating_business.get("foreignJurisdiction", {}).get("country"),
-                                                                            amalgamating_business.get("foreignJurisdiction", {}).get("region"),
+                                                                            (foreign_jurisdiction or {}).get("country"),
+                                                                            (foreign_jurisdiction or {}).get("region"),
                                                                             ting_business)
             ting_businesses.append(amalgamated_businesses_info)
 
@@ -1019,85 +1021,13 @@ class Report:  # pylint: disable=too-few-public-methods, too-many-lines
     def _get_versioned_amalgamating_business(self, identifier):
         # until TED business is created, get it from business table
         ting_business = Business.find_by_identifier(identifier)
-        if self._filing.transaction_id:
+        if ting_business and self._filing.transaction_id:
             # get TING business from version
             # when TED is dissolved by staff (with court order) and TING is restored, user can modify TING data
             # which should not be reflected here
             ting_business = VersionedBusinessDetailsService.get_business_revision_obj(
                 self._filing, ting_business.id)
         return ting_business
-
-    def _set_from_primary_or_holding_business_data(self, filing):  # noqa: PLR0912
-        ting_business = next(x for x in filing["amalgamationApplication"]["amalgamatingBusinesses"]
-                             if x["role"] in [AmalgamatingBusiness.Role.holding.name,
-                                              AmalgamatingBusiness.Role.primary.name])
-        primary_or_holding_business = self._get_versioned_amalgamating_business(ting_business["identifier"])
-        filing["nameRequest"]["legalName"] = primary_or_holding_business.legal_name
-
-        parties = []
-        # copy director
-        if self._filing.transaction_id:
-            parties_version = VersionedBusinessDetailsService.get_party_role_revision(
-                self._filing,
-                primary_or_holding_business.id,
-                role=PartyRole.RoleTypes.DIRECTOR.value)
-            for director_json in parties_version:
-                director_json["roles"] = [{"roleType": "Director"}]
-                parties.append(director_json)
-        else:
-            active_directors = PartyRole.get_active_directors(primary_or_holding_business.id,
-                                                              self._filing.effective_date.date())
-            for director in active_directors:
-                director_json = director.json
-                director_json["roles"] = [{"roleType": "Director"}]
-                parties.append(director_json)
-
-        # copy completing party from filing json
-        for party_info in filing["amalgamationApplication"].get("parties"):
-            if comp_party_role := next((x for x in party_info.get("roles")
-                                        if x["roleType"].lower() == "completing party"), None):
-                party_info["roles"] = [comp_party_role]  # override roles to have only completing party
-                parties.append(party_info)
-                break
-        filing["parties"] = parties
-
-        # copy offices
-        offices = {}
-        if self._filing.transaction_id:
-            offices = VersionedBusinessDetailsService.get_office_revision(
-                self._filing.id,
-                self._filing.transaction_id,
-                primary_or_holding_business.id)
-        else:
-            officelist = primary_or_holding_business.offices.all()
-            for i in officelist:
-                if i.office_type in [OfficeType.REGISTERED, OfficeType.RECORDS]:
-                    offices[i.office_type] = {}
-                    for address in i.addresses:
-                        offices[i.office_type][f"{address.address_type}Address"] = address.json
-        filing["offices"] = offices
-
-        # copy shares
-        share_classes = []
-        if self._filing.transaction_id:
-            share_classes = VersionedBusinessDetailsService.get_share_class_revision(
-                self._filing.transaction_id,
-                primary_or_holding_business.id)
-        else:
-            for share_class in primary_or_holding_business.share_classes.all():
-                share_classes.append(share_class.json)
-        filing["shareClasses"] = share_classes
-
-        # copy resolution dates
-        resolutions = []
-        if self._filing.transaction_id:
-            resolutions = VersionedBusinessDetailsService.get_resolution_dates_revision(
-                self._filing.transaction_id,
-                primary_or_holding_business.id)
-        else:
-            for resolution in primary_or_holding_business.resolutions.all():
-                resolutions.append({"date": resolution.resolution_date.strftime(OUTPUT_DATE_FORMAT)})
-        filing["resolutions"] = resolutions
 
     def _format_change_of_registration_data(self, filing, filing_type):  # noqa: PLR0912, PLR0915
         prev_completed_filing = Filing.get_previous_completed_filing(self._filing)

--- a/legal-api/src/legal_api/reports/utils.py
+++ b/legal-api/src/legal_api/reports/utils.py
@@ -65,56 +65,58 @@ def get_formatted_amalg_business_data(
     ting_business: Business | None = None
 ):
     """Return the amalgamation business data for the report output."""
-    is_bc_company = False
-    is_extraprovincial = False
-
     if foreign_name:
         # Set identifier to 'N/A' for foreign businesses (we are showing the 'Number in BC' in the output)
-        display_identifier = "N/A"
-        business_legal_name = foreign_name or "N/A"
-        country_code = foreign_country_code
-        region_code = foreign_region_code
+        return _format_amalg_business_data(identifier, foreign_name, "N/A",
+                                           foreign_country_code, foreign_region_code)
+    if ting_business:
+        return _format_amalg_business_data(identifier, ting_business.legal_name, ting_business._identifier,
+                                           "CA", "BC", is_bc_company=True)
+    if identifier:
+        return _colin_amalg_business_data(identifier)
 
-    elif ting_business:
-        display_identifier = ting_business._identifier
-        business_legal_name = ting_business.legal_name
-        country_code = "CA"
-        region_code = "BC"
-        is_bc_company = True
+    raise BusinessException(
+        "Error: Tried to process an amalgamating business which is not a foreign business or a ting business",
+        HTTPStatus.UNPROCESSABLE_ENTITY)
 
-    elif identifier:
-        # a COLIN business not loaded in LEAR - resolve its name and type from COLIN at render time
-        colin_json, colin_status = ColinService.query_business(identifier)
-        colin_business = (colin_json or {}).get("business") if colin_status == HTTPStatus.OK else None
-        is_extraprovincial = bool(colin_business and
-                                  colin_business.get("legalType") == Business.LegalTypes.EXTRA_PRO_A.value)
-        if (
-            not colin_business or
-            not (business_legal_name := colin_business.get("legalName")) or
-            not colin_business.get("legalType") or
-            (is_extraprovincial and not colin_business.get("jurisdiction"))
-        ):
-            # Needed COLIN data cannot be resolved, so the amalgamation report should not be generated
-            current_app.logger.error("Unable to get COLIN data for amalgamating business %s (status %s)",
-                                     identifier, colin_status)
-            raise BusinessException(
-                f"Unable to get COLIN data for amalgamating business {identifier}",
-                HTTPStatus.SERVICE_UNAVAILABLE)
 
-        display_identifier = identifier
-        country_code = "CA"
-        region_code = colin_business["jurisdiction"] if is_extraprovincial else "BC"
-        is_bc_company = not is_extraprovincial
-
-    else:
+def _colin_amalg_business_data(identifier: str) -> dict:
+    """Return the data of a COLIN business not loaded in LEAR, resolved from COLIN at render time."""
+    colin_json, colin_status = ColinService.query_business(identifier)
+    colin_business = (colin_json or {}).get("business") if colin_status == HTTPStatus.OK else None
+    is_extraprovincial = bool(colin_business and
+                              colin_business.get("legalType") == Business.LegalTypes.EXTRA_PRO_A.value)
+    if (
+        not colin_business or
+        not (business_legal_name := colin_business.get("legalName")) or
+        not colin_business.get("legalType") or
+        (is_extraprovincial and not colin_business.get("jurisdiction"))
+    ):
+        # Needed COLIN data cannot be resolved, so the amalgamation report should not be generated
+        current_app.logger.error("Unable to get COLIN data for amalgamating business %s (status %s)",
+                                 identifier, colin_status)
         raise BusinessException(
-            "Error: Tried to process an amalgamating business which is not a foreign business or a ting business",
-            HTTPStatus.UNPROCESSABLE_ENTITY)
+            f"Unable to get COLIN data for amalgamating business {identifier}",
+            HTTPStatus.SERVICE_UNAVAILABLE)
 
+    region_code = colin_business["jurisdiction"] if is_extraprovincial else "BC"
+    return _format_amalg_business_data(identifier, business_legal_name, identifier, "CA", region_code,
+                                       is_bc_company=not is_extraprovincial,
+                                       is_extraprovincial=is_extraprovincial)
+
+
+def _format_amalg_business_data(  # noqa: PLR0913
+        identifier: str | None,
+        legal_name: str | None,
+        display_identifier: str | None,
+        country_code: str | None,
+        region_code: str | None,
+        is_bc_company: bool = False,
+        is_extraprovincial: bool = False) -> dict:
     jurisdiction = get_amalg_formatted_jurisdiction(identifier, country_code, region_code)
-    
+
     return {
-        "legalName": business_legal_name or "N/A",
+        "legalName": legal_name or "N/A",
         "identifier": display_identifier or "N/A",
         "jurisdiction": jurisdiction or "N/A",
         "isBcCompany": is_bc_company,

--- a/legal-api/src/legal_api/reports/utils.py
+++ b/legal-api/src/legal_api/reports/utils.py
@@ -74,17 +74,7 @@ def get_formatted_amalg_business_data(
         business_legal_name = foreign_name or "N/A"
         country_code = foreign_country_code
         region_code = foreign_region_code
-        # FUTURE: rework this once expros are in lear
-        # Check if this is an expro
-        if identifier and identifier.startswith("A"):
-            colin_json, colin_status = ColinService.query_business(identifier)
-            if colin_json is not None and colin_status == HTTPStatus.OK:
-                # this is an expro so set the identifier (it is the BC expro identifier)
-                display_identifier = identifier
-                is_extraprovincial = True
-                # overwrite the region_code if jurisdiction is available in the response
-                region_code = colin_json.get("business", {}).get("jurisdiction")
-            
+
     elif ting_business:
         display_identifier = ting_business._identifier
         business_legal_name = ting_business.legal_name
@@ -93,16 +83,28 @@ def get_formatted_amalg_business_data(
         is_bc_company = True
 
     elif identifier:
-        # a COLIN business not loaded in LEAR - resolve its name from COLIN at render time
+        # a COLIN business not loaded in LEAR - resolve its name and type from COLIN at render time
         colin_json, colin_status = ColinService.query_business(identifier)
-        business_legal_name = None
-        if colin_status == HTTPStatus.OK:
-            business_legal_name = (colin_json or {}).get("business", {}).get("legalName")
-        if not business_legal_name:
-            current_app.logger.error("Unable to get COLIN legal name for amalgamating business %s", identifier)
+        colin_business = (colin_json or {}).get("business") if colin_status == HTTPStatus.OK else None
+        is_extraprovincial = bool(colin_business and
+                                  colin_business.get("legalType") == Business.LegalTypes.EXTRA_PRO_A.value)
+        if (
+            not colin_business or
+            not (business_legal_name := colin_business.get("legalName")) or
+            not colin_business.get("legalType") or
+            (is_extraprovincial and not colin_business.get("jurisdiction"))
+        ):
+            # Needed COLIN data cannot be resolved, so the amalgamation report should not be generated
+            current_app.logger.error("Unable to get COLIN data for amalgamating business %s (status %s)",
+                                     identifier, colin_status)
+            raise BusinessException(
+                f"Unable to get COLIN data for amalgamating business {identifier}",
+                HTTPStatus.SERVICE_UNAVAILABLE)
+
         display_identifier = identifier
         country_code = "CA"
-        region_code = "BC"
+        region_code = colin_business["jurisdiction"] if is_extraprovincial else "BC"
+        is_bc_company = not is_extraprovincial
 
     else:
         raise BusinessException(

--- a/legal-api/src/legal_api/reports/utils.py
+++ b/legal-api/src/legal_api/reports/utils.py
@@ -85,17 +85,29 @@ def get_formatted_amalg_business_data(
                 # overwrite the region_code if jurisdiction is available in the response
                 region_code = colin_json.get("business", {}).get("jurisdiction")
             
-    else:
-        if not ting_business:
-            raise BusinessException(
-                "Error: Tried to process an amalgamating business which is not a foreign business or a ting business",
-                HTTPStatus.UNPROCESSABLE_ENTITY)
-
+    elif ting_business:
         display_identifier = ting_business._identifier
         business_legal_name = ting_business.legal_name
         country_code = "CA"
         region_code = "BC"
         is_bc_company = True
+
+    elif identifier:
+        # a COLIN business not loaded in LEAR - resolve its name from COLIN at render time
+        colin_json, colin_status = ColinService.query_business(identifier)
+        business_legal_name = None
+        if colin_status == HTTPStatus.OK:
+            business_legal_name = (colin_json or {}).get("business", {}).get("legalName")
+        if not business_legal_name:
+            current_app.logger.error("Unable to get COLIN legal name for amalgamating business %s", identifier)
+        display_identifier = identifier
+        country_code = "CA"
+        region_code = "BC"
+
+    else:
+        raise BusinessException(
+            "Error: Tried to process an amalgamating business which is not a foreign business or a ting business",
+            HTTPStatus.UNPROCESSABLE_ENTITY)
 
     jurisdiction = get_amalg_formatted_jurisdiction(identifier, country_code, region_code)
     

--- a/legal-api/src/legal_api/resources/v2/business/business_extended.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_extended.py
@@ -187,11 +187,18 @@ def _get_amalgamation_application_data(business: Business, for_correction: bool 
                 "identifier": ting.colin_identifier
             })
             if for_correction:
-                colin_json, colin_status = colin.query_business(ting.colin_identifier)
-                if colin_status == HTTPStatus.OK:
+                snapshot_json, snapshot_status = colin.get_snapshot(ting.colin_identifier)
+                if snapshot_status == HTTPStatus.OK:
+                    snapshot_business = (snapshot_json or {}).get("business") or {}
                     ting_info.update({
-                        "legalName": (colin_json or {}).get("business", {}).get("legalName")
+                        "legalName": snapshot_business.get("legalName"),
+                        "legalType": snapshot_business.get("legalType"),
+                        "jurisdiction": snapshot_business.get("jurisdiction")
                     })
+                    mailing_address = (((snapshot_json or {}).get("offices") or {})
+                                       .get("registeredOffice") or {}).get("mailingAddress")
+                    if mailing_address:
+                        ting_info["mailingAddress"] = mailing_address
         else:
             ting_info.update({
                 "identifier": ting.foreign_identifier,

--- a/legal-api/src/legal_api/resources/v2/business/business_extended.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_extended.py
@@ -20,7 +20,7 @@ from flask_cors import cross_origin
 from business_model.models import Business, Filing, Jurisdiction
 from business_model.utils.legislation_datetime import LegislationDatetime
 from legal_api.core import Filing as CoreFiling
-from legal_api.services import authorized
+from legal_api.services import authorized, colin
 from legal_api.utils.auth import jwt
 
 from .bp import bp
@@ -181,6 +181,17 @@ def _get_amalgamation_application_data(business: Business, for_correction: bool 
                 mailing_address = ting_business.mailing_address.one_or_none()
                 if mailing_address:
                     ting_info["mailingAddress"] = mailing_address.json
+        elif ting.colin_identifier:
+            # a COLIN business not loaded in LEAR
+            ting_info.update({
+                "identifier": ting.colin_identifier
+            })
+            if for_correction:
+                colin_json, colin_status = colin.query_business(ting.colin_identifier)
+                if colin_status == HTTPStatus.OK:
+                    ting_info.update({
+                        "legalName": (colin_json or {}).get("business", {}).get("legalName")
+                    })
         else:
             ting_info.update({
                 "identifier": ting.foreign_identifier,

--- a/legal-api/src/legal_api/resources/v2/business/business_extended.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_extended.py
@@ -164,51 +164,17 @@ def _get_amalgamation_application_data(business: Business, for_correction: bool 
 
     amalgamating_businesses = []
     for ting in amalgamation.amalgamating_businesses:
-        ting_info = {
-            "id": ting.id,
-            "role": ting.role.name
-        }
         if ting.business_id:
-            ting_business = Business.find_by_internal_id(ting.business_id)
-            ting_info.update({
-                "identifier": ting_business.identifier
-            })
-            if for_correction:
-                ting_info.update({
-                    "legalName": ting_business.legal_name,
-                    "legalType": ting_business.legal_type
-                })
-                mailing_address = ting_business.mailing_address.one_or_none()
-                if mailing_address:
-                    ting_info["mailingAddress"] = mailing_address.json
+            ting_info = _lear_ting_info(ting, for_correction)
         elif ting.colin_identifier:
-            # a COLIN business not loaded in LEAR
-            ting_info.update({
-                "identifier": ting.colin_identifier
-            })
-            if for_correction:
-                snapshot_json, snapshot_status = colin.get_snapshot(ting.colin_identifier)
-                if snapshot_status == HTTPStatus.OK:
-                    snapshot_business = (snapshot_json or {}).get("business") or {}
-                    ting_info.update({
-                        "legalName": snapshot_business.get("legalName"),
-                        "legalType": snapshot_business.get("legalType"),
-                        "jurisdiction": snapshot_business.get("jurisdiction")
-                    })
-                    mailing_address = (((snapshot_json or {}).get("offices") or {})
-                                       .get("registeredOffice") or {}).get("mailingAddress")
-                    if mailing_address:
-                        ting_info["mailingAddress"] = mailing_address
+            ting_info = _colin_ting_info(ting, for_correction)
         else:
-            ting_info.update({
-                "identifier": ting.foreign_identifier,
-                "foreignJurisdiction": {
-                    "country": ting.foreign_jurisdiction,
-                    "region": ting.foreign_jurisdiction_region
-                },
-                "legalName": ting.foreign_name
-            })
-        amalgamating_businesses.append(ting_info)
+            ting_info = _foreign_ting_info(ting)
+        amalgamating_businesses.append({
+            "id": ting.id,
+            "role": ting.role.name,
+            **ting_info
+        })
 
     return {
         "amalgamation": {
@@ -216,3 +182,50 @@ def _get_amalgamation_application_data(business: Business, for_correction: bool 
             "courtApproval": amalgamation.court_approval
         }
     }, HTTPStatus.OK
+
+
+def _lear_ting_info(ting, for_correction: bool) -> dict:
+    ting_business = Business.find_by_internal_id(ting.business_id)
+    ting_info = {"identifier": ting_business.identifier}
+    if for_correction:
+        ting_info.update({
+            "legalName": ting_business.legal_name,
+            "legalType": ting_business.legal_type
+        })
+        if mailing_address := ting_business.mailing_address.one_or_none():
+            ting_info["mailingAddress"] = mailing_address.json
+    return ting_info
+
+
+def _colin_ting_info(ting, for_correction: bool) -> dict:
+    """Return the data of a COLIN business not loaded in LEAR, resolved from its snapshot."""
+    ting_info = {"identifier": ting.colin_identifier}
+    if not for_correction:
+        return ting_info
+
+    snapshot_json, snapshot_status = colin.get_snapshot(ting.colin_identifier)
+    if snapshot_status != HTTPStatus.OK:
+        return ting_info
+
+    snapshot_business = (snapshot_json or {}).get("business") or {}
+    ting_info.update({
+        "legalName": snapshot_business.get("legalName"),
+        "legalType": snapshot_business.get("legalType"),
+        "jurisdiction": snapshot_business.get("jurisdiction")
+    })
+    mailing_address = (((snapshot_json or {}).get("offices") or {})
+                       .get("registeredOffice") or {}).get("mailingAddress")
+    if mailing_address:
+        ting_info["mailingAddress"] = mailing_address
+    return ting_info
+
+
+def _foreign_ting_info(ting) -> dict:
+    return {
+        "identifier": ting.foreign_identifier,
+        "foreignJurisdiction": {
+            "country": ting.foreign_jurisdiction,
+            "region": ting.foreign_jurisdiction_region
+        },
+        "legalName": ting.foreign_name
+    }

--- a/legal-api/src/legal_api/resources/v2/business/colin_sync.py
+++ b/legal-api/src/legal_api/resources/v2/business/colin_sync.py
@@ -22,12 +22,9 @@ from flask import current_app, jsonify, request
 from flask_cors import cross_origin
 from sqlalchemy import or_, text
 
-from business_common.utils.legislation_datetime import LegislationDatetime
 from business_model.models import (
     Address,
     Alias,
-    AmalgamatingBusiness,
-    Amalgamation,
     BatchProcessing,
     Business,
     Filing,
@@ -43,7 +40,7 @@ from business_model.models import (
 from business_model.models.colin_event_id import ColinEventId
 from business_model.models.db import VersioningProxy
 from legal_api.exceptions import BusinessException
-from legal_api.services.business_details_version import OPERATION_TYPE_DELETE, VersionedBusinessDetailsService
+from legal_api.services.business_details_version import VersionedBusinessDetailsService
 from legal_api.utils.auth import jwt
 
 from .bp import bp
@@ -75,17 +72,6 @@ def get_completed_filings_for_colin():
                     _set_relationship_parties(business, filing, inner_filing_json)
             except Exception as ex:
                 current_app.logger.error(f"correction: filingId={filing.id}, error: {ex!s}")
-                # to skip this filing and block subsequent filing from syncing in update-colin-filings
-                filing_json["filing"]["header"]["name"] = None
-
-        elif (filing.filing_type == "amalgamationApplication" and
-              filing_json["filing"]["amalgamationApplication"]["type"] in [
-                  Amalgamation.AmalgamationTypes.horizontal.name,
-                  Amalgamation.AmalgamationTypes.vertical.name]):
-            try:
-                set_from_primary_or_holding_business_data(filing_json, filing)
-            except Exception as ex:
-                current_app.logger.error(f"amalgamation: filingId={filing.id}, error: {ex!s}")
                 # to skip this filing and block subsequent filing from syncing in update-colin-filings
                 filing_json["filing"]["header"]["name"] = None
 
@@ -269,80 +255,6 @@ def has_share_changed(filing: Filing) -> bool:
                               [int(share_class["id"]) for share_class in share_classes]))
                           .exists())
     return bool(db.session.query(share_series_query).scalar())
-
-
-def set_from_primary_or_holding_business_data(filing_json, filing: Filing):
-    """Set legal_name, director, office and shares from holding/primary business."""
-    amalgamation_filing = filing_json["filing"]["amalgamationApplication"]
-    primary_or_holding = next(x for x in amalgamation_filing["amalgamatingBusinesses"]
-                              if x["role"] in [AmalgamatingBusiness.Role.holding.name,
-                                               AmalgamatingBusiness.Role.primary.name])
-
-    ting_business = Business.find_by_identifier(primary_or_holding["identifier"])
-    primary_or_holding_business = VersionedBusinessDetailsService.get_business_revision_obj(filing, ting_business.id)
-
-    amalgamation_filing["nameRequest"]["legalName"] = primary_or_holding_business.legal_name
-
-    _set_parties(primary_or_holding_business, filing, amalgamation_filing)
-    _set_offices(primary_or_holding_business, amalgamation_filing, filing.id, filing.transaction_id)
-    _set_shares(primary_or_holding_business, amalgamation_filing, filing.transaction_id)
-
-
-def _set_parties(primary_or_holding_business, filing, amalgamation_filing):
-    parties = []
-    parties_version = VersionedBusinessDetailsService.get_party_role_revision(filing,
-                                                                              primary_or_holding_business.id,
-                                                                              role=PartyRole.RoleTypes.DIRECTOR.value)
-    # copy director
-    for director_json in parties_version:
-        director_json["roles"] = [{
-            "roleType": "Director",
-            "appointmentDate": LegislationDatetime.format_as_legislation_date(filing.effective_date)
-        }]
-        parties.append(director_json)
-
-    # copy completing party from filing json
-    for party_info in amalgamation_filing.get("parties"):
-        if comp_party_role := next((x for x in party_info.get("roles")
-                                    if x["roleType"].lower() == "completing party"), None):
-            party_info["roles"] = [comp_party_role]  # override roles to have only completing party
-            parties.append(party_info)
-            break
-    amalgamation_filing["parties"] = parties
-
-
-def _set_offices(primary_or_holding_business, amalgamation_filing, filing_id, transaction_id):
-    # copy offices
-    amalgamation_filing["offices"] = VersionedBusinessDetailsService.get_office_revision(filing_id,
-                                                                                         transaction_id,
-                                                                                         primary_or_holding_business.id)
-
-
-def _set_shares(primary_or_holding_business, amalgamation_filing, transaction_id):
-    """Set shares from holding/primary business."""
-    # Copy shares
-    share_classes = VersionedBusinessDetailsService.get_share_class_revision(transaction_id,
-                                                                             primary_or_holding_business.id)
-    amalgamation_filing["shareStructure"] = {"shareClasses": share_classes}
-
-    # Get resolution dates using versioned query
-    resolution_version = VersioningProxy.version_class(db.session(), Resolution)
-    resolutions_query = (
-        db.session.query(resolution_version.resolution_date)
-        .filter(resolution_version.transaction_id <= transaction_id)  # Get records valid at or before the transaction
-        .filter(resolution_version.operation_type != OPERATION_TYPE_DELETE)  # Exclude deleted records
-        .filter(resolution_version.business_id == primary_or_holding_business.id)
-        .filter(or_(
-            resolution_version.end_transaction_id.is_(None),  # Records not yet ended
-            resolution_version.end_transaction_id > transaction_id  # Records ended after our transaction
-        ))
-        .order_by(resolution_version.transaction_id)
-        .all()
-    )
-
-    business_dates = [res.resolution_date.isoformat() for res in resolutions_query]
-    if business_dates:
-        amalgamation_filing["shareStructure"]["resolutionDates"] = business_dates
 
 
 def _map_entity_to_officer(entity: dict[str, str]):

--- a/legal-api/src/legal_api/services/filings/validations/amalgamation_application.py
+++ b/legal-api/src/legal_api/services/filings/validations/amalgamation_application.py
@@ -49,6 +49,8 @@ COLIN_AMALGAMATION_LEGAL_TYPES: Final = [
     Business.LegalTypes.COMP.value,
     Business.LegalTypes.BC_ULC_COMPANY.value,
     Business.LegalTypes.BC_CCC.value,
+    # extraprovincials get the foreign-corporation rule set, not the COLIN TING checks
+    Business.LegalTypes.EXTRA_PRO_A.value,
 ]
 
 
@@ -201,6 +203,7 @@ def validate_amalgamating_businesses(  # noqa: PLR0912, PLR0915
     }
     amalgamating_businesses = {}
     colin_businesses = {}
+    expro_businesses = {}
     colin_fetch_failures = []
 
     # collect data for validation
@@ -214,11 +217,8 @@ def validate_amalgamating_businesses(  # noqa: PLR0912, PLR0915
         business_identifiers.append(identifier)
 
         # Check if its a foreign business
-        if foreign_jurisdiction := amalgamating_business_json.get("foreignJurisdiction"):
+        if amalgamating_business_json.get("foreignJurisdiction"):
             is_any_foreign = True
-            if (identifier.startswith("A") and
-                    foreign_jurisdiction.get("country") == "CA" and foreign_jurisdiction.get("region") == "BC"):
-                is_any_expro_a = True
             continue
 
         if business := Business.find_by_identifier(identifier):
@@ -230,6 +230,10 @@ def validate_amalgamating_businesses(  # noqa: PLR0912, PLR0915
             if not colin_business:
                 if colin_fetch_failed:
                     colin_fetch_failures.append(identifier)
+                continue
+            if colin_business["legalType"] == Business.LegalTypes.EXTRA_PRO_A.value:
+                is_any_expro_a = True
+                expro_businesses[identifier] = colin_business
                 continue
             colin_businesses[identifier] = colin_business
             ting_legal_type, ting_legal_name = colin_business["legalType"], colin_business["legalName"]
@@ -265,6 +269,17 @@ def validate_amalgamating_businesses(  # noqa: PLR0912, PLR0915
                 business_info = _business_info_from_lear(amalgamating_business, is_staff)
             elif colin_business := colin_businesses.get(identifier):
                 business_info = colin_business
+            elif expro_business := expro_businesses.get(identifier):
+                # extraprovincial: the foreign-corporation rule set, with the name from COLIN;
+                # skips the affiliation/state/good-standing checks exactly as a foreign entry does
+                msg.extend(_validate_foreign_rules(is_staff,
+                                                   is_any_bc_company,
+                                                   is_any_business[Business.LegalTypes.BC_ULC_COMPANY.value],
+                                                   legal_type,
+                                                   expro_business["legalName"],
+                                                   amalgamating_business_json["role"],
+                                                   amalgamating_business_path))
+                continue
             elif identifier in colin_fetch_failures:
                 # COLIN could not be reached - a clear retryable error, not "not found"
                 msg.append({
@@ -356,12 +371,35 @@ def _validate_foreign_businesses(  # noqa: PLR0913
     if is_staff:
         msg.extend(validate_foreign_jurisdiction(amalgamating_business["foreignJurisdiction"],
                                                  f"{amalgamating_business_path}/foreignJurisdiction",
-                                                 is_region_bc_valid=True,
+                                                 is_region_bc_valid=False,
                                                  is_region_for_us_required=False))
 
+    msg.extend(_validate_foreign_rules(is_staff,
+                                       is_any_bc_company,
+                                       is_any_ulc,
+                                       legal_type,
+                                       foreign_legal_name,
+                                       amalgamating_business["role"],
+                                       amalgamating_business_path))
+
+    return msg
+
+
+def _validate_foreign_rules(  # noqa: PLR0913
+        is_staff,
+        is_any_bc_company,
+        is_any_ulc,
+        legal_type,
+        legal_name,
+        role,
+        amalgamating_business_path) -> list:
+    """Validate the rules shared by foreign corporations and extraprovincial (A) corps."""
+    msg = []
+
+    if is_staff:
         if legal_type == Business.LegalTypes.BC_ULC_COMPANY.value and is_any_bc_company:
             msg.append({
-                "error": (f"{foreign_legal_name} foreign corporation must not amalgamate with "
+                "error": (f"{legal_name} foreign corporation must not amalgamate with "
                           "a BC company to form a BC Unlimited Liability Company."),
                 "path": amalgamating_business_path
             })
@@ -369,14 +407,14 @@ def _validate_foreign_businesses(  # noqa: PLR0913
         if is_any_ulc:
             msg.append({
                 "error": ("A BC Unlimited Liability Company cannot amalgamate with "
-                          f"a foreign company {foreign_legal_name}."),
+                          f"a foreign company {legal_name}."),
                 "path": amalgamating_business_path
             })
 
-        if amalgamating_business["role"] in [AmalgamatingBusiness.Role.primary.name,
-                                             AmalgamatingBusiness.Role.holding.name]:
+        if role in [AmalgamatingBusiness.Role.primary.name,
+                    AmalgamatingBusiness.Role.holding.name]:
             msg.append({
-                "error": f"A {foreign_legal_name} foreign corporation cannot be marked as Primary or Holding.",
+                "error": f"A {legal_name} foreign corporation cannot be marked as Primary or Holding.",
                 "path": amalgamating_business_path
             })
     elif flags.is_on("enabled-deeper-permission-action"):
@@ -392,7 +430,7 @@ def _validate_foreign_businesses(  # noqa: PLR0913
             return msg
     else:
         msg.append({
-            "error": (f"{foreign_legal_name} foreign corporation cannot "
+            "error": (f"{legal_name} foreign corporation cannot "
                     "be amalgamated except by Registries staff."),
             "path": amalgamating_business_path
         })
@@ -499,7 +537,7 @@ def _find_colin_business(identifier: str) -> tuple:
         return None, True
 
     business_json = snapshot_json.get("business") or {}
-    if business_json.get("legalType") not in COLIN_AMALGAMATION_LEGAL_TYPES:
+    if not business_json.get("legalName") or business_json.get("legalType") not in COLIN_AMALGAMATION_LEGAL_TYPES:
         return None, False
     return business_json, False
 

--- a/legal-api/src/legal_api/services/filings/validations/correction.py
+++ b/legal-api/src/legal_api/services/filings/validations/correction.py
@@ -240,7 +240,8 @@ def _validate_amalgamation_correction(filing_dict, filing_type, business: Busine
             msg.append({"error": _("Amalgamating business not found."), "path": path})
             continue
 
-        if ting.business_id:
+        if ting.business_id or ting.colin_identifier:
+            # LEAR and COLIN (incl. extraprovincial) entries carry no correctable filing data
             msg.append({"error": _("Can only correct foreign businesses."), "path": path})
             continue
 

--- a/legal-api/tests/unit/reports/__init__.py
+++ b/legal-api/tests/unit/reports/__init__.py
@@ -45,6 +45,19 @@ def make_foreign_amalgamating_business(foreign_identifier, foreign_name='Foreign
     ab.foreign_identifier = foreign_identifier
     ab.foreign_jurisdiction = foreign_jurisdiction
     ab.foreign_jurisdiction_region = foreign_jurisdiction_region
+    ab.colin_identifier = None
+    return ab
+
+
+def make_colin_amalgamating_business(colin_identifier):
+    """Return a lightweight mock that behaves like an AmalgamatingBusiness for a COLIN business."""
+    ab = MagicMock()
+    ab.foreign_name = None
+    ab.foreign_identifier = None
+    ab.foreign_jurisdiction = None
+    ab.foreign_jurisdiction_region = None
+    ab.colin_identifier = colin_identifier
+    ab.business_id = None
     return ab
 
 

--- a/legal-api/tests/unit/reports/test_business_document.py
+++ b/legal-api/tests/unit/reports/test_business_document.py
@@ -118,51 +118,36 @@ def test_get_pdf(session, app, jwt, identifier, entity_type, document_name):
 
 
 @pytest.mark.parametrize(
-    'foreign_id,foreign_country,foreign_region,colin_status,colin_jurisdiction,'
-    'expected_id,expected_jurisdiction,expected_mock_calls,'
-    'expected_is_bc_company,expected_is_extraprovincial',
+    'foreign_id,foreign_country,foreign_region,expected_jurisdiction',
     [
-        ('A1234567', 'CA', 'BC', 200, 'ON', 'A1234567', 'Ontario', 1, False, True),
-        ('A1234567', 'CA', 'BC', 200, 'FD', 'A1234567', 'Federal', 1, False, True),
-        ('A1234567', 'CA', 'BC', 200, None, 'A1234567', 'N/A', 1, False, True),
-        ('A1234567', 'US', 'WA', 404, None, 'N/A', 'United States', 1, False, False),
-        ('UK1234567', 'GB', None, None, None, 'N/A', 'United Kingdom', 0, False, False),
-    ], 
+        ('A1234567', 'US', 'WA', 'United States'),
+        ('UK1234567', 'GB', None, 'United Kingdom'),
+        ('7654321', 'CA', 'AB', 'Alberta'),
+    ],
     ids=[
-        'expro province',
-        'expro federal',
-        'expro no jurisdiction',
-        'Non expro with expro like identifier',
-        'Non expro',
+        'foreign with A-prefix identifier',
+        'foreign GB',
+        'foreign CA province',
     ],
 )
 def test_set_amalgamation_details(
-    session, app, jwt, monkeypatch, foreign_id, foreign_country, foreign_region,
-    colin_status, colin_jurisdiction, expected_id, expected_jurisdiction, expected_mock_calls,
-    expected_is_bc_company, expected_is_extraprovincial
+    session, app, jwt, monkeypatch, foreign_id, foreign_country, foreign_region, expected_jurisdiction
 ):
-    """Assert that expros resolve as expected. 
-    
-    Foreign businesses with identifier starting with 'A' and existing in colin are treated as an expro: 
-     - identifier is set to the foreign_identifier
-     - region_code is taken from the colin response's business.jurisdiction field.
-    """
+    """Assert a foreign row renders from its stored columns alone - N/A identifier, COLIN never called."""
     foreign_name = 'Foreign Corp'
 
     ab = make_foreign_amalgamating_business(
         foreign_identifier=foreign_id,
         foreign_name=foreign_name,
         foreign_jurisdiction=foreign_country,
-        foreign_jurisdiction_region=foreign_region,  # original region — is overwritten for expros
+        foreign_jurisdiction_region=foreign_region,
     )
 
     colin_call_count = {'count': 0}
 
     def mock_colin(identifier):
         colin_call_count['count'] += 1
-        if colin_status == HTTPStatus.OK:
-            return {'business': {'jurisdiction': colin_jurisdiction}}, colin_status
-        return None, colin_status
+        return None, None
 
     business_json = set_amalgamation_details(
         app, jwt, session, monkeypatch,
@@ -174,12 +159,50 @@ def test_set_amalgamation_details(
     assert len(entities) == 1
     entity = entities[0]
 
-    assert colin_call_count['count'] == expected_mock_calls
-    assert entity['identifier'] == expected_id
+    assert colin_call_count['count'] == 0
+    assert entity['identifier'] == 'N/A'
     assert entity['jurisdiction'] == expected_jurisdiction
     assert entity['legalName'] == foreign_name
-    assert entity['isBcCompany'] is expected_is_bc_company
-    assert entity['isExtraprovincial'] is expected_is_extraprovincial
+    assert entity['isBcCompany'] is False
+    assert entity['isExtraprovincial'] is False
+
+
+@pytest.mark.parametrize(
+    'colin_jurisdiction, expected_jurisdiction',
+    [
+        ('ON', 'Ontario'),
+        ('FD', 'Federal'),
+    ],
+    ids=[
+        'expro province',
+        'expro federal',
+    ],
+)
+def test_set_amalgamation_details_expro(session, app, jwt, monkeypatch, colin_jurisdiction, expected_jurisdiction):
+    """Assert an expro row (colin_identifier) resolves its name and home jurisdiction from COLIN."""
+    expro_identifier = 'A1234567'
+    ab = make_colin_amalgamating_business(expro_identifier)
+
+    def mock_colin(identifier):
+        assert identifier == expro_identifier
+        return {'business': {'legalName': 'Expro Corp', 'legalType': 'A',
+                             'jurisdiction': colin_jurisdiction}}, HTTPStatus.OK
+
+    business_json = set_amalgamation_details(
+        app, jwt, session, monkeypatch,
+        amalgamating_businesses_list=[ab],
+        colin_query_side_effect=mock_colin,
+    )
+
+    entities = business_json.get('amalgamatedEntities', [])
+    assert len(entities) == 1
+    entity = entities[0]
+
+    assert entity['identifier'] == expro_identifier
+    assert entity['legalName'] == 'Expro Corp'
+    assert entity['jurisdiction'] == expected_jurisdiction
+    assert entity['isBcCompany'] is False
+    assert entity['isExtraprovincial'] is True
 
 
 def test_set_amalgamation_details_colin_business(session, app, jwt, monkeypatch):
@@ -189,7 +212,7 @@ def test_set_amalgamation_details_colin_business(session, app, jwt, monkeypatch)
 
     def mock_colin(identifier):
         assert identifier == colin_identifier
-        return {'business': {'legalName': 'Colin Corp Ltd.'}}, HTTPStatus.OK
+        return {'business': {'legalName': 'Colin Corp Ltd.', 'legalType': 'BC'}}, HTTPStatus.OK
 
     business_json = set_amalgamation_details(
         app, jwt, session, monkeypatch,
@@ -204,6 +227,8 @@ def test_set_amalgamation_details_colin_business(session, app, jwt, monkeypatch)
     assert entity['identifier'] == colin_identifier
     assert entity['legalName'] == 'Colin Corp Ltd.'
     assert entity['jurisdiction'] == 'British Columbia'
+    assert entity['isBcCompany'] is True
+    assert entity['isExtraprovincial'] is False
 
 
 @pytest.mark.parametrize('has_receiver, cessation_date, expected_count', [

--- a/legal-api/tests/unit/reports/test_business_document.py
+++ b/legal-api/tests/unit/reports/test_business_document.py
@@ -23,7 +23,12 @@ from legal_api.services.authz import STAFF_ROLE
 from tests.unit.services.utils import create_header
 
 from tests.unit.models import factory_address, factory_business, factory_business_mailing_address, factory_party_role
-from tests.unit.reports import make_amalgamation_filing_mock, make_foreign_amalgamating_business, set_amalgamation_details
+from tests.unit.reports import (
+    make_amalgamation_filing_mock,
+    make_colin_amalgamating_business,
+    make_foreign_amalgamating_business,
+    set_amalgamation_details,
+)
 
 
 @pytest.mark.parametrize(
@@ -175,6 +180,30 @@ def test_set_amalgamation_details(
     assert entity['legalName'] == foreign_name
     assert entity['isBcCompany'] is expected_is_bc_company
     assert entity['isExtraprovincial'] is expected_is_extraprovincial
+
+
+def test_set_amalgamation_details_colin_business(session, app, jwt, monkeypatch):
+    """Assert a COLIN amalgamating business renders from the COLIN lookup with BC jurisdiction."""
+    colin_identifier = 'BC5556667'
+    ab = make_colin_amalgamating_business(colin_identifier)
+
+    def mock_colin(identifier):
+        assert identifier == colin_identifier
+        return {'business': {'legalName': 'Colin Corp Ltd.'}}, HTTPStatus.OK
+
+    business_json = set_amalgamation_details(
+        app, jwt, session, monkeypatch,
+        amalgamating_businesses_list=[ab],
+        colin_query_side_effect=mock_colin,
+    )
+
+    entities = business_json.get('amalgamatedEntities', [])
+    assert len(entities) == 1
+    entity = entities[0]
+
+    assert entity['identifier'] == colin_identifier
+    assert entity['legalName'] == 'Colin Corp Ltd.'
+    assert entity['jurisdiction'] == 'British Columbia'
 
 
 @pytest.mark.parametrize('has_receiver, cessation_date, expected_count', [

--- a/legal-api/tests/unit/reports/test_report.py
+++ b/legal-api/tests/unit/reports/test_report.py
@@ -1028,26 +1028,22 @@ def _make_report_with_amalgamating_businesses(amalgamating_businesses_list, sess
 
 
 @pytest.mark.parametrize(
-    'test_name, foreign_jurisdiction, foreign_region, colin_status, colin_jurisdiction, expected_id, expected_jurisdiction',
+    'test_name, foreign_jurisdiction, foreign_region, expected_jurisdiction',
     [
-        ('expro-on', 'CA', 'BC', HTTPStatus.OK, 'ON', 'A1234567', 'Ontario'),
-        ('expro-federal', 'CA', 'BC', HTTPStatus.OK, 'FD', 'A1234567', 'Federal'),
-        ('a-prefix-colin-404', 'US', 'WA', HTTPStatus.NOT_FOUND, None, 'N/A', 'United States'),
+        ('a-prefix-identifier', 'US', 'WA', 'United States'),
+        ('ca-province', 'CA', 'AB', 'Alberta'),
     ],
     ids=[
-        '_set_amalgamating_businesses: expro ON',
-        '_set_amalgamating_businesses: expro FD federal',
-        '_set_amalgamating_businesses: A-prefix colin 404 stays N/A',
+        '_set_amalgamating_businesses: foreign with A-prefix identifier',
+        '_set_amalgamating_businesses: foreign CA province',
     ]
 )
 def test_set_amalgamating_businesses_foreign(
         session, monkeypatch, test_name,
-        foreign_jurisdiction, foreign_region,
-        colin_status, colin_jurisdiction,
-        expected_id, expected_jurisdiction):
-    """Assert that _set_amalgamating_businesses correctly formats foreign and expro entries."""
+        foreign_jurisdiction, foreign_region, expected_jurisdiction):
+    """Assert a foreign entry renders from the filing alone - N/A identifier, COLIN never called."""
     foreign_identifier = 'A1234567'
-    foreign_name = 'Foreign Expro Corp'
+    foreign_name = 'Foreign Corp'
 
     amalgamating_businesses = [
         {
@@ -1066,7 +1062,7 @@ def test_set_amalgamating_businesses_foreign(
 
     def mock_colin(id_):
         colin_call_count['count'] += 1
-        return {'business': {'jurisdiction': colin_jurisdiction}}, colin_status
+        return None, None
 
     monkeypatch.setattr(ColinService, 'query_business', mock_colin)
 
@@ -1078,8 +1074,54 @@ def test_set_amalgamating_businesses_foreign(
     entry = ting_businesses[0]
 
     assert entry['legalName'] == foreign_name
-    assert entry['identifier'] == expected_id
+    assert entry['identifier'] == 'N/A'
     assert entry['jurisdiction'] == expected_jurisdiction
+    assert colin_call_count['count'] == 0
+
+
+@pytest.mark.parametrize(
+    'colin_jurisdiction, expected_jurisdiction',
+    [
+        ('ON', 'Ontario'),
+        ('FD', 'Federal'),
+    ],
+    ids=[
+        '_set_amalgamating_businesses: expro ON',
+        '_set_amalgamating_businesses: expro FD federal',
+    ]
+)
+def test_set_amalgamating_businesses_expro(session, monkeypatch, colin_jurisdiction, expected_jurisdiction):
+    """Assert an expro entry (identifier only) resolves its name and home jurisdiction from COLIN."""
+    expro_identifier = 'A1234567'
+
+    amalgamating_businesses = [
+        {
+            'role': 'amalgamating',
+            'identifier': expro_identifier,
+        }
+    ]
+
+    report = _make_report_with_amalgamating_businesses(amalgamating_businesses, session)
+
+    def mock_colin(id_):
+        assert id_ == expro_identifier
+        return {'business': {'legalName': 'Expro Corp', 'legalType': 'A',
+                             'jurisdiction': colin_jurisdiction}}, HTTPStatus.OK
+
+    monkeypatch.setattr(ColinService, 'query_business', mock_colin)
+
+    filing = report._filing.filing_json['filing']
+    report._set_amalgamating_businesses(filing)
+
+    ting_businesses = filing.get('amalgamatingBusinesses', [])
+    assert len(ting_businesses) == 1
+    entry = ting_businesses[0]
+
+    assert entry['identifier'] == expro_identifier
+    assert entry['legalName'] == 'Expro Corp'
+    assert entry['jurisdiction'] == expected_jurisdiction
+    assert entry['isBcCompany'] is False
+    assert entry['isExtraprovincial'] is True
 
 
 def test_set_amalgamating_businesses_bc_domestic(session, monkeypatch):
@@ -1169,7 +1211,7 @@ def test_set_amalgamating_businesses_colin(session, monkeypatch):
 
     def mock_colin(id_):
         assert id_ == colin_identifier
-        return {'business': {'legalName': 'Colin Corp Ltd.'}}, HTTPStatus.OK
+        return {'business': {'legalName': 'Colin Corp Ltd.', 'legalType': 'BC'}}, HTTPStatus.OK
 
     monkeypatch.setattr(ColinService, 'query_business', mock_colin)
 

--- a/legal-api/tests/unit/reports/test_report.py
+++ b/legal-api/tests/unit/reports/test_report.py
@@ -32,6 +32,7 @@ from legal_api.reports.report import Report
 from registry_schemas.example_data import (
     AGM_LOCATION_CHANGE,
     ALTERATION_FILING_TEMPLATE,
+    AMALGAMATION_APPLICATION,
     ANNUAL_REPORT,
     CHANGE_OF_ADDRESS,
     CHANGE_OF_DIRECTORS,
@@ -1151,6 +1152,70 @@ def test_set_amalgamating_businesses_foreign_non_a_prefix(session, monkeypatch):
     assert entry['legalName'] == foreign_name
     assert entry['jurisdiction'] == 'United Kingdom'
     assert colin_call_count['count'] == 0
+
+
+def test_set_amalgamating_businesses_colin(session, monkeypatch):
+    """Assert a COLIN business entry (identifier only, no LEAR row) resolves its name from COLIN."""
+    colin_identifier = 'BC5556667'
+
+    amalgamating_businesses = [
+        {
+            'role': 'amalgamating',
+            'identifier': colin_identifier,
+        }
+    ]
+
+    report = _make_report_with_amalgamating_businesses(amalgamating_businesses, session)
+
+    def mock_colin(id_):
+        assert id_ == colin_identifier
+        return {'business': {'legalName': 'Colin Corp Ltd.'}}, HTTPStatus.OK
+
+    monkeypatch.setattr(ColinService, 'query_business', mock_colin)
+
+    filing = report._filing.filing_json['filing']
+    report._set_amalgamating_businesses(filing)
+
+    ting_businesses = filing.get('amalgamatingBusinesses', [])
+    assert len(ting_businesses) == 1
+    entry = ting_businesses[0]
+
+    assert entry['identifier'] == colin_identifier
+    assert entry['legalName'] == 'Colin Corp Ltd.'
+    assert entry['jurisdiction'] == 'British Columbia'
+
+
+def test_format_amalgamation_data_uses_filing_json(session):
+    """Assert short-form report data comes from the filing json - not rebuilt from the primary/holding DB rows."""
+    identifier = 'BC9900002'
+    filing_json = copy.deepcopy(FILING_HEADER)
+    filing_json['filing']['header']['name'] = 'amalgamationApplication'
+    filing_json['filing']['business']['identifier'] = identifier
+    filing_json['filing']['business']['legalType'] = 'BC'
+    filing_json['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
+    aml = filing_json['filing']['amalgamationApplication']
+    aml['type'] = 'vertical'
+    aml['amalgamatingBusinesses'] = [
+        {'role': 'holding', 'identifier': 'US7654321', 'legalName': 'Foreign Holding Corp',
+         'foreignJurisdiction': {'country': 'US', 'region': 'WA'}}
+    ]
+    aml['shareStructure']['resolutionDates'] = ['2020-05-13']
+
+    business = factory_business(identifier=identifier, entity_type='BC')
+    filing = factory_completed_filing(business, filing_json)
+
+    report = Report(filing)
+    report._business = business
+    report._report_key = 'amalgamationApplication'
+
+    filing_data = report._filing.filing_json['filing']
+    report._format_amalgamation_data(filing_data)
+
+    assert filing_data['nameRequest']['legalName'] == aml['nameRequest']['legalName']
+    assert len(filing_data['offices']) == len(aml['offices'])
+    assert len(filing_data['parties']) == len(aml['parties'])
+    assert filing_data['shareClasses'] == aml['shareStructure']['shareClasses']
+    assert filing_data['resolutions'] == [{'date': 'May 13, 2020'}]
 
 
 @pytest.mark.parametrize('filing_type,expected_report_type', [

--- a/legal-api/tests/unit/reports/test_utils.py
+++ b/legal-api/tests/unit/reports/test_utils.py
@@ -135,53 +135,82 @@ def test_get_formatted_amalg_business_data_foreign_non_expro(
     assert colin_call_count['count'] == 0
 
 
-@pytest.mark.parametrize('test_name, colin_jurisdiction, expected_id, expected_jurisdiction', [
-    ('expro-on-province', 'ON', 'A1234567', 'Ontario'),
-    ('expro-federal', 'FD', 'A1234567', 'Federal'),
-    ('expro-no-jurisdiction-in-colin', None, 'A1234567', 'N/A'),
+@pytest.mark.parametrize('test_name, colin_jurisdiction, expected_jurisdiction', [
+    ('expro-on-province', 'ON', 'Ontario'),
+    ('expro-federal', 'FD', 'Federal'),
 ], ids=[
     'expro ON province',
     'expro FD federal',
-    'expro no jurisdiction in colin',
 ])
-def test_get_formatted_amalg_business_data_foreign_expro_colin_200(
-        app, monkeypatch, test_name, colin_jurisdiction, expected_id, expected_jurisdiction):
-    """Assert that a foreign business whose identifier starts with A and COLIN returns 200 is treated as an expro."""
-    foreign_identifier = 'A1234567'
-    foreign_name = 'Expro Corp'
+def test_get_formatted_amalg_business_data_expro(
+        app, monkeypatch, test_name, colin_jurisdiction, expected_jurisdiction):
+    """Assert an extraprovincial (identifier-only A entry) resolves its name and home jurisdiction from COLIN."""
+    expro_identifier = 'A1234567'
     colin_call_count = {'count': 0}
 
     def mock_colin(id_):
         colin_call_count['count'] += 1
-        return _make_colin_response(HTTPStatus.OK, jurisdiction=colin_jurisdiction)
+        return {'business': {'legalName': 'Expro Corp', 'legalType': 'A',
+                             'jurisdiction': colin_jurisdiction}}, HTTPStatus.OK
 
     monkeypatch.setattr(ColinService, 'query_business', mock_colin)
 
     with app.app_context():
         result = get_formatted_amalg_business_data(
-            identifier=foreign_identifier,
-            foreign_name=foreign_name,
-            foreign_country_code='CA',
-            foreign_region_code='BC',
+            identifier=expro_identifier,
+            foreign_name=None,
+            foreign_country_code=None,
+            foreign_region_code=None,
+            ting_business=None,
         )
 
-    assert result['identifier'] == expected_id
-    assert result['legalName'] == foreign_name
+    assert result['identifier'] == expro_identifier
+    assert result['legalName'] == 'Expro Corp'
     assert result['jurisdiction'] == expected_jurisdiction
     assert result['isBcCompany'] is False
     assert result['isExtraprovincial'] is True
     assert colin_call_count['count'] == 1
 
 
-def test_get_formatted_amalg_business_data_foreign_a_prefix_colin_non_200(app, monkeypatch):
-    """Assert that a foreign A-prefix business where COLIN returns non-200 keeps N/A identifier and original jurisdiction."""
+@pytest.mark.parametrize('colin_response', [
+    (None, None),
+    ({'message': 'not found'}, HTTPStatus.NOT_FOUND),
+    ({'business': {'legalType': 'BC', 'jurisdiction': 'BC'}}, HTTPStatus.OK),
+    ({'business': {'legalName': 'Colin Corp Ltd.', 'jurisdiction': 'BC'}}, HTTPStatus.OK),
+    ({'business': {'legalName': 'Expro Corp', 'legalType': 'A', 'jurisdiction': None}}, HTTPStatus.OK),
+], ids=[
+    'colin down',
+    'colin 404',
+    'missing legal name',
+    'missing legal type',
+    'expro missing jurisdiction',
+])
+def test_get_formatted_amalg_business_data_colin_incomplete_fails_loudly(app, monkeypatch, colin_response):
+    """Assert a COLIN entry fails loudly when COLIN can't provide the data the render needs."""
+    monkeypatch.setattr(ColinService, 'query_business', lambda id_: colin_response)
+
+    with app.app_context():
+        with pytest.raises(BusinessException) as exc_info:
+            get_formatted_amalg_business_data(
+                identifier='A1234567',
+                foreign_name=None,
+                foreign_country_code=None,
+                foreign_region_code=None,
+                ting_business=None,
+            )
+
+    assert exc_info.value.status_code == HTTPStatus.SERVICE_UNAVAILABLE
+
+
+def test_get_formatted_amalg_business_data_foreign_a_prefix_never_calls_colin(app, monkeypatch):
+    """Assert a foreign entry is rendered from the filing alone, even with an A-prefix identifier."""
     foreign_identifier = 'A1234567'
-    foreign_name = 'Would-be Expro Corp'
+    foreign_name = 'Foreign Corp'
     colin_call_count = {'count': 0}
 
     def mock_colin(id_):
         colin_call_count['count'] += 1
-        return _make_colin_response(HTTPStatus.NOT_FOUND)
+        return _make_colin_response(HTTPStatus.OK)
 
     monkeypatch.setattr(ColinService, 'query_business', mock_colin)
 
@@ -198,7 +227,7 @@ def test_get_formatted_amalg_business_data_foreign_a_prefix_colin_non_200(app, m
     assert result['jurisdiction'] == 'United States'
     assert result['isBcCompany'] is False
     assert result['isExtraprovincial'] is False
-    assert colin_call_count['count'] == 1
+    assert colin_call_count['count'] == 0
 
 
 def test_get_formatted_amalg_business_data_bc_business_with_ting(app):
@@ -243,7 +272,7 @@ def test_get_formatted_amalg_business_data_colin_business(app, monkeypatch):
 
     def mock_colin(id_):
         colin_call_count['count'] += 1
-        return {'business': {'legalName': 'Colin Corp Ltd.'}}, HTTPStatus.OK
+        return {'business': {'legalName': 'Colin Corp Ltd.', 'legalType': 'BC'}}, HTTPStatus.OK
 
     monkeypatch.setattr(ColinService, 'query_business', mock_colin)
 
@@ -259,31 +288,9 @@ def test_get_formatted_amalg_business_data_colin_business(app, monkeypatch):
     assert result['identifier'] == colin_identifier
     assert result['legalName'] == 'Colin Corp Ltd.'
     assert result['jurisdiction'] == 'British Columbia'
+    assert result['isBcCompany'] is True
+    assert result['isExtraprovincial'] is False
     assert colin_call_count['count'] == 1
-
-
-@pytest.mark.parametrize('colin_response', [
-    (None, None),
-    ({'message': 'not found'}, HTTPStatus.NOT_FOUND),
-], ids=['colin down', 'colin 404'])
-def test_get_formatted_amalg_business_data_colin_business_unavailable(app, monkeypatch, colin_response):
-    """Assert a COLIN business renders with an N/A name (not an error) when COLIN cannot provide one."""
-    colin_identifier = 'BC5556667'
-
-    monkeypatch.setattr(ColinService, 'query_business', lambda id_: colin_response)
-
-    with app.app_context():
-        result = get_formatted_amalg_business_data(
-            identifier=colin_identifier,
-            foreign_name=None,
-            foreign_country_code=None,
-            foreign_region_code=None,
-            ting_business=None,
-        )
-
-    assert result['identifier'] == colin_identifier
-    assert result['legalName'] == 'N/A'
-    assert result['jurisdiction'] == 'British Columbia'
 
 
 def test_get_formatted_amalg_business_data_foreign_no_identifier_skips_colin(app, monkeypatch):

--- a/legal-api/tests/unit/reports/test_utils.py
+++ b/legal-api/tests/unit/reports/test_utils.py
@@ -221,12 +221,12 @@ def test_get_formatted_amalg_business_data_bc_business_with_ting(app):
     assert result['isExtraprovincial'] is False
 
 
-def test_get_formatted_amalg_business_data_raises_when_no_foreign_name_and_no_ting(app):
-    """Assert that BusinessException with UNPROCESSABLE_ENTITY is raised when neither foreign_name nor ting_business is provided."""
+def test_get_formatted_amalg_business_data_raises_when_nothing_identifies_the_business(app):
+    """Assert that BusinessException with UNPROCESSABLE_ENTITY is raised when there is no foreign_name, ting_business or identifier."""
     with app.app_context():
         with pytest.raises(BusinessException) as exc_info:
             get_formatted_amalg_business_data(
-                identifier='BC1234567',
+                identifier=None,
                 foreign_name=None,
                 foreign_country_code=None,
                 foreign_region_code=None,
@@ -234,6 +234,56 @@ def test_get_formatted_amalg_business_data_raises_when_no_foreign_name_and_no_ti
             )
 
     assert exc_info.value.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+def test_get_formatted_amalg_business_data_colin_business(app, monkeypatch):
+    """Assert a COLIN business (identifier only, no LEAR row) resolves its name from COLIN with BC jurisdiction."""
+    colin_identifier = 'BC5556667'
+    colin_call_count = {'count': 0}
+
+    def mock_colin(id_):
+        colin_call_count['count'] += 1
+        return {'business': {'legalName': 'Colin Corp Ltd.'}}, HTTPStatus.OK
+
+    monkeypatch.setattr(ColinService, 'query_business', mock_colin)
+
+    with app.app_context():
+        result = get_formatted_amalg_business_data(
+            identifier=colin_identifier,
+            foreign_name=None,
+            foreign_country_code=None,
+            foreign_region_code=None,
+            ting_business=None,
+        )
+
+    assert result['identifier'] == colin_identifier
+    assert result['legalName'] == 'Colin Corp Ltd.'
+    assert result['jurisdiction'] == 'British Columbia'
+    assert colin_call_count['count'] == 1
+
+
+@pytest.mark.parametrize('colin_response', [
+    (None, None),
+    ({'message': 'not found'}, HTTPStatus.NOT_FOUND),
+], ids=['colin down', 'colin 404'])
+def test_get_formatted_amalg_business_data_colin_business_unavailable(app, monkeypatch, colin_response):
+    """Assert a COLIN business renders with an N/A name (not an error) when COLIN cannot provide one."""
+    colin_identifier = 'BC5556667'
+
+    monkeypatch.setattr(ColinService, 'query_business', lambda id_: colin_response)
+
+    with app.app_context():
+        result = get_formatted_amalg_business_data(
+            identifier=colin_identifier,
+            foreign_name=None,
+            foreign_country_code=None,
+            foreign_region_code=None,
+            ting_business=None,
+        )
+
+    assert result['identifier'] == colin_identifier
+    assert result['legalName'] == 'N/A'
+    assert result['jurisdiction'] == 'British Columbia'
 
 
 def test_get_formatted_amalg_business_data_foreign_no_identifier_skips_colin(app, monkeypatch):

--- a/legal-api/tests/unit/resources/v2/test_business_extended.py
+++ b/legal-api/tests/unit/resources/v2/test_business_extended.py
@@ -146,15 +146,27 @@ def test_get_business_extended_amalgamation_colin_ting(app, session, client, jwt
     ting.save()
 
     colin_call_count = {'count': 0}
+    mailing_address = {
+        'streetAddress': '123 Fake St',
+        'streetAddressAdditional': None,
+        'addressCity': 'Victoria',
+        'addressRegion': 'BC',
+        'addressCountry': 'CA',
+        'postalCode': 'V8V 8V8',
+        'deliveryInstructions': None
+    }
 
-    def mock_colin(id_):
+    def mock_colin_snapshot(id_):
         colin_call_count['count'] += 1
         assert id_ == colin_identifier
-        return {'business': {'legalName': 'Colin Corp Ltd.'}}, HTTPStatus.OK
+        return {
+            'business': {'legalName': 'Colin Corp Ltd.', 'legalType': 'BC', 'jurisdiction': 'BC'},
+            'offices': {'registeredOffice': {'mailingAddress': mailing_address}}
+        }, HTTPStatus.OK
 
-    # staticmethod: the endpoint calls query_business through the colin singleton instance,
+    # staticmethod: the endpoint calls get_snapshot through the colin singleton instance,
     # so a bare function would get bound and receive the instance as its argument
-    monkeypatch.setattr(ColinService, 'query_business', staticmethod(mock_colin))
+    monkeypatch.setattr(ColinService, 'get_snapshot', staticmethod(mock_colin_snapshot))
 
     query_string = '?forCorrection=true' if for_correction else ''
     rv = client.get(f'/api/v2/businesses/{identifier}/extended/amalgamationApplication{query_string}',
@@ -169,6 +181,9 @@ def test_get_business_extended_amalgamation_colin_ting(app, session, client, jwt
     }
     if for_correction:
         expected_entry['legalName'] = 'Colin Corp Ltd.'
+        expected_entry['legalType'] = 'BC'
+        expected_entry['jurisdiction'] = 'BC'
+        expected_entry['mailingAddress'] = mailing_address
     assert rv.json['amalgamation']['amalgamatingBusinesses'] == [expected_entry]
     assert colin_call_count['count'] == (1 if for_correction else 0)
 

--- a/legal-api/tests/unit/resources/v2/test_business_extended.py
+++ b/legal-api/tests/unit/resources/v2/test_business_extended.py
@@ -24,6 +24,7 @@ import pytest
 from business_model.models import Amalgamation, AmalgamatingBusiness, Business, Jurisdiction
 from business_model.utils.legislation_datetime import LegislationDatetime
 from legal_api.services.authz import PUBLIC_USER, STAFF_ROLE
+from legal_api.services.colin import ColinService
 from registry_schemas.example_data import (
     AMALGAMATION_APPLICATION,
     AMALGAMATION_OUT,
@@ -114,6 +115,62 @@ def test_get_business_extended_amalgamation(app, session, client, jwt, for_corre
 
     assert rv.status_code == HTTPStatus.OK
     assert rv.json['amalgamation'] == data
+
+
+@pytest.mark.parametrize('for_correction', [True, False])
+def test_get_business_extended_amalgamation_colin_ting(app, session, client, jwt, monkeypatch, for_correction):
+    """Assert a COLIN amalgamating business is queried by identifier and uses its name from COLIN for corrections."""
+    identifier = 'BC7654321'
+    colin_identifier = 'BC5556667'
+    business = factory_business(identifier, entity_type='BC')
+
+    filing_json = copy.deepcopy(FILING_HEADER)
+    filing_json['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
+    filing_json['filing']['header']['name'] = 'amalgamationApplication'
+    filing = factory_completed_filing(business, filing_json)
+
+    amalgamation = Amalgamation(
+        amalgamation_type=Amalgamation.AmalgamationTypes.regular,
+        amalgamation_date=LegislationDatetime.now(),
+        court_approval=False,
+        filing_id=filing.id,
+        business_id=business.id,
+    )
+    amalgamation.save()
+
+    ting = AmalgamatingBusiness(
+        role=AmalgamatingBusiness.Role.amalgamating,
+        colin_identifier=colin_identifier,
+        amalgamation_id=amalgamation.id
+    )
+    ting.save()
+
+    colin_call_count = {'count': 0}
+
+    def mock_colin(id_):
+        colin_call_count['count'] += 1
+        assert id_ == colin_identifier
+        return {'business': {'legalName': 'Colin Corp Ltd.'}}, HTTPStatus.OK
+
+    # staticmethod: the endpoint calls query_business through the colin singleton instance,
+    # so a bare function would get bound and receive the instance as its argument
+    monkeypatch.setattr(ColinService, 'query_business', staticmethod(mock_colin))
+
+    query_string = '?forCorrection=true' if for_correction else ''
+    rv = client.get(f'/api/v2/businesses/{identifier}/extended/amalgamationApplication{query_string}',
+                    headers=create_header(jwt, [STAFF_ROLE], identifier)
+                    )
+
+    assert rv.status_code == HTTPStatus.OK
+    expected_entry = {
+        'id': ting.id,
+        'role': 'amalgamating',
+        'identifier': colin_identifier
+    }
+    if for_correction:
+        expected_entry['legalName'] = 'Colin Corp Ltd.'
+    assert rv.json['amalgamation']['amalgamatingBusinesses'] == [expected_entry]
+    assert colin_call_count['count'] == (1 if for_correction else 0)
 
 
 def test_get_business_extended_bad_request(app, session, client, jwt):

--- a/legal-api/tests/unit/resources/v2/test_colin_sync.py
+++ b/legal-api/tests/unit/resources/v2/test_colin_sync.py
@@ -23,10 +23,12 @@ from business_model.models.colin_event_id import ColinEventId
 from business_model.models.db import VersioningProxy
 from legal_api.services.authz import COLIN_SVC_ROLE
 from registry_schemas.example_data import (
+    AMALGAMATION_APPLICATION,
     ANNUAL_REPORT,
     CORRECTION_AR,
     CORRECTION_COL,
-    CORRECTION_COR
+    CORRECTION_COR,
+    FILING_HEADER
 )
 from tests.unit.services.utils import create_header
 from tests.unit.models import (
@@ -236,3 +238,40 @@ def test_get_completed_filings_for_colin_corps_correction(session, client, jwt):
     assert len(director['roles']) == 1
     assert director['roles'][0]['roleType'] == 'Director'
     assert director['roles'][0]['appointmentDate']
+
+def test_get_completed_filings_for_colin_short_form_amalgamation(session, client, jwt):
+    """Assert a short-form amalgamation sync payload is the stored filing json, passed through unchanged."""
+    identifier = 'BC7654322'
+    b = factory_business(identifier=identifier, entity_type=Business.LegalTypes.COMP.value)
+    factory_business_mailing_address(b)
+
+    filing_json = copy.deepcopy(FILING_HEADER)
+    filing_json['filing']['header']['name'] = 'amalgamationApplication'
+    filing_json['filing']['business']['identifier'] = identifier
+    filing_json['filing']['business']['legalType'] = 'BC'
+    filing_json['filing']['amalgamationApplication'] = copy.deepcopy(AMALGAMATION_APPLICATION)
+    aml = filing_json['filing']['amalgamationApplication']
+    aml['type'] = 'vertical'
+    aml['nameRequest']['legalName'] = 'Holding Business Ltd.'
+    aml['amalgamatingBusinesses'] = [
+        {'role': 'holding', 'identifier': 'BC5556667'},
+        {'role': 'amalgamating', 'identifier': 'BC5556668'}
+    ]
+    aml['shareStructure']['resolutionDates'] = ['2020-05-13']
+
+    filing = factory_completed_filing(b, filing_json)
+    assert filing.status == Filing.Status.COMPLETED.value
+
+    rv = client.get('/api/v2/businesses/internal/filings',
+                    headers=create_header(jwt, [COLIN_SVC_ROLE]))
+    assert rv.status_code == HTTPStatus.OK
+    filings = rv.json.get('filings')
+    assert len(filings) == 1
+    synced = filings[0]['filing']
+    # the header is never poisoned and the certified sections flow through untouched
+    assert synced['header']['name'] == 'amalgamationApplication'
+    assert synced['amalgamationApplication']['nameRequest']['legalName'] == 'Holding Business Ltd.'
+    assert synced['amalgamationApplication']['offices'] == aml['offices']
+    assert synced['amalgamationApplication']['parties'] == aml['parties']
+    assert synced['amalgamationApplication']['shareStructure'] == aml['shareStructure']
+    assert synced['amalgamationApplication']['amalgamatingBusinesses'] == aml['amalgamatingBusinesses']

--- a/legal-api/tests/unit/services/filings/validations/test_amalgamation_application.py
+++ b/legal-api/tests/unit/services/filings/validations/test_amalgamation_application.py
@@ -2154,11 +2154,9 @@ def test_expro_amalgamating_business(mocker, app, session, jwt, test_status, exp
         assert expected_msg in [x['error'] for x in err.msg]
 
 
-def test_expro_amalgamating_business_staff_only(mocker, app, session, jwt):
-    """Assert a non-staff user cannot amalgamate an extraprovincial."""
-    account_id = '123456'
+def _setup_basic_expro_amalgamation(mocker) -> dict:
+    """Wire the standard expro mocks and return a filing with one LEAR TING plus one expro entry."""
     filing = _get_amalg_template()
-    filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
     filing['filing']['amalgamationApplication']['amalgamatingBusinesses'] = [
         {'role': AmalgamatingBusiness.Role.amalgamating.name, 'identifier': 'BC1234567'},
         {'role': AmalgamatingBusiness.Role.amalgamating.name, 'identifier': EXPRO_IDENTIFIER}
@@ -2181,6 +2179,14 @@ def test_expro_amalgamating_business_staff_only(mocker, app, session, jwt):
     mocker.patch('business_model.models.business.Business.find_by_identifier', side_effect=mock_find_by_identifier)
     mocker.patch('legal_api.services.filings.validations.amalgamation_application.colin.get_snapshot',
                  return_value=_mock_expro_snapshot_response())
+    return filing
+
+
+def test_expro_amalgamating_business_staff_only(mocker, app, session, jwt):
+    """Assert a non-staff user cannot amalgamate an extraprovincial."""
+    account_id = '123456'
+    filing = _setup_basic_expro_amalgamation(mocker)
+    filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
 
     with jwt_request_context(app, jwt, [BASIC_USER], 'basic-user', account_id):
         err = validate(None, filing, account_id)
@@ -2193,31 +2199,9 @@ def test_expro_amalgamating_business_staff_only(mocker, app, session, jwt):
 def test_expro_name_not_adoptable(mocker, app, session, jwt):
     """Assert an expro's name is not an adoptable name for the resulting business."""
     account_id = '123456'
-    filing = _get_amalg_template()
+    filing = _setup_basic_expro_amalgamation(mocker)
     filing['filing']['amalgamationApplication']['nameRequest'].pop('nrNumber', None)
     filing['filing']['amalgamationApplication']['nameRequest']['legalName'] = 'EXPRO TEST COMPANY LTD.'
-    filing['filing']['amalgamationApplication']['amalgamatingBusinesses'] = [
-        {'role': AmalgamatingBusiness.Role.amalgamating.name, 'identifier': 'BC1234567'},
-        {'role': AmalgamatingBusiness.Role.amalgamating.name, 'identifier': EXPRO_IDENTIFIER}
-    ]
-
-    def mock_find_by_identifier(identifier):
-        if identifier == EXPRO_IDENTIFIER:
-            return None
-        return Business(identifier=identifier,
-                        founding_date=datetime.now(timezone.utc),
-                        state=Business.State.ACTIVE,
-                        legal_type=Business.LegalTypes.BCOMP.value)
-
-    mocker.patch('legal_api.services.filings.validations.amalgamation_application.validate_name_request',
-                 return_value=[])
-    mocker.patch('legal_api.services.filings.validations.amalgamation_application._has_pending_filing',
-                 return_value=False)
-    mocker.patch('legal_api.services.filings.validations.amalgamation_application._is_business_affliated',
-                 return_value=True)
-    mocker.patch('business_model.models.business.Business.find_by_identifier', side_effect=mock_find_by_identifier)
-    mocker.patch('legal_api.services.filings.validations.amalgamation_application.colin.get_snapshot',
-                 return_value=_mock_expro_snapshot_response())
 
     with jwt_request_context(app, jwt, [STAFF_ROLE], 'staff-user', account_id):
         err = validate(None, filing, account_id)

--- a/legal-api/tests/unit/services/filings/validations/test_amalgamation_application.py
+++ b/legal-api/tests/unit/services/filings/validations/test_amalgamation_application.py
@@ -1306,18 +1306,25 @@ def test_amalgamating_expro_to_cc_or_ulc(mocker, app, session, jwt, test_status,
             'role': AmalgamatingBusiness.Role.amalgamating.name,
             'identifier': 'BC1234567'
         },
+        # FAIL: an extraprovincial, submitted as an identifier-only COLIN entry;
+        # SUCCESS: a true foreign entry
         {
+            'role': AmalgamatingBusiness.Role.amalgamating.name,
+            'identifier': 'A1234567'
+        } if test_status == 'FAIL' else {
             'role': AmalgamatingBusiness.Role.amalgamating.name,
             'legalName': 'Foreign Co.',
             'foreignJurisdiction': {
                 'country': 'CA',
-                'region': 'BC'
+                'region': 'AB'
             },
-            'identifier': 'A1234567' if test_status == 'FAIL' else '7654321'
+            'identifier': '7654321'
         }
     ]
 
     def mock_find_by_identifier(identifier):
+        if identifier.startswith('A'):
+            return None
         return Business(identifier=identifier,
                         legal_type=Business.LegalTypes.BC_CCC.value)
 
@@ -1328,6 +1335,10 @@ def test_amalgamating_expro_to_cc_or_ulc(mocker, app, session, jwt, test_status,
     mocker.patch('legal_api.services.filings.validations.amalgamation_application._is_business_affliated',
                  return_value=True)
     mocker.patch('business_model.models.business.Business.find_by_identifier', side_effect=mock_find_by_identifier)
+    mocker.patch('legal_api.services.filings.validations.amalgamation_application.colin.get_snapshot',
+                 return_value=_mock_colin_snapshot_response(identifier='A1234567',
+                                                            legalName='EXPRO TEST COMPANY LTD.',
+                                                            legalType=Business.LegalTypes.EXTRA_PRO_A.value))
 
     with jwt_request_context(app, jwt, [STAFF_ROLE], 'staff-user', account_id):
         err = validate(None, filing, account_id)
@@ -1602,9 +1613,19 @@ def test_horizontal_amalgamation(mocker, app, session, jwt, test_name, expected_
     filing['filing']['amalgamationApplication']['amalgamatingBusinesses'][0]['role'] = \
         AmalgamatingBusiness.Role.primary.name
     if test_name == 'FAIL_EXPRO':
-        filing['filing']['amalgamationApplication']['amalgamatingBusinesses'][1]['foreignJurisdiction']['region'] = 'BC'
+        # an extraprovincial is an identifier-only COLIN entry
+        filing['filing']['amalgamationApplication']['amalgamatingBusinesses'][1] = {
+            'role': AmalgamatingBusiness.Role.amalgamating.name,
+            'identifier': 'A1234567'
+        }
+        mocker.patch('legal_api.services.filings.validations.amalgamation_application.colin.get_snapshot',
+                     return_value=_mock_colin_snapshot_response(identifier='A1234567',
+                                                                legalName='EXPRO TEST COMPANY LTD.',
+                                                                legalType=Business.LegalTypes.EXTRA_PRO_A.value))
 
     def mock_find_by_identifier(identifier):
+        if identifier.startswith('A'):
+            return None
         return Business(identifier=identifier,
                         legal_type=Business.LegalTypes.COMP.value)
 
@@ -2050,6 +2071,194 @@ def test_colin_holding_business_legal_type_match(mocker, app, session, jwt, resu
         assert type_error in [x['error'] for x in err.msg]
     else:
         assert not err
+
+
+EXPRO_IDENTIFIER = 'A1234567'
+
+
+def _mock_expro_snapshot_response(**overrides):
+    """Return a mocked colin-api snapshot for an extraprovincial (A) corp."""
+    return _mock_colin_snapshot_response(identifier=EXPRO_IDENTIFIER,
+                                         legalName='EXPRO TEST COMPANY LTD.',
+                                         legalType=Business.LegalTypes.EXTRA_PRO_A.value,
+                                         jurisdiction='ON',
+                                         **overrides)
+
+
+@pytest.mark.parametrize(
+    'test_status, expected_msg',
+    [
+        ('SUCCESS', None),
+        # foreign rules apply; state/affiliation/good-standing checks do not
+        ('HISTORICAL_IGNORED', None),
+        ('NOT_GOOD_STANDING_IGNORED', None),
+        ('HORIZONTAL', 'A foreign corporation or extra-Pro cannot be part of a Horizontal amalgamation.'),
+        ('HOLDING_ROLE', 'A EXPRO TEST COMPANY LTD. foreign corporation cannot be marked as Primary or Holding.'),
+        ('ULC_TING', 'A BC Unlimited Liability Company cannot amalgamate with '
+                     'a foreign company EXPRO TEST COMPANY LTD..'),
+    ]
+)
+def test_expro_amalgamating_business(mocker, app, session, jwt, test_status, expected_msg):
+    """Assert an identifier-only extraprovincial entry gets the foreign rule set with COLIN's name."""
+    account_id = '123456'
+    filing = _get_amalg_template()
+    filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
+    expro_role = (AmalgamatingBusiness.Role.holding.name if test_status == 'HOLDING_ROLE'
+                  else AmalgamatingBusiness.Role.amalgamating.name)
+    filing['filing']['amalgamationApplication']['amalgamatingBusinesses'] = [
+        {'role': AmalgamatingBusiness.Role.amalgamating.name, 'identifier': 'BC1234567'},
+        {'role': AmalgamatingBusiness.Role.amalgamating.name, 'identifier': 'BC1234568'},
+        {'role': expro_role, 'identifier': EXPRO_IDENTIFIER}
+    ]
+    if test_status == 'HORIZONTAL':
+        filing['filing']['amalgamationApplication']['type'] = Amalgamation.AmalgamationTypes.horizontal.name
+        filing['filing']['amalgamationApplication']['amalgamatingBusinesses'][0]['role'] = \
+            AmalgamatingBusiness.Role.primary.name
+
+    def mock_find_by_identifier(identifier):
+        if identifier == EXPRO_IDENTIFIER:
+            return None
+        legal_type = (Business.LegalTypes.BC_ULC_COMPANY.value if test_status == 'ULC_TING'
+                      else Business.LegalTypes.BCOMP.value)
+        return Business(identifier=identifier,
+                        founding_date=datetime.now(timezone.utc),
+                        state=Business.State.ACTIVE,
+                        legal_type=legal_type)
+
+    mocker.patch('legal_api.services.filings.validations.amalgamation_application.validate_name_request',
+                 return_value=[])
+    mocker.patch('legal_api.services.filings.validations.amalgamation_application._has_pending_filing',
+                 return_value=False)
+    mocker.patch('business_model.models.business.Business.find_by_identifier', side_effect=mock_find_by_identifier)
+    # the expro entry never consults affiliation - fail loudly if it does
+    mocker.patch('legal_api.services.filings.validations.amalgamation_application._is_business_affliated',
+                 side_effect=lambda identifier, account_id: identifier != EXPRO_IDENTIFIER)
+
+    snapshot_responses = {
+        'HISTORICAL_IGNORED': _mock_expro_snapshot_response(state=Business.State.HISTORICAL.name),
+        'NOT_GOOD_STANDING_IGNORED': _mock_expro_snapshot_response(goodStanding=False),
+    }
+    mocker.patch('legal_api.services.filings.validations.amalgamation_application.colin.get_snapshot',
+                 return_value=snapshot_responses.get(test_status, _mock_expro_snapshot_response()))
+    # short-form data match is out of scope here (only reached by the HORIZONTAL case)
+    mocker.patch('legal_api.services.filings.validations.amalgamation_application.validate_primary_or_holding_match',
+                 return_value=[])
+
+    with jwt_request_context(app, jwt, [STAFF_ROLE], 'staff-user', account_id):
+        err = validate(None, filing, account_id)
+
+    if expected_msg is None:
+        assert not err
+    else:
+        assert err.code == HTTPStatus.BAD_REQUEST
+        assert expected_msg in [x['error'] for x in err.msg]
+
+
+def test_expro_amalgamating_business_staff_only(mocker, app, session, jwt):
+    """Assert a non-staff user cannot amalgamate an extraprovincial."""
+    account_id = '123456'
+    filing = _get_amalg_template()
+    filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
+    filing['filing']['amalgamationApplication']['amalgamatingBusinesses'] = [
+        {'role': AmalgamatingBusiness.Role.amalgamating.name, 'identifier': 'BC1234567'},
+        {'role': AmalgamatingBusiness.Role.amalgamating.name, 'identifier': EXPRO_IDENTIFIER}
+    ]
+
+    def mock_find_by_identifier(identifier):
+        if identifier == EXPRO_IDENTIFIER:
+            return None
+        return Business(identifier=identifier,
+                        founding_date=datetime.now(timezone.utc),
+                        state=Business.State.ACTIVE,
+                        legal_type=Business.LegalTypes.BCOMP.value)
+
+    mocker.patch('legal_api.services.filings.validations.amalgamation_application.validate_name_request',
+                 return_value=[])
+    mocker.patch('legal_api.services.filings.validations.amalgamation_application._has_pending_filing',
+                 return_value=False)
+    mocker.patch('legal_api.services.filings.validations.amalgamation_application._is_business_affliated',
+                 return_value=True)
+    mocker.patch('business_model.models.business.Business.find_by_identifier', side_effect=mock_find_by_identifier)
+    mocker.patch('legal_api.services.filings.validations.amalgamation_application.colin.get_snapshot',
+                 return_value=_mock_expro_snapshot_response())
+
+    with jwt_request_context(app, jwt, [BASIC_USER], 'basic-user', account_id):
+        err = validate(None, filing, account_id)
+
+    assert err.code == HTTPStatus.BAD_REQUEST
+    assert ('EXPRO TEST COMPANY LTD. foreign corporation cannot be amalgamated except by Registries staff.'
+            in [x['error'] for x in err.msg])
+
+
+def test_expro_name_not_adoptable(mocker, app, session, jwt):
+    """Assert an expro's name is not an adoptable name for the resulting business."""
+    account_id = '123456'
+    filing = _get_amalg_template()
+    filing['filing']['amalgamationApplication']['nameRequest'].pop('nrNumber', None)
+    filing['filing']['amalgamationApplication']['nameRequest']['legalName'] = 'EXPRO TEST COMPANY LTD.'
+    filing['filing']['amalgamationApplication']['amalgamatingBusinesses'] = [
+        {'role': AmalgamatingBusiness.Role.amalgamating.name, 'identifier': 'BC1234567'},
+        {'role': AmalgamatingBusiness.Role.amalgamating.name, 'identifier': EXPRO_IDENTIFIER}
+    ]
+
+    def mock_find_by_identifier(identifier):
+        if identifier == EXPRO_IDENTIFIER:
+            return None
+        return Business(identifier=identifier,
+                        founding_date=datetime.now(timezone.utc),
+                        state=Business.State.ACTIVE,
+                        legal_type=Business.LegalTypes.BCOMP.value)
+
+    mocker.patch('legal_api.services.filings.validations.amalgamation_application.validate_name_request',
+                 return_value=[])
+    mocker.patch('legal_api.services.filings.validations.amalgamation_application._has_pending_filing',
+                 return_value=False)
+    mocker.patch('legal_api.services.filings.validations.amalgamation_application._is_business_affliated',
+                 return_value=True)
+    mocker.patch('business_model.models.business.Business.find_by_identifier', side_effect=mock_find_by_identifier)
+    mocker.patch('legal_api.services.filings.validations.amalgamation_application.colin.get_snapshot',
+                 return_value=_mock_expro_snapshot_response())
+
+    with jwt_request_context(app, jwt, [STAFF_ROLE], 'staff-user', account_id):
+        err = validate(None, filing, account_id)
+
+    assert err.code == HTTPStatus.BAD_REQUEST
+    assert ('Adopt a name that have the same business type as the resulting business.'
+            in [x['error'] for x in err.msg])
+
+
+def test_foreign_business_region_bc_rejected(mocker, app, session, jwt):
+    """Assert a foreign entry in region BC is rejected."""
+    account_id = '123456'
+    filing = _get_amalg_template()
+    filing['filing']['amalgamationApplication']['nameRequest']['nrNumber'] = 'NR 1234567'
+    filing['filing']['amalgamationApplication']['amalgamatingBusinesses'] = [
+        {'role': AmalgamatingBusiness.Role.amalgamating.name, 'identifier': 'BC1234567'},
+        {
+            'role': AmalgamatingBusiness.Role.amalgamating.name,
+            'legalName': 'EXPRO TEST COMPANY LTD.',
+            'foreignJurisdiction': {'country': 'CA', 'region': 'BC'},
+            'identifier': EXPRO_IDENTIFIER
+        }
+    ]
+
+    mocker.patch('legal_api.services.filings.validations.amalgamation_application.validate_name_request',
+                 return_value=[])
+    mocker.patch('legal_api.services.filings.validations.amalgamation_application._has_pending_filing',
+                 return_value=False)
+    mocker.patch('legal_api.services.filings.validations.amalgamation_application._is_business_affliated',
+                 return_value=True)
+    mocker.patch('business_model.models.business.Business.find_by_identifier',
+                 side_effect=lambda identifier: Business(identifier=identifier,
+                                                         founding_date=datetime.now(timezone.utc),
+                                                         state=Business.State.ACTIVE,
+                                                         legal_type=Business.LegalTypes.BCOMP.value))
+
+    with jwt_request_context(app, jwt, [STAFF_ROLE], 'staff-user', account_id):
+        err = validate(None, filing, account_id)
+
+    assert err.code == HTTPStatus.BAD_REQUEST
+    assert 'Region should not be BC.' in [x['error'] for x in err.msg]
 
 
 REFRESH_HINT = "Refresh the draft with the business's current data."

--- a/legal-api/tests/unit/services/filings/validations/test_correction_ia.py
+++ b/legal-api/tests/unit/services/filings/validations/test_correction_ia.py
@@ -1027,6 +1027,48 @@ def test_validate_correction_amalgamation_ting_invalid(mocker, app, session, jwt
     assert err.msg[0]['path'] == '/filing/correction/amalgamation/amalgamatingBusinesses/0'
 
 
+def test_validate_correction_amalgamation_colin_ting(mocker, app, session, jwt):
+    """Assert a COLIN (incl. extraprovincial) ting is not correctable and errors cleanly."""
+    identifier = 'BC1234567'
+    business = factory_business(identifier, entity_type='BC')
+    filing_type = 'amalgamationApplication'
+    data, corrected_filing = _create_amalgation_business(business)
+
+    # swap in a COLIN-identifier ting (an extraprovincial)
+    amalgamation = business.amalgamation.first()
+    colin_ting = AmalgamatingBusiness(
+        role=AmalgamatingBusiness.Role.amalgamating,
+        colin_identifier='A7654321'
+    )
+    amalgamation.amalgamating_businesses.append(colin_ting)
+    business.save()
+    # schema-valid correction entry attempting to attach foreign data to the COLIN ting
+    data['amalgamatingBusinesses'] = [
+        {
+            'role': 'amalgamating',
+            'identifier': 'A7654321',
+            'id': colin_ting.id,
+            'legalName': 'NOT A FOREIGN CO',
+            'foreignJurisdiction': {'country': 'CA', 'region': 'AB'}
+        }
+    ]
+
+    filing = copy.deepcopy(CORRECTION)
+    filing['filing']['header']['identifier'] = identifier
+    filing['filing']['correction']['correctedFilingId'] = corrected_filing.id
+    filing['filing']['correction']['correctedFilingType'] = filing_type
+    filing['filing']['correction']['amalgamation'] = data
+    filing['filing']['business']['legalType'] = 'BC'
+    del filing['filing']['correction']['commentOnly']
+
+    with jwt_request_context(app, jwt, [BASIC_USER]):
+        err = validate(business, filing)
+
+    assert len(err.msg) == 1
+    assert err.msg[0]['error'] == 'Can only correct foreign businesses.'
+    assert err.msg[0]['path'] == '/filing/correction/amalgamation/amalgamatingBusinesses/0'
+
+
 def _create_amalgation_business(business):
     amalgamating_identifier = 'BC1234567'
     amalgamating_business = factory_business(amalgamating_identifier, entity_type='BC')


### PR DESCRIPTION
*Issue #:* /bcgov/entity#34085 , bcgov/entity#34087

*Description of changes:*
- outputs for amalg can now use filing json for all cases and handle colin businesses
- colin sync can now use filing json for all cases

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
