### PR TITLE
continuation in 2 step nr check

### DIFF
--- a/legal-api/pyproject.toml
+++ b/legal-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "legal-api"
-version = "3.1.18"
+version = "3.1.19"
 description = ""
 authors = [
     {name = "thor",email = "1042854+thorwolpert@users.noreply.github.com"}

--- a/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_filings/business_filings.py
@@ -155,7 +155,7 @@ def saving_filings(body: FilingModel,  # noqa: PLR0911, PLR0912
             business_validate = RegistrationBootstrap.find_by_identifier(identifier)
         else:
             business_validate = business
-        err = validate(business_validate, json_input, payment_account_id)
+        err = validate(business_validate, json_input, payment_account_id, filing_id=filing_id)
         if err or query.only_validate:
             if err:
                 json_input["errors"] = err.msg

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -129,11 +129,10 @@ NR_BLOCKING_STATUSES = [
 def _nr_in_pending_filing(nr_number: str, exclude_filing_id: int | None = None) -> bool:
     """Return True if the NR is already referenced in a non-draft/non-completed filing.
 
-    exclude_filing_id: the ID of the filing currently being validated. Some filings (e.g.
-    continuationIn) go through a 2-step staff review — the filing sits in AWAITING_REVIEW
-    while staff approves it. Without this exclusion, the 2-step approval would find the
-    same filing in APPROVED and incorrectly block itself with a duplicate-NR error.
-    Excluding the current filing ensures only *other* filings are checked.
+    exclude_filing_id: the ID of the filing currently being validated. Continuation In filings
+    go through a 2-step process which require staff review. When the second step is submitted,
+   the status of the filing is sitting in APPROVED. Excluding the current filing ensures only
+    *other* filings are checked and does not incorrectly block itself with a duplicate-NR error.
     """
     for filing_type in FILING_TYPES_WITH_NR:
         query = Filing.query.filter(

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -127,7 +127,14 @@ NR_BLOCKING_STATUSES = [
 
 
 def _nr_in_pending_filing(nr_number: str, exclude_filing_id: int | None = None) -> bool:
-    """Return True if the NR is already referenced in a non-draft/non-completed filing."""
+    """Return True if the NR is already referenced in a non-draft/non-completed filing.
+
+    exclude_filing_id: the ID of the filing currently being validated. Some filings (e.g.
+    continuationIn) go through a 2-step staff review — the filing sits in AWAITING_REVIEW
+    while staff approves it. Without this exclusion, the 2-step approval would find the
+    same filing in AWAITING_REVIEW and incorrectly block itself with a duplicate-NR error.
+    Excluding the current filing ensures only *other* filings are checked.
+    """
     for filing_type in FILING_TYPES_WITH_NR:
         query = Filing.query.filter(
             Filing._status.in_([s.value for s in NR_BLOCKING_STATUSES]),

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -126,13 +126,16 @@ NR_BLOCKING_STATUSES = [
 ]
 
 
-def _nr_in_pending_filing(nr_number: str) -> bool:
+def _nr_in_pending_filing(nr_number: str, exclude_filing_id: int | None = None) -> bool:
     """Return True if the NR is already referenced in a non-draft/non-completed filing."""
     for filing_type in FILING_TYPES_WITH_NR:
-        if Filing.query.filter(
+        query = Filing.query.filter(
             Filing._status.in_([s.value for s in NR_BLOCKING_STATUSES]),
             Filing.filing_json["filing"][filing_type.value]["nameRequest"]["nrNumber"].astext == nr_number
-        ).first():
+        )
+        if exclude_filing_id:
+            query = query.filter(Filing.id != exclude_filing_id)
+        if query.first():
             return True
     return False
 
@@ -978,7 +981,8 @@ def _validate_relationship_date(date_value: date,
 def validate_name_request(filing_json: dict,  # pylint: disable=too-many-locals
                           legal_type: str,
                           filing_type: str,
-                          accepted_request_types: list | None = None) -> list:
+                          accepted_request_types: list | None = None,
+                          filing_id: int | None = None) -> list:
     """Validate name request section."""
     nr_path = f"/filing/{filing_type}/nameRequest"
     nr_number_path = f"{nr_path}/nrNumber"
@@ -1012,7 +1016,7 @@ def validate_name_request(filing_json: dict,  # pylint: disable=too-many-locals
         msg.append({"error": _("Name Request is not approved."), "path": nr_number_path})
 
     # ensure NR is not already referenced in another pending/paid filing
-    if _nr_in_pending_filing(nr_number):
+    if _nr_in_pending_filing(nr_number, exclude_filing_id=filing_id):
         msg.append({"error": _("Name Request is already part of a pending filing."),
                     "path": nr_number_path})
 

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -132,7 +132,7 @@ def _nr_in_pending_filing(nr_number: str, exclude_filing_id: int | None = None) 
     exclude_filing_id: the ID of the filing currently being validated. Some filings (e.g.
     continuationIn) go through a 2-step staff review — the filing sits in AWAITING_REVIEW
     while staff approves it. Without this exclusion, the 2-step approval would find the
-    same filing in AWAITING_REVIEW and incorrectly block itself with a duplicate-NR error.
+    same filing in APPROVED and incorrectly block itself with a duplicate-NR error.
     Excluding the current filing ensures only *other* filings are checked.
     """
     for filing_type in FILING_TYPES_WITH_NR:

--- a/legal-api/src/legal_api/services/filings/validations/continuation_in.py
+++ b/legal-api/src/legal_api/services/filings/validations/continuation_in.py
@@ -43,7 +43,7 @@ from legal_api.services.utils import get_bool, get_str
 FOREIGN_JURISDICTION_IDENTIFIER_MAX_LENGTH = 50
 FOREIGN_JURISDICTION_LEGAL_NAME_MAX_LENGTH = 1000
 
-def validate(filing_json: dict) -> Error | None:  # pylint: disable=too-many-branches;
+def validate(filing_json: dict, filing_id: int | None = None) -> Error | None:  # pylint: disable=too-many-branches;
     """Validate the Continuation In filing."""
     filing_type = "continuationIn"
     if not filing_json:
@@ -73,7 +73,7 @@ def validate(filing_json: dict) -> Error | None:  # pylint: disable=too-many-bra
         foreign_jurisdiction,
         f"/filing/{filing_type}/foreignJurisdiction"
     ))
-    msg.extend(validate_name_request(filing_json, legal_type, filing_type))
+    msg.extend(validate_name_request(filing_json, legal_type, filing_type, filing_id=filing_id))
 
     if get_bool(filing_json, "/filing/continuationIn/isApproved"):
         msg.extend(validate_offices(filing_json, legal_type, filing_type))

--- a/legal-api/src/legal_api/services/filings/validations/validation.py
+++ b/legal-api/src/legal_api/services/filings/validations/validation.py
@@ -64,7 +64,8 @@ from .transparency_register import validate as transparency_register_validate
 
 def validate(business: Business,  # noqa: PLR0915, PLR0912, PLR0911
              filing_json: dict,
-             account_id=None) -> Error:
+             account_id=None,
+             filing_id: int | None = None) -> Error:
     """Validate the filing JSON."""
     err = validate_against_schema(filing_json)
     if err:
@@ -237,7 +238,7 @@ def validate(business: Business,  # noqa: PLR0915, PLR0912, PLR0911
                     err = amalgamation_application_validate(filing_json, account_id)
 
                 elif k == Filing.FILINGS["continuationIn"].get("name"):
-                    err = continuation_in_validate(filing_json)
+                    err = continuation_in_validate(filing_json, filing_id=filing_id)
 
                 elif k == Filing.FILINGS["noticeOfWithdrawal"].get("name"):
                     err = notice_of_withdrawal_validate(filing_json)

--- a/legal-api/tests/unit/services/filings/validations/test_common_validations.py
+++ b/legal-api/tests/unit/services/filings/validations/test_common_validations.py
@@ -2379,29 +2379,33 @@ def test_get_file_data_drs_failure(session, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "test_name, filing_type, status, has_nr, expected",
+    "test_name, filing_type, status, has_nr, expected, exclude_own_id",
     [
         # All valid NR filing types in PENDING state are blocked
-        ("ia_pending", "incorporationApplication", "PENDING", True, True),
-        ("reg_pending", "registration", "PENDING", True, True),
-        ("amalg_pending", "amalgamationApplication", "PENDING", True, True),
-        ("cont_in_pending", "continuationIn", "PENDING", True, True),
-        ("alt_pending", "alteration", "PENDING", True, True),
-        ("con_name_pending", "changeOfName", "PENDING", True, True),
-        ("cor_reg_pending", "changeOfRegistration", "PENDING", True, True),
-        ("conv_pending", "conversion", "PENDING", True, True),
+        ("ia_pending", "incorporationApplication", "PENDING", True, True, False),
+        ("reg_pending", "registration", "PENDING", True, True, False),
+        ("amalg_pending", "amalgamationApplication", "PENDING", True, True, False),
+        ("cont_in_pending", "continuationIn", "PENDING", True, True, False),
+        ("alt_pending", "alteration", "PENDING", True, True, False),
+        ("con_name_pending", "changeOfName", "PENDING", True, True, False),
+        ("cor_reg_pending", "changeOfRegistration", "PENDING", True, True, False),
+        ("conv_pending", "conversion", "PENDING", True, True, False),
         # PAID filing blocks
-        ("ia_paid", "incorporationApplication", "PAID", True, True),
+        ("ia_paid", "incorporationApplication", "PAID", True, True, False),
         # DRAFT filing does not block
-        ("ia_draft", "incorporationApplication", "DRAFT", True, False),
+        ("ia_draft", "incorporationApplication", "DRAFT", True, False, False),
         # Valid NR filing type but no NR information present — does not block
-        ("ia_no_nr", "incorporationApplication", "PENDING", False, False),
+        ("ia_no_nr", "incorporationApplication", "PENDING", False, False, False),
         # Invalid NR filing type (dissolution is not in FILING_TYPES_WITH_NR) — does not block
-        ("dissolution_pending", "dissolution", "PENDING", True, False),
+        ("dissolution_pending", "dissolution", "PENDING", True, False, False),
+        # exclude_filing_id: excluding self does not block (continuationIn 2-step approval fix)
+        ("cont_in_self_exclude", "continuationIn", "PENDING", True, False, True),
+        # exclude_filing_id: excluding a different id still blocks
+        ("cont_in_other_exclude", "continuationIn", "PENDING", True, True, False),
     ]
 )
-def test_nr_in_pending_filing(session, test_name, filing_type, status, has_nr, expected):
-    """Assert _nr_in_pending_filing blocks based on filing type, status, and NR presence."""
+def test_nr_in_pending_filing(session, test_name, filing_type, status, has_nr, expected, exclude_own_id):
+    """Assert _nr_in_pending_filing blocks based on filing type, status, NR presence, and exclusion."""
     import random
     nr_number = f"NR {random.randint(1000000, 9999999)}"
 
@@ -2430,6 +2434,7 @@ def test_nr_in_pending_filing(session, test_name, filing_type, status, has_nr, e
         f.filing_json = filing_json
         f.save()
     else:  # PENDING
-        factory_pending_filing(None, filing_json)
+        f = factory_pending_filing(None, filing_json)
 
-    assert _nr_in_pending_filing(nr_number) is expected
+    exclude_filing_id = f.id if exclude_own_id else None
+    assert _nr_in_pending_filing(nr_number, exclude_filing_id=exclude_filing_id) is expected


### PR DESCRIPTION
*Issue #:* /bcgov/entity#32831

*Description of changes:*

Bug:
When a Continuation In filing goes through its 2-step approval process, the NR duplicate check introduced blocks step 2. Because the same filing that used the NR in step 1 is being flagged as a Duplicate when staff tries to approve it in step 2. ( Double NR Check on same filing) .

Fix:

Pass the current filing's ID into the NR duplicate check so it can skip itself — allowing the same filing to proceed from step 1 to step 2 with the same NR it originally submitted.