### PR TITLE
34522 - Remove Active CAO Validation for Amalgamation Out Filing

### DIFF
--- a/legal-api/pyproject.toml
+++ b/legal-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "legal-api"
-version = "3.1.19"
+version = "3.1.20"
 description = ""
 authors = [
     {name = "thor",email = "1042854+thorwolpert@users.noreply.github.com"}

--- a/legal-api/src/legal_api/services/filings/validations/amalgamation_out.py
+++ b/legal-api/src/legal_api/services/filings/validations/amalgamation_out.py
@@ -18,7 +18,7 @@ from typing import Final
 from flask_babel import _ as babel
 
 from business_common.utils.legislation_datetime import LegislationDatetime
-from business_model.models import Business, ConsentContinuationOut
+from business_model.models import Business
 from legal_api.errors import Error
 from legal_api.services import flags
 from legal_api.services.filings.validations.common_validations import (
@@ -41,20 +41,11 @@ def validate(business: Business, filing: dict) -> Error | None:
     msg = []
     filing_type = "amalgamationOut"
 
-    is_valid_co_date = True
-    is_valid_foreign_jurisdiction = True
-
-    if err := validate_amalgamation_out_date(filing, f"/filing/{filing_type}/amalgamationOutDate"):
-        msg.extend(err)
-        is_valid_co_date = False
-
-    if err := validate_foreign_jurisdiction(filing["filing"][filing_type]["foreignJurisdiction"],
-                                            f"/filing/{filing_type}/foreignJurisdiction"):
-        msg.extend(err)
-        is_valid_foreign_jurisdiction = False
-
-    if is_valid_co_date and is_valid_foreign_jurisdiction:
-        msg.extend(validate_active_cao(business, filing, filing_type))
+    msg.extend(validate_amalgamation_out_date(filing, f"/filing/{filing_type}/amalgamationOutDate"))
+    msg.extend(validate_foreign_jurisdiction(
+        filing["filing"][filing_type]["foreignJurisdiction"],
+        f"/filing/{filing_type}/foreignJurisdiction"
+    ))
 
     if court_order := filing.get("filing", {}).get(filing_type, {}).get("courtOrder", None):
         court_order_path: Final = f"/filing/{filing_type}/courtOrder"
@@ -63,35 +54,6 @@ def validate(business: Business, filing: dict) -> Error | None:
     if msg:
         return Error(HTTPStatus.BAD_REQUEST, msg)
     return None
-
-
-def validate_active_cao(business: Business, filing: dict, filing_type: str) -> list:
-    """Validate active consent amalgamation out."""
-    msg = []
-    amalgamation_out_date_str = filing["filing"][filing_type]["amalgamationOutDate"]
-    amalgamation_out_date = LegislationDatetime.as_legislation_timezone_from_date_str(amalgamation_out_date_str)
-
-    foreign_jurisdiction = filing["filing"][filing_type]["foreignJurisdiction"]
-    country_code = foreign_jurisdiction.get("country")
-    region = foreign_jurisdiction.get("region")
-
-    amalgamation_out_date_utc = LegislationDatetime.as_utc_timezone(amalgamation_out_date)
-    caos = ConsentContinuationOut.get_active_cco(business.id, amalgamation_out_date_utc, country_code, region,
-                                                 consent_type=ConsentContinuationOut.ConsentTypes.amalgamation_out)
-
-    active_consent = False
-    # Make sure amalgamation_out_date is on or after consent filing effective date
-    for consent in caos:
-        if amalgamation_out_date.date() >= \
-                LegislationDatetime.as_legislation_timezone(consent.filing.effective_date).date():
-            active_consent = True
-            break
-
-    if not active_consent:
-        msg.extend([{"error": "No active consent amalgamation out for this date and/or jurisdiction.",
-                    "path": f"/filing/{filing_type}/amalgamationOutDate"}])
-
-    return msg
 
 
 def validate_amalgamation_out_date(filing: dict, amalgamation_out_date_path: str) -> list:

--- a/legal-api/tests/unit/services/filings/validations/test_amalgamation_out.py
+++ b/legal-api/tests/unit/services/filings/validations/test_amalgamation_out.py
@@ -28,7 +28,6 @@ from tests.unit.models import factory_business, factory_completed_filing, get_cc
 
 date_format = '%Y-%m-%d'
 legal_name = 'Test name request'
-validate_active_cao_path = 'legal_api.services.filings.validations.amalgamation_out.validate_active_cao'
 
 
 def _create_consent_amalgamation_out(business, foreign_jurisdiction, effective_date=datetime.utcnow()):
@@ -55,7 +54,7 @@ def _create_consent_amalgamation_out(business, foreign_jurisdiction, effective_d
     'test_name, expected_code, message',
     [
         ('FAIL_IN_FUTURE', HTTPStatus.BAD_REQUEST, 'Amalgamation out date must be today or past.'),
-        ('FAIL_NO_CAO', HTTPStatus.BAD_REQUEST, 'No active consent amalgamation out for this date and/or jurisdiction.'),
+        ('SUCCESS_NO_CAO', None, None),
         ('SUCCESS', None, None)
     ]
 )
@@ -76,7 +75,7 @@ def test_validate_amalgamation_out_date(session, test_name, expected_code, messa
     if test_name == 'FAIL_IN_FUTURE':
         filing['filing']['amalgamationOut']['amalgamationOutDate'] = \
             (LegislationDatetime.now() + datedelta.datedelta(days=1)).strftime(date_format)
-    elif test_name == 'FAIL_NO_CAO':
+    elif test_name == 'SUCCESS_NO_CAO':
         effective_date -= datedelta.datedelta(months=6, days=1)
 
     _create_consent_amalgamation_out(business,
@@ -85,7 +84,7 @@ def test_validate_amalgamation_out_date(session, test_name, expected_code, messa
     err = validate(business, filing)
 
     # validate outcomes
-    if test_name != 'SUCCESS':
+    if test_name == 'FAIL_IN_FUTURE':
         assert expected_code == err.code
         assert message == err.msg[0]['error']
     else:
@@ -126,7 +125,6 @@ def test_validate_foreign_jurisdiction(session, mocker, test_name, expected_code
         filing['filing']['amalgamationOut']['foreignJurisdiction']['country'] = 'US'
         filing['filing']['amalgamationOut']['foreignJurisdiction']['region'] = 'NONE'
 
-    mocker.patch(validate_active_cao_path, return_value=[])
     err = validate(business, filing)
 
     # validate outcomes
@@ -147,7 +145,6 @@ def test_valid_foreign_jurisdiction(session, mocker, monkeypatch):
     business = factory_business(identifier='BC1234567', entity_type='BC', founding_date=datetime.utcnow())
     filing = copy.deepcopy(FILING_HEADER)
     filing['filing']['header']['name'] = 'amalgamationOut'
-    mocker.patch(validate_active_cao_path, return_value=[])
 
     for country in pycountry.countries:
         filing['filing']['amalgamationOut'] = copy.deepcopy(AMALGAMATION_OUT)
@@ -191,7 +188,6 @@ def test_amalgamation_out_court_order(session, mocker, test_status, file_number,
     else:
         del filing['filing']['amalgamationOut']['courtOrder']['fileNumber']
 
-    mocker.patch(validate_active_cao_path, return_value=[])
     err = validate(business, filing)
 
     # validate outcomes


### PR DESCRIPTION
*Issue #:* /bcgov/entity#34522

*Description of changes:*
- Remove validation that requires an active consent to amalgamate out
- Update unit tests

Note: amalgamationOut is a staff-only filing (listed only under the staff section of the allowable filings in authz), so loosening this validation only affects staff. This matches the same change made for continuation out in #4561.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).