### PR TITLE
34553 skip completing party name check for SBC staff

### DIFF
--- a/legal-api/pyproject.toml
+++ b/legal-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "legal-api"
-version = "3.1.20"
+version = "3.1.19a"
 description = ""
 authors = [
     {name = "thor",email = "1042854+thorwolpert@users.noreply.github.com"}

--- a/legal-api/pyproject.toml
+++ b/legal-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "legal-api"
-version = "3.1.19"
+version = "3.1.20"
 description = ""
 authors = [
     {name = "thor",email = "1042854+thorwolpert@users.noreply.github.com"}

--- a/legal-api/src/legal_api/services/filings/validations/registration.py
+++ b/legal-api/src/legal_api/services/filings/validations/registration.py
@@ -27,6 +27,7 @@ from business_model.models import Business, PartyRole, User
 from legal_api.core.filing import Filing
 from legal_api.errors import Error
 from legal_api.services import STAFF_ROLE, NaicsService, flags
+from legal_api.services.authz import SBC_STAFF_ROLE
 from legal_api.services.filings.validations.common_validations import (
     is_same_str,
     validate_court_order,
@@ -171,14 +172,16 @@ def validate_completing_party_name(filing: dict, filing_type="registration") -> 
     """Validate the completing party name matches the submitting user's name.
 
     Clients cannot edit the completing party (it is pre-populated from their login),
-    so the submitted name must match their user record; staff enter it manually from
-    a paper form and API gateway users have their own workflow, so both are skipped.
+    so the submitted name must match their user record; registry and SBC staff enter it
+    manually from a paper form and API gateway users have their own workflow, so those
+    are skipped.
     """
     api_login_source = "API_GW"  # jwt loginSource of an API gateway user
     msg = []
     current_user = getattr(request_ctx, "current_user", None) if has_request_context() else None
     if (not current_user
             or jwt.validate_roles(current_user, [STAFF_ROLE])
+            or jwt.validate_roles(current_user, [SBC_STAFF_ROLE])
             or current_user.get("loginSource") == api_login_source):
         return msg
 

--- a/legal-api/tests/unit/services/filings/validations/test_registration.py
+++ b/legal-api/tests/unit/services/filings/validations/test_registration.py
@@ -24,7 +24,7 @@ from business_common.utils.legislation_datetime import LegislationDatetime
 from business_model.models import Business, User
 from legal_api.services import NaicsService, NameXService, flags 
 from legal_api.services.filings.validations.validation import validate
-from legal_api.services.authz import BASIC_USER, STAFF_ROLE
+from legal_api.services.authz import BASIC_USER, SBC_STAFF_ROLE, STAFF_ROLE
 from registry_schemas.example_data import FILING_HEADER, REGISTRATION
 
 from tests.unit.services.filings.validations import create_party, create_party_address
@@ -457,6 +457,7 @@ MISMATCH_ERROR = 'Completing party name must match the name of the logged in use
          MISMATCH_ERROR),
         ('client_user_record_no_name', [BASIC_USER], 'BCSC', (None, None, None), None, MISMATCH_ERROR),
         ('staff_skipped', [STAFF_ROLE], 'IDIR', ('Different', None, 'Person'), None, None),
+        ('sbc_staff_skipped', [SBC_STAFF_ROLE], 'IDIR', ('Different', None, 'Person'), None, None),
         ('api_gw_skipped', [BASIC_USER], 'API_GW', ('Different', None, 'Person'), None, None),
     ]
 )


### PR DESCRIPTION
*Issue:* bcgov/entity#34553

Description of changes:
Exclude the sbc_staff role (alongside staff) from the logged-in user name check on firm registrations, since SBC staff enter the completing party manually from the paper form.