### PR TITLE
34514 fix tasks load for legacy data with year 1 founding date

### DIFF
--- a/legal-api/src/legal_api/resources/v2/business/business_tasks.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_tasks.py
@@ -151,7 +151,7 @@ def construct_task_list(business: Business):  # noqa: PLR0915
         tasks.append(task)
         order += 1
 
-    # Skip AR todos when founding date is the COLIN year-1 sentinel / unknown. Without this,
+    # Skip AR todos when founding date is the COLIN year 0001 (for legacy data like railways). Without this,
     # a sentinel founding_date of 0001-01-01 generates ~2000 AR todos and a multi-MB /tasks payload.
     unknown_founding_date = (
         not business.founding_date or business.founding_date.year <= 1

--- a/legal-api/src/legal_api/resources/v2/business/business_tasks.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_tasks.py
@@ -151,7 +151,16 @@ def construct_task_list(business: Business):  # noqa: PLR0915
         tasks.append(task)
         order += 1
 
-    if business.legal_type not in entity_types_no_ar and not business.in_liquidation:
+    # Skip AR todos when founding date is the COLIN year-1 sentinel / unknown. Without this,
+    # a sentinel founding_date of 0001-01-01 generates ~2000 AR todos and a multi-MB /tasks payload.
+    unknown_founding_date = (
+        not business.founding_date or business.founding_date.year <= 1
+    )
+    if (
+        business.legal_type not in entity_types_no_ar
+        and not business.in_liquidation
+        and not unknown_founding_date
+    ):
         # If this is the first calendar year since incorporation, there is no previous ar year.
         next_ar_year = (business.last_ar_year if business.last_ar_year else business.founding_date.year) + 1
 

--- a/legal-api/tests/unit/resources/v2/test_business_tasks.py
+++ b/legal-api/tests/unit/resources/v2/test_business_tasks.py
@@ -94,7 +94,7 @@ def test_get_tasks_no_filings(session, client, jwt):
 
     rv = client.get(f'/api/v2/businesses/{identifier}/tasks', headers=create_header(jwt, [STAFF_ROLE], identifier))
     assert rv.status_code == HTTPStatus.OK
-    assert num_filings_owed == len(rv.json.get('tasks'))
+    assert len(rv.json.get('tasks')) == num_filings_owed
 
 
 def test_get_tasks_sentinel_founding_date_skips_ar(session, client, jwt):
@@ -126,7 +126,7 @@ def test_get_tasks_next_year(session, client, jwt):
 
     rv = client.get(f'/api/v2/businesses/{identifier}/tasks', headers=create_header(jwt, [STAFF_ROLE], identifier))
     assert rv.status_code == HTTPStatus.OK
-    assert 1 == len(rv.json.get('tasks'))
+    assert len(rv.json.get('tasks')) == 1
 
 
 def test_bcorps_get_tasks_no_filings(session, client, jwt):

--- a/legal-api/tests/unit/resources/v2/test_business_tasks.py
+++ b/legal-api/tests/unit/resources/v2/test_business_tasks.py
@@ -97,6 +97,25 @@ def test_get_tasks_no_filings(session, client, jwt):
     assert num_filings_owed == len(rv.json.get('tasks'))
 
 
+def test_get_tasks_sentinel_founding_date_skips_ar(session, client, jwt):
+    """Assert COLIN year-1 sentinel founding date does not generate thousands of AR todos."""
+    identifier = 'RLY0000004'
+    factory_business(
+        identifier,
+        founding_date=datetime(1, 1, 1, 8, 0, 0, tzinfo=UTC),
+        entity_type=Business.LegalTypes.COMP.value,
+        state=Business.State.ACTIVE,
+    )
+
+    rv = client.get(f'/api/v2/businesses/{identifier}/tasks', headers=create_header(jwt, [STAFF_ROLE], identifier))
+    assert rv.status_code == HTTPStatus.OK
+    ar_tasks = [
+        t for t in rv.json.get('tasks')
+        if t.get('task', {}).get('todo', {}).get('header', {}).get('name') == 'annualReport'
+    ]
+    assert ar_tasks == []
+
+
 def test_get_tasks_next_year(session, client, jwt):
     """Assert that one todo item is returned in the calendar year following incorporation."""
     identifier = 'CP7654321'

--- a/legal-api/tests/unit/resources/v2/test_business_tasks.py
+++ b/legal-api/tests/unit/resources/v2/test_business_tasks.py
@@ -99,7 +99,7 @@ def test_get_tasks_no_filings(session, client, jwt):
 
 def test_get_tasks_sentinel_founding_date_skips_ar(session, client, jwt):
     """Assert COLIN year-1 sentinel founding date does not generate thousands of AR todos."""
-    identifier = 'RLY0000004'
+    identifier = 'BC1234567'
     factory_business(
         identifier,
         founding_date=datetime(1, 1, 1, 8, 0, 0, tzinfo=UTC),
@@ -113,7 +113,7 @@ def test_get_tasks_sentinel_founding_date_skips_ar(session, client, jwt):
         t for t in rv.json.get('tasks')
         if t.get('task', {}).get('todo', {}).get('header', {}).get('name') == 'annualReport'
     ]
-    assert ar_tasks == []
+    assert len(ar_tasks) == 0
 
 
 def test_get_tasks_next_year(session, client, jwt):


### PR DESCRIPTION
*Issue #:* /bcgov/entity#34514

*Description of changes:*
<img width="2217" height="542" alt="image" src="https://github.com/user-attachments/assets/a06d1fd9-61bc-4102-96ac-a11faeab5ee8" />

The tasks call was timing out after a minute and a half in the UI because it was trying to load 2025 annual report filings TODOs. This is because the founding date is 0001 for the old legacy railway data. This PR fixes that. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
