### PR TITLE
34564 - Add Completing Party Confirmation Section to CCO Output

### DIFF
--- a/legal-api/report-templates/consentContinuationOut.html
+++ b/legal-api/report-templates/consentContinuationOut.html
@@ -38,8 +38,26 @@
       </div>
       <div class="container pt-4">
          <div class="no-page-break">
-            <div class="section-title mt-4">New jurisdiction</div>
-            <div class="section-data pt-2">{{ jurisdiction }}</div>
+            <div class="section-title mt-4">Foreign jurisdiction into which the company is continuing:</div>
+            <div class="section-data pt-2 bold">{{ jurisdiction }}</div>
+         </div>
+
+         <div class="no-page-break">
+            <div class="separator mt-4"></div>
+            <div class="section-title mt-4">Completing Party Confirmation</div>
+            <div class="section-data mt-4">
+               I,
+               <span class="capitalize-text">{{ header.certifiedBy }}</span>,
+               confirm that the laws of the foreign jurisdiction to which the continued corporation will be
+               subject provide, in effect, for the following:
+               <ul class="certify-statement-list">
+                  <li class="pt-2">the property, rights and interest of the company continue to be the property, rights and interests of the continued corporation,</li>
+                  <li class="pt-2">the continued corporation continues to be liable for the obligations of the company,</li>
+                  <li class="pt-2">an existing cause of action, claim or liability to prosecution is unaffected,</li>
+                  <li class="pt-2">a legal proceeding being prosecuted or pending by or against the company may be prosecuted or its prosecution may be continued, as the case may be, by or against the continued corporation, and</li>
+                  <li class="pt-2">a conviction against, or a ruling, or judgment in favour of or against, the company may be enforced by or against the continued corporation.</li>
+               </ul>
+            </div>
          </div>
       </div>
    </body>

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -1451,7 +1451,8 @@ def validate_certified_by(filing_json: dict, filing_type: str, legal_type: str) 
         # so certifiedBy is required for them on a corp incorporation application
         api_login_source = "API_GW"  # jwt loginSource of an API gateway user
         current_user = getattr(request_ctx, "current_user", None) if has_request_context() else None
-        if ((filing_type == CoreFiling.FilingTypes.INCORPORATIONAPPLICATION or CoreFiling.FilingTypes.CONSENTCONTINUATIONOUT)
+        if (filing_type in (CoreFiling.FilingTypes.INCORPORATIONAPPLICATION,
+                    CoreFiling.FilingTypes.CONSENTCONTINUATIONOUT)
                 and current_user
                 and (jwt.validate_roles(current_user, [STAFF_ROLE])
                      or current_user.get("loginSource") == api_login_source)):

--- a/legal-api/src/legal_api/services/filings/validations/common_validations.py
+++ b/legal-api/src/legal_api/services/filings/validations/common_validations.py
@@ -1451,7 +1451,7 @@ def validate_certified_by(filing_json: dict, filing_type: str, legal_type: str) 
         # so certifiedBy is required for them on a corp incorporation application
         api_login_source = "API_GW"  # jwt loginSource of an API gateway user
         current_user = getattr(request_ctx, "current_user", None) if has_request_context() else None
-        if (filing_type == CoreFiling.FilingTypes.INCORPORATIONAPPLICATION
+        if ((filing_type == CoreFiling.FilingTypes.INCORPORATIONAPPLICATION or CoreFiling.FilingTypes.CONSENTCONTINUATIONOUT)
                 and current_user
                 and (jwt.validate_roles(current_user, [STAFF_ROLE])
                      or current_user.get("loginSource") == api_login_source)):

--- a/legal-api/tests/unit/services/filings/validations/test_common_validations.py
+++ b/legal-api/tests/unit/services/filings/validations/test_common_validations.py
@@ -35,6 +35,7 @@ from registry_schemas.example_data import (
     CHANGE_OF_REGISTRATION,
     CHANGE_OF_REGISTRATION_TEMPLATE,
     CONTINUATION_IN,
+    CONSENT_CONTINUATION_OUT,
     CORRECTION_INCORPORATION,
     DISSOLUTION,
     FILING_HEADER,
@@ -605,6 +606,11 @@ def test_validate_certified_by_corps(session, legal_type, input_value, expected_
             assert errors[0]['error'] == 'Certified by field is required.'
         assert errors[0]['path'] == '/filing/header/certifiedBy'
 
+
+@pytest.mark.parametrize('filing_type', [
+    CoreFiling.FilingTypes.INCORPORATIONAPPLICATION,
+    CoreFiling.FilingTypes.CONSENTCONTINUATIONOUT,
+])
 @pytest.mark.parametrize('test_name, roles, login_source, certified_by, expected_error', [
     ('api_user_missing', [], 'API_GW', '', 'Certified by field is required.'),
     ('api_user_whitespace', [], 'API_GW', ' John Doe ', 'Certified by field cannot start or end with whitespace.'),
@@ -613,12 +619,18 @@ def test_validate_certified_by_corps(session, legal_type, input_value, expected_
     ('staff_valid', ['staff'], 'IDIR', 'John Doe', None),
     ('public_user_not_required', [], 'BCSC', '', None),
 ])
-def test_validate_certified_by_corps_completing_party(app, session, test_name, roles,
-                                                      login_source, certified_by, expected_error):
-    """Corps IA requires certifiedBy for staff and API users (API users identified by loginSource)."""
+def test_validate_certified_by_corps_completing_party(app, session, filing_type, test_name, roles,
+                                                        login_source, certified_by, expected_error):
+    """Corps IA and CCO require certifiedBy for staff and API users (API users identified by loginSource)."""
+    filing_type_data = {
+        CoreFiling.FilingTypes.INCORPORATIONAPPLICATION: ('incorporationApplication', INCORPORATION),
+        CoreFiling.FilingTypes.CONSENTCONTINUATIONOUT: ('consentContinuationOut', CONSENT_CONTINUATION_OUT),
+    }
+    filing_key, filing_data = filing_type_data[filing_type]
+
     filing = copy.deepcopy(FILING_HEADER)
     filing['filing']['header']['certifiedBy'] = certified_by
-    filing['filing']['incorporationApplication'] = INCORPORATION
+    filing['filing'][filing_key] = filing_data
 
     with (
         patch('legal_api.services.filings.validations.common_validations.jwt.validate_roles',
@@ -627,7 +639,7 @@ def test_validate_certified_by_corps_completing_party(app, session, test_name, r
     ):
         from flask.globals import request_ctx
         request_ctx.current_user = {'sub': 'test-user', 'loginSource': login_source}
-        errors = validate_certified_by(filing, 'incorporationApplication', 'BEN')
+        errors = validate_certified_by(filing, filing_type, 'BEN')
 
     if expected_error:
         assert errors


### PR DESCRIPTION
*Issue #:* /bcgov/entity#34564

*Description of changes:*
- Update CCO Output
- Wire up Certified by validation for completing party

[Consent to Continue Out Appication.pdf](https://github.com/user-attachments/files/31534062/Consent.to.Continue.Out.Appication.pdf)

*note: will wait for [UI ticket](34646) to go in first

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
