### PR TITLE
34467 Colin API - snapshot, normalize shares and currency

### DIFF
--- a/colin-api/src/colin_api/models/business_snapshot.py
+++ b/colin-api/src/colin_api/models/business_snapshot.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 
 import pycountry
 from flask import current_app
@@ -33,6 +33,9 @@ class BusinessSnapshot:  # pylint: disable=too-few-public-methods
 
     # snapshot offices are limited to the two the amalgamation flow prepopulates
     OFFICE_TYPES = ('registeredOffice', 'recordsOffice')
+
+    # the share name suffix legal-api requires (common_validations.py)
+    SHARE_NAME_SUFFIX = ' Shares'
 
     @classmethod
     def get_snapshot(cls, orig_identifier: str) -> Dict:
@@ -153,17 +156,19 @@ class BusinessSnapshot:  # pylint: disable=too-few-public-methods
     @classmethod
     def _normalize_share_class(cls, share_class: Dict) -> Dict:
         """Return a share class in the structure of LEAR's /share-classes items."""
+        currency, currency_additional = cls._normalize_currency(
+            share_class['currency'], share_class['currencyAdditional'])
         return {
             'id': share_class['id'],
-            'name': share_class['name'],
+            'name': cls._normalize_share_name(share_class['name']),
             # COLIN never stores a priority - the class id preserves creation order
             'priority': share_class['displayOrder'],
             'hasMaximumShares': share_class['hasMaximumShares'],
             'maxNumberOfShares': cls._to_int(share_class['maxNumberOfShares']),
             'hasParValue': share_class['hasParValue'],
             'parValue': float(share_class['parValue']) if share_class['parValue'] is not None else None,
-            'currency': share_class['currency'],
-            'currencyAdditional': share_class['currencyAdditional'],
+            'currency': currency,
+            'currencyAdditional': currency_additional,
             'hasRightsOrRestrictions': share_class['hasRightsOrRestrictions'],
             'series': [cls._normalize_share_series(series) for series in share_class['series']],
         }
@@ -173,12 +178,36 @@ class BusinessSnapshot:  # pylint: disable=too-few-public-methods
         """Return a share series in the structure of LEAR's series json."""
         return {
             'id': series['id'],
-            'name': series['name'],
+            'name': cls._normalize_share_name(series['name']),
             'priority': series['displayOrder'],
             'hasMaximumShares': series['hasMaximumShares'],
             'maxNumberOfShares': cls._to_int(series['maxNumberOfShares']),
             'hasRightsOrRestrictions': series['hasRightsOrRestrictions'],
         }
+
+    @classmethod
+    def _normalize_share_name(cls, name: Optional[str]) -> Optional[str]:
+        """Append the ' Shares' suffix legal-api requires, dropping any existing any-case suffix."""
+        if not name:
+            return name
+        if name.endswith(cls.SHARE_NAME_SUFFIX):
+            return name
+        stripped = name.rstrip()
+        if stripped.lower().endswith(cls.SHARE_NAME_SUFFIX.lower()):
+            stripped = stripped[:-len(cls.SHARE_NAME_SUFFIX)].rstrip()
+        return f'{stripped}{cls.SHARE_NAME_SUFFIX}'
+
+    @classmethod
+    def _normalize_currency(cls,
+                            currency: Optional[str],
+                            currency_additional: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
+        """Map COLIN's OTH currency the way the tombstone migration does."""
+        if currency != 'OTH':
+            return currency, currency_additional
+        code = (currency_additional or '').strip().upper()
+        if code and pycountry.currencies.get(alpha_3=code):
+            return code, None
+        return 'OTHER', currency_additional
 
     _country_cache: Dict[str, str] = {}
 

--- a/colin-api/src/colin_api/version.py
+++ b/colin-api/src/colin_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.172.2'  # pylint: disable=invalid-name
+__version__ = '2.172.3'  # pylint: disable=invalid-name

--- a/colin-api/tests/unit/api/test_business_snapshot.py
+++ b/colin-api/tests/unit/api/test_business_snapshot.py
@@ -17,10 +17,39 @@ from datetime import datetime
 
 from colin_api.exceptions import BusinessNotFoundException, PartiesNotFoundException
 from colin_api.models import Business, Party, ShareObject
+from colin_api.models.shares import Share, ShareClass
 from tests.unit import LEAR_ADDRESS, build_business, build_director, bypass_auth
+import pytest
 
 
 SNAPSHOT_URL = '/api/v1/businesses/BC0870226/snapshot'
+
+
+def build_share_structure_variant(class_name, currency='CAD', other_currency=None, series_name=None):
+    """Return a current ShareObject with the subject class name / currency."""
+    share_class = ShareClass()
+    share_class.share_id = 0
+    share_class.share_name = class_name
+    share_class.currency_type = currency
+    share_class.other_currency = other_currency
+    share_class.has_max_shares = 'N'  # COLIN semantics: 'N' means has a maximum
+    share_class.has_par_value = 'Y'
+    share_class.has_special_rights = 'Y'
+    share_class.par_value_amt = 1.5
+    share_class.max_number_shares = 10000
+    share_class.series = []
+    if series_name:
+        series = Share()
+        series.share_id = 1
+        series.share_name = series_name
+        series.has_max_shares = 'Y'
+        series.has_special_rights = 'N'
+        series.max_number_shares = None
+        share_class.series = [series]
+    share_struct = ShareObject()
+    share_struct.end_event_id = None
+    share_struct.share_classes = [share_class]
+    return share_struct
 
 
 def test_get_snapshot(client, mocker, authorized, mock_db, mock_lookups):  # pylint: disable=unused-argument
@@ -64,18 +93,18 @@ def test_get_snapshot(client, mocker, authorized, mock_db, mock_lookups):  # pyl
         },
         'shareClasses': [{
             'id': 0,
-            'name': 'CLASS A',
+            'name': 'CLASS A Shares',
             'priority': 0,
             'hasMaximumShares': True,
             'maxNumberOfShares': 10000,
             'hasParValue': True,
             'parValue': 1.5,
-            'currency': 'OTH',
+            'currency': 'OTHER',
             'currencyAdditional': 'BITCOIN',
             'hasRightsOrRestrictions': True,
             'series': [{
                 'id': 1,
-                'name': 'SERIES 1',
+                'name': 'SERIES 1 Shares',
                 'priority': 1,
                 'hasMaximumShares': False,
                 'maxNumberOfShares': None,
@@ -150,6 +179,46 @@ def test_get_snapshot_without_share_structure(client, mocker, authorized, mock_d
 
     assert rv.status_code == 200
     assert rv.json['shareClasses'] == []
+
+
+@pytest.mark.parametrize('colin_name, expected_name', [
+    ('CLASS A COMMON SHARES', 'CLASS A COMMON Shares'),  # all-caps legacy suffix replaced
+    ('preferred shares', 'preferred Shares'),  # lowercase suffix replaced (tombstone migration parity)
+    ('Class A Shares', 'Class A Shares'),  # already normalized - unchanged
+    ('CLASS B', 'CLASS B Shares'),  # no suffix - appended
+])
+def test_get_snapshot_normalizes_share_names(client, mocker, authorized, mock_db, mock_lookups,
+                                             colin_name, expected_name):  # pylint: disable=unused-argument
+    """Assert class and series names get the ' Shares' suffix legal-api requires."""
+    mocker.patch.object(ShareObject, 'get_all', return_value=[
+        build_share_structure_variant(colin_name, series_name='SERIES 1')])
+
+    rv = client.get(SNAPSHOT_URL)
+
+    assert rv.status_code == 200
+    assert rv.json['shareClasses'][0]['name'] == expected_name
+    assert rv.json['shareClasses'][0]['series'][0]['name'] == 'SERIES 1 Shares'
+
+
+@pytest.mark.parametrize('currency, other_currency, expected, expected_additional', [
+    ('CAD', None, 'CAD', None),  # real code passes through
+    ('OTH', 'CAD', 'CAD', None),  # tombstone migration parity fold
+    ('OTH', ' usd ', 'USD', None),  # any valid ISO 4217 code is promoted
+    ('OTH', 'BITCOIN', 'OTHER', 'BITCOIN'),  # non-ISO free text stays flagged
+    ('OTH', None, 'OTHER', None),
+])
+def test_get_snapshot_normalizes_currency(client, mocker, authorized, mock_db, mock_lookups,
+                                          currency, other_currency, expected,
+                                          expected_additional):  # pylint: disable=unused-argument
+    """Assert COLIN's OTH currency is folded to an ISO code or OTHER."""
+    mocker.patch.object(ShareObject, 'get_all', return_value=[
+        build_share_structure_variant('Class A Shares', currency=currency, other_currency=other_currency)])
+
+    rv = client.get(SNAPSHOT_URL)
+
+    assert rv.status_code == 200
+    assert rv.json['shareClasses'][0]['currency'] == expected
+    assert rv.json['shareClasses'][0]['currencyAdditional'] == expected_additional
 
 
 def test_get_snapshot_null_good_standing(client, mocker, authorized, mock_db,

--- a/colin-api/tests/unit/api/test_business_snapshot.py
+++ b/colin-api/tests/unit/api/test_business_snapshot.py
@@ -15,11 +15,12 @@
 """Tests to assure the business snapshot end-point."""
 from datetime import datetime
 
+import pytest
+
 from colin_api.exceptions import BusinessNotFoundException, PartiesNotFoundException
 from colin_api.models import Business, Party, ShareObject
 from colin_api.models.shares import Share, ShareClass
 from tests.unit import LEAR_ADDRESS, build_business, build_director, bypass_auth
-import pytest
 
 
 SNAPSHOT_URL = '/api/v1/businesses/BC0870226/snapshot'


### PR DESCRIPTION
*Issue #:* /bcgov/entity#34467

*Description of changes:*
- add ' Shares' suffix to colin share names when necessary in snapshot response
- normalize currency to lear rules in snapshot response

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
