### PR TITLE
34729 - Add Additional Data for FED Amalg Alert Warning

### DIFF
--- a/legal-api/pyproject.toml
+++ b/legal-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "legal-api"
-version = "3.1.21"
+version = "3.1.22"
 description = ""
 authors = [
     {name = "thor",email = "1042854+thorwolpert@users.noreply.github.com"}

--- a/legal-api/src/legal_api/resources/v2/business/business.py
+++ b/legal-api/src/legal_api/resources/v2/business/business.py
@@ -28,16 +28,16 @@ from legal_api.core import Filing as CoreFiling
 from legal_api.resources.v2.business.business_filings import saving_filings
 from legal_api.services import (
     ACCOUNT_IDENTITY,
-    SYSTEM_ROLE,
     STAFF_ROLE,
+    SYSTEM_ROLE,
     RegistrationBootstrapService,
     check_warnings,
     colin,
     flags,
 )
 from legal_api.services.authz import (
-    CONTACT_CENTRE_STAFF_ROLE,
     COLIN_SVC_ROLE,
+    CONTACT_CENTRE_STAFF_ROLE,
     MAXIMUS_STAFF_ROLE,
     SBC_STAFF_ROLE,
     authorized,

--- a/legal-api/src/legal_api/resources/v2/business/business.py
+++ b/legal-api/src/legal_api/resources/v2/business/business.py
@@ -29,12 +29,23 @@ from legal_api.resources.v2.business.business_filings import saving_filings
 from legal_api.services import (
     ACCOUNT_IDENTITY,
     SYSTEM_ROLE,
+    STAFF_ROLE,
     RegistrationBootstrapService,
     check_warnings,
     colin,
     flags,
 )
-from legal_api.services.authz import authorized, get_allowable_actions, get_allowed, get_could_files
+from legal_api.services.authz import (
+    CONTACT_CENTRE_STAFF_ROLE,
+    COLIN_SVC_ROLE,
+    MAXIMUS_STAFF_ROLE,
+    SBC_STAFF_ROLE,
+    authorized,
+    get_allowable_actions,
+    get_allowed,
+    get_could_files,
+    has_any_roles,
+)
 from legal_api.services.permissions import ListActionsPermissionsAllowed, PermissionService
 from legal_api.services.search_service import AffiliationSearchDetails, BusinessSearchService
 from legal_api.utils.auth import jwt
@@ -72,7 +83,15 @@ def get_businesses(identifier: str):
                         f"You are not authorized to view business {identifier}."}), \
             HTTPStatus.UNAUTHORIZED
 
-    warnings = check_warnings(business)
+    is_staff = has_any_roles(jwt, [
+        STAFF_ROLE,
+        SYSTEM_ROLE,
+        COLIN_SVC_ROLE,
+        SBC_STAFF_ROLE,
+        CONTACT_CENTRE_STAFF_ROLE,
+        MAXIMUS_STAFF_ROLE,
+    ])
+    warnings = check_warnings(business, is_staff)
     # TODO remove complianceWarnings line when UI has been integrated to use warnings instead of complianceWarnings
     business.compliance_warnings = warnings
     business.warnings = warnings

--- a/legal-api/src/legal_api/services/warnings/business/business_checks/business.py
+++ b/legal-api/src/legal_api/services/warnings/business/business_checks/business.py
@@ -22,7 +22,7 @@ from .firms import check_business as firms_check
 from .involuntary_dissolution import check_business as involuntary_dissolution_check
 
 
-def check_business(business: Business) -> list:
+def check_business(business: Business, is_staff: bool = False) -> list:
     """Check business for warnings."""
     result = []
 
@@ -31,7 +31,7 @@ def check_business(business: Business) -> list:
              Business.LegalTypes.PARTNERSHIP.value):
         result = firms_check(business)
     elif business.legal_type in Business.CORPS:
-        result = corps_check(business)
+        result = corps_check(business, is_staff)
 
     if business.legal_type in InvoluntaryDissolutionService.ELIGIBLE_TYPES:
         result.extend(involuntary_dissolution_check(business))

--- a/legal-api/src/legal_api/services/warnings/business/business_checks/corps.py
+++ b/legal-api/src/legal_api/services/warnings/business/business_checks/corps.py
@@ -18,11 +18,11 @@ from business_model.models import Business
 from legal_api.services.warnings.business.business_checks import BusinessWarningCodes, WarningType
 
 
-def check_business(business: Business) -> list:
+def check_business(business: Business, is_staff: bool = False) -> list:
     """Check business data."""
     result = []
 
-    result.extend(check_amalgamating_business(business))
+    result.extend(check_amalgamating_business(business, is_staff))
     result.extend(check_transition_application(business))
 
     return result
@@ -43,7 +43,7 @@ def check_transition_application(business: Business) -> list:
     return result
 
 
-def check_amalgamating_business(business: Business) -> list:
+def check_amalgamating_business(business: Business, is_staff: bool = False) -> list:
     """Check if business is currently pending amalgamation."""
     result = []
 
@@ -51,13 +51,17 @@ def check_amalgamating_business(business: Business) -> list:
 
     # Check if a matching filing was found and if its effective date is greater than payment completion date
     if filing and filing.effective_date > filing.payment_completion_date:
-        result.append({
+        warning = {
             "code": "AMALGAMATING_BUSINESS",
             "message": "This business is part of a future effective amalgamation.",
             "warningType": WarningType.FUTURE_EFFECTIVE_AMALGAMATION,
             "data": {
-                "amalgamationDate": filing.effective_date
+                "amalgamationDate": filing.effective_date,
+                "amalgamatingBusinesses": filing.filing_json["filing"]["amalgamationApplication"]["amalgamatingBusinesses"]
             }
-        })
+        }
+        if is_staff:
+            warning["data"]["filingId"] = filing.id
+        result.append(warning)
 
     return result

--- a/legal-api/src/legal_api/services/warnings/warning.py
+++ b/legal-api/src/legal_api/services/warnings/warning.py
@@ -18,12 +18,12 @@ from business_model.models import Business
 from .business import check_business
 
 
-def check_warnings(business: Business) -> list:
+def check_warnings(business: Business, is_staff: bool = False) -> list:
     """Check warnings for a business."""
     result = []
 
     # Currently only checks for missing business info warnings but in future other warning checks can be included
     # e.g. compliance checks - result.extend(check_compliance(business))
-    result.extend(check_business(business))
+    result.extend(check_business(business, is_staff))
 
     return result

--- a/legal-api/tests/unit/resources/v2/test_business.py
+++ b/legal-api/tests/unit/resources/v2/test_business.py
@@ -28,7 +28,16 @@ from business_common.utils.datetime import datetime
 from requests import exceptions
 
 from business_model.models import Amalgamation, Batch, Business, Filing, RegistrationBootstrap
-from legal_api.services.authz import ACCOUNT_IDENTITY, PUBLIC_USER, STAFF_ROLE, SYSTEM_ROLE
+from legal_api.services.authz import (
+    ACCOUNT_IDENTITY,
+    COLIN_SVC_ROLE,
+    CONTACT_CENTRE_STAFF_ROLE,
+    MAXIMUS_STAFF_ROLE,
+    PUBLIC_USER,
+    SBC_STAFF_ROLE,
+    STAFF_ROLE,
+    SYSTEM_ROLE,
+)
 from legal_api.services import flags
 from legal_api.services.cache import cache
 from legal_api.services.bootstrap import RegistrationBootstrapService
@@ -241,6 +250,40 @@ def test_get_business_info(app, session, client, jwt, requests_mock, test_name, 
     print('valid schema?', registry_schemas.validate(rv.json, 'business'))
 
     assert registry_schemas.validate(rv.json, 'business')
+
+
+@pytest.mark.parametrize('role,expected_staff', [
+    (STAFF_ROLE, True),
+    (SYSTEM_ROLE, True),
+    (COLIN_SVC_ROLE, True),
+    (SBC_STAFF_ROLE, True),
+    (CONTACT_CENTRE_STAFF_ROLE, True),
+    (MAXIMUS_STAFF_ROLE, True),
+    (PUBLIC_USER, False),
+])
+def test_get_business_info_passes_staff_status_to_warnings(
+    app, session, client, jwt, role, expected_staff, monkeypatch, requests_mock):
+    """Assert that business warnings receive the correct staff status for each role."""
+    identifier = 'BC7654321'
+    factory_business_model(legal_name=f'{identifier} legal name',
+                           identifier=identifier,
+                           founding_date=datetime.fromtimestamp(0, UTC),
+                           last_ledger_timestamp=datetime.fromtimestamp(0, UTC),
+                           last_modified=datetime.fromtimestamp(0, UTC))
+    warning_staff_values = []
+    monkeypatch.setattr(
+        'legal_api.resources.v2.business.business.check_warnings',
+        lambda business, is_staff: warning_staff_values.append(is_staff) or []
+    )
+    if role == PUBLIC_USER:
+        requests_mock.get(f"{app.config['AUTH_SVC_URL']}/entities/{identifier}/authorizations",
+                          json={'roles': ['view']})
+
+    rv = client.get(f'/api/v2/businesses/{identifier}',
+                    headers=create_header(jwt, [role], identifier))
+
+    assert rv.status_code == HTTPStatus.OK
+    assert warning_staff_values == [expected_staff]
 
 
 @pytest.mark.parametrize('test_name,role,amalgamated', [

--- a/legal-api/tests/unit/services/warnings/business/business_checks/test_corps.py
+++ b/legal-api/tests/unit/services/warnings/business/business_checks/test_corps.py
@@ -28,6 +28,14 @@ def test_check_business(session, has_amalgamation, expected_warning):
     business = factory_business(identifier="BC1234567")
 
     mock_filing = Mock()
+    mock_filing.id = "filing-id"
+    mock_filing.filing_json = {
+        "filing": {
+            "amalgamationApplication": {
+                "amalgamatingBusinesses": [{"identifier": "BC7654321"}]
+            }
+        }
+    }
     if has_amalgamation:
         # Set effective_date in the future to simulate an amalgamation
         mock_filing.effective_date = datetime.now() + timedelta(days=1)
@@ -38,7 +46,7 @@ def test_check_business(session, has_amalgamation, expected_warning):
         mock_filing.payment_completion_date = datetime.now()
 
     with patch('business_model.models.business.Business.is_pending_amalgamating_business', return_value=mock_filing):
-        result = check_business(business)
+        result = check_business(business, is_staff=True)
 
         if expected_warning:
             assert len(result) == 1
@@ -48,5 +56,32 @@ def test_check_business(session, has_amalgamation, expected_warning):
             assert warning['warningType'] == WarningType.FUTURE_EFFECTIVE_AMALGAMATION
             assert 'amalgamationDate' in warning['data']
             assert isinstance(warning['data']['amalgamationDate'], datetime)
+            assert warning['data']['filingId'] == "filing-id"
+            assert warning['data']['amalgamatingBusinesses'] == [{"identifier": "BC7654321"}]
         else:
             assert len(result) == 0
+
+
+def test_check_business_excludes_filing_id_for_non_staff(session):
+    """Test that filing ids are only included for staff users."""
+    business = factory_business(identifier="BC1234567")
+    mock_filing = Mock(
+        id="filing-id",
+        effective_date=datetime.now() + timedelta(days=1),
+        payment_completion_date=datetime.now(),
+        filing_json={
+            "filing": {
+                "amalgamationApplication": {
+                    "amalgamatingBusinesses": [{"identifier": "BC7654321"}]
+                }
+            }
+        }
+    )
+
+    with patch('business_model.models.business.Business.is_pending_amalgamating_business', return_value=mock_filing):
+        warning = check_business(business)[0]
+
+    assert warning['data'] == {
+        "amalgamationDate": mock_filing.effective_date,
+        "amalgamatingBusinesses": [{"identifier": "BC7654321"}]
+    }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#34729

*Description of changes:*
- `filingId` should only be provided for staff
- `amalgamatingBusinesses` data should always be provided

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
