### PR TITLE
34729 - Add resultingBusinessName to FED Amalg Warning Data

### DIFF
--- a/legal-api/pyproject.toml
+++ b/legal-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "legal-api"
-version = "3.1.22"
+version = "3.1.23"
 description = ""
 authors = [
     {name = "thor",email = "1042854+thorwolpert@users.noreply.github.com"}

--- a/legal-api/src/legal_api/services/warnings/business/business_checks/corps.py
+++ b/legal-api/src/legal_api/services/warnings/business/business_checks/corps.py
@@ -51,15 +51,22 @@ def check_amalgamating_business(business: Business, is_staff: bool = False) -> l
 
     # Check if a matching filing was found and if its effective date is greater than payment completion date
     if filing and filing.effective_date > filing.payment_completion_date:
+        amalgamation_application = filing.filing_json["filing"]["amalgamationApplication"]
+        name_request = amalgamation_application.get("nameRequest", {})
+        # legalName is only present when the resulting business will be named
+        resulting_business_name = name_request.get("legalName")
+ 
         warning = {
             "code": "AMALGAMATING_BUSINESS",
             "message": "This business is part of a future effective amalgamation.",
             "warningType": WarningType.FUTURE_EFFECTIVE_AMALGAMATION,
             "data": {
                 "amalgamationDate": filing.effective_date,
-                "amalgamatingBusinesses": filing.filing_json["filing"]["amalgamationApplication"]["amalgamatingBusinesses"]
+                "amalgamatingBusinesses": amalgamation_application["amalgamatingBusinesses"]
             }
         }
+        if resulting_business_name:
+            warning["data"]["resultingBusinessName"] = resulting_business_name
         if is_staff:
             warning["data"]["filingId"] = filing.id
         result.append(warning)

--- a/legal-api/tests/unit/services/warnings/business/business_checks/test_corps.py
+++ b/legal-api/tests/unit/services/warnings/business/business_checks/test_corps.py
@@ -32,7 +32,11 @@ def test_check_business(session, has_amalgamation, expected_warning):
     mock_filing.filing_json = {
         "filing": {
             "amalgamationApplication": {
-                "amalgamatingBusinesses": [{"identifier": "BC7654321"}]
+                "amalgamatingBusinesses": [{"identifier": "BC7654321"}],
+                "nameRequest": {
+                    "legalName": "NAMED AMALG CORP.",
+                    "legalType": "BC"
+                }
             }
         }
     }
@@ -58,8 +62,45 @@ def test_check_business(session, has_amalgamation, expected_warning):
             assert isinstance(warning['data']['amalgamationDate'], datetime)
             assert warning['data']['filingId'] == "filing-id"
             assert warning['data']['amalgamatingBusinesses'] == [{"identifier": "BC7654321"}]
+            assert warning['data']['resultingBusinessName'] == "NAMED AMALG CORP."
         else:
             assert len(result) == 0
+
+
+@pytest.mark.parametrize("name_request, expected_resulting_name", [
+    # named amalgamation result - legalName present
+    ({"legalName": "NAMED AMALG CORP.", "legalType": "BC"}, "NAMED AMALG CORP."),
+    # numbered amalgamation result - no legalName key at all
+    ({"correctNameOption": "correct-aml-numbered", "legalType": "BC"}, None),
+    # no nameRequest present at all
+    ({}, None),
+])
+def test_check_business_amalgamation_resulting_name(session, name_request, expected_resulting_name):
+    """Test that resultingBusinessName reflects whether the amalgamation result is named or numbered."""
+    business = factory_business(identifier="BC1234567")
+
+    mock_filing = Mock()
+    mock_filing.id = "filing-id"
+    mock_filing.effective_date = datetime.now() + timedelta(days=1)
+    mock_filing.payment_completion_date = datetime.now()
+    mock_filing.filing_json = {
+        "filing": {
+            "amalgamationApplication": {
+                "amalgamatingBusinesses": [{"identifier": "BC7654321"}],
+                "nameRequest": name_request
+            }
+        }
+    }
+
+    with patch('business_model.models.business.Business.is_pending_amalgamating_business', return_value=mock_filing):
+        warning = check_business(business, is_staff=True)[0]
+
+    assert warning['data'].get('resultingBusinessName') == expected_resulting_name
+
+    if expected_resulting_name is None:
+        assert 'resultingBusinessName' not in warning['data']
+    else:
+        assert 'resultingBusinessName' in warning['data']
 
 
 def test_check_business_excludes_filing_id_for_non_staff(session):
@@ -72,7 +113,11 @@ def test_check_business_excludes_filing_id_for_non_staff(session):
         filing_json={
             "filing": {
                 "amalgamationApplication": {
-                    "amalgamatingBusinesses": [{"identifier": "BC7654321"}]
+                    "amalgamatingBusinesses": [{"identifier": "BC7654321"}],
+                    "nameRequest": {
+                        "legalName": "NAMED AMALG CORP.",
+                        "legalType": "BC"
+                    }
                 }
             }
         }
@@ -83,5 +128,6 @@ def test_check_business_excludes_filing_id_for_non_staff(session):
 
     assert warning['data'] == {
         "amalgamationDate": mock_filing.effective_date,
-        "amalgamatingBusinesses": [{"identifier": "BC7654321"}]
+        "amalgamatingBusinesses": [{"identifier": "BC7654321"}],
+        "resultingBusinessName": "NAMED AMALG CORP."
     }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#34729

*Description of changes:*
- Also need to add resulting business name to the response, as it is not provided in `amalgamatingBusinesses`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
