### PR TITLE
Bump legal-api version to 3.1.24

### DIFF
--- a/legal-api/pyproject.toml
+++ b/legal-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "legal-api"
-version = "3.1.23"
+version = "3.1.24"
 description = ""
 authors = [
     {name = "thor",email = "1042854+thorwolpert@users.noreply.github.com"}


### PR DESCRIPTION
Description of changes:
Bump legal-api version 3.1.23 -> 3.1.24 for release.