### PR TITLE
34821 Suppress Annual Report filing todos for mainframe entities

### DIFF
--- a/legal-api/src/legal_api/resources/v2/business/business_tasks.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_tasks.py
@@ -98,11 +98,9 @@ def construct_task_list(business: Business):  # noqa: PLR0915
         - Corporations must file one AR per year, on or after the anniversary of the founding date
     """
     # Legal types that never get AR todos. SP/GP don't file annual reports at all. The rest are
-    # legacy/mainframe-migrated legal types where annualReport filing is disabled/greyed out in the
-    # UI - some of these were founded decades ago (e.g. 1940s), so without this exclusion they'd
+    # legacy/mainframe migrated legal types where annualReport filing is disabled/greyed out in the
+    # UI - some of these were founded decades ago (for example,1940s), so without this exclusion they'd
     # generate a large backlog of AR todos that can never actually be filed.
-    # NOTE: there may be other legacy/hidden legal types not yet in this list that also can't file
-    # ARs - add them here as they're identified.
     entity_types_no_ar = [
         "SP", "GP",
         "RLY",  # Railways

--- a/legal-api/src/legal_api/resources/v2/business/business_tasks.py
+++ b/legal-api/src/legal_api/resources/v2/business/business_tasks.py
@@ -97,7 +97,21 @@ def construct_task_list(business: Business):  # noqa: PLR0915
 
         - Corporations must file one AR per year, on or after the anniversary of the founding date
     """
-    entity_types_no_ar = ["SP", "GP"]
+    # Legal types that never get AR todos. SP/GP don't file annual reports at all. The rest are
+    # legacy/mainframe-migrated legal types where annualReport filing is disabled/greyed out in the
+    # UI - some of these were founded decades ago (e.g. 1940s), so without this exclusion they'd
+    # generate a large backlog of AR todos that can never actually be filed.
+    # NOTE: there may be other legacy/hidden legal types not yet in this list that also can't file
+    # ARs - add them here as they're identified.
+    entity_types_no_ar = [
+        "SP", "GP",
+        "RLY",  # Railways
+        "LIB",  # Public Library Association
+        "CEM",  # Cemetery
+        "TMY",  # Tramways
+        "PFS",  # Pension Funded Society
+        "SB",  # Society Branch
+    ]
     tasks = []
     order = 1
 
@@ -151,8 +165,8 @@ def construct_task_list(business: Business):  # noqa: PLR0915
         tasks.append(task)
         order += 1
 
-    # Skip AR todos when founding date is the COLIN year 0001 (for legacy data like railways). Without this,
-    # a sentinel founding_date of 0001-01-01 generates ~2000 AR todos and a multi-MB /tasks payload.
+    # Also skip AR todos when founding date is the COLIN year-1 sentinel/unknown - without this, a
+    # sentinel founding_date of 0001-01-01 generates ~2000 AR todos and a multi-MB /tasks payload.
     unknown_founding_date = (
         not business.founding_date or business.founding_date.year <= 1
     )

--- a/legal-api/tests/unit/resources/v2/test_business_tasks.py
+++ b/legal-api/tests/unit/resources/v2/test_business_tasks.py
@@ -116,6 +116,38 @@ def test_get_tasks_sentinel_founding_date_skips_ar(session, client, jwt):
     assert len(ar_tasks) == 0
 
 
+@pytest.mark.parametrize('test_name, legal_type', [
+    ('railways', Business.LegalTypes.RAILWAYS.value),
+    ('library', Business.LegalTypes.LIBRARY.value),
+    ('cemetery', Business.LegalTypes.CEMETARY.value),
+    ('tramways', Business.LegalTypes.TRAMWAYS.value),
+    ('pension_funded_society', Business.LegalTypes.PENS_FUND_SOC.value),
+    ('society_branch', Business.LegalTypes.SOCIETY_BRANCH.value),
+])
+def test_get_tasks_legacy_migrated_types_no_ar(session, client, jwt, test_name, legal_type):
+    """Assert legacy/mainframe-migrated legal types never get AR todos, even with a real old founding date.
+
+    These legal types don't support annualReport filing (see ANNUAL_REPORT_LEGAL_TYPES in authz.py), so
+    filing is greyed out in the UI regardless. Businesses founded decades ago (e.g. 1940) should not
+    generate a huge backlog of AR todos that can never actually be filed.
+    """
+    identifier = 'BC1234567'
+    factory_business(
+        identifier,
+        founding_date=datetime(1940, 1, 1, tzinfo=UTC),
+        entity_type=legal_type,
+        state=Business.State.ACTIVE,
+    )
+
+    rv = client.get(f'/api/v2/businesses/{identifier}/tasks', headers=create_header(jwt, [STAFF_ROLE], identifier))
+    assert rv.status_code == HTTPStatus.OK
+    ar_tasks = [
+        t for t in rv.json.get('tasks')
+        if t.get('task', {}).get('todo', {}).get('header', {}).get('name') == 'annualReport'
+    ]
+    assert len(ar_tasks) == 0
+
+
 def test_get_tasks_next_year(session, client, jwt):
     """Assert that one todo item is returned in the calendar year following incorporation."""
     identifier = 'CP7654321'


### PR DESCRIPTION
*Issue #:* /bcgov/entity#34821

*Description of changes:*
This was brought up in our latest demo. Legacy/mainframe entities have all usually old founding dates. Here's an example of a library from 1940:
<img width="1061" height="895" alt="image" src="https://github.com/user-attachments/assets/03dbc4fc-f072-4cb5-8c08-377365c89438" />

The todos show 87 annual report filings. It was brought up, these entities won't have the ability to submit these annual report filings. So, we wanna suppress that and not show them. This PR fixes that:
<img width="2191" height="771" alt="image" src="https://github.com/user-attachments/assets/bfc529f4-7a2f-427a-a8f7-f5866d6d4bf8" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
