### PR TITLE
Bump lear Dockerfiles from bullseye to bookworm

### DIFF
--- a/gcp-jobs/bn-retry/Dockerfile
+++ b/gcp-jobs/bn-retry/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-bullseye AS development_build
+FROM python:3.13-bookworm AS development_build
 
 USER root
 

--- a/gcp-jobs/email-reminder/Dockerfile
+++ b/gcp-jobs/email-reminder/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-bullseye AS development_build
+FROM python:3.13-bookworm AS development_build
 
 USER root
 

--- a/gcp-jobs/entity-bn/Dockerfile
+++ b/gcp-jobs/entity-bn/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-bullseye AS development_build
+FROM python:3.13-bookworm AS development_build
 
 USER root
 

--- a/gcp-jobs/expired-limited-restoration/Dockerfile
+++ b/gcp-jobs/expired-limited-restoration/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-bullseye AS development_build
+FROM python:3.13-bookworm AS development_build
 
 USER root
 

--- a/gcp-jobs/filings-notebook-report/Dockerfile
+++ b/gcp-jobs/filings-notebook-report/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-bullseye AS development_build
+FROM python:3.13-bookworm AS development_build
 
 USER root
 

--- a/gcp-jobs/furnishings/Dockerfile
+++ b/gcp-jobs/furnishings/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-bullseye AS development_build
+FROM python:3.13-bookworm AS development_build
 
 USER root
 

--- a/gcp-jobs/future-effective-filings/Dockerfile
+++ b/gcp-jobs/future-effective-filings/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-bullseye AS development_build
+FROM python:3.13-bookworm AS development_build
 
 USER root
 

--- a/gcp-jobs/involuntary-dissolutions/Dockerfile
+++ b/gcp-jobs/involuntary-dissolutions/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-bullseye AS development_build
+FROM python:3.13-bookworm AS development_build
 
 USER root
 

--- a/gcp-jobs/update-colin-filings/Dockerfile
+++ b/gcp-jobs/update-colin-filings/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-bullseye AS development_build
+FROM python:3.13-bookworm AS development_build
 
 USER root
 

--- a/gcp-jobs/update-legal-filings/Dockerfile
+++ b/gcp-jobs/update-legal-filings/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-bullseye AS development_build
+FROM python:3.13-bookworm AS development_build
 
 USER root
 

--- a/legal-api/Dockerfile
+++ b/legal-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.3-bullseye AS development_build
+FROM python:3.13.3-bookworm AS development_build
 
 USER root
 

--- a/queue_services/business-bn/Dockerfile
+++ b/queue_services/business-bn/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-bullseye AS development_build
+FROM python:3.13-bookworm AS development_build
 
 USER root
 

--- a/queue_services/business-digital-credentials/Dockerfile
+++ b/queue_services/business-digital-credentials/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-bullseye AS development_build
+FROM python:3.13-bookworm AS development_build
 
 USER root
 

--- a/queue_services/business-emailer/Dockerfile
+++ b/queue_services/business-emailer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-bullseye AS development_build
+FROM python:3.13-bookworm AS development_build
 
 USER root
 

--- a/queue_services/business-filer/Dockerfile
+++ b/queue_services/business-filer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.3-bullseye AS development_build
+FROM python:3.13.3-bookworm AS development_build
 
 USER root
 

--- a/queue_services/business-pay/Dockerfile
+++ b/queue_services/business-pay/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.3-bullseye AS development_build
+FROM python:3.13.3-bookworm AS development_build
 
 USER root
 


### PR DESCRIPTION
*Issue:* bcgov/entity#34508

Description of changes: Bump every lear service Dockerfile base image from `python:3.13[.3]-bullseye` to `-bookworm` (legal-api, business-emailer/filer/pay/bn/digital-credentials, all gcp-jobs) because the bullseye-security apt Release file has expired and `apt-get update` now fails verify-build on every PR.
