### PR TITLE
34622 - Tombstone pipline: Court order mapping 

### DIFF
--- a/data-tool/flows/corps_tombstone_flow.py
+++ b/data-tool/flows/corps_tombstone_flow.py
@@ -286,6 +286,12 @@ def load_placeholder_filings(conn: Connection, tombstone_data: dict, business_id
             jurisdiction_id = load_data(conn, 'jurisdictions', jurisdiction)
             versioning_mapper['jurisdictions_version'].append(jurisdiction_id)
 
+        if court_order:= data['court_order']:
+            court_order['business_id'] = business_id
+            court_order['filing_id'] = filing_id
+            court_order_id = load_data(conn, 'court_orders', court_order)
+            versioning_mapper['court_orders_version'].append(court_order_id)
+
         # load amalgamation snapshot linked to the current filing
         if amalgamation_data := data['amalgamations']:
             load_amalgamation_snapshot(conn, amalgamation_data, business_id, filing_id, versioning_mapper)
@@ -737,5 +743,5 @@ if __name__ == "__main__":
     #     name="tombstone-deployment",
     #     tags=["tombstone-migration"],
     #     work_pool_name="tombstone-pool",
-    #     interval=timedelta(seconds=40)  # Run every x seconds
+    #     interval=timedelta(seconds=50)  # Run every x seconds
     # )

--- a/data-tool/flows/corps_tombstone_flow.py
+++ b/data-tool/flows/corps_tombstone_flow.py
@@ -743,5 +743,5 @@ if __name__ == "__main__":
     #     name="tombstone-deployment",
     #     tags=["tombstone-migration"],
     #     work_pool_name="tombstone-pool",
-    #     interval=timedelta(seconds=50)  # Run every x seconds
+    #     interval=timedelta(seconds=40)  # Run every x seconds
     # )

--- a/data-tool/flows/tombstone/tombstone_base_data.py
+++ b/data-tool/flows/tombstone/tombstone_base_data.py
@@ -173,6 +173,14 @@ JURISDICTION = {
     'expro_legal_name': None,
 }
 
+COURT_ORDER = {
+    'business_id': None,
+    'file_number': None,
+    'order_date': None,  # date
+    'effect_of_order': None,
+    'order_details': None,
+}
+
 
 # ======== filing ========
 FILING_JSON = {

--- a/data-tool/flows/tombstone/tombstone_queries.py
+++ b/data-tool/flows/tombstone/tombstone_queries.py
@@ -80,7 +80,7 @@ def get_unprocessed_corps_subquery(flow_name, environment):
     # [2]->[1]->[3] (may fetch fewer eligible corps in [2] at the beginning, if so, go to [1] and then go back to [2], repeatedly)
     # Other usage:
     # [0] is used for other purposes, e.g. tweak query to select specific corps
-    subquery = subqueries[3]
+    subquery = subqueries[0]
     return subquery['cte'], subquery['where']
 
 def get_unprocessed_corps_query(flow_name, config, batch_size, *, include_account_ids: bool = False):
@@ -185,7 +185,7 @@ def get_unprocessed_corps_query(flow_name, config, batch_size, *, include_accoun
            AND cp.environment = '{environment}'
         WHERE 1=1
         {where_clause}
-        --    and c.corp_num = 'BC0000621' -- state changes a lot
+            and c.corp_num = 'BC1435838' -- state changes a lot
         --    and cs.state_type_cd = 'ACT'
         AND c.corp_type_cd IN {corp_type_filter}
         AND cp.corp_num IS NULL
@@ -695,6 +695,24 @@ def get_jurisdictions_query(corp_num):
     """
     return query
 
+def get_court_order_query(corp_num):
+    query = f"""
+    select
+            -- event
+            e.event_id             as e_event_id,
+            e.corp_num             as e_corp_num,
+            f.arrangement_ind      as f_arrangement_ind,
+            f.court_order_num      as f_court_order_num
+        from event e
+                 left outer join filing f on e.event_id = f.event_id
+        where 1 = 1
+            and e.corp_num = '{corp_num}'
+            and f.court_order_num is not NULL
+        order by e.event_id
+        ;
+    """
+    return query
+
 
 def get_filings_query(corp_num):
     query = f"""
@@ -950,6 +968,7 @@ def get_corp_snapshot_filings_queries(config, corp_num):
         'resolutions': get_resolutions_query(corp_num),
         'jurisdictions': get_jurisdictions_query(corp_num),
         'filings': get_filings_query(corp_num),
+        'court_order':get_court_order_query(corp_num),
         'amalgamations': get_amalgamation_query(corp_num),
         'business_comments': get_business_comments_query(corp_num),
         'filing_comments': get_filing_comments_query(corp_num),

--- a/data-tool/flows/tombstone/tombstone_queries.py
+++ b/data-tool/flows/tombstone/tombstone_queries.py
@@ -185,7 +185,7 @@ def get_unprocessed_corps_query(flow_name, config, batch_size, *, include_accoun
            AND cp.environment = '{environment}'
         WHERE 1=1
         {where_clause}
-            and c.corp_num = 'BC1435838' -- state changes a lot
+            and c.corp_num = 'BC0000621' -- state changes a lot
         --    and cs.state_type_cd = 'ACT'
         AND c.corp_type_cd IN {corp_type_filter}
         AND cp.corp_num IS NULL

--- a/data-tool/flows/tombstone/tombstone_queries.py
+++ b/data-tool/flows/tombstone/tombstone_queries.py
@@ -185,7 +185,7 @@ def get_unprocessed_corps_query(flow_name, config, batch_size, *, include_accoun
            AND cp.environment = '{environment}'
         WHERE 1=1
         {where_clause}
-            and c.corp_num = 'BC0000621' -- state changes a lot
+        --    and c.corp_num = 'BC0000621' -- state changes a lot
         --    and cs.state_type_cd = 'ACT'
         AND c.corp_type_cd IN {corp_type_filter}
         AND cp.corp_num IS NULL

--- a/data-tool/flows/tombstone/tombstone_queries.py
+++ b/data-tool/flows/tombstone/tombstone_queries.py
@@ -702,9 +702,11 @@ def get_court_order_query(corp_num):
             e.event_id             as e_event_id,
             e.corp_num             as e_corp_num,
             f.arrangement_ind      as f_arrangement_ind,
-            f.court_order_num      as f_court_order_num
+            f.court_order_num      as f_court_order_num,
+            lt.notation            as lt_notation
         from event e
                  left outer join filing f on e.event_id = f.event_id
+                 left outer join ledger_text lt on lt.event_id = f.event_id
         where 1 = 1
             and e.corp_num = '{corp_num}'
             and f.court_order_num is not NULL

--- a/data-tool/flows/tombstone/tombstone_utils.py
+++ b/data-tool/flows/tombstone/tombstone_utils.py
@@ -8,7 +8,8 @@ from typing import Final, Optional
 import pandas as pd
 import pytz
 from sqlalchemy import Connection, bindparam, text
-from tombstone.tombstone_base_data import (ALIAS, AMALGAMATION, FILING,
+from tombstone.tombstone_base_data import (ALIAS, AMALGAMATION,
+                                           COURT_ORDER, FILING,
                                            FILING_JSON, IN_DISSOLUTION,
                                            JURISDICTION, OFFICE, OFFICES_HELD,
                                            PARTY, PARTY_ROLE, RESOLUTION,
@@ -369,6 +370,24 @@ def format_resolutions_data(data: dict, config=None) -> list[dict]:
     return formatted_resolutions
 
 
+def format_court_order_data(data: dict, event_id: Decimal) -> dict:
+    court_order_data = data['court_order']
+
+    matched_court_order = [
+        item for item in court_order_data if item.get('e_event_id') == event_id
+    ]
+
+    if not matched_court_order:
+        return None
+    
+    formatted_court_order = copy.deepcopy(COURT_ORDER)
+    formatted_court_order['file_number'] = matched_court_order[0]['f_court_order_num']
+    formatted_court_order['effect_of_order'] = matched_court_order[0]['f_arrangement_ind']
+    formatted_court_order['order_date'] = None  # Note: order_date is not available in the current data, so set it to None
+    formatted_court_order['order_details'] = None  # Note: order_details is not available in the current data, so set it to None
+
+    return formatted_court_order
+
 def format_jurisdictions_data(data: dict, event_id: Decimal) -> dict:
     jurisdictions_data = data['jurisdictions']
 
@@ -463,6 +482,7 @@ def format_filings_data(data: dict, config=None) -> dict:
         jurisdiction = None
         amalgamation = None
         consent_continuation_out = None
+        court_order = None
 
         user_id = get_username(x)
 
@@ -520,6 +540,8 @@ def format_filings_data(data: dict, config=None) -> dict:
 
         comments = format_filing_comments_data(data, x['e_event_id'])
 
+        court_order = format_court_order_data(data, x['e_event_id'])
+
         colin_event_ids = {'colin_event_id': x['e_event_id']}
         filing = {
             'filings': filing_body,
@@ -527,7 +549,8 @@ def format_filings_data(data: dict, config=None) -> dict:
             'amalgamations': amalgamation,
             'comments': comments,
             'colin_event_ids': colin_event_ids,
-            'consent_continuation_out': consent_continuation_out
+            'consent_continuation_out': consent_continuation_out,
+            'court_order': court_order
         }
 
         formatted_filings.append(filing)

--- a/data-tool/flows/tombstone/tombstone_utils.py
+++ b/data-tool/flows/tombstone/tombstone_utils.py
@@ -900,14 +900,14 @@ def get_business_update_value(key: str, effective_date: str, trigger_date: str, 
 
 
 def update_court_order(meta_data: dict, filing_data: dict) -> None:
-    court_order_num = filing_data.get('f_court_order_num')
+    court_order_num = filing_data.get('court_order_num')
     if not court_order_num:
         return
 
     meta_data['court_order'] = meta_data.get('court_order', {})
     meta_data['court_order']['fileNumber'] = court_order_num
 
-    if effect_of_order := filing_data.get('f_arrangement_ind'):
+    if effect_of_order := filing_data.get('arrangement_ind'):
         meta_data['court_order']['effectOfOrder'] = effect_of_order
 
 

--- a/data-tool/flows/tombstone/tombstone_utils.py
+++ b/data-tool/flows/tombstone/tombstone_utils.py
@@ -899,6 +899,18 @@ def get_business_update_value(key: str, effective_date: str, trigger_date: str, 
     return value
 
 
+def update_court_order(meta_data: dict, filing_data: dict) -> None:
+    court_order_num = filing_data.get('f_court_order_num')
+    if not court_order_num:
+        return
+
+    meta_data['court_order'] = meta_data.get('court_order', {})
+    meta_data['court_order']['fileNumber'] = court_order_num
+
+    if effect_of_order := filing_data.get('f_arrangement_ind'):
+        meta_data['court_order']['effectOfOrder'] = effect_of_order
+
+
 def build_filing_json_meta_data(raw_filing_type: str,
                                 filing_type: str,
                                 filing_subtype: str,
@@ -1047,6 +1059,9 @@ def build_filing_json_meta_data(raw_filing_type: str,
             **meta_data,
             'withdrawnDate': withdrawn_ts.isoformat()
         }
+
+    # populate court order info in meta_data if available
+    update_court_order(meta_data, filing_data)
 
     # TODO: populate meta_data for correction to display correct filing name
 

--- a/data-tool/flows/tombstone/tombstone_utils.py
+++ b/data-tool/flows/tombstone/tombstone_utils.py
@@ -370,7 +370,7 @@ def format_resolutions_data(data: dict, config=None) -> list[dict]:
     return formatted_resolutions
 
 
-def format_court_order_data(data: dict, event_id: Decimal) -> dict:
+def format_court_order_data(data: dict, event_id: Decimal) -> Optional[dict]:
     court_order_data = data['court_order']
 
     matched_court_order = [
@@ -379,7 +379,7 @@ def format_court_order_data(data: dict, event_id: Decimal) -> dict:
 
     if not matched_court_order:
         return None
-    
+
     formatted_court_order = copy.deepcopy(COURT_ORDER)
     formatted_court_order['file_number'] = matched_court_order[0]['f_court_order_num']
     formatted_court_order['effect_of_order'] = matched_court_order[0]['f_arrangement_ind']

--- a/data-tool/flows/tombstone/tombstone_utils.py
+++ b/data-tool/flows/tombstone/tombstone_utils.py
@@ -384,7 +384,7 @@ def format_court_order_data(data: dict, event_id: Decimal) -> Optional[dict]:
     formatted_court_order['file_number'] = matched_court_order[0]['f_court_order_num']
     formatted_court_order['effect_of_order'] = matched_court_order[0]['f_arrangement_ind']
     formatted_court_order['order_date'] = None  # Note: order_date is not available in the current data, so set it to None
-    formatted_court_order['order_details'] = None  # Note: order_details is not available in the current data, so set it to None
+    formatted_court_order['order_details'] = matched_court_order[0]['lt_notation']
 
     return formatted_court_order
 
@@ -899,16 +899,29 @@ def get_business_update_value(key: str, effective_date: str, trigger_date: str, 
     return value
 
 
-def update_court_order(meta_data: dict, filing_data: dict) -> None:
-    court_order_num = filing_data.get('court_order_num')
+def update_court_order(meta_data: dict, data: dict, filing_data: dict) -> None:
+    court_order_data = data['court_order']
+
+    matched_court_order = [
+        item for item in court_order_data if item.get('e_event_id') == filing_data['e_event_id']
+    ]
+
+    if not matched_court_order:
+        return None
+
+    court_order_num = matched_court_order[0]['f_court_order_num']
+
     if not court_order_num:
         return
 
     meta_data['courtOrder'] = meta_data.get('courtOrder', {})
     meta_data['courtOrder']['fileNumber'] = court_order_num
 
-    if effect_of_order := filing_data.get('arrangement_ind'):
+    if effect_of_order := matched_court_order[0]['f_arrangement_ind']:
         meta_data['courtOrder']['effectOfOrder'] = effect_of_order
+
+    if order_details := matched_court_order[0]['lt_notation']:
+        meta_data['courtOrder']['orderDetails'] = order_details
 
 
 def build_filing_json_meta_data(raw_filing_type: str,
@@ -1061,7 +1074,7 @@ def build_filing_json_meta_data(raw_filing_type: str,
         }
 
     # populate court order info in meta_data if available
-    update_court_order(meta_data, filing_data)
+    update_court_order(meta_data, data, filing_data)
 
     # TODO: populate meta_data for correction to display correct filing name
 

--- a/data-tool/flows/tombstone/tombstone_utils.py
+++ b/data-tool/flows/tombstone/tombstone_utils.py
@@ -904,11 +904,11 @@ def update_court_order(meta_data: dict, filing_data: dict) -> None:
     if not court_order_num:
         return
 
-    meta_data['court_order'] = meta_data.get('court_order', {})
-    meta_data['court_order']['fileNumber'] = court_order_num
+    meta_data['courtOrder'] = meta_data.get('courtOrder', {})
+    meta_data['courtOrder']['fileNumber'] = court_order_num
 
     if effect_of_order := filing_data.get('arrangement_ind'):
-        meta_data['court_order']['effectOfOrder'] = effect_of_order
+        meta_data['courtOrder']['effectOfOrder'] = effect_of_order
 
 
 def build_filing_json_meta_data(raw_filing_type: str,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#34622

*Description of changes:*

- Court order is mapped per filing. 
- Court order details are added to `meta_data` and version tables

Coprs below are migrated to **DEV** for tetsing.
BC0499196, BC1246931 (has ledger notation), BC1286496, BC1435838

Example:

<img width="1716" height="485" alt="image" src="https://github.com/user-attachments/assets/eded18af-e8c2-46a9-9a78-82c1bdfda08b" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the lear license (Apache 2.0).
